### PR TITLE
Fix long poll cancellation

### DIFF
--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -152,6 +152,8 @@ func (c *clientImpl) PollForActivityTask(
 		partition,
 		resp.LoadBalancerHints,
 	)
+	// caller needs to know the actual partition for cancelling long poll, so modify the request to pass this information
+	request.PollRequest.TaskList.Name = partition
 	return resp, nil
 }
 
@@ -191,6 +193,8 @@ func (c *clientImpl) PollForDecisionTask(
 		partition,
 		resp.LoadBalancerHints,
 	)
+	// caller needs to know the actual partition for cancelling long poll, so modify the request to pass this information
+	request.PollRequest.TaskList.Name = partition
 	return resp, nil
 }
 

--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -365,6 +365,8 @@ func (wh *WorkflowHandler) PollForActivityTask(
 				tag.Error(err))
 			return nil, err
 		}
+		// Must be cancellation error.  Doesn't matter what we return here.  Client already went away.
+		return nil, nil
 	}
 	return &types.PollForActivityTaskResponse{
 		TaskToken:                       matchingResp.TaskToken,
@@ -501,7 +503,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 			return nil, err
 		}
 
-		// Must be cancellation error.  Does'nt matter what we return here.  Client already went away.
+		// Must be cancellation error.  Doesn't matter what we return here.  Client already went away.
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix a nil pointer dereference issue in frontend's PollForActivityTask handler
- Update matching client's polling methods to modify the requests so that caller can cancel the long poll requests

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix bugs

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye ball check

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
