### PR TITLE
[gocql] Allow to set gocql HostSelectionPolicy

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -260,6 +260,8 @@ type (
 		// Otherwise please add new fields to the struct for better documentation
 		// If being used in any database, update this comment here to make it clear
 		ConnectAttributes map[string]string `yaml:"connectAttributes"`
+		// HostSelectionPolicy sets gocql policy for selecting host for a query
+		HostSelectionPolicy string `yaml:"hostSelectionPolicy"`
 	}
 
 	// ShardedNoSQL contains configuration to connect to a set of NoSQL Database clusters in a sharded manner

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -261,6 +261,7 @@ type (
 		// If being used in any database, update this comment here to make it clear
 		ConnectAttributes map[string]string `yaml:"connectAttributes"`
 		// HostSelectionPolicy sets gocql policy for selecting host for a query
+		// Available selections are: "tokenaware,roundrobin", "hostpool-epsilon-greedy", "roundrobin"
 		HostSelectionPolicy string `yaml:"hostSelectionPolicy"`
 	}
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -93,7 +93,12 @@ func newCassandraCluster(cfg ClusterConfig) *gocql.ClusterConfig {
 		cluster.NumConns = cfg.MaxConns
 	}
 
-	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+	if cfg.HostSelectionPolicy != nil {
+		cluster.PoolConfig.HostSelectionPolicy = cfg.HostSelectionPolicy
+	} else {
+		// set default option if configuration was not provided
+		cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+	}
 
 	return cluster
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
@@ -26,6 +26,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/gocql/gocql"
+
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
@@ -116,5 +118,6 @@ type (
 		SerialConsistency     SerialConsistency
 		Timeout               time.Duration
 		ConnectTimeout        time.Duration
+		HostSelectionPolicy   gocql.HostSelectionPolicy
 	}
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
@@ -21,7 +21,12 @@
 package cassandra
 
 import (
+	"errors"
+	"fmt"
 	"time"
+
+	gogocql "github.com/gocql/gocql"
+	"github.com/hailocab/go-hostpool"
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
@@ -116,8 +121,13 @@ func toGoCqlConfig(cfg *config.NoSQL) (gocql.ClusterConfig, error) {
 	if err != nil {
 		return gocql.ClusterConfig{}, err
 	}
-	serialConsistency, err := gocql.ParseSerialConsistency(cfg.SerialConsistency)
 
+	serialConsistency, err := gocql.ParseSerialConsistency(cfg.SerialConsistency)
+	if err != nil {
+		return gocql.ClusterConfig{}, err
+	}
+
+	hostSelection, err := toHostSelectionPolicy(cfg.HostSelectionPolicy)
 	if err != nil {
 		return gocql.ClusterConfig{}, err
 	}
@@ -138,5 +148,21 @@ func toGoCqlConfig(cfg *config.NoSQL) (gocql.ClusterConfig, error) {
 		SerialConsistency:     serialConsistency,
 		Timeout:               cfg.Timeout,
 		ConnectTimeout:        cfg.ConnectTimeout,
+		HostSelectionPolicy:   hostSelection,
 	}, nil
+}
+
+func toHostSelectionPolicy(policy string) (gogocql.HostSelectionPolicy, error) {
+	switch policy {
+	case "", "tokenaware,roundrobin":
+		return gogocql.TokenAwareHostPolicy(gogocql.RoundRobinHostPolicy()), nil
+	case "hostpool-epsilon-greedy":
+		return gogocql.HostPoolHostPolicy(
+			hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
+		), nil
+	case "roundrobin":
+		return gogocql.RoundRobinHostPolicy(), nil
+	default:
+		return nil, errors.New(fmt.Sprintf("unknown gocql host selection policy: %q", policy))
+	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
@@ -21,7 +21,6 @@
 package cassandra
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -163,6 +162,6 @@ func toHostSelectionPolicy(policy string) (gogocql.HostSelectionPolicy, error) {
 	case "roundrobin":
 		return gogocql.RoundRobinHostPolicy(), nil
 	default:
-		return nil, errors.New(fmt.Sprintf("unknown gocql host selection policy: %q", policy))
+		return nil, fmt.Errorf("unknown gocql host selection policy: %q", policy)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/gogo/status v1.1.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
+	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding "hostSelectionPolicy" to Cassandra config

<!-- Tell your future self why have you made these changes -->
**Why?**
`gocql` driver allows you to define "host selection" part using config. 
This PR makes it possible to pick one of three pre-defined policies instead of relying on hard coded "Token based" policy.

This PR provides 
* Token based (default)
* Round robin
* Greedy


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
