### PR TITLE
Change Isolation Group Fallback Behavior

### DIFF
--- a/common/partition/default-partitioner_test.go
+++ b/common/partition/default-partitioner_test.go
@@ -25,11 +25,9 @@ package partition
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/cadence/common/isolationgroup"
@@ -72,13 +70,13 @@ func TestPickingAZone(t *testing.T) {
 			},
 			expected: igA,
 		},
-		"default behaviour - wf starting in a zone/isolationGroup must run in an available zone only. If not in available list, pick a random one": {
+		"default behaviour - wf starting in a zone/isolationGroup must run in an available zone only. If not in available list, return no zone": {
 			availablePartitionGroups: isolationGroupsAllHealthy,
 			wfPartitionCfg: defaultWorkflowPartitionConfig{
 				WorkflowStartIsolationGroup: string("something-else"),
 				WFID:                        "BDF3D8D9-5235-4CE8-BBDF-6A37589C9DC7",
 			},
-			expected: igC,
+			expected: "",
 		},
 		"... and it should be deterministic": {
 			availablePartitionGroups: isolationGroupsAllHealthy,
@@ -86,7 +84,7 @@ func TestPickingAZone(t *testing.T) {
 				WorkflowStartIsolationGroup: string("something-else"),
 				WFID:                        "BDF3D8D9-5235-4CE8-BBDF-6A37589C9DC7",
 			},
-			expected: igC,
+			expected: "",
 		},
 	}
 
@@ -99,35 +97,6 @@ func TestPickingAZone(t *testing.T) {
 			res := partitioner.pickIsolationGroup(td.wfPartitionCfg, td.availablePartitionGroups)
 			assert.Equal(t, td.expected, res)
 		})
-	}
-}
-
-func TestDefaultPartitionerFallbackPickerDistribution(t *testing.T) {
-
-	count := make(map[string]int)
-	var isolationGroups []string
-
-	for i := 0; i < 100; i++ {
-		ig := string(fmt.Sprintf("isolationGroup-%d", i))
-		isolationGroups = append(isolationGroups, ig)
-		count[ig] = 0
-	}
-
-	for i := 0; i < 100000; i++ {
-		result := pickIsolationGroupFallback(isolationGroups, defaultWorkflowPartitionConfig{
-			WorkflowStartIsolationGroup: "not-a-present-isolationGroup", // always force a fallback to the simple hash
-			WFID:                        uuid.New().String(),
-		})
-
-		c, ok := count[result]
-		if !ok {
-			t.Fatal("the result wasn't found in the healthy list, something is wrong with the logic for selecting healthy isolationGroups")
-		}
-		count[result] = c + 1
-	}
-
-	for k, v := range count {
-		assert.True(t, v > 0, "failed to pick a isolationGroup %s", k)
 	}
 }
 
@@ -173,7 +142,7 @@ func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 			stateAffordance: func(state *isolationgroup.MockState) {
 				state.EXPECT().AvailableIsolationGroupsByDomainID(gomock.Any(), domainID, isolationGroups).Return(validIsolationGroup, nil)
 			},
