### PR TITLE
Update codecov config with new github org

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,6 @@
 name: Workflow for Codecov integration
 on: [push, pull_request]
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,4 +27,4 @@ jobs:
           file: .build/coverage/unit_cover.out
           exclude: ./
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: uber/cadence
+          slug: cadence-workflow/cadence


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Repo has moved from `uber` org to `cadence-workflow` org. 
