### PR TITLE
Task manager - task cleanup on passive side using task completer

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1648,6 +1648,12 @@ const (
 	// Value type: Bool
 	// Default value: false
 	MatchingEnableTasklistGuardAgainstOwnershipShardLoss
+	// MatchingEnableStandbyTaskCompletion is to enable completion of tasks in the domain's passive side
+	// KeyName: matching.enableStandbyTaskCompletion
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName,TasklistName,TasklistType
+	MatchingEnableStandbyTaskCompletion
 
 	MatchingEnableGetNumberOfPartitionsFromCache
 	MatchingEnableAdaptiveScaler
@@ -4024,6 +4030,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "matching.enableGetNumberOfPartitionsFromCache",
 		Filters:      []Filter{DomainName, TaskListName, TaskType},
 		Description:  "MatchingEnableGetNumberOfPartitionsFromCache is to enable getting number of partitions from cache instead of dynamic config",
+		DefaultValue: false,
+	},
+	MatchingEnableStandbyTaskCompletion: {
+		KeyName:      "matching.enableStandbyTaskCompletion",
+		Filters:      []Filter{DomainName, TaskListName, TaskType},
+		Description:  "MatchingEnableStandbyTaskCompletion is to enable completion of tasks in the domain's passive side",
 		DefaultValue: false,
 	},
 	MatchingEnableAdaptiveScaler: {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2634,6 +2634,8 @@ const (
 	EstimatedAddTaskQPSGauge
 	TaskListPartitionUpscaleThresholdGauge
 	TaskListPartitionDownscaleThresholdGauge
+	StandbyClusterTasksCompletedCounterPerTaskList
+	StandbyClusterTasksNotStartedCounterPerTaskList
 
 	NumMatchingMetrics
 )
@@ -3326,6 +3328,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		EstimatedAddTaskQPSGauge:                                {metricName: "estimated_add_task_qps_per_tl", metricType: Gauge},
 		TaskListPartitionUpscaleThresholdGauge:                  {metricName: "tasklist_partition_upscale_threshold", metricType: Gauge},
 		TaskListPartitionDownscaleThresholdGauge:                {metricName: "tasklist_partition_downscale_threshold", metricType: Gauge},
+		StandbyClusterTasksCompletedCounterPerTaskList:          {metricName: "standby_cluster_tasks_completed_per_tl", metricType: Counter},
+		StandbyClusterTasksNotStartedCounterPerTaskList:         {metricName: "standby_cluster_tasks_not_started_per_tl", metricType: Counter},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2636,6 +2636,7 @@ const (
 	TaskListPartitionDownscaleThresholdGauge
 	StandbyClusterTasksCompletedCounterPerTaskList
 	StandbyClusterTasksNotStartedCounterPerTaskList
+	StandbyClusterTasksCompletionFailurePerTaskList
 
 	NumMatchingMetrics
 )
@@ -3330,6 +3331,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskListPartitionDownscaleThresholdGauge:                {metricName: "tasklist_partition_downscale_threshold", metricType: Gauge},
 		StandbyClusterTasksCompletedCounterPerTaskList:          {metricName: "standby_cluster_tasks_completed_per_tl", metricType: Counter},
 		StandbyClusterTasksNotStartedCounterPerTaskList:         {metricName: "standby_cluster_tasks_not_started_per_tl", metricType: Counter},
+		StandbyClusterTasksCompletionFailurePerTaskList:         {metricName: "standby_cluster_tasks_completion_failure_per_tl", metricType: Counter},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/common/util.go
+++ b/common/util.go
@@ -80,6 +80,10 @@ const (
 	replicationServiceBusyMaxInterval        = 10 * time.Second
 	replicationServiceBusyExpirationInterval = 5 * time.Minute
 
+	taskCompleterInitialInterval    = 1 * time.Second
+	taskCompleterMaxInterval        = 10 * time.Second
+	taskCompleterExpirationInterval = 5 * time.Minute
+
 	contextExpireThreshold = 10 * time.Millisecond
 
 	// FailureReasonCompleteResultExceedsLimit is failureReason for complete result exceeds limit
@@ -199,6 +203,15 @@ func CreateReplicationServiceBusyRetryPolicy() backoff.RetryPolicy {
 	policy := backoff.NewExponentialRetryPolicy(replicationServiceBusyInitialInterval)
 	policy.SetMaximumInterval(replicationServiceBusyMaxInterval)
 	policy.SetExpirationInterval(replicationServiceBusyExpirationInterval)
+
+	return policy
+}
+
+// CreateTaskCompleterRetryPolicy creates a retry policy to handle tasks not being started
+func CreateTaskCompleterRetryPolicy() backoff.RetryPolicy {
+	policy := backoff.NewExponentialRetryPolicy(taskCompleterInitialInterval)
+	policy.SetMaximumInterval(taskCompleterMaxInterval)
+	policy.SetExpirationInterval(taskCompleterExpirationInterval)
 
 	return policy
 }

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -4,6 +4,15 @@ frontend.enableClientVersionCheck:
 system.minRetentionDays:
 - value: 0
   constraints: {}
+matching.enableStandbyTaskCompletion:
+- value: true
+  constraints: {}
+history.standbyClusterDelay:
+- value: 30s
+  constraints: {}
+history.standbyTaskMissingEventsResendDelay:
+- value: 30s
+  constraints: {}
 history.EnableConsistentQueryByDomain:
 - value: true
   constraints: {}

--- a/service/history/constants/test_constants.go
+++ b/service/history/constants/test_constants.go
@@ -134,4 +134,22 @@ var (
 		},
 		TestVersion,
 	)
+
+	// TestGlobalStandbyDomainEntry is the global standby domain cache entry for test
+	TestGlobalStandbyDomainEntry = cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: TestDomainID, Name: TestDomainName},
+		&persistence.DomainConfig{
+			Retention:                1,
+			VisibilityArchivalStatus: types.ArchivalStatusEnabled,
+			VisibilityArchivalURI:    "test:///visibility/archival",
+		},
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		TestVersion,
+	)
 )

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -60,7 +60,7 @@ type (
 		PartitionDownscaleSustainedDuration  dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		AdaptiveScalerUpdateInterval         dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		EnableAdaptiveScaler                 dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
-		EnableStandByTaskCompletion          dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
+		EnableStandbyTaskCompletion          dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskListInfoFilters

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -140,7 +140,7 @@ type (
 		// task gc configuration
 		MaxTimeBetweenTaskDeletes time.Duration
 		// standby task completion configuration
-		EnableStandByTaskCompletion func() bool
+		EnableStandbyTaskCompletion func() bool
 	}
 )
 