-			expectedValue: "zone-3",
+			expectedValue: "",
 		},
 		"Error condition - No zones listed though the feature is enabled": {
 			partitionKeyPassedIn: PartitionConfig{

--- a/service/matching/liveness/liveness.go
+++ b/service/matching/liveness/liveness.go
@@ -68,7 +68,8 @@ func (l *Liveness) Start() {
 	}
 
 	l.wg.Add(1)
-	go l.eventLoop()
+	checkTimer := l.timeSource.NewTicker(l.ttl / 2)
+	go l.eventLoop(checkTimer)
 }
 
 func (l *Liveness) Stop() {
@@ -81,14 +82,13 @@ func (l *Liveness) Stop() {
 	l.wg.Wait()
 }
 
-func (l *Liveness) eventLoop() {
+func (l *Liveness) eventLoop(ticker clock.Ticker) {
 	defer l.wg.Done()
-	checkTimer := time.NewTicker(l.ttl / 2)
-	defer checkTimer.Stop()
+	defer ticker.Stop()
 
 	for {
 		select {
-		case <-checkTimer.C:
+		case <-ticker.Chan():
 			if !l.IsAlive() {
 				l.Stop()
 			}

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -83,7 +83,7 @@ type (
 		handleErr                func(error) error
 		onFatalErr               func()
 		dispatchTask             func(context.Context, *InternalTask) error
-		getIsolationGroupForTask func(context.Context, *persistence.TaskInfo) (string, error)
+		getIsolationGroupForTask func(context.Context, *persistence.TaskInfo) (string, time.Duration, error)
 		ratePerSecond            func() float64
 
 		// stopWg is used to wait for all dispatchers to stop.
@@ -182,7 +182,7 @@ dispatchLoop:
 				TaskInfo:     *taskInfo,
 				EventName:    "Attempting to Dispatch Buffered Task",
 			})
-			breakDispatchLoop := tr.dispatchSingleTaskFromBufferWithRetries(isolationGroup, taskInfo)
+			breakDispatchLoop := tr.dispatchSingleTaskFromBufferWithRetries(taskInfo)
 			if breakDispatchLoop {
 				// shutting down
 				break dispatchLoop
@@ -323,7 +323,8 @@ func (tr *taskReader) addSingleTaskToBuffer(task *persistence.TaskInfo) bool {
 	if err != nil {
 		tr.logger.Fatal("critical bug when adding item to ackManager", tag.Error(err))
 	}
-	isolationGroup, err := tr.getIsolationGroupForTask(tr.cancelCtx, task)
+	// Ignore the isolation duration as we're just putting it into a buffer to be dispatched later.
+	isolationGroup, _, err := tr.getIsolationGroupForTask(tr.cancelCtx, task)
 	if err != nil {
 		// it only errors when the tasklist is a sticky tasklist and
 		// the sticky pollers are not available, in this case, we just complete the task
@@ -390,16 +391,10 @@ func (tr *taskReader) completeTask(task *persistence.TaskInfo, err error) {
 	tr.taskGC.Run(ackLevel)
 }
 
-func (tr *taskReader) newDispatchContext(isolationGroup string) (context.Context, context.CancelFunc) {
+func (tr *taskReader) newDispatchContext(isolationGroup string, isolationDuration time.Duration) (context.Context, context.CancelFunc) {
 	rps := tr.ratePerSecond()
 	if isolationGroup != "" || rps > 1e-7 { // 1e-7 is a random number chosen to avoid overflow, normally user don't set such a low rps
-		// this is the minimum timeout required to dispatch a task, if the timeout value is smaller than this
-		// async task dispatch can be completely throttled, which could happen when ratePerSecond is pretty low
-		minTimeout := time.Duration(float64(len(tr.taskBuffers))/rps) * time.Second
-		timeout := tr.config.AsyncTaskDispatchTimeout()
-		if timeout < minTimeout {
-			timeout = minTimeout
-		}
+		timeout := tr.getDispatchTimeout(rps, isolationDuration)
 		domainEntry, err := tr.domainCache.GetDomainByID(tr.taskListID.GetDomainID())
 		if err != nil {
 			// we don't know if the domain is active in the current cluster, assume it is active and set the timeout
@@ -413,21 +408,50 @@ func (tr *taskReader) newDispatchContext(isolationGroup string) (context.Context
 	return tr.cancelCtx, func() {}
 }
 
-func (tr *taskReader) dispatchSingleTaskFromBufferWithRetries(isolationGroup string, taskInfo *persistence.TaskInfo) (breakDispatchLoop bool) {
+func (tr *taskReader) getDispatchTimeout(rps float64, isolationDuration time.Duration) time.Duration {
+	// this is the minimum timeout required to dispatch a task, if the timeout value is smaller than this
+	// async task dispatch can be completely throttled, which could happen when ratePerSecond is pretty low
+	minTimeout := time.Duration(float64(len(tr.taskBuffers))/rps) * time.Second
+	// timeout = max (min(asyncDispatchTimeout, isolationDuration), minTimeout)
+	timeout := tr.config.AsyncTaskDispatchTimeout()
+	if timeout > isolationDuration && isolationDuration != noIsolationTimeout {
+		timeout = isolationDuration
+	}
+	if timeout < minTimeout {
+		timeout = minTimeout
+	}
+	return timeout
+}
+
+func (tr *taskReader) dispatchSingleTaskFromBufferWithRetries(taskInfo *persistence.TaskInfo) (breakDispatchLoop bool) {
 	// retry loop for dispatching a single task
 	for {
-		breakDispatchLoop, breakRetryLoop := tr.dispatchSingleTaskFromBuffer(isolationGroup, taskInfo)
+		breakDispatchLoop, breakRetryLoop := tr.dispatchSingleTaskFromBuffer(taskInfo)
 		if breakRetryLoop {
 			return breakDispatchLoop
 		}
 	}
 }
 
-func (tr *taskReader) dispatchSingleTaskFromBuffer(isolationGroup string, taskInfo *persistence.TaskInfo) (breakDispatchLoop bool, breakRetries bool) {
+func (tr *taskReader) dispatchSingleTaskFromBuffer(taskInfo *persistence.TaskInfo) (breakDispatchLoop bool, breakRetries bool) {
+	isolationGroup, isolationDuration, err := tr.getIsolationGroupForTask(tr.cancelCtx, taskInfo)
+	if err != nil {
+		// it should never happen, unless there is a bug in 'getIsolationGroupForTask' method
+		tr.logger.Error("taskReader: unexpected error getting isolation group",
+			tag.Error(err),
+			tag.PartitionConfig(taskInfo.PartitionConfig))
+		isolationGroup = defaultTaskBufferIsolationGroup
+		isolationDuration = noIsolationTimeout
+	}
+	_, isolationGroupIsKnown := tr.taskBuffers[isolationGroup]
+	if !isolationGroupIsKnown {
+		isolationGroup = defaultTaskBufferIsolationGroup
+		isolationDuration = noIsolationTimeout
+	}
 	task := newInternalTask(taskInfo, tr.completeTask, types.TaskSourceDbBacklog, "", false, nil, isolationGroup)
-	dispatchCtx, cancel := tr.newDispatchContext(isolationGroup)
+	dispatchCtx, cancel := tr.newDispatchContext(isolationGroup, isolationDuration)
 	timerScope := tr.scope.StartTimer(metrics.AsyncMatchLatencyPerTaskList)
-	err := tr.dispatchTask(dispatchCtx, task)
+	err = tr.dispatchTask(dispatchCtx, task)
 	timerScope.Stop()
 	cancel()
 
@@ -467,121 +491,7 @@ func (tr *taskReader) dispatchSingleTaskFromBuffer(isolationGroup string, taskIn
 		e.EventName = "Dispatch Timed Out"
 		event.Log(e)
 		tr.scope.IncCounter(metrics.AsyncMatchDispatchTimeoutCounterPerTaskList)
-
-		// the idea here is that by re-fetching the isolation-groups, if something has shifted
-		// it will get a new isolation group to be placed. If it needs re-routing, then
-		// this will be the new routing destination.
-		group, err := tr.getIsolationGroupForTask(tr.cancelCtx, taskInfo)
-		if err != nil {
-			// it only errors when the tasklist is a sticky tasklist and
-			// the sticky pollers are not available, in this case, we just complete the task
-			// and let the decision get timed out and rescheduled to non-sticky tasklist
-			if err == _stickyPollerUnavailableError {
-				tr.completeTask(taskInfo, nil)
-				e.EventName = "Dispatch Failed because StickyPollerUnavailable"
-				event.Log(e)
-				return false, true
-			}
-			// it should never happen, unless there is a bug in 'getIsolationGroupForTask' method
-			tr.logger.Error("taskReader: unexpected error getting isolation group",
-				tag.Error(err),
-				tag.IsolationGroup(group))
-
-			e.EventName = "Dispatch Failed due to unexpected error getting isolation group"
-			e.Payload = map[string]any{
-				"error": err,
-			}
-			event.Log(e)
-			e.Payload = nil
-
-			tr.completeTask(taskInfo, err)
-			return false, true
-		}
-
-		if group == isolationGroup {
-			// no change, retry to dispatch the task again
-			return false, false
-		}
-
-		// ensure the isolation group is configured and available
-		_, taskGroupReaderIsPresent := tr.taskBuffers[group]
-		if !taskGroupReaderIsPresent {
-			// there's a programmatic error. Something has gone wrong with tasklist instantiation
-			// don't block and redirect to the default group
-			tr.scope.IncCounter(metrics.BufferIsolationGroupRedirectFailureCounter)
-			tr.logger.Error("An isolation group buffer was misconfigured and couldn't be found. Redirecting to default",
-				tag.Dynamic("redirection-from-isolation-group", isolationGroup),
-				tag.Dynamic("redirection-to-isolation-group", group),
-				tag.IsolationGroup(group),
-				tag.WorkflowRunID(taskInfo.RunID),
-				tag.WorkflowID(taskInfo.WorkflowID),
-				tag.TaskID(taskInfo.TaskID),
-				tag.WorkflowDomainID(taskInfo.DomainID),
-			)
-
-			select {
-			case <-tr.cancelCtx.Done():
-				// the task reader is shutting down
-				e.EventName = "Dispatch Failed because task reader is shutting down"
-				event.Log(e)
-				return true, true
-			case tr.taskBuffers[defaultTaskBufferIsolationGroup] <- taskInfo:
-				// task successfully rerouted to default tasklist
-				e.EventName = "Task rerouted to default isolation group"
-				event.Log(e)
-				return false, true
-			default:
-				// couldn't redirect, loop and try again
-				e.EventName = "Task is not rerouted to default isolation group. Will retry dispatch"
-				event.Log(e)
-				return false, false
-			}
-		}
-
-		// if there is no poller in the isolation group or the isolation group is drained,
-		// we want to redistribute the tasks to other isolation groups in this case to drain
-		// the backlog.
-		select {
-		case <-tr.cancelCtx.Done():
-			// the task reader is shutting down
-			e.EventName = "Dispatch Failed because task reader is shutting down"
-			event.Log(e)
-			return true, true
-		case tr.taskBuffers[group] <- taskInfo:
-			// successful redirect
-			tr.scope.IncCounter(metrics.BufferIsolationGroupRedirectCounter)
-			tr.logger.Warn("some tasks were redirected to another isolation group.",
-				tag.Dynamic("redirection-from-isolation-group", isolationGroup),
-				tag.Dynamic("redirection-to-isolation-group", group),
-				tag.WorkflowRunID(taskInfo.RunID),
-				tag.WorkflowID(taskInfo.WorkflowID),
-				tag.TaskID(taskInfo.TaskID),
-				tag.WorkflowDomainID(taskInfo.DomainID),
-			)
-
-			e.EventName = "Task forwarded to another isolation group"
-			e.Payload = map[string]any{
-				"redirection-from-isolation-group": isolationGroup,
-				"redirection-to-isolation-group":   group,
-			}
-			event.Log(e)
-			e.Payload = nil
-			return false, true
-		default:
-			tr.scope.IncCounter(metrics.BufferIsolationGroupRedirectFailureCounter)
-			e.EventName = "Task is not rerouted to another isolation group. Will retry dispatch"
-			event.Log(e)
-			tr.logger.Error("some tasks could not be redirected to another isolation group as the buffer's already full",
-				tag.WorkflowRunID(taskInfo.RunID),
-				tag.Dynamic("redirection-from-isolation-group", isolationGroup),
-				tag.Dynamic("redirection-to-isolation-group", group),
-				tag.WorkflowID(taskInfo.WorkflowID),
-				tag.TaskID(taskInfo.TaskID),
-				tag.WorkflowDomainID(taskInfo.DomainID),
-			)
-			// the task async buffers on the other isolation-group are already full, wait and retry
-			return false, false
-		}
+		return false, false
 	}
 
 	if errors.Is(err, ErrTasklistThrottled) {

--- a/service/matching/tasklist/task_reader_test.go
+++ b/service/matching/tasklist/task_reader_test.go
@@ -1,0 +1,293 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package tasklist
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/service/matching/config"
+)
+
+const defaultIsolationGroup = "a"
+const defaultAsyncDispatchTimeout = 3 * time.Second
+
+var defaultIsolationGroups = []string{
+	"a",
+	"b",
+	"c",
+	"d",
+}
+
+func TestDispatchSingleTaskFromBuffer(t *testing.T) {
+	testCases := []struct {
+		name          string
+		allowances    func(t *testing.T, reader *taskReader)
+		breakDispatch bool
+		breakRetries  bool
+	}{
+		{
+			name: "success - no isolation",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return "", -1, nil
+				}
+				markCalled := requireCallbackInvocation(t, "expected task to be dispatched")
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					assert.Equal(t, "", task.isolationGroup)
+					markCalled()
+					return nil
+				}
+			},
+			breakDispatch: false,
+			breakRetries:  true,
+		},
+		{
+			name: "success - isolation",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return defaultIsolationGroup, -1, nil
+				}
+				markCalled := requireCallbackInvocation(t, "expected task to be dispatched")
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					assert.Equal(t, defaultIsolationGroup, task.isolationGroup)
+					markCalled()
+					return nil
+				}
+			},
+			breakDispatch: false,
+			breakRetries:  true,
+		},
+		{
+			name: "success - isolation group error",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return "", -1, errors.New("wow")
+				}
+				markCalled := requireCallbackInvocation(t, "expected task to be dispatched")
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					assert.Equal(t, "", task.isolationGroup)
+					markCalled()
+					return nil
+				}
+			},
+			breakDispatch: false,
+			breakRetries:  true,
+		},
+		{
+			name: "success - unknown isolation group",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return "mystery group", -1, nil
+				}
+				markCalled := requireCallbackInvocation(t, "expected task to be dispatched")
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					assert.Equal(t, "", task.isolationGroup)
+					markCalled()
+					return nil
+				}
+
+			},
+			breakDispatch: false,
+			breakRetries:  true,
+		},
+		{
+			name: "Error - context cancelled, should stop",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return defaultIsolationGroup, -1, nil
+				}
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					return context.Canceled
+				}
+
+			},
+			breakDispatch: true,
+			breakRetries:  true,
+		},
+		{
+			name: "Error - Deadline Exceeded, should retry",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return defaultIsolationGroup, -1, nil
+				}
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					return context.DeadlineExceeded
+				}
+
+			},
+			breakDispatch: false,
+			breakRetries:  false,
+		},
+		{
+			name: "Error - throttled, should retry",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return defaultIsolationGroup, -1, nil
+				}
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					return ErrTasklistThrottled
+				}
+			},
+			breakDispatch: false,
+			breakRetries:  false,
+		},
+		{
+			name: "Error - unknown, should retry",
+			allowances: func(t *testing.T, reader *taskReader) {
+				reader.getIsolationGroupForTask = func(ctx context.Context, info *persistence.TaskInfo) (string, time.Duration, error) {
+					return defaultIsolationGroup, -1, nil
+				}
+				reader.dispatchTask = func(ctx context.Context, task *InternalTask) error {
+					return errors.New("wow")
+				}
+			},
+			breakDispatch: false,
+			breakRetries:  false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			timeSource := clock.NewMockedTimeSource()
+			c := defaultConfig()
+			tlm := createTestTaskListManagerWithConfig(t, testlogger.New(t), controller, c, timeSource)
+			reader := tlm.taskReader
+			tc.allowances(t, reader)
+			taskInfo := newTask(timeSource)
+
+			breakDispatch, breakRetries := reader.dispatchSingleTaskFromBuffer(taskInfo)
+			assert.Equal(t, tc.breakDispatch, breakDispatch)
+			assert.Equal(t, tc.breakRetries, breakRetries)
+		})
+	}
+}
+
+func TestGetDispatchTimeout(t *testing.T) {
+	testCases := []struct {
+		name              string
+		isolationDuration time.Duration
+		dispatchRps       float64
+		expected          time.Duration
+	}{
+		{
+			name:              "default - async dispatch timeout",
+			isolationDuration: noIsolationTimeout,
+			dispatchRps:       1000,
+			expected:          defaultAsyncDispatchTimeout,
+		},
+		{
+			name:              "isolation duration below async dispatch timeout",
+			isolationDuration: 1 * time.Second,
+			dispatchRps:       1000,
+			expected:          1 * time.Second,
+		},
+		{
+			name:              "isolation duration above async dispatch timeout",
+			isolationDuration: 5 * time.Second,
+			dispatchRps:       1000,
+			expected:          defaultAsyncDispatchTimeout,
+		},
+		{
+			name:              "no isolation - low dispatch rps extends timeout",
+			isolationDuration: noIsolationTimeout,
+			dispatchRps:       0.1,
+			// rate is divided by 4 isolation groups (plus default buffer) and only one task gets dispatched per 10 seconds
+			expected: 50 * time.Second,
+		},
+		{
+			name:              "with isolation - low dispatch rps extends timeout",
+			isolationDuration: time.Second,
+			dispatchRps:       0.1,
+			// rate is divided by 4 isolation groups (plus default buffer) and only one task gets dispatched per 10 seconds
+			// This means taskIsolationDuration is extended, and we don't leak tasks as quickly if the
+			// task list has a very low RPS
+			expected: 50 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			timeSource := clock.NewMockedTimeSource()
+			c := defaultConfig()
+			tlm := createTestTaskListManagerWithConfig(t, testlogger.New(t), controller, c, timeSource)
+			reader := tlm.taskReader
+
+			actual := reader.getDispatchTimeout(tc.dispatchRps, tc.isolationDuration)
+			assert.Equal(t, tc.expected, actual)
+
+		})
+	}
+}
+
+func defaultConfig() *config.Config {
+	config := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", func() []string {
+		return defaultIsolationGroups
+	})
+	config.EnableTasklistIsolation = dynamicconfig.GetBoolPropertyFnFilteredByDomain(true)
+	config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(100 * time.Millisecond)
+	config.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(1)
+	config.GetTasksBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(10)
+	config.AsyncTaskDispatchTimeout = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(defaultAsyncDispatchTimeout)
+	config.LocalTaskWaitTime = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(time.Millisecond)
+	return config
+}
+
+func newTask(timeSource clock.TimeSource) *persistence.TaskInfo {
+	return &persistence.TaskInfo{
+		DomainID:                      "domain-id",
+		WorkflowID:                    "workflow-id",
+		RunID:                         "run-id",
+		TaskID:                        1,
+		ScheduleID:                    2,
+		ScheduleToStartTimeoutSeconds: 10,
+		Expiry:                        timeSource.Now().Add(10 * time.Second),
+		CreatedTime:                   timeSource.Now(),
+		PartitionConfig: map[string]string{
+			"isolation-group": defaultIsolationGroup,
+		},
+	}
+}
+
+func requireCallbackInvocation(t *testing.T, msg string) func() {
+	called := false
+	t.Cleanup(func() {
+		if !called {
+			t.Fatal(msg)
+		}
+	})
+
+	return func() {
+		called = true
+	}
+}


