### PR TITLE
Update root partition to refresh non-root partition on start

### DIFF
--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -123,6 +123,7 @@ type (
 		outstandingPollsLock sync.Mutex
 		outstandingPollsMap  map[string]outstandingPollerInfo
 		startWG              sync.WaitGroup // ensures that background processes do not start until setup is ready
+		stopWG               sync.WaitGroup
 		stopped              int32
 		closeCallback        func(Manager)
 		throttleRetry        *backoff.ThrottleRetry
@@ -274,6 +275,14 @@ func (c *taskListManagerImpl) Start() error {
 	if c.taskListID.IsRoot() && c.taskListKind == types.TaskListKindNormal {
 		c.partitionConfig = c.db.PartitionConfig().ToInternalType()
 		c.logger.Info("get task list partition config from db", tag.Dynamic("root-partition", c.taskListID.GetRoot()), tag.Dynamic("task-list-partition-config", c.partitionConfig))
+		if c.partitionConfig != nil {
+			// push update notification to all non-root partitions on start
+			c.stopWG.Add(1)
+			go func() {
+				defer c.stopWG.Done()
+				c.notifyPartitionConfig(context.Background(), *c.partitionConfig, int(c.partitionConfig.NumReadPartitions))
+			}()
+		}
 	}
 	c.liveness.Start()
 	c.taskReader.Start()
@@ -299,6 +308,7 @@ func (c *taskListManagerImpl) Stop() {
 	c.taskWriter.Stop()
 	c.taskReader.Stop()
 	c.matcher.DisconnectBlockedPollers()
+	c.stopWG.Wait()
 	c.logger.Info("Task list manager state changed", tag.LifeCycleStopped)
 }
 
@@ -423,7 +433,7 @@ func (c *taskListManagerImpl) notifyPartitionConfig(ctx context.Context, config 
 
 			_, e = c.matchingClient.RefreshTaskListPartitionConfig(ctx, &types.MatchingRefreshTaskListPartitionConfigRequest{
 				DomainUUID:      c.taskListID.GetDomainID(),
-				TaskList:        &types.TaskList{Name: taskListName},
+				TaskList:        &types.TaskList{Name: taskListName, Kind: &c.taskListKind},
 				TaskListType:    taskListType,
 				PartitionConfig: &config,
 			})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update root partition to refresh non-root partition on start

<!-- Tell your future self why have you made these changes -->
**Why?**
If root partition is stopped while it's trying to send notifications about an update to non-root partitions, some partitions may not receive the notification. In this case, update root partition to send notification on start so that they can receive the notification.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