@@ -192,6 +192,6 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, getIsolationGroups
 		TaskDispatchRPSTTL:                   time.Minute,
 		MaxTimeBetweenTaskDeletes:            time.Second,
 		AllIsolationGroups:                   getIsolationGroups,
-		EnableStandByTaskCompletion:          dc.GetBoolPropertyFilteredByTaskListInfo(dynamicconfig.MatchingEnableStandbyTaskCompletion),
+		EnableStandbyTaskCompletion:          dc.GetBoolPropertyFilteredByTaskListInfo(dynamicconfig.MatchingEnableStandbyTaskCompletion),
 	}
 }

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -60,6 +60,7 @@ type (
 		PartitionDownscaleSustainedDuration  dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		AdaptiveScalerUpdateInterval         dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		EnableAdaptiveScaler                 dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
+		EnableStandByTaskCompletion          dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
@@ -138,6 +139,8 @@ type (
 		TaskDispatchRPSTTL time.Duration
 		// task gc configuration
 		MaxTimeBetweenTaskDeletes time.Duration
+		// standby task completion configuration
+		EnableStandByTaskCompletion func() bool
 	}
 )
 
@@ -189,5 +192,6 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, getIsolationGroups
 		TaskDispatchRPSTTL:                   time.Minute,
 		MaxTimeBetweenTaskDeletes:            time.Second,
 		AllIsolationGroups:                   getIsolationGroups,
+		EnableStandByTaskCompletion:          dc.GetBoolPropertyFilteredByTaskListInfo(dynamicconfig.MatchingEnableStandbyTaskCompletion),
 	}
 }

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -87,6 +87,7 @@ func TestNewConfig(t *testing.T) {
 		"PartitionDownscaleSustainedDuration":  {dynamicconfig.MatchingPartitionDownscaleSustainedDuration, time.Duration(33)},
 		"AdaptiveScalerUpdateInterval":         {dynamicconfig.MatchingAdaptiveScalerUpdateInterval, time.Duration(34)},
 		"EnableAdaptiveScaler":                 {dynamicconfig.MatchingEnableAdaptiveScaler, true},
+		"EnableStandbyTaskCompletion":          {dynamicconfig.MatchingEnableStandbyTaskCompletion, false},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -245,6 +245,7 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *tasklist.Identifier, t
 		e.config,
 		e.timeSource,
 		e.timeSource.Now(),
+		e.historyService,
 	)
 	if err != nil {
 		e.taskListsLock.Unlock()

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -225,7 +225,8 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 		&tlKind,
 		s.matchingEngine.config,
 		s.matchingEngine.timeSource,
-		s.matchingEngine.timeSource.Now())
+		s.matchingEngine.timeSource.Now(),
+		s.matchingEngine.historyService)
 	s.Require().NoError(err)
 
 	// try to unload a different tlm instance with the same taskListID

--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -23,6 +23,7 @@
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist Manager
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist TaskMatcher
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist Forwarder
+//go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist TaskCompleter
 
 package tasklist
 
@@ -82,5 +83,9 @@ type (
 		ForwardPoll(ctx context.Context) (*InternalTask, error)
 		AddReqTokenC() <-chan *ForwarderReqToken
 		PollReqTokenC(isolationGroup string) <-chan *ForwarderReqToken
+	}
+
+	TaskCompleter interface {
+		CompleteTaskIfStarted(ctx context.Context, task *InternalTask) error
 	}
 )

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -526,3 +526,40 @@ func (mr *MockForwarderMockRecorder) PollReqTokenC(isolationGroup interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollReqTokenC", reflect.TypeOf((*MockForwarder)(nil).PollReqTokenC), isolationGroup)
 }
