### PR TITLE
Bugfix/correct mapper error

### DIFF
--- a/common/persistence/versionHistory.go
+++ b/common/persistence/versionHistory.go
@@ -49,11 +49,9 @@ func NewVersionHistoryItem(
 func NewVersionHistoryItemFromInternalType(
 	input *types.VersionHistoryItem,
 ) *VersionHistoryItem {
-
 	if input == nil {
-		panic("version history item is null")
+		return nil
 	}
-
 	return NewVersionHistoryItem(input.EventID, input.Version)
 }
 
@@ -107,7 +105,7 @@ func NewVersionHistoryFromInternalType(
 ) *VersionHistory {
 
 	if input == nil {
-		panic("version history is null")
+		return nil
 	}
 
 	items := make([]*VersionHistoryItem, 0, len(input.Items))
@@ -125,6 +123,9 @@ func (v *VersionHistory) Duplicate() *VersionHistory {
 
 // ToInternalType return internal format of version history
 func (v *VersionHistory) ToInternalType() *types.VersionHistory {
+	if v == nil {
+		return nil
+	}
 
 	token := make([]byte, len(v.BranchToken))
 	copy(token, v.BranchToken)
@@ -363,11 +364,9 @@ func (v *VersionHistory) Equals(
 func NewVersionHistories(
 	versionHistory *VersionHistory,
 ) *VersionHistories {
-
 	if versionHistory == nil {
-		panic("version history cannot be null")
+		return nil
 	}
-
 	return &VersionHistories{
 		CurrentVersionHistoryIndex: 0,
 		Histories:                  []*VersionHistory{versionHistory},
@@ -378,9 +377,8 @@ func NewVersionHistories(
 func NewVersionHistoriesFromInternalType(
 	input *types.VersionHistories,
 ) *VersionHistories {
-
 	if input == nil {
-		panic("version histories is null")
+		return nil
 	}
 	if len(input.Histories) == 0 {
 		panic("version histories cannot have empty")

--- a/common/persistence/versionHistory_test.go
+++ b/common/persistence/versionHistory_test.go
@@ -21,6 +21,7 @@
 package persistence
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -702,4 +703,11 @@ func (s *versionHistoriesSuite) TestCurrentVersionHistoryIndexIsInReplay() {
 	isInReplay, err = histories.IsRebuilt()
 	s.NoError(err)
 	s.False(isInReplay)
+}
+
+func TestNilHandling(t *testing.T) {
+	assert.Nil(t, NewVersionHistoriesFromInternalType(nil))
+	assert.Nil(t, NewVersionHistories(nil))
+	var vh *VersionHistory
+	assert.Nil(t, vh.ToInternalType())
 }

--- a/common/persistence/versionHistory_test.go
+++ b/common/persistence/versionHistory_test.go
@@ -21,9 +21,9 @@
 package persistence
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixes (hopefully) some mapping bugs I introduced with https://github.com/cadence-workflow/cadence/pull/6523 due to the version history being passed in being nil sometimes, therefore causing panics. 

The mapping code as it's currently written panics (and is changed by this PR) which I think is the correct architectural choice. The mappers, by panicing as they presently are, are confusing validation with mapping. This corrects the mapper to gracefully handle nil input, and a quick survey appears to show that there are no expected areas which should never be nil that don't already have nil-check validation in place.  

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- [X] Unit tests
- [ ] Staging deploy


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
