### PR TITLE
[Wf-Diagnostics] add retry invariant to diagnose workflow retries

### DIFF
--- a/service/worker/diagnostics/invariant/retry/retry.go
+++ b/service/worker/diagnostics/invariant/retry/retry.go
@@ -1,0 +1,90 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package retry
+
+import (
+	"context"
+
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+)
+
+// Retry is an invariant that will be used to identify the issues regarding retries in the workflow execution history
+type Retry invariant.Invariant
+
+type retry struct {
+	workflowExecutionHistory *types.GetWorkflowExecutionHistoryResponse
+}
+
+type Params struct {
+	WorkflowExecutionHistory *types.GetWorkflowExecutionHistoryResponse
+}
+
+func NewInvariant(p Params) Retry {
+	return &retry{
+		workflowExecutionHistory: p.WorkflowExecutionHistory,
+	}
+}
+
+func (r *retry) Check(context.Context) ([]invariant.InvariantCheckResult, error) {
+	result := make([]invariant.InvariantCheckResult, 0)
+	events := r.workflowExecutionHistory.GetHistory().GetEvents()
+	lastEvent := fetchContinuedAsNewEvent(events)
+	startedEvent := fetchStartedEvent(events)
+	if lastEvent != nil && startedEvent != nil {
+		if startedEvent.RetryPolicy != nil {
+			result = append(result, invariant.InvariantCheckResult{
+				InvariantType: WorkflowRetry.String(),
+				Reason:        *lastEvent.FailureReason,
+				Metadata: invariant.MarshalData(RetryMetadata{
+					RetryPolicy: startedEvent.RetryPolicy,
+					Attempt:     startedEvent.Attempt,
+				}),
+			})
+		}
+	}
+	return result, nil
+}
+
+func fetchContinuedAsNewEvent(events []*types.HistoryEvent) *types.WorkflowExecutionContinuedAsNewEventAttributes {
+	for _, event := range events {
+		if event.GetWorkflowExecutionContinuedAsNewEventAttributes() != nil {
+			return event.GetWorkflowExecutionContinuedAsNewEventAttributes()
+		}
+	}
+	return nil
+}
+
+func fetchStartedEvent(events []*types.HistoryEvent) *types.WorkflowExecutionStartedEventAttributes {
+	for _, event := range events {
+		if event.GetWorkflowExecutionStartedEventAttributes() != nil {
+			return event.GetWorkflowExecutionStartedEventAttributes()
+		}
+	}
+	return nil
+}
+
+func (r *retry) RootCause(ctx context.Context, issues []invariant.InvariantCheckResult) ([]invariant.InvariantRootCauseResult, error) {
+	result := make([]invariant.InvariantRootCauseResult, 0)
+	return result, nil
+}

--- a/service/worker/diagnostics/invariant/retry/retry_test.go
+++ b/service/worker/diagnostics/invariant/retry/retry_test.go
@@ -1,0 +1,100 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package retry
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+)
+
+func Test__Check(t *testing.T) {
+	metadata := RetryMetadata{
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 1,
+			MaximumAttempts:          2,
+		},
+		Attempt: 0,
+	}
+	metadataInBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	testCases := []struct {
+		name           string
+		testData       *types.GetWorkflowExecutionHistoryResponse
+		expectedResult []invariant.InvariantCheckResult
+		err            error
+	}{
+		{
+			name:     "workflow execution timeout",
+			testData: retriedWfHistory(),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					InvariantType: WorkflowRetry.String(),
+					Reason:        "cadenceInternal:Timeout START_TO_CLOSE",
+					Metadata:      metadataInBytes,
+				},
+			},
+			err: nil,
+		},
+	}
+	for _, tc := range testCases {
+		inv := NewInvariant(Params{
+			WorkflowExecutionHistory: tc.testData,
+		})
+		result, err := inv.Check(context.Background())
+		require.Equal(t, tc.err, err)
+		require.Equal(t, len(tc.expectedResult), len(result))
+		require.ElementsMatch(t, tc.expectedResult, result)
+	}
+}
+
+func retriedWfHistory() *types.GetWorkflowExecutionHistoryResponse {
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History: &types.History{
+			Events: []*types.HistoryEvent{
+				{
+					ID: 1,
+					WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+						RetryPolicy: &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          2,
+						},
+						Attempt: 0,
+					},
+				},
+				{
+					WorkflowExecutionContinuedAsNewEventAttributes: &types.WorkflowExecutionContinuedAsNewEventAttributes{
+						FailureReason:                common.StringPtr("cadenceInternal:Timeout START_TO_CLOSE"),
+						DecisionTaskCompletedEventID: 10,
+					},
+				},
+			},
+		},
+	}
+}

--- a/service/worker/diagnostics/invariant/retry/types.go
+++ b/service/worker/diagnostics/invariant/retry/types.go
@@ -1,0 +1,40 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package retry
+
+import "github.com/uber/cadence/common/types"
+
+type RetryType string
+
+const (
+	WorkflowRetry RetryType = "Workflow Retry"
+)
+
+func (r RetryType) String() string {
+	return string(r)
+}
+
+type RetryMetadata struct {
+	RetryPolicy *types.RetryPolicy
+	Attempt     int32
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
workflow retries added to diagnostic invariant

<!-- Tell your future self why have you made these changes -->
**Why?**
workflow retries when configured continue-as-new and it is hard to understand for a user

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
