### PR TITLE
Batcher will now by default retry it's activity 5 times

### DIFF
--- a/service/worker/batcher/batcher_test.go
+++ b/service/worker/batcher/batcher_test.go
@@ -31,6 +31,8 @@ import (
 	"go.uber.org/cadence/.gen/go/shared"
 
 	"github.com/uber/cadence/client"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"
@@ -60,5 +62,19 @@ func setuptest(t *testing.T) (*Batcher, *resource.Test) {
 		ServiceClient: sdkClient,
 		ClientBean:    mockClientBean,
 		TallyScope:    tally.TestScope(nil),
+		Config: Config{
+			ClusterMetadata: cluster.NewMetadata(
+				12,
+				"test-primary-cluster",
+				"test-primary-cluster",
+				map[string]config.ClusterInformation{
+					"test-primary-cluster":   {},
+					"test-secondary-cluster": {},
+				},
+				nil,
+				metrics.NewClient(tally.NoopScope, metrics.Worker),
+				testlogger.New(t),
+			),
+		},
 	}), mockResource
 }

--- a/service/worker/batcher/entities.go
+++ b/service/worker/batcher/entities.go
@@ -1,0 +1,115 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package batcher
+
+import (
+	"time"
+
+	"github.com/uber/cadence/common/types"
+)
+
+// TerminateParams is the parameters for terminating workflow
+type TerminateParams struct {
+	// this indicates whether to terminate children workflow. Default to true.
+	// TODO https://github.com/uber/cadence/issues/2159
+	// Ideally default should be childPolicy of the workflow. But it's currently totally broken.
+	TerminateChildren *bool
+}
+
+// CancelParams is the parameters for canceling workflow
+type CancelParams struct {
+	// this indicates whether to cancel children workflow. Default to true.
+	// TODO https://github.com/uber/cadence/issues/2159
+	// Ideally default should be childPolicy of the workflow. But it's currently totally broken.
+	CancelChildren *bool
+}
+
+// SignalParams is the parameters for signaling workflow
+type SignalParams struct {
+	SignalName string
+	Input      string
+}
+
+// ReplicateParams is the parameters for replicating workflow
+type ReplicateParams struct {
+	SourceCluster string
+	TargetCluster string
+}
+
+// BatchParams is the parameters for batch operation workflow
+type BatchParams struct {
+	// Target domain to execute batch operation
+	DomainName string
+	// To get the target workflows for processing
+	Query string
+	// Reason for the operation
+	Reason string
+	// Supporting: reset,terminate
+	BatchType string
+
+	// Below are all optional
+	// TerminateParams is params only for BatchTypeTerminate
+	TerminateParams TerminateParams
+	// CancelParams is params only for BatchTypeCancel
+	CancelParams CancelParams
+	// SignalParams is params only for BatchTypeSignal
+	SignalParams SignalParams
+	// ReplicateParams is params only for BatchTypeReplicate
+	ReplicateParams ReplicateParams
+	// RPS of processing. Default to DefaultRPS
+	// TODO we will implement smarter way than this static rate limiter: https://github.com/uber/cadence/issues/2138
+	RPS int
+	// Number of goroutines running in parallel to process
+	Concurrency int
+	// Number of workflows processed in a batch
+	PageSize int
+	// Number of attempts for each workflow to process in case of retryable error before giving up
+	AttemptsOnRetryableError int
+	// timeout for activity heartbeat
+	ActivityHeartBeatTimeout time.Duration
+	// Max number of attempts for the activity to retry. Default to 0 (unlimited)
+	MaxActivityRetries int
+	// errors that will not retry which consumes AttemptsOnRetryableError. Default to empty
+	NonRetryableErrors []string
+	// internal conversion for NonRetryableErrors
+	_nonRetryableErrors map[string]struct{}
+}
+
+// HeartBeatDetails is the struct for heartbeat details
+type HeartBeatDetails struct {
+	PageToken   []byte
+	CurrentPage int
+	// This is just an estimation for visibility
+	TotalEstimate int64
+	// Number of workflows processed successfully
+	SuccessCount int
+	// Number of workflows that give up due to errors.
+	ErrorCount int
+}
+
+type taskDetail struct {
+	execution types.WorkflowExecution
+	attempts  int
+	// passing along the current heartbeat details to make heartbeat within a task so that it won't timeout
+	hbd HeartBeatDetails
+}

