### PR TITLE
Update development_xdc_cluster#.yaml to have shard-distributor instead of shard-manager

### DIFF
--- a/config/development_xdc_cluster0.yaml
+++ b/config/development_xdc_cluster0.yaml
@@ -69,7 +69,7 @@ services:
       port: 7941
 
 
-  shard-manager:
+  shard-distributor:
     rpc:
       port: 7951
       bindOnLocalHost: true

--- a/config/development_xdc_cluster1.yaml
+++ b/config/development_xdc_cluster1.yaml
@@ -68,7 +68,7 @@ services:
     pprof:
       port: 8941
 
-  shard-manager:
+  shard-distributor:
     rpc:
       port: 7952
       bindOnLocalHost: true

--- a/config/development_xdc_cluster2.yaml
+++ b/config/development_xdc_cluster2.yaml
@@ -68,7 +68,7 @@ services:
     pprof:
       port: 9941
 
-  shard-manager:
+  shard-distributor:
     rpc:
       port: 7953
       bindOnLocalHost: true


### PR DESCRIPTION
**What changed?**
Renamed shard-manager to shard-distributor on development_xdc_cluster#.yaml

**Why?**
ShardManager was renamed to ShardDistributor but these yaml files were missed
https://github.com/cadence-workflow/cadence/commit/b97e5536eb2e9d534441a54c42173476792ef912

**How did you test it?**
Tested the xdc server locally

**Potential risks**

**Release notes**

**Documentation Changes**