+
+// MockTaskCompleter is a mock of TaskCompleter interface.
+type MockTaskCompleter struct {
+	ctrl     *gomock.Controller
+	recorder *MockTaskCompleterMockRecorder
+}
+
+// MockTaskCompleterMockRecorder is the mock recorder for MockTaskCompleter.
+type MockTaskCompleterMockRecorder struct {
+	mock *MockTaskCompleter
+}
+
+// NewMockTaskCompleter creates a new mock instance.
+func NewMockTaskCompleter(ctrl *gomock.Controller) *MockTaskCompleter {
+	mock := &MockTaskCompleter{ctrl: ctrl}
+	mock.recorder = &MockTaskCompleterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTaskCompleter) EXPECT() *MockTaskCompleterMockRecorder {
+	return m.recorder
+}
+
+// CompleteTaskIfStarted mocks base method.
+func (m *MockTaskCompleter) CompleteTaskIfStarted(ctx context.Context, task *InternalTask) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompleteTaskIfStarted", ctx, task)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CompleteTaskIfStarted indicates an expected call of CompleteTaskIfStarted.
+func (mr *MockTaskCompleterMockRecorder) CompleteTaskIfStarted(ctx, task interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTaskIfStarted", reflect.TypeOf((*MockTaskCompleter)(nil).CompleteTaskIfStarted), ctx, task)
+}

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -1,0 +1,201 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package tasklist
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/uber/cadence/client/history"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+)
+
+type (
+	taskCompleterImpl struct {
+		domainCache     cache.DomainCache
+		taskListID      *Identifier
+		clusterMetadata cluster.Metadata
+		historyService  history.Client
+		scope           metrics.Scope
+		logger          log.Logger
+		throttleRetry   *backoff.ThrottleRetry
+	}
+)
+
+// DomainIsActiveInThisClusterError type
+type DomainIsActiveInThisClusterError struct {
+	Message string
+}
+
+// Implement the Error method for DomainIsActiveInThisClusterError
+func (e *DomainIsActiveInThisClusterError) Error() string {
+	return e.Message
+}
+
+var (
+	errWorkflowExecutionInfoIsNil      = errors.New("workflow execution info is nil")
+	errTaskTypeNotSupported            = errors.New("task type not supported")
+	errTaskNotStarted                  = errors.New("task not started")
+	errDomainIsActive                  = &DomainIsActiveInThisClusterError{Message: "domain is active"}
+	historyServiceOperationRetryPolicy = common.CreateHistoryServiceRetryPolicy()
+)
+
+func newTaskCompleter(tlMgr *taskListManagerImpl, retryPolicy backoff.RetryPolicy) TaskCompleter {
+	return &taskCompleterImpl{
+		domainCache:     tlMgr.domainCache,
+		historyService:  tlMgr.historyService,
+		taskListID:      tlMgr.taskListID,
+		clusterMetadata: tlMgr.clusterMetadata,
+		scope:           tlMgr.scope,
+		logger:          tlMgr.logger,
+		throttleRetry: backoff.NewThrottleRetry(
+			backoff.WithRetryPolicy(retryPolicy),
+			backoff.WithRetryableError(isRetryableError),
+		),
+	}
+}
+
+func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *InternalTask) error {
+	op := func() (err error) {
+		domainEntry, err := tc.domainCache.GetDomainByID(task.Event.TaskInfo.DomainID)
+		if err != nil {
+			return fmt.Errorf("unable to fetch domain from cache: %w", err)
+		}
+
+		if _, err = domainEntry.IsActiveIn(tc.clusterMetadata.GetCurrentClusterName()); err == nil {
+			return errDomainIsActive
+		}
+
+		req := &types.HistoryDescribeWorkflowExecutionRequest{
+			DomainUUID: task.Event.TaskInfo.DomainID,
+			Request: &types.DescribeWorkflowExecutionRequest{
+				Domain: task.domainName,
+				Execution: &types.WorkflowExecution{
+					WorkflowID: task.Event.WorkflowID,
+					RunID:      task.Event.RunID,
+				},
+			},
+		}
+
+		workflowExecutionResponse, err := tc.historyService.DescribeWorkflowExecution(ctx, req)
+
+		if errors.As(err, new(*types.EntityNotExistsError)) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("unable to fetch workflow execution from the history service: %w", err)
+		}
+
+		if workflowExecutionResponse.WorkflowExecutionInfo == nil {
+			return errWorkflowExecutionInfoIsNil
+		}
+
+		isTaskStarted, err := tc.isTaskStarted(task, workflowExecutionResponse)
+		if err != nil {
+			return fmt.Errorf("unable to determine if task has started: %w", err)
+		}
+
+		if isTaskStarted {
+			return nil
+		}
+
+		return errTaskNotStarted
+	}
+
+	err := tc.throttleRetry.Do(ctx, op)
+
+	if errors.Is(err, errDomainIsActive) {
+		// add metric
+		return err
+	}
+
+	if err == nil || !isRetryableError(err) {
+		// add metric
+		task.Finish(nil)
+		return nil
+	}
+
+	// add metric
+
+	return err
+}
+
+func (tc *taskCompleterImpl) isTaskStarted(task *InternalTask, workflowExecutionResponse *types.DescribeWorkflowExecutionResponse) (bool, error) {
+	if workflowExecutionResponse.WorkflowExecutionInfo.CloseStatus != nil {
+		return true, nil
+	}
+
+	// taskType can only be Activity or Decision, leaving the default case for future proofing
+	switch tc.taskListID.taskType {
+	case persistence.TaskListTypeActivity:
+		return isActivityTaskStarted(task, workflowExecutionResponse), nil
+	case persistence.TaskListTypeDecision:
+		return isDecisionTaskStarted(task, workflowExecutionResponse), nil
+	default:
+		return false, errTaskTypeNotSupported
+	}
+}
+
+func isDecisionTaskStarted(task *InternalTask, workflowExecutionResponse *types.DescribeWorkflowExecutionResponse) bool {
+	// if there is no pending decision task, that means that this task has been already started
+	if workflowExecutionResponse.PendingDecision == nil {
+		return true
+	}
+
+	// if the scheduleID is different from the pending decision scheduleID or the state is started, then the decision task with the task's scheduleID has already been started
+	if task.Event.ScheduleID < workflowExecutionResponse.PendingDecision.ScheduleID || (task.Event.ScheduleID == workflowExecutionResponse.PendingDecision.ScheduleID && *workflowExecutionResponse.PendingDecision.State == types.PendingDecisionStateStarted) {
+		return true
+	}
+
+	return false
+}
+
+func isActivityTaskStarted(task *InternalTask, workflowExecutionResponse *types.DescribeWorkflowExecutionResponse) bool {
+	// if the scheduleID is different from all pending tasks' scheduleID or the pending activity has PendingActivityStateStarted, then the activity task with the task's scheduleID has already been started
+	for _, pendingActivity := range workflowExecutionResponse.PendingActivities {
+		if task.Event.ScheduleID == pendingActivity.ScheduleID {
+			if *pendingActivity.State == types.PendingActivityStateStarted {
+				return true
+			}
+			return false
+		}
+	}
+	return true
+}
+
+func isRetryableError(err error) bool {
+	// entityNotExistsError is returned when the workflow is not found in the database
+	var domainIsActiveInThisClusterError *DomainIsActiveInThisClusterError
+	switch {
+	case errors.As(err, &domainIsActiveInThisClusterError):
+		return false
+	}
+	return true
+}

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -91,7 +91,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 			return fmt.Errorf("unable to fetch domain from cache: %w", err)
 		}
 
