### PR TITLE
[Wf-Diagnostics] include checks on retry policies while rootcausing heartbeat timeouts

### DIFF
--- a/service/worker/diagnostics/invariant/interface.go
+++ b/service/worker/diagnostics/invariant/interface.go
@@ -43,13 +43,15 @@ type InvariantRootCauseResult struct {
 type RootCause string
 
 const (
-	RootCauseTypeMissingPollers                      RootCause = "There are no pollers for the tasklist"
-	RootCauseTypePollersStatus                       RootCause = "There are pollers for the tasklist. Check backlog status"
-	RootCauseTypeHeartBeatingNotEnabled              RootCause = "HeartBeating not enabled for activity"
-	RootCauseTypeHeartBeatingEnabledMissingHeartbeat RootCause = "HeartBeating enabled for activity but timed out due to missing heartbeat"
-	RootCauseTypeServiceSideIssue                    RootCause = "There is an issue in the worker service that is causing a failure. Check identity for service logs"
-	RootCauseTypeServiceSidePanic                    RootCause = "There is a panic in the activity/workflow that is causing a failure"
-	RootCauseTypeServiceSideCustomError              RootCause = "Customised error returned by the activity/workflow"
+	RootCauseTypeMissingPollers                        RootCause = "There are no pollers for the tasklist"
+	RootCauseTypePollersStatus                         RootCause = "There are pollers for the tasklist. Check backlog status"
+	RootCauseTypeNoHeartBeatTimeoutNoRetryPolicy       RootCause = "Heartbeat timeout and retry policy are not configured"
+	RootCauseTypeHeartBeatingNotEnabledWithRetryPolicy RootCause = "Heartbeat timeout not enabled for activity but there is a retry policy configured"
+	RootCauseTypeHeartBeatingEnabledWithoutRetryPolicy RootCause = "Heartbeat timeout enabled for activity but there is no retry policy configured"
+	RootCauseTypeHeartBeatingEnabledMissingHeartbeat   RootCause = "Heartbeat timeout enabled for activity but timed out due to missing heartbeat"
+	RootCauseTypeServiceSideIssue                      RootCause = "There is an issue in the worker service that is causing a failure. Check identity for service logs"
+	RootCauseTypeServiceSidePanic                      RootCause = "There is a panic in the activity/workflow that is causing a failure"
+	RootCauseTypeServiceSideCustomError                RootCause = "Customised error returned by the activity/workflow"
 )
 
 func (r RootCause) String() string {

--- a/service/worker/diagnostics/invariant/timeout/types.go
+++ b/service/worker/diagnostics/invariant/timeout/types.go
@@ -73,4 +73,5 @@ type PollersMetadata struct {
 
 type HeartbeatingMetadata struct {
 	TimeElapsed time.Duration
+	RetryPolicy *types.RetryPolicy
 }

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -221,8 +221,7 @@ func retrieveTimeoutIssues(issues []invariant.InvariantCheckResult) ([]*timeoutI
 func retrieveTimeoutRootCause(rootCause []invariant.InvariantRootCauseResult) ([]*timeoutRootCauseResult, error) {
 	result := make([]*timeoutRootCauseResult, 0)
 	for _, rc := range rootCause {
-		switch rc.RootCause {
-		case invariant.RootCauseTypePollersStatus, invariant.RootCauseTypeMissingPollers:
+		if rootCausePollersRelated(rc.RootCause) {
 			var metadata timeout.PollersMetadata
 			err := json.Unmarshal(rc.Metadata, &metadata)
 			if err != nil {
@@ -232,7 +231,7 @@ func retrieveTimeoutRootCause(rootCause []invariant.InvariantRootCauseResult) ([
 				RootCauseType:   rc.RootCause.String(),
 				PollersMetadata: &metadata,
 			})
-		case invariant.RootCauseTypeHeartBeatingNotEnabled, invariant.RootCauseTypeHeartBeatingEnabledMissingHeartbeat:
+		} else if rootCauseHeartBeatRelated(rc.RootCause) {
 			var metadata timeout.HeartbeatingMetadata
 			err := json.Unmarshal(rc.Metadata, &metadata)
 			if err != nil {
@@ -244,6 +243,7 @@ func retrieveTimeoutRootCause(rootCause []invariant.InvariantRootCauseResult) ([
 			})
 		}
 	}
+
 	return result, nil
 }
 
@@ -274,4 +274,25 @@ func retrieveFailureRootCause(rootCause []invariant.InvariantRootCauseResult) []
 		}
 	}
 	return result
+}
+
+func rootCauseHeartBeatRelated(rootCause invariant.RootCause) bool {
+	for _, rc := range []invariant.RootCause{invariant.RootCauseTypeNoHeartBeatTimeoutNoRetryPolicy,
+		invariant.RootCauseTypeHeartBeatingNotEnabledWithRetryPolicy,
+		invariant.RootCauseTypeHeartBeatingEnabledWithoutRetryPolicy,
+		invariant.RootCauseTypeHeartBeatingEnabledMissingHeartbeat} {
+		if rc == rootCause {
+			return true
+		}
+	}
+	return false
+}
+
+func rootCausePollersRelated(rootCause invariant.RootCause) bool {
+	for _, rc := range []invariant.RootCause{invariant.RootCauseTypePollersStatus, invariant.RootCauseTypeMissingPollers} {
+		if rc == rootCause {
+			return true
+		}
+	}
+	return false
 }

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -267,7 +267,7 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRootCause() {
 			Metadata:  pollersMetadataInBytes,
 		},
 		{
-			RootCause: invariant.RootCauseTypeHeartBeatingNotEnabled,
+			RootCause: invariant.RootCauseTypeNoHeartBeatTimeoutNoRetryPolicy,
 			Metadata:  heartBeatingMetadataInBytes,
 		},
 	}
@@ -277,7 +277,7 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRootCause() {
 			PollersMetadata: &timeout.PollersMetadata{TaskListBacklog: taskListBacklog},
 		},
 		{
-			RootCauseType:        invariant.RootCauseTypeHeartBeatingNotEnabled.String(),
+			RootCauseType:        invariant.RootCauseTypeNoHeartBeatTimeoutNoRetryPolicy.String(),
 			HeartBeatingMetadata: &timeout.HeartbeatingMetadata{TimeElapsed: 5 * time.Second},
 		},
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Heartbeat timeouts rootcause includes checks for retry policy

<!-- Tell your future self why have you made these changes -->
**Why?**
heartbeating config should be done together with a retry config for effectiveness

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
