### PR TITLE
[Wf-Diagnostics] Incorporate retry diagnostics in workflow diagnostics workflow

### DIFF
--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -24,7 +24,6 @@ package diagnostics
 
 import (
 	"context"
-	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/messaging/kafka"
@@ -32,6 +31,7 @@ import (
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
 )
 

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/messaging/kafka"
@@ -81,6 +82,15 @@ func (w *dw) identifyIssues(ctx context.Context, info identifyIssuesParams) ([]i
 		return nil, err
 	}
 	result = append(result, failureIssues...)
+
+	retryInvariant := retry.NewInvariant(retry.Params{
+		WorkflowExecutionHistory: info.History,
+	})
+	retryIssues, err := retryInvariant.Check(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, retryIssues...)
 
 	return result, nil
 }

--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -25,6 +25,7 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"testing"
 	"time"
 
@@ -85,6 +86,10 @@ func Test__identifyIssues(t *testing.T) {
 		ActivityScheduled: &types.ActivityTaskScheduledEventAttributes{
 			ActivityID:   "101",
 			ActivityType: &types.ActivityType{Name: "test-activity"},
+			RetryPolicy: &types.RetryPolicy{
+				InitialIntervalInSeconds: 1,
+				MaximumAttempts:          1,
+			},
 		},
 		ActivityStarted: &types.ActivityTaskStartedEventAttributes{
 			Identity: "localhost",
@@ -92,6 +97,14 @@ func Test__identifyIssues(t *testing.T) {
 		},
 	}
 	actMetadataInBytes, err := json.Marshal(actMetadata)
+	require.NoError(t, err)
+	retryMetadata := retry.RetryMetadata{
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 1,
+			MaximumAttempts:          1,
+		},
+	}
+	retryMetadataInBytes, err := json.Marshal(retryMetadata)
 	require.NoError(t, err)
 	expectedResult := []invariant.InvariantCheckResult{
 		{
@@ -103,6 +116,11 @@ func Test__identifyIssues(t *testing.T) {
 			InvariantType: failure.ActivityFailed.String(),
 			Reason:        failure.GenericError.String(),
 			Metadata:      actMetadataInBytes,
+		},
+		{
+			InvariantType: retry.ActivityRetryIssue.String(),
+			Reason:        retry.RetryPolicyValidationMaxAttempts.String(),
+			Metadata:      retryMetadataInBytes,
 		},
 	}
 	result, err := dwtest.identifyIssues(context.Background(), identifyIssuesParams{History: testWorkflowExecutionHistoryResponse()})
@@ -219,6 +237,10 @@ func testWorkflowExecutionHistoryResponse() *types.GetWorkflowExecutionHistoryRe
 					ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
 						ActivityID:   "101",
 						ActivityType: &types.ActivityType{Name: "test-activity"},
+						RetryPolicy: &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          1,
+						},
 					},
 				},
 				{

--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -25,7 +25,6 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
-	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"testing"
 	"time"
 
@@ -40,6 +39,7 @@ import (
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
 )
 

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -25,7 +25,6 @@ package diagnostics
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"time"
 
 	"go.uber.org/cadence/workflow"
@@ -34,6 +33,7 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
 )
 

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -25,6 +25,7 @@ package diagnostics
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"time"
 
 	"go.uber.org/cadence/workflow"