-		if _, err = domainEntry.IsActiveIn(tc.clusterMetadata.GetCurrentClusterName()); err == nil {
+		if isActive, _ := domainEntry.IsActiveIn(tc.clusterMetadata.GetCurrentClusterName()); isActive {
 			return errDomainIsActive
 		}
 
@@ -109,7 +109,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 		workflowExecutionResponse, err := tc.historyService.DescribeWorkflowExecution(ctx, req)
 
 		if errors.As(err, new(*types.EntityNotExistsError)) {
-			tc.logger.Info("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))
+			tc.logger.Warn("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("unable to fetch workflow execution from the history service: %w", err)

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -127,10 +127,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 			return nil
 		}
 
-		tc.scope.
-			Tagged(metrics.DomainTag(task.domainName)).
-			Tagged(metrics.TaskListTag(tc.taskListID.GetName())).
-			IncCounter(metrics.StandbyClusterTasksNotStartedCounterPerTaskList)
+		tc.scope.IncCounter(metrics.StandbyClusterTasksNotStartedCounterPerTaskList)
 
 		return errTaskNotStarted
 	}
@@ -140,15 +137,13 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 	if err == nil {
 		task.Finish(nil)
 
-		tc.scope.
-			Tagged(metrics.DomainTag(task.domainName)).
-			Tagged(metrics.TaskListTag(tc.taskListID.GetName())).
-			IncCounter(metrics.StandbyClusterTasksCompletedCounterPerTaskList)
+		tc.scope.IncCounter(metrics.StandbyClusterTasksCompletedCounterPerTaskList)
 
 		return nil
 	}
 
 	if !errors.Is(err, errDomainIsActive) && !errors.Is(err, errTaskNotStarted) {
+		tc.scope.IncCounter(metrics.StandbyClusterTasksCompletionFailurePerTaskList)
 		tc.logger.Error("Error completing task on domain's standby cluster", tag.Error(err))
 	}
 

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -131,12 +131,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 
 	err := tc.throttleRetry.Do(ctx, op)
 
-	if errors.Is(err, errDomainIsActive) {
-		// add metric
-		return err
-	}
-
-	if err == nil || !isRetryableError(err) {
+	if err == nil {
 		// add metric
 		task.Finish(nil)
 		return nil

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/uber/cadence/common/log/tag"
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
@@ -34,6 +33,7 @@ import (
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -109,7 +109,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 		workflowExecutionResponse, err := tc.historyService.DescribeWorkflowExecution(ctx, req)
 
 		if errors.As(err, new(*types.EntityNotExistsError)) {
-			tc.logger.Debug("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))
+			tc.logger.Info("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("unable to fetch workflow execution from the history service: %w", err)

--- a/service/matching/tasklist/task_completer_test.go
+++ b/service/matching/tasklist/task_completer_test.go
@@ -438,9 +438,9 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 			if tc.err != nil {
 				assert.Error(t, err)
 				if errors.Unwrap(err) != nil {
-					assert.Equal(t, tc.err, errors.Unwrap(err))
+					assert.ErrorContains(t, errors.Unwrap(err), tc.err.Error())
 				} else {
-					assert.Equal(t, tc.err, err)
+					assert.ErrorContains(t, err, tc.err.Error())
 				}
 			} else {
 				assert.NoError(t, err)

--- a/service/matching/tasklist/task_completer_test.go
+++ b/service/matching/tasklist/task_completer_test.go
@@ -1,0 +1,450 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package tasklist
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/client/history"
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/constants"
+)
+
+var retryPolicyMaxAttempts = 3
+
+func createTestTaskCompleter(controller *gomock.Controller, taskType int) *taskCompleterImpl {
+	mockDomainCache := cache.NewMockDomainCache(controller)
+	mockHistoryService := history.NewMockClient(controller)
+
+	retryPolicy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
+	retryPolicy.SetMaximumAttempts(retryPolicyMaxAttempts)
+
+	tlMgr := &taskListManagerImpl{
+		domainCache:     mockDomainCache,
+		historyService:  mockHistoryService,
+		taskListID:      &Identifier{domainID: constants.TestDomainID, taskType: taskType},
+		clusterMetadata: cluster.GetTestClusterMetadata(true),
+		scope:           metrics.NoopScope(1),
+		logger:          log.NewNoop(),
+	}
+	tc := newTaskCompleter(tlMgr, retryPolicy)
+
+	return tc.(*taskCompleterImpl)
+}
+
+func TestCompleteTaskIfStarted(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name      string
+		setupMock func(*types.HistoryDescribeWorkflowExecutionRequest, *cache.MockDomainCache, *history.MockClient)
+		task      *InternalTask
+		taskType  int
+		err       error
+	}{
+		{
+			name: "error - could not get domain by ID from cache",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID: constants.TestDomainID,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(nil, errors.New("error-getting-domain-by-id")).Times(retryPolicyMaxAttempts + 1)
+			},
+			err: errors.New("error-getting-domain-by-id"),
+		},
+		{
+			name: "error - domain is active",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID: constants.TestDomainID,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalDomainEntry, nil).Times(1)
+			},
+			err: errDomainIsActive,
+		},
+		{
+			name: "error - could not fetch workflow execution from history service",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(nil, errors.New("error-describing-workflow-execution")).Times(retryPolicyMaxAttempts + 1)
+			},
+			err: errors.New("error-describing-workflow-execution"),
+		},
+		{
+			name: "error - no WorkflowExecutionInfo in workflow execution response",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
+				resp := &types.DescribeWorkflowExecutionResponse{}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+			},
+			err: errWorkflowExecutionInfoIsNil,
+		},
+		{
+			name: "error - task type not supported",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+			},
+			taskType: 999,
+			err:      errTaskTypeNotSupported,
+		},
+		{
+			name: "error - decision task not started - scheduleID greater than PendingDecision scheduleID",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					PendingDecision: &types.PendingDecisionInfo{
+						ScheduleID: 2,
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+			},
+			taskType: persistence.TaskListTypeDecision,
+			err:      errTaskNotStarted,
+		},
+		{
+			name: "error - decision task not started - scheduleID equal to PendingDecision scheduleID but PendingDecision state is not PendingDecisionStateStarted",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					PendingDecision: &types.PendingDecisionInfo{
+						ScheduleID: 3,
+						State:      types.PendingDecisionStateScheduled.Ptr(),
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+			},
+			taskType: persistence.TaskListTypeDecision,
+			err:      errTaskNotStarted,
+		},
+		{
+			name: "error - activity task not started - activity matching scheduleID is in PendingActivities but its state is not PendingActivityStateStarted",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					PendingActivities: []*types.PendingActivityInfo{
+						{
+							ScheduleID: 3,
+							State:      types.PendingActivityStateScheduled.Ptr(),
+						},
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+			},
+			taskType: persistence.TaskListTypeActivity,
+			err:      errTaskNotStarted,
+		},
+		{
+			name: "complete task - workflow not found",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(nil, &types.EntityNotExistsError{}).Times(1)
+			},
+			err: nil,
+		},
+		{
+			name: "complete task - workflow closed",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{
+						CloseStatus: types.WorkflowExecutionCloseStatusCompleted.Ptr(),
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+			},
+			taskType: persistence.TaskListTypeDecision,
+			err:      nil,
+		},
+		{
+			name: "complete decision task - no pending decision",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+			},
+			taskType: persistence.TaskListTypeDecision,
+			err:      nil,
+		},
+		{
+			name: "complete decision task - scheduleID is less than PendingDecision scheduleID",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 2,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					PendingDecision: &types.PendingDecisionInfo{
+						ScheduleID: 3,
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+			},
+			taskType: persistence.TaskListTypeDecision,
+			err:      nil,
+		},
+		{
+			name: "complete decision task - scheduleID is equal to PendingDecision scheduleID and PendingDecision state is PendingDecisionStateStarted",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					PendingDecision: &types.PendingDecisionInfo{
+						ScheduleID: 3,
+						State:      types.PendingDecisionStateStarted.Ptr(),
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+			},
+			taskType: persistence.TaskListTypeDecision,
+			err:      nil,
+		},
+		{
+			name: "complete activity task - no activity matching scheduleID in PendingActivities",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					PendingActivities: []*types.PendingActivityInfo{
+						{
+							ScheduleID: 2,
+							State:      types.PendingActivityStateScheduled.Ptr(),
+						},
+						{
+							ScheduleID: 4,
+							State:      types.PendingActivityStateScheduled.Ptr(),
+						},
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+			},
+			taskType: persistence.TaskListTypeActivity,
+			err:      nil,
+		},
+		{
+			name: "complete activity task - activity matching scheduleID is in PendingActivities and its state is PendingActivityStateStarted",
+			task: &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+						ScheduleID: 3,
+					},
+				},
+			},
+			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient) {
+				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
+				resp := &types.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					PendingActivities: []*types.PendingActivityInfo{
+						{
+							ScheduleID: 3,
+							State:      types.PendingActivityStateStarted.Ptr(),
+						},
+					},
+				}
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+			},
+			taskType: persistence.TaskListTypeActivity,
+			err:      nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			tCmp := createTestTaskCompleter(ctrl, tc.taskType)
+
+			defer ctrl.Finish()
+
+			req := &types.HistoryDescribeWorkflowExecutionRequest{
+				DomainUUID: tc.task.Event.TaskInfo.DomainID,
+				Request: &types.DescribeWorkflowExecutionRequest{
+					Domain: tc.task.domainName,
+					Execution: &types.WorkflowExecution{
+						WorkflowID: tc.task.Event.WorkflowID,
+						RunID:      tc.task.Event.RunID,
+					},
+				},
+			}
+
+			tc.setupMock(req, tCmp.domainCache.(*cache.MockDomainCache), tCmp.historyService.(*history.MockClient))
+
+			err := tCmp.CompleteTaskIfStarted(ctx, tc.task)
+
+			if tc.err != nil {
+				assert.Error(t, err)
+				if errors.Unwrap(err) != nil {
+					assert.Equal(t, tc.err, errors.Unwrap(err))
+				} else {
+					assert.Equal(t, tc.err, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -536,7 +536,7 @@ func (c *taskListManagerImpl) AddTask(ctx context.Context, params AddTaskParams)
 // to complete the task if it has already been started.
 func (c *taskListManagerImpl) DispatchTask(ctx context.Context, task *InternalTask) error {
 	// optional configuration to enable clean up of standby tasks that have already been started
-	if c.config.EnableStandByTaskCompletion() {
+	if c.config.EnableStandbyTaskCompletion() {
 		// add a timer to measure latency in case the task is in the active side
 
 		if err := c.taskCompleter.CompleteTaskIfStarted(ctx, task); err != nil {
@@ -1013,8 +1013,8 @@ func newTaskListConfig(id *Identifier, cfg *config.Config, domainName string) *c
 		TaskDispatchRPS:           cfg.TaskDispatchRPS,
 		TaskDispatchRPSTTL:        cfg.TaskDispatchRPSTTL,
 		MaxTimeBetweenTaskDeletes: cfg.MaxTimeBetweenTaskDeletes,
-		EnableStandByTaskCompletion: func() bool {
-			return cfg.EnableStandByTaskCompletion(domainName, taskListName, taskType)
+		EnableStandbyTaskCompletion: func() bool {
+			return cfg.EnableStandbyTaskCompletion(domainName, taskListName, taskType)
 		},
 	}
 }

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -535,10 +535,8 @@ func (c *taskListManagerImpl) AddTask(ctx context.Context, params AddTaskParams)
 // *will not* be persisted to db. On the passive side, dispatches the task to the taskCompleter; it will attempt
 // to complete the task if it has already been started.
 func (c *taskListManagerImpl) DispatchTask(ctx context.Context, task *InternalTask) error {
-	// optional configuration to enable clean up of standby tasks that have already been started
+	// optional configuration to enable cleanup of tasks, in the standby cluster, that have already been started
 	if c.config.EnableStandbyTaskCompletion() {
-		// add a timer to measure latency in case the task is in the active side
-
 		if err := c.taskCompleter.CompleteTaskIfStarted(ctx, task); err != nil {
 			if errors.Is(err, errDomainIsActive) {
 				return c.matcher.MustOffer(ctx, task)

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -541,7 +541,7 @@ func (c *taskListManagerImpl) DispatchTask(ctx context.Context, task *InternalTa
 		return fmt.Errorf("unable to fetch domain from cache: %w", err)
 	}
 
-	if _, err = domainEntry.IsActiveIn(c.clusterMetadata.GetCurrentClusterName()); err == nil {
+	if isActive, _ := domainEntry.IsActiveIn(c.clusterMetadata.GetCurrentClusterName()); isActive {
 		return c.matcher.MustOffer(ctx, task)
 	}
 

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber-go/tally"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
@@ -48,6 +49,7 @@ import (
 	"github.com/uber/cadence/common/partition"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/constants"
 	"github.com/uber/cadence/service/matching/config"
 	"github.com/uber/cadence/service/matching/poller"
 )
@@ -77,6 +79,8 @@ func setupMocksForTaskListManager(t *testing.T, taskListID *Identifier, taskList
 	}
 	deps.mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).Times(1)
 	config := config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), "hostname", getIsolationgroupsHelper)
+	mockHistoryService := history.NewMockClient(ctrl)
+
 	tlm, err := NewManager(
 		deps.mockDomainCache,
 		logger,
@@ -91,6 +95,7 @@ func setupMocksForTaskListManager(t *testing.T, taskListID *Identifier, taskList
 		config,
 		deps.mockTimeSource,
 		deps.mockTimeSource.Now(),
+		mockHistoryService,
 	)
 	require.NoError(t, err)
 	return tlm.(*taskListManagerImpl), deps
@@ -219,6 +224,7 @@ func createTestTaskListManagerWithConfig(t *testing.T, logger log.Logger, contro
 	mockDomainCache := cache.NewMockDomainCache(controller)
 	mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry("domainName"), nil).AnyTimes()
 	mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).AnyTimes()
+	mockHistoryService := history.NewMockClient(controller)
 	tl := "tl"
 	dID := "domain"
 	tlID, err := NewIdentifier(dID, tl, persistence.TaskListTypeActivity)
@@ -226,7 +232,7 @@ func createTestTaskListManagerWithConfig(t *testing.T, logger log.Logger, contro
 		panic(err)
 	}
 	tlKind := types.TaskListKindNormal
-	tlMgr, err := NewManager(mockDomainCache, logger, metrics.NewClient(tally.NoopScope, metrics.Matching), tm, cluster.GetTestClusterMetadata(true), mockPartitioner, nil, func(Manager) {}, tlID, &tlKind, cfg, timeSource, timeSource.Now())
+	tlMgr, err := NewManager(mockDomainCache, logger, metrics.NewClient(tally.NoopScope, metrics.Matching), tm, cluster.GetTestClusterMetadata(true), mockPartitioner, nil, func(Manager) {}, tlID, &tlKind, cfg, timeSource, timeSource.Now(), mockHistoryService)
 	if err != nil {
 		logger.Fatal("error when createTestTaskListManager", tag.Error(err))
 	}
@@ -566,6 +572,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 	mockDomainCache := cache.NewMockDomainCache(controller)
 	mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry("domainName"), nil).AnyTimes()
 	mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).AnyTimes()
+	mockHistoryService := history.NewMockClient(controller)
 	logger := testlogger.New(t)
 	timeSource := clock.NewRealTimeSource()
 	tm := NewTestTaskManager(t, logger, timeSource)
@@ -586,6 +593,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 		cfg,
 		timeSource,
 		timeSource.Now(),
+		mockHistoryService,
 	)
 	assert.NoError(t, err)
 	tlm := tlMgr.(*taskListManagerImpl)
@@ -656,6 +664,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 		cfg,
 		timeSource,
 		timeSource.Now(),
+		mockHistoryService,
 	)
 	assert.NoError(t, err)
 	tlm = tlMgr.(*taskListManagerImpl)
@@ -689,6 +698,7 @@ func TestTaskListReaderPumpAdvancesAckLevelAfterEmptyReads(t *testing.T) {
 	mockDomainCache := cache.NewMockDomainCache(controller)
 	mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry("domainName"), nil).AnyTimes()
 	mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).AnyTimes()
+	mockHistoryService := history.NewMockClient(controller)
 
 	logger := testlogger.New(t)
 	timeSource := clock.NewRealTimeSource()
@@ -711,6 +721,7 @@ func TestTaskListReaderPumpAdvancesAckLevelAfterEmptyReads(t *testing.T) {
 		cfg,
 		timeSource,
 		timeSource.Now(),
+		mockHistoryService,
 	)
 	require.NoError(t, err)
 	tlm := tlMgr.(*taskListManagerImpl)
@@ -821,6 +832,7 @@ func TestTaskExpiryAndCompletion(t *testing.T) {
 			mockDomainCache := cache.NewMockDomainCache(controller)
 			mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry("domainName"), nil).AnyTimes()
 			mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).AnyTimes()
+			mockHistoryService := history.NewMockClient(controller)
 			logger := testlogger.New(t)
 			timeSource := clock.NewRealTimeSource()
 			tm := NewTestTaskManager(t, logger, timeSource)
@@ -846,6 +858,7 @@ func TestTaskExpiryAndCompletion(t *testing.T) {
 				cfg,
 				timeSource,
 				timeSource.Now(),
+				mockHistoryService,
 			)
 			assert.NoError(t, err)
 			tlm := tlMgr.(*taskListManagerImpl)
@@ -1357,4 +1370,114 @@ func TestManagerStart_NonRootPartition(t *testing.T) {
 		NumReadPartitions:  3,
 		NumWritePartitions: 3,
 	}, tlm.TaskListPartitionConfig())
+}
+
+func TestDispatchTask(t *testing.T) {
+	testCases := []struct {
+		name                        string
+		mockSetup                   func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask)
+		enableStandByTaskCompletion bool
+		err                         error
+	}{
+		{
+			name: "active side - disabled StandByTaskCompletion - task sent to MustOffer and no error returned",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				matcher.EXPECT().MustOffer(ctx, task).Return(nil).Times(1)
+			},
+			err: nil,
+		},
+		{
+			name: "active side - disabled StandByTaskCompletion - task sent to MustOffer and error returned",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				matcher.EXPECT().MustOffer(ctx, task).Return(errors.New("no-task-completion-must-offer-error")).Times(1)
+			},
+			err: errors.New("no-task-completion-must-offer-error"),
+		},
+		{
+			name: "active side - enabled StandByTaskCompletion - task sent to MustOffer and no error returned",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				taskCompleter.EXPECT().CompleteTaskIfStarted(ctx, task).Return(errDomainIsActive).Times(1)
+				matcher.EXPECT().MustOffer(ctx, task).Return(nil).Times(1)
+			},
+			enableStandByTaskCompletion: true,
+			err:                         nil,
+		},
+		{
+			name: "active side - enabled StandByTaskCompletion - task sent to MustOffer and error returned",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				taskCompleter.EXPECT().CompleteTaskIfStarted(ctx, task).Return(errDomainIsActive).Times(1)
+				matcher.EXPECT().MustOffer(ctx, task).Return(errors.New("task-completion-must-offer-error")).Times(1)
+			},
+			enableStandByTaskCompletion: true,
+			err:                         errors.New("task-completion-must-offer-error"),
+		},
+		{
+			name: "standby side - disabled StandByTaskCompletion - task sent to MustOffer and no error returned",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				matcher.EXPECT().MustOffer(ctx, task).Return(nil).Times(1)
+			},
+			err: nil,
+		},
+		{
+			name: "standby side - disabled StandByTaskCompletion - task sent to MustOffer and error returned",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				matcher.EXPECT().MustOffer(ctx, task).Return(errors.New("no-task-completion-must-offer-error")).Times(1)
+			},
+			err: errors.New("no-task-completion-must-offer-error"),
+		},
+		{
+			name: "standby side - enabled StandByTaskCompletion - task completed",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				taskCompleter.EXPECT().CompleteTaskIfStarted(ctx, task).Return(nil).Times(1)
+			},
+			enableStandByTaskCompletion: true,
+			err:                         nil,
+		},
+		{
+			name: "standby side - enabled StandByTaskCompletion - task completion error",
+			mockSetup: func(matcher *MockTaskMatcher, taskCompleter *MockTaskCompleter, ctx context.Context, task *InternalTask) {
+				taskCompleter.EXPECT().CompleteTaskIfStarted(ctx, task).Return(errTaskNotStarted).Times(1)
+			},
+			enableStandByTaskCompletion: true,
+			err:                         errTaskNotStarted,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			logger := testlogger.New(t)
+			tlm := createTestTaskListManager(t, logger, controller)
+
+			task := &InternalTask{
+				Event: &genericTaskInfo{
+					TaskInfo: &persistence.TaskInfo{
+						DomainID:   constants.TestDomainID,
+						WorkflowID: constants.TestWorkflowID,
+						RunID:      constants.TestRunID,
+					},
+				},
+			}
+
+			taskMatcher := NewMockTaskMatcher(controller)
+			taskCompleter := NewMockTaskCompleter(controller)
+			tlm.matcher = taskMatcher
+			tlm.taskCompleter = taskCompleter
+			tlm.config.EnableStandByTaskCompletion = func() bool {
+				return tc.enableStandByTaskCompletion
+			}
+
+			ctx := context.Background()
+			tc.mockSetup(taskMatcher, taskCompleter, ctx, task)
+
+			err := tlm.DispatchTask(ctx, task)
+
+			if tc.err != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tc.err, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -1463,7 +1463,7 @@ func TestDispatchTask(t *testing.T) {
 			taskCompleter := NewMockTaskCompleter(controller)
 			tlm.matcher = taskMatcher
 			tlm.taskCompleter = taskCompleter
-			tlm.config.EnableStandByTaskCompletion = func() bool {
+			tlm.config.EnableStandbyTaskCompletion = func() bool {
 				return tc.enableStandByTaskCompletion
 			}
 

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -502,6 +502,12 @@ func (tr *taskReader) dispatchSingleTaskFromBuffer(taskInfo *persistence.TaskInf
 		return false, false
 	}
 
+	if errors.Is(err, errTaskNotStarted) {
+		e.EventName = "Dispatch failed on completing task on the passive side because task not started. Will retry dispatch"
+		event.Log(e)
+		return false, false
+	}
+
 	e.EventName = "Dispatch failed because of unknown error. Will retry dispatch"
 	e.Payload = map[string]any{
 		"error": err,


### PR DESCRIPTION
**What changed?**
This change adds the TaskCompleter to the TaskListManager.

The TaskCompleter is used to clean up *started* tasks in the domain's standby cluster. For every dispatched task, from the TaskReader to the TaskMatcher, the TaskCompleter checks if the current cluster is the standby. If it's not (it's the active cluster), the task is dispatched to MustOffer in the TaskMatcher as it's normally done. If it's the standby cluster, it gets the WorkflowExecution using the DescribeWorkflowExecution history endpoint, and checks whether the task has been started in the active cluster or not. If it's not, it retries. If it is, it marks the task completed the same way it's currently done in the active side. This advances the ackLevel and calls the gc.

**Why?**
Cadence does not process activity/decision tasks on a domain's standby cluster. It only process query tasks. That's by design and works as intended. But it has a side effect that the tasks added to the tasks table rely on their TTL to be removed from it. This side effect contributes to:

- large partitions observed on the domain's standby cluster. Not only it's a storage cost, but it can also prohibit domains from failing over due to very large partition size
- too many calls to the database after a failover, that incurs in database latency as well as workflow completion latency after a failover

These changes aims to actively complete (remove from the database) tasks that have already been started in the active cluster. It does it in a sequential way the same way that the active cluster does it, leveraging the advance of the ackLevel and also performing range deletions using the garbage collector, minimizing the database calls and possible performance issues (such as tombstones in cassandra).

**How did you test it?**
Created unit tests for it and tested on a multicluster setup locally.

**Potential risks**
The taskCompleter is inserted in the TaskListManager dispatcher, which is the way that all async tasks are matched to pollers. It intercepts the dispatches in order to determine if the cluster is the standby cluster or not. An issue here will also disturb the active cluster and most likely interrupt the processing of async tasks.

**Release notes**
Active completion of already started tasks on the domain's standby cluster.

**Documentation Changes**
