### PR TITLE
[Wf-Diagnostics] add retry policy validation to diagnostics

### DIFF
--- a/service/worker/diagnostics/invariant/retry/types.go
+++ b/service/worker/diagnostics/invariant/retry/types.go
@@ -27,14 +27,26 @@ import "github.com/uber/cadence/common/types"
 type RetryType string
 
 const (
-	WorkflowRetry RetryType = "Workflow Retry"
+	WorkflowRetryInfo  RetryType = "Workflow Retry configured and applied"
+	WorkflowRetryIssue RetryType = "Workflow Retry configured but invalid"
+	ActivityRetryIssue RetryType = "Activity Retry configured but invalid"
 )
 
 func (r RetryType) String() string {
 	return string(r)
 }
 
+type IssueType string
+
+const (
+	RetryPolicyValidationMaxAttempts IssueType = "MaximumAttempts set to 1 will not retry since maximum attempts includes the first attempt."
+	RetryPolicyValidationExpInterval IssueType = "ExpirationIntervalInSeconds less than  InitialIntervalInSeconds  will not retry."
+)
+
+func (i IssueType) String() string {
+	return string(i)
+}
+
 type RetryMetadata struct {
 	RetryPolicy *types.RetryPolicy
-	Attempt     int32
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Retry policy validation added to retry invariant in diagnostics

<!-- Tell your future self why have you made these changes -->
**Why?**
Customers have invalid policies running in production and hence cannot be stopped via server side validation but they still cause a lot of questions in support channel and hence it is better to convey via diagnostics

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