--- a/service/worker/batcher/workflow_retry_test.go
+++ b/service/worker/batcher/workflow_retry_test.go
@@ -1,0 +1,124 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package batcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+
+	"github.com/uber/cadence/common/metrics"
+	mmocks "github.com/uber/cadence/common/metrics/mocks"
+	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/types"
+)
+
+type workflowRetrySuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+	workflowEnv  *testsuite.TestWorkflowEnvironment
+	activityEnv  *testsuite.TestActivityEnvironment
+	mockResource *resource.Test
+	metricsMock  *mmocks.Client
+}
+
+func TestWorkflowRetrySuite(t *testing.T) {
+	suite.Run(t, new(workflowRetrySuite))
+}
+
+func (s *workflowRetrySuite) SetupTest() {
+	s.workflowEnv = s.NewTestWorkflowEnvironment()
+	s.workflowEnv.RegisterWorkflow(BatchWorkflow)
+
+	s.activityEnv = s.NewTestActivityEnvironment()
+	s.activityEnv.RegisterActivity(BatchActivity)
+
+	batcher, mockResource := setuptest(s.T())
+	s.mockResource = mockResource
+
+	s.metricsMock = &mmocks.Client{}
+	batcher.metricsClient = s.metricsMock
+
+	mockResource.FrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(&types.DescribeDomainResponse{}, nil).AnyTimes()
+
+	mockResource.FrontendClient.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&types.CountWorkflowExecutionsResponse{Count: 1}, nil).AnyTimes()
+	mockResource.FrontendClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockResource.FrontendClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.DescribeWorkflowExecutionResponse{}, nil).AnyTimes()
+
+	ctx := context.WithValue(context.Background(), batcherContextKey, batcher)
+	workerOpts := worker.Options{
+		MetricsScope:              tally.TestScope(nil),
+		BackgroundActivityContext: ctx,
+		Tracer:                    opentracing.GlobalTracer(),
+	}
+	s.workflowEnv.SetWorkerOptions(workerOpts)
+	s.activityEnv.SetWorkerOptions(workerOpts)
+
+}
+
+func (s *workflowRetrySuite) TestActivityRetries() {
+	params := createParams(BatchTypeCancel)
+	params.MaxActivityRetries = 4
+
+	s.metricsMock.On("IncCounter", metrics.BatcherScope, metrics.BatcherProcessorSuccess).Times(2)
+	s.metricsMock.On("IncCounter", metrics.BatcherScope, metrics.BatcherProcessorFailures).Times(5)
+
+	// First call to scan workflow executions succeeds, but returns a bad page token
+	s.mockResource.FrontendClient.EXPECT().ScanWorkflowExecutions(gomock.Any(), &types.ListWorkflowExecutionsRequest{
+		Domain:        params.DomainName,
+		PageSize:      int32(params.PageSize),
+		NextPageToken: nil,
+		Query:         params.Query,
+	}).
+		Return(&types.ListWorkflowExecutionsResponse{
+			Executions:    []*types.WorkflowExecutionInfo{{Execution: &types.WorkflowExecution{WorkflowID: "wid", RunID: "rid"}}},
+			NextPageToken: []byte("bad-page-token"),
+		}, nil).Times(1)
+
+	// Max attempt is set to 4, so we try 5 times, 0,1,2,3,4
+	s.mockResource.FrontendClient.EXPECT().ScanWorkflowExecutions(gomock.Any(), &types.ListWorkflowExecutionsRequest{
+		Domain:        params.DomainName,
+		PageSize:      int32(params.PageSize),
+		NextPageToken: []byte("bad-page-token"),
+		Query:         params.Query,
+	}).
+		Return(&types.ListWorkflowExecutionsResponse{
+			Executions:    []*types.WorkflowExecutionInfo{{Execution: &types.WorkflowExecution{WorkflowID: "wid", RunID: "rid"}}},
+			NextPageToken: []byte("bad-page-token"),
+		}, assert.AnError).Times(5)
+
+	s.workflowEnv.ExecuteWorkflow(BatchWorkflow, params)
+	s.True(s.workflowEnv.IsWorkflowCompleted())
+	s.ErrorContains(s.workflowEnv.GetWorkflowError(), assert.AnError.Error())
+}
+
+func (s *workflowRetrySuite) TearDownTest() {
+	s.workflowEnv.AssertExpectations(s.T())
+}

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -193,6 +193,7 @@ const (
 	FlagFailoverDrill                  = "failover_drill"
 	FlagRetryInterval                  = "retry_interval"
 	FlagRetryAttempts                  = "retry_attempts"
+	FlagMaxActivityRetries             = "max_activity_retries"
 	FlagRetryExpiration                = "retry_expiration"
 	FlagRetryBackoff                   = "retry_backoff"
 	FlagRetryMaxInterval               = "retry_max_interval"

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -536,6 +536,11 @@ func newBatchCommands() []*cli.Command {
 					Value: batcher.DefaultConcurrency,
 					Usage: "Concurrency of batch activity",
 				},
+				&cli.IntFlag{
+					Name:  FlagMaxActivityRetries,
+					Value: batcher.DefaultMaxActivityRetries,
+					Usage: "Max retries of batch activity, before retrying the whole workflow (0 means unlimited)",
+				},
 			},
 			Action: StartBatchJob,
 		},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The batcher activity will now retry 5 times by default, instead of forever. 

After 5 retries the whole workflow will be retried, insuring any bad state in the heartbeat state is cleared. 

The retry policy for the workflow is controlled by the CLI. If the workflow is triggered from an old CLI the workflow will work as before this commit. If the workflow is trigered from the new CLI, it will do the new behaviour with 5 times retry.

The change should be safe as old CLI clients will default to the old
behaviour of retrying forever.

Also: 
- did a small refactor of existing tests to simplify the new test. 
- moved entities to their own file, to make it easier to read the workflow code

<!-- Tell your future self why have you made these changes -->
**Why?**
In an incident we had the activity retry forever with bad state. The workflow never recovered or progessed from this. 

This change should let the workflow recover in these situations. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tested, and tested in staging environment.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
