### PR TITLE
[Wf-Diagnostics] Update workflow retry with failure reason message

### DIFF
--- a/service/worker/diagnostics/invariant/failure/failure.go
+++ b/service/worker/diagnostics/invariant/failure/failure.go
@@ -60,7 +60,7 @@ func (f *failure) Check(context.Context) ([]invariant.InvariantCheckResult, erro
 			identity := fetchIdentity(attr, events)
 			result = append(result, invariant.InvariantCheckResult{
 				InvariantType: WorkflowFailed.String(),
-				Reason:        errorTypeFromReason(*reason).String(),
+				Reason:        ErrorTypeFromReason(*reason).String(),
 				Metadata:      invariant.MarshalData(FailureMetadata{Identity: identity}),
 			})
 		}
@@ -71,7 +71,7 @@ func (f *failure) Check(context.Context) ([]invariant.InvariantCheckResult, erro
 			started := fetchStartedEvent(attr, events)
 			result = append(result, invariant.InvariantCheckResult{
 				InvariantType: ActivityFailed.String(),
-				Reason:        errorTypeFromReason(*reason).String(),
+				Reason:        ErrorTypeFromReason(*reason).String(),
 				Metadata: invariant.MarshalData(FailureMetadata{
 					Identity:          attr.Identity,
 					ActivityScheduled: scheduled,
@@ -83,7 +83,7 @@ func (f *failure) Check(context.Context) ([]invariant.InvariantCheckResult, erro
 	return result, nil
 }
 
-func errorTypeFromReason(reason string) ErrorType {
+func ErrorTypeFromReason(reason string) ErrorType {
 	if strings.Contains(reason, "Generic") {
 		return GenericError
 	}

--- a/service/worker/diagnostics/invariant/retry/retry.go
+++ b/service/worker/diagnostics/invariant/retry/retry.go
@@ -24,6 +24,7 @@ package retry
 
 import (
 	"context"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
@@ -55,7 +56,7 @@ func (r *retry) Check(context.Context) ([]invariant.InvariantCheckResult, error)
 		if startedEvent.RetryPolicy != nil {
 			result = append(result, invariant.InvariantCheckResult{
 				InvariantType: WorkflowRetry.String(),
-				Reason:        *lastEvent.FailureReason,
+				Reason:        failure.ErrorTypeFromReason(*lastEvent.FailureReason).String(),
 				Metadata: invariant.MarshalData(RetryMetadata{
 					RetryPolicy: startedEvent.RetryPolicy,
 					Attempt:     startedEvent.Attempt,
@@ -85,6 +86,8 @@ func fetchStartedEvent(events []*types.HistoryEvent) *types.WorkflowExecutionSta
 }
 
 func (r *retry) RootCause(ctx context.Context, issues []invariant.InvariantCheckResult) ([]invariant.InvariantRootCauseResult, error) {
+	// Not implemented since this invariant does not have any root cause.
+	// Issue identified in Check() is a workflow retry which is essentially handled by failure invariant
 	result := make([]invariant.InvariantRootCauseResult, 0)
 	return result, nil
 }

--- a/service/worker/diagnostics/invariant/retry/retry_test.go
+++ b/service/worker/diagnostics/invariant/retry/retry_test.go
@@ -56,7 +56,7 @@ func Test__Check(t *testing.T) {
 			expectedResult: []invariant.InvariantCheckResult{
 				{
 					InvariantType: WorkflowRetry.String(),
-					Reason:        "cadenceInternal:Timeout START_TO_CLOSE",
+					Reason:        "The failure is caused by a timeout during the execution",
 					Metadata:      metadataInBytes,
 				},
 			},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Failure reason for workflow retries is categorised like activity failures

<!-- Tell your future self why have you made these changes -->
**Why?**
Workflow retry is caused by a failure. Thus the reason can be categorised the same way we categorise activity failures. Moreover the rootcause for workflow retries is the same as failure invariant

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