### PR DESCRIPTION
Change default-partitioner to fall back to any group if the requested group isn't available rather than attempting to pick a stable zone based on the workflow ID. This optimizes for lower task latency and allows for better recovery from skew or drain scenarios.

Allow for tasks to fall back from the requested zone outside of the root partition. If workflows are started in an isolation group where no pollers are present, only the root partition will allow those tasks to leak to other isolation groups. This bottlenecks the rate at which those tasks can be completed by the rate at which we forward tasks to the root partition.

Change task_reader.go to recalculate the isolation group of each task in the buffer before dispatching it. Currently taskReader calculates the isolation group of each task when it reads it from persistence, places it in the buffer for that isolation group, and then dispatches it using that same isolation group. When an isolation group becomes unavailable any buffered tasks will need to experience a dispatch timeout before they're reassigned. This will happen sequentially, dispatching tasks at a rate of 1 task per 3 seconds (async dispatch timeout). This is particularly problematic when combined with the startup behavior that considers all isolation groups to be present. The only relief from this behavior is forwarding tasks to the root partition, which will incidentally recalculate the isolation group of the task when it dispatches it. In the future, this will also be important for supporting task isolation duration.

Since the returned group is now guaranteed to be either the original group for the task or the default buffer, we can remove the logic for copying tasks between buffers upon group reassignment. Tasks previously could be reassigned to any zone and needed to be copied to the buffer for that zone to ensure that attempting to dispatch in that zone didn't block dispatching any other buffered tasks for the original zone.

Additionally include some refactoring to allow for a task isolation duration in the future.

<!-- Describe what has changed in this PR -->
**What changed?**
- See above

<!-- Tell your future self why have you made these changes -->
**Why?**
- Simplify isolation fallback behavior to better support task isolation duration in the future

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