@@ -54,6 +55,7 @@ type DiagnosticsWorkflowInput struct {
 type DiagnosticsWorkflowResult struct {
 	Timeouts *timeoutDiagnostics
 	Failures *failureDiagnostics
+	Retries  *retryDiagnostics
 }
 
 type timeoutDiagnostics struct {
@@ -89,6 +91,17 @@ type failuresIssuesResult struct {
 	Metadata      failure.FailureMetadata
 }
 
+type retryDiagnostics struct {
+	Issues   []*retryIssuesResult
+	Runbooks []string
+}
+
+type retryIssuesResult struct {
+	InvariantType string
+	Reason        string
+	Metadata      retry.RetryMetadata
+}
+
 func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (*DiagnosticsWorkflowResult, error) {
 	scope := w.metricsClient.Scope(metrics.DiagnosticsWorkflowScope, metrics.DomainTag(params.Domain))
 	scope.IncCounter(metrics.DiagnosticsWorkflowStartedCount)
@@ -97,6 +110,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 
 	var timeoutsResult timeoutDiagnostics
 	var failureResult failureDiagnostics
+	var retryResult retryDiagnostics
 	var checkResult []invariant.InvariantCheckResult
 	var rootCauseResult []invariant.InvariantRootCauseResult
 
@@ -158,10 +172,17 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	failureResult.RootCause = retrieveFailureRootCause(rootCauseResult)
 	failureResult.Runbooks = []string{linkToFailuresRunbook}
 
+	retryIssues, err := retrieveRetryIssues(checkResult)
+	if err != nil {
+		return nil, fmt.Errorf("RetrieveRetryIssues: %w", err)
+	}
+	retryResult.Issues = retryIssues
+
 	scope.IncCounter(metrics.DiagnosticsWorkflowSuccess)
 	return &DiagnosticsWorkflowResult{
 		Timeouts: &timeoutsResult,
 		Failures: &failureResult,
+		Retries:  &retryResult,
 	}, nil
 }
 
@@ -274,6 +295,25 @@ func retrieveFailureRootCause(rootCause []invariant.InvariantRootCauseResult) []
 		}
 	}
 	return result
+}
+
+func retrieveRetryIssues(issues []invariant.InvariantCheckResult) ([]*retryIssuesResult, error) {
+	result := make([]*retryIssuesResult, 0)
+	for _, issue := range issues {
+		if issue.InvariantType == retry.WorkflowRetryIssue.String() || issue.InvariantType == retry.WorkflowRetryInfo.String() || issue.InvariantType == retry.ActivityRetryIssue.String() {
+			var data retry.RetryMetadata
+			err := json.Unmarshal(issue.Metadata, &data)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, &retryIssuesResult{
+				InvariantType: issue.InvariantType,
+				Reason:        issue.Reason,
+				Metadata:      data,
+			})
+		}
+	}
+	return result, nil
 }
 
 func rootCauseHeartBeatRelated(rootCause invariant.RootCause) bool {

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"testing"
 	"time"
 
@@ -317,4 +318,42 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveFailureIssues() {
 	result, err := retrieveFailureIssues(issues)
 	s.NoError(err)
 	s.Equal(failureIssues, result)
+}
+
+func (s *diagnosticsWorkflowTestSuite) Test__retrieveRetryIssues() {
+	retryMetadata := retry.RetryMetadata{
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 1,
+			MaximumAttempts:          1,
+		},
+	}
+	retryMetadataInBytes, err := json.Marshal(retryMetadata)
+	s.NoError(err)
+	issues := []invariant.InvariantCheckResult{
+		{
+			InvariantType: retry.ActivityRetryIssue.String(),
+			Reason:        retry.RetryPolicyValidationMaxAttempts.String(),
+			Metadata:      retryMetadataInBytes,
+		},
+		{
+			InvariantType: retry.WorkflowRetryIssue.String(),
+			Reason:        retry.RetryPolicyValidationMaxAttempts.String(),
+			Metadata:      retryMetadataInBytes,
+		},
+	}
+	retryIssues := []*retryIssuesResult{
+		{
+			InvariantType: retry.ActivityRetryIssue.String(),
+			Reason:        retry.RetryPolicyValidationMaxAttempts.String(),
+			Metadata:      retryMetadata,
+		},
+		{
+			InvariantType: retry.WorkflowRetryIssue.String(),
+			Reason:        retry.RetryPolicyValidationMaxAttempts.String(),
+			Metadata:      retryMetadata,
+		},
+	}
+	result, err := retrieveRetryIssues(issues)
+	s.NoError(err)
+	s.Equal(retryIssues, result)
 }

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"testing"
 	"time"
 
@@ -43,6 +42,7 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Diagnostics workflow includes retry related issues

<!-- Tell your future self why have you made these changes -->
**Why?**
adding the retry usecase for diagnostics

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
