### PR TITLE
Fix bug in vis double read when source visibility manager is primary

### DIFF
--- a/common/persistence/visibility_triple_manager.go
+++ b/common/persistence/visibility_triple_manager.go
@@ -373,13 +373,16 @@ func (v *visibilityTripleManager) getShadowMgrForDoubleRead(domain string) Visib
 	}
 
 	// Valid cases:
-	// case3: when it is double read, and both advanced visibility are available, and read mode is from destination
-	if v.readModeIsFromDestination(domain) {
-		return v.sourceVisibilityManager
-	}
-	// case4: when it is double read, and both advanced visibility are available, and read mode is from source
+	// case3: when it is double read, and both advanced visibility are available, and read mode is from source
+	// we first check readModeIsFromSource since we use this flag to control which is the primary visibility manager
 	if v.readModeIsFromSource(domain) {
 		return v.destinationVisibilityManager
+	}
+
+	// case4: when it is double read, and both advanced visibility are available, and read mode is from destination
+	// normally readModeIsFromDestination will always be true when it is in the migration mode
+	if v.readModeIsFromDestination(domain) {
+		return v.sourceVisibilityManager
 	}
 	// exclude all other cases
 	return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix bug in vis double read when source visibility manager is primary. In the original logic, we check readModeIsFromDestination first which will be true by default in the migration mode, it will never send query to destination vis manager when source is primary.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix bug

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
