### PR TITLE
Align Postgres `workflow_id` Column with Cassandra

### DIFF
--- a/schema/postgres/cadence/schema.sql
+++ b/schema/postgres/cadence/schema.sql
@@ -46,7 +46,7 @@ CREATE TABLE cross_cluster_tasks(
 CREATE TABLE executions(
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   --
   next_event_id BIGINT NOT NULL,
@@ -59,7 +59,7 @@ CREATE TABLE executions(
 CREATE TABLE current_executions(
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   --
   run_id BYTEA NOT NULL,
   create_request_id VARCHAR(64) NOT NULL,
@@ -74,7 +74,7 @@ CREATE TABLE buffered_events (
   id BIGSERIAL NOT NULL,
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   --
   data BYTEA NOT NULL,
@@ -140,7 +140,7 @@ CREATE TABLE activity_info_maps (
 -- each row corresponds to one key of one map<string, ActivityInfo>
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   schedule_id BIGINT NOT NULL,
 --
@@ -154,7 +154,7 @@ CREATE TABLE activity_info_maps (
 CREATE TABLE timer_info_maps (
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   timer_id VARCHAR(255) NOT NULL,
 --
@@ -166,7 +166,7 @@ CREATE TABLE timer_info_maps (
 CREATE TABLE child_execution_info_maps (
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   initiated_id BIGINT NOT NULL,
 --
@@ -178,7 +178,7 @@ CREATE TABLE child_execution_info_maps (
 CREATE TABLE request_cancel_info_maps (
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   initiated_id BIGINT NOT NULL,
 --
@@ -190,7 +190,7 @@ CREATE TABLE request_cancel_info_maps (
 CREATE TABLE signal_info_maps (
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   initiated_id BIGINT NOT NULL,
 --
@@ -202,7 +202,7 @@ CREATE TABLE signal_info_maps (
 CREATE TABLE buffered_replication_task_maps (
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   first_event_id BIGINT NOT NULL,
 --
@@ -220,7 +220,7 @@ CREATE TABLE buffered_replication_task_maps (
 CREATE TABLE signals_requested_sets (
   shard_id INTEGER NOT NULL,
   domain_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
+  workflow_id TEXT NOT NULL,
   run_id BYTEA NOT NULL,
   signal_id VARCHAR(64) NOT NULL,
   --

--- a/schema/postgres/cadence/versioned/v0.6/extend_workflow_id_length.sql
+++ b/schema/postgres/cadence/versioned/v0.6/extend_workflow_id_length.sql
@@ -1,0 +1,19 @@
+ALTER TABLE executions ALTER workflow_id TYPE text;
+
+ALTER TABLE current_executions ALTER workflow_id TYPE text;
+
+ALTER TABLE buffered_events ALTER workflow_id TYPE text;
+
+ALTER TABLE activity_info_maps ALTER workflow_id TYPE text;
+
+ALTER TABLE timer_info_maps ALTER workflow_id TYPE text;
+
+ALTER TABLE child_execution_info_maps ALTER workflow_id TYPE text;
+
+ALTER TABLE request_cancel_info_maps ALTER workflow_id TYPE text;
+
+ALTER TABLE signal_info_maps ALTER workflow_id TYPE text;
+
+ALTER TABLE buffered_replication_task_maps ALTER workflow_id TYPE text;
+
+ALTER TABLE signals_requested_sets ALTER workflow_id TYPE text;

--- a/schema/postgres/cadence/versioned/v0.6/manifest.json
+++ b/schema/postgres/cadence/versioned/v0.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.6",
+  "MinCompatibleVersion": "0.6",
+  "Description": "update type of workflow_id to text to remove length restriction",
+  "SchemaUpdateCqlFiles": [
+    "extend_workflow_id_length.sql"
+  ]
+}

--- a/schema/postgres/version.go
+++ b/schema/postgres/version.go
@@ -24,8 +24,8 @@ package postgres
 
 // Version is the Postgres database release version
 // Cadence supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const Version = "0.5"
+const Version = "0.6"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Cadence supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const VisibilityVersion = "0.7"
+const VisibilityVersion = "0.8"

--- a/schema/postgres/visibility/schema.sql
+++ b/schema/postgres/visibility/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE executions_visibility (
   run_id               CHAR(64) NOT NULL,
   start_time           TIMESTAMP NOT NULL,
   execution_time       TIMESTAMP NOT NULL,
-  workflow_id          VARCHAR(255) NOT NULL,
+  workflow_id          TEXT NOT NULL,
   workflow_type_name   VARCHAR(255) NOT NULL,
   close_status         INTEGER,  -- enum WorkflowExecutionCloseStatus {COMPLETED, FAILED, CANCELED, TERMINATED, CONTINUED_AS_NEW, TIMED_OUT}
   close_time           TIMESTAMP NULL,

--- a/schema/postgres/visibility/versioned/v0.8/extend_workflow_id_length.sql
+++ b/schema/postgres/visibility/versioned/v0.8/extend_workflow_id_length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions_visibility ALTER workflow_id TYPE TEXT;

--- a/schema/postgres/visibility/versioned/v0.8/manifest.json
+++ b/schema/postgres/visibility/versioned/v0.8/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.8",
+  "MinCompatibleVersion": "0.8",
+  "Description": "update type of workflow_id to text to remove length restriction",
+  "SchemaUpdateCqlFiles": [
+    "extend_workflow_id_length.sql"
+  ]
+}

--- a/tools/cli/workflow_batch_commands_test.go
+++ b/tools/cli/workflow_batch_commands_test.go
@@ -467,11 +467,11 @@ func TestListBatchJobs(t *testing.T) {
 			expectedOutput: []map[string]string{
 				{
 					"jobID":     "example-workflow-1",
-					"startTime": "1970-01-01T01:00:01+01:00",
+					"startTime": "1970-01-01T00:00:01Z",
 					"reason":    "Testing reason",
 					"operator":  "test-operator",
 					"status":    "COMPLETED",
-					"closeTime": "1970-01-01T01:00:00+01:00",
+					"closeTime": "1970-01-01T00:00:00Z",
 				},
 			},
 		},

--- a/tools/cli/workflow_batch_commands_test.go
+++ b/tools/cli/workflow_batch_commands_test.go
@@ -467,11 +467,11 @@ func TestListBatchJobs(t *testing.T) {
 			expectedOutput: []map[string]string{
 				{
 					"jobID":     "example-workflow-1",
-					"startTime": "1970-01-01T00:00:01Z",
+					"startTime": "1970-01-01T01:00:01+01:00",
 					"reason":    "Testing reason",
 					"operator":  "test-operator",
 					"status":    "COMPLETED",
-					"closeTime": "1970-01-01T00:00:00Z",
+					"closeTime": "1970-01-01T01:00:00+01:00",
 				},
 			},
 		},

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -138,13 +138,13 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.3", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.4", "v0.5"}, ans)
+	s.Equal([]string{"v0.4", "v0.5", "v0.6"}, ans)
 
 	fsys, err = fs.Sub(postgres.SchemaFS, "visibility/versioned")
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.5", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.6", "v0.7"}, ans)
+	s.Equal([]string{"v0.6", "v0.7", "v0.8"}, ans)
 }
 
 func (s *UpdateTaskTestSuite) TestReadManifest() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**  
The `workflow_id` column in the PostgreSQL schema has been updated from `VARCHAR(255)` to `TEXT`, removing the 255-character limit and aligning it with Cassandra’s schema, which allows longer workflow identifiers.

<!-- Tell your future self why have you made these changes -->
**Why?**  
The 255-character limit restricted how much context we could include in workflow identifiers, which was limiting in certain cases. Updating the column to `TEXT` aligns PostgreSQL with Cassandra ([reference](https://github.com/uber/cadence/blob/552953a208c577ef2c0aa10ad8796fbebb1c20af/schema/cassandra/cadence/schema.cql#L40)) and allows higher-level enforcement of length restrictions if needed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**  
- `POSTGRES=1 make test` has been run successfully with some [minor adjustments](https://github.com/cadence-workflow/cadence/pull/6520/commits/127edeaff51575ccfb7c62858bf588f7e31d4548). 
- I have also tested it in my own development environment with long ids (exceeding 255) and it works fine.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**  
- Longer workflow identifiers could increase database row sizes, potentially impacting performance for workflows with large identifiers.
- Applications relying on the 255-character limit might need adjustments to enforce length restrictions at a higher level.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**  
- Schema update: `workflow_id` column in PostgreSQL now uses `TEXT` instead of `VARCHAR(255)`.
- Users relying on the 255-character limit should enforce it at the application level if needed.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**  
Not sure if documentation is needed, since these changes will make the PostgreSQL schema more aligned with the Cassandra schema.

**Detailed Description**
These changes relax the constraints on the `workflow_id` columns and should not cause issues during upgrades.

**Impact Analysis**
- **Backward Compatibility**: These changes only alter the column constraints, not the data. Downgrades should be fine as long as `workflow_id` values remain within the previous 255-character limit. If any exceed this limit, users would have already encountered errors in PostgreSQL.
- **Forward Compatibility**: Forward compatibility is unaffected since this only relaxes constraints. Users with very long `workflow_id `values may need to monitor memory usage, storage, and performance.

**Testing Plan**
- **Unit Tests**: Unit tests likely do not cover PostgreSQL schema changes.
- **Persistence Tests**: No new tables are added, so current persistence tests should suffice.
- **Integration Tests**: Existing tests that create and start workflows should already cover this. Additional tests for `workflow_id` values longer than 255 characters could be added but may not be necessary.
- **Compatibility Tests**: Compatibility should be fine since the data remains unchanged. However, if users upgrade and use longer `workflow_id` values, downgrades will require truncating those IDs manually. This scenario is rare, and users can handle it themselves if needed.

**Rollout Plan**
**What is the rollout plan?** 
Rollout as usual.
**Does the order of deployment matter?**
No, even if `cadence_visibility` still uses the old schema, it should still work since old `workflow_id`s should be covered by the old column type `VARCHAR(255)`
**Is it safe to rollback?**  
 Should be safe to rollback, unless `workflow_id` configuration has been changed, resulting in ids exceeding 255 character limit.
**Does the order of rollback matter?** 
Not to my knowledge.
**Is there a kill switch to mitigate the impact immediately?** 
Should not be necessary.
