### PR TITLE
Changed flag in cassandra README

### DIFF
--- a/tools/cassandra/README.md
+++ b/tools/cassandra/README.md
@@ -29,20 +29,20 @@ cadence-cassandra-tool --ep $CASSANDRA_SEEDS create -k $KEYSPACE --rf $RF
 See https://www.ecyrd.com/cassandracalculator for an easy way to determine how many nodes and what replication factor you will want to use.  Note that Cadence by default uses `Quorum` for read and write consistency.
 
 ```
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence setup-schema -v 0.0 -- this sets up just the schema version tables with initial version of 0.0
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned -- upgrades your schema to the latest version
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence setup-schema -v 0.0 # this sets up just the schema version tables with initial version of 0.0
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned # upgrades your schema to the latest version
 
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility setup-schema -v 0.0 -- this sets up just the schema version tables with initial version of 0.0 for visibility
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/cassandra/visibility/versioned -- upgrades your schema to the latest version for visibility
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility setup-schema -v 0.0 # this sets up just the schema version tables with initial version of 0.0 for visibility
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/cassandra/visibility/versioned # upgrades your schema to the latest version for visibility
 ```
 
 ### Update schema as part of a release
 You can only upgrade to a new version after the initial setup done above.
 
 ```
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned -v x.x -y -- executes a dryrun of upgrade to version x.x
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned -v x.x    -- actually executes the upgrade to version x.x
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned -v x.xx -dryrun # executes a dryrun of upgrade to version x.xx
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned -v x.xx # actually executes the upgrade to version x.xx
 
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/cassandra/visibility/versioned -v x.x -y -- executes a dryrun of upgrade to version x.x
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/cassandra/visibility/versioned -v x.x    -- actually executes the upgrade to version x.x
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/cassandra/visibility/versioned -v x.xx --dryrun # executes a dryrun of upgrade to version x.xx
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/cassandra/visibility/versioned -v x.xx  # actually executes the upgrade to version x.xx
 ```


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
There is no `-y` flag to ./cadence-cassandra-tool
Changed x.x to x.xx as versions are named like 0.38 and it is more
obviously corresponds
nit: moved explanation to comment


<!-- Tell your future self why have you made these changes -->
**Why?**
The existing reference was not working. Had to upgrade schema locally:
```bash
$ ./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned -v 0.38 --dryrun
$ ./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cassandra/cadence/versioned -v 0.38
```
worked fine

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
