### PR TITLE
Introducing Cadence Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Build Status](https://badge.buildkite.com/159887afd42000f11126f85237317d4090de97b26c287ebc40.svg?theme=github&branch=master)](https://buildkite.com/uberopensource/cadence-server)
 [![Coverage](https://codecov.io/gh/uber/cadence/graph/badge.svg?token=7SD244ImNF)](https://codecov.io/gh/uber/cadence)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](http://t.uber.com/cadence-slack)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Cadence%20Guru-006BFF)](https://gurubase.io/g/cadence)
 
 [![Github release](https://img.shields.io/github/v/release/uber/cadence.svg)](https://GitHub.com/uber/cadence/releases)
 [![License](https://img.shields.io/github/license/uber/cadence.svg)](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Cadence Guru](https://gurubase.io/g/cadence) to Gurubase. Cadence Guru uses the data from this repo and data from the [docs](https://cadenceworkflow.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Cadence Guru", which highlights that Cadence now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Cadence Guru in Gurubase, just let me know that's totally fine.
