### PR TITLE
Add task isolation leaking

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2796,6 +2796,20 @@ const (
 	// Allowed filters: domainName, taskListName, taskListType
 	LocalTaskWaitTime
 
+	// TaskIsolationDuration is the time period for which we attempt to respect tasklist isolation before allowing any poller to process the task
+	// KeyName: matching.taskIsolationDuration
+	// Value type: Duration
+	// Default value: 0
+	// Allowed filters: domainName, taskListName, taskListType
+	TaskIsolationDuration
+
+	// TaskIsolationPollerWindow is the time period for which pollers are remembered when deciding whether to skip tasklist isolation due to unpolled isolation groups.
+	// KeyName: matching.taskIsolationPollerWindow
+	// Value type: Duration
+	// Default value: 10s
+	// Allowed filters: domainName, taskListName, taskListType
+	TaskIsolationPollerWindow
+
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
 )
@@ -5076,6 +5090,18 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		Filters:      []Filter{DomainName, TaskListName, TaskType},
 		Description:  "LocalTaskWaitTime is the time a task waits for a poller to arrive before considering task forwarding",
 		DefaultValue: time.Millisecond * 10,
+	},
+	TaskIsolationDuration: {
+		KeyName:      "matching.taskIsolationDuration",
+		Filters:      []Filter{DomainName, TaskListName, TaskType},
+		Description:  "TaskIsolationDuration is the time period for which we attempt to respect tasklist isolation before allowing any poller to process the task",
+		DefaultValue: 0,
+	},
+	TaskIsolationPollerWindow: {
+		KeyName:      "matching.taskIsolationPollerWindow",
+		Filters:      []Filter{DomainName, TaskListName, TaskType},
+		Description:  "TaskIsolationDuration is the time period for which we attempt to respect tasklist isolation before allowing any poller to process the task",
+		DefaultValue: time.Second * 10,
 	},
 }
 

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -982,6 +982,14 @@ func IsolationGroup(group string) Tag {
 	return newStringTag("isolation-group", group)
 }
 
+func TaskLatency(duration time.Duration) Tag {
+	return newDurationTag("task-latency", duration)
+}
+
+func IsolationDuration(duration time.Duration) Tag {
+	return newDurationTag("isolation-duration", duration)
+}
+
 func PartitionConfig(p map[string]string) Tag {
 	return newObjectTag("partition-config", p)
 }

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2638,7 +2638,8 @@ const (
 	StandbyClusterTasksCompletedCounterPerTaskList
 	StandbyClusterTasksNotStartedCounterPerTaskList
 	StandbyClusterTasksCompletionFailurePerTaskList
-
+	TaskIsolationExpiredPerTaskList
+	TaskIsolationErrorPerTaskList
 	NumMatchingMetrics
 )
 
@@ -3334,6 +3335,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		StandbyClusterTasksCompletedCounterPerTaskList:          {metricName: "standby_cluster_tasks_completed_per_tl", metricType: Counter},
 		StandbyClusterTasksNotStartedCounterPerTaskList:         {metricName: "standby_cluster_tasks_not_started_per_tl", metricType: Counter},
 		StandbyClusterTasksCompletionFailurePerTaskList:         {metricName: "standby_cluster_tasks_completion_failure_per_tl", metricType: Counter},
+		TaskIsolationExpiredPerTaskList:                         {metricName: "task_isolation_expired_per_tl", metricRollupName: "task_isolation_expired"},
+		TaskIsolationErrorPerTaskList:                           {metricName: "task_isolation_error_per_tl", metricRollupName: "task_isolation_error"},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -21,7 +21,6 @@
 package metrics
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
 )
@@ -65,6 +64,8 @@ const (
 	workflowTerminationReason = "workflow_termination_reason"
 	workflowCloseStatus       = "workflow_close_status"
 	isolationEnabled          = "isolation_enabled"
+	isolationGroup            = "isolation_group"
+	originalIsolationGroup    = "original_isolation_group"
 	topic                     = "topic"
 	mode                      = "mode"
 
@@ -312,19 +313,13 @@ func WorkflowCloseStatusTag(value string) Tag {
 	return simpleMetric{key: workflowCloseStatus, value: value}
 }
 
-// PartitionConfigTags returns a list of partition config tags
-func PartitionConfigTags(partitionConfig map[string]string) []Tag {
-	tags := make([]Tag, 0, len(partitionConfig))
-	for k, v := range partitionConfig {
-		if len(k) == 0 {
-			continue
-		}
-		if len(v) == 0 {
-			v = unknownValue
-		}
-		tags = append(tags, simpleMetric{key: sanitizer.Value(fmt.Sprintf("pk_%s", k)), value: sanitizer.Value(v)})
-	}
-	return tags
+func OriginalIsolationGroupTag(group string) Tag {
+	return simpleMetric{key: originalIsolationGroup, value: sanitizer.Value(group)}
+}
+
+func IsolationGroupTag(group string) Tag {
+	return simpleMetric{key: isolationGroup, value: sanitizer.Value(group)}
+
 }
 
 // IsolationEnabledTag returns whether isolation is enabled

--- a/common/partition/default-partitioner.go
+++ b/common/partition/default-partitioner.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	IsolationGroupKey = "isolation-group"
-	WorkflowIDKey     = "wf-id"
+	IsolationGroupKey         = "isolation-group"
+	OriginalIsolationGroupKey = "original-isolation-group"
+	WorkflowIDKey             = "wf-id"
 )
 
 // ErrNoIsolationGroupsAvailable is returned when there are no available isolation-groups

--- a/host/matching_simulation_test.go
+++ b/host/matching_simulation_test.go
@@ -125,6 +125,7 @@ func TestMatchingSimulationSuite(t *testing.T) {
 		dynamicconfig.MatchingPartitionUpscaleSustainedDuration:    clusterConfig.MatchingConfig.SimulationConfig.PartitionUpscaleSustainedDuration,
 		dynamicconfig.MatchingPartitionDownscaleSustainedDuration:  clusterConfig.MatchingConfig.SimulationConfig.PartitionDownscaleSustainedDuration,
 		dynamicconfig.MatchingAdaptiveScalerUpdateInterval:         clusterConfig.MatchingConfig.SimulationConfig.AdaptiveScalerUpdateInterval,
+		dynamicconfig.TaskIsolationDuration:                        clusterConfig.MatchingConfig.SimulationConfig.TaskIsolationDuration,
 	}
 
 	ctrl := gomock.NewController(t)

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -204,6 +204,7 @@ type (
 		PartitionUpscaleSustainedDuration   time.Duration
 		PartitionDownscaleSustainedDuration time.Duration
 		AdaptiveScalerUpdateInterval        time.Duration
+		TaskIsolationDuration               time.Duration
 	}
 
 	SimulationPollerConfiguration struct {
@@ -1109,7 +1110,10 @@ func (c *cadenceImpl) newRPCFactory(serviceName string, host membership.HostInfo
 		TChannelAddress: tchannelAddress,
 		GRPCAddress:     grpcAddress,
 		InboundMiddleware: yarpc.InboundMiddleware{
-			Unary: &versionMiddleware{},
+			Unary: yarpc.UnaryInboundMiddleware(&versionMiddleware{}, &rpc.ClientPartitionConfigMiddleware{}, &rpc.ForwardPartitionConfigMiddleware{}),
+		},
+		OutboundMiddleware: yarpc.OutboundMiddleware{
+			Unary: &rpc.ForwardPartitionConfigMiddleware{},
 		},
 
 		// For integration tests to generate client out of the same outbound.

--- a/host/task_list_isolation_test.go
+++ b/host/task_list_isolation_test.go
@@ -1,0 +1,213 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package host
+
+import (
+	"errors"
+	"flag"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/yarpc"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/types"
+)
+
+const (
+	tl = "integration-task-list-isolation-tl"
+)
+
+func TestTaskListIsolationSuite(t *testing.T) {
+	flag.Parse()
+
+	var isolationGroups = []any{
+		"a", "b", "c",
+	}
+	clusterConfig, err := GetTestClusterConfig("testdata/task_list_isolation_test_cluster.yaml")
+	if err != nil {
+		panic(err)
+	}
+	testCluster := NewPersistenceTestCluster(t, clusterConfig)
+	clusterConfig.FrontendDynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+		dynamicconfig.EnableTasklistIsolation:            true,
+		dynamicconfig.AllIsolationGroups:                 isolationGroups,
+		dynamicconfig.MatchingNumTasklistWritePartitions: 1,
+		dynamicconfig.MatchingNumTasklistReadPartitions:  1,
+	}
+	clusterConfig.HistoryDynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+		dynamicconfig.EnableTasklistIsolation:            true,
+		dynamicconfig.AllIsolationGroups:                 isolationGroups,
+		dynamicconfig.MatchingNumTasklistWritePartitions: 1,
+		dynamicconfig.MatchingNumTasklistReadPartitions:  1,
+	}
+	clusterConfig.MatchingDynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+		dynamicconfig.EnableTasklistIsolation:            true,
+		dynamicconfig.AllIsolationGroups:                 isolationGroups,
+		dynamicconfig.TaskIsolationDuration:              time.Second * 5,
+		dynamicconfig.MatchingNumTasklistWritePartitions: 1,
+		dynamicconfig.MatchingNumTasklistReadPartitions:  1,
+	}
+
+	s := new(TaskListIsolationIntegrationSuite)
+	params := IntegrationBaseParams{
+		DefaultTestCluster:    testCluster,
+		VisibilityTestCluster: testCluster,
+		TestClusterConfig:     clusterConfig,
+	}
+	s.IntegrationBase = NewIntegrationBase(params)
+	suite.Run(t, s)
+}
+
+func (s *TaskListIsolationIntegrationSuite) SetupSuite() {
+	s.setupSuite()
+}
+
+func (s *TaskListIsolationIntegrationSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+func (s *TaskListIsolationIntegrationSuite) SetupTest() {
+	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+	s.Assertions = require.New(s.T())
+}
+
+func (s *TaskListIsolationIntegrationSuite) TestTaskListIsolation() {
+	aPoller := s.createPoller("a")
+	bPoller := s.createPoller("b")
+
+	cancelB := bPoller.PollAndProcessDecisions()
+	defer cancelB()
+	cancelA := aPoller.PollAndProcessDecisions()
+	defer cancelA()
+
+	// Give pollers time to start
+	time.Sleep(time.Second)
+
+	// Running a single workflow is a bit of a coinflip: if isolation didn't work, it would pass 50% of the time.
+	// Run 10 workflows to demonstrate that we consistently isolate tasks to the correct poller
+	for i := 0; i < 10; i++ {
+		runID := s.startWorkflow("a").RunID
+		result, err := s.getWorkflowResult(runID)
+		s.NoError(err)
+		s.Equal("a", result)
+	}
+}
+
+func (s *TaskListIsolationIntegrationSuite) TestTaskListIsolationLeak() {
+	runID := s.startWorkflow("a").RunID
+
+	bPoller := s.createPoller("b")
+	// B will get the task as there are no pollers from A
+	cancelB := bPoller.PollAndProcessDecisions()
+	defer cancelB()
+
+	result, err := s.getWorkflowResult(runID)
+	s.NoError(err)
+	s.Equal("b", result)
+}
+
+func (s *TaskListIsolationIntegrationSuite) createPoller(group string) *TaskPoller {
+	return &TaskPoller{
+		Engine:   s.engine,
+		Domain:   s.domainName,
+		TaskList: &types.TaskList{Name: tl, Kind: types.TaskListKindNormal.Ptr()},
+		Identity: group,
+		DecisionHandler: func(execution *types.WorkflowExecution, wt *types.WorkflowType, previousStartedEventID, startedEventID int64, history *types.History) ([]byte, []*types.Decision, error) {
+			// Complete the workflow with the group name
+			return []byte(strconv.Itoa(0)), []*types.Decision{{
+				DecisionType: types.DecisionTypeCompleteWorkflowExecution.Ptr(),
+				CompleteWorkflowExecutionDecisionAttributes: &types.CompleteWorkflowExecutionDecisionAttributes{
+					Result: []byte(group),
+				},
+			}}, nil
+		},
+		Logger:      s.Logger,
+		T:           s.T(),
+		CallOptions: []yarpc.CallOption{withIsolationGroup(group)},
+	}
+}
+
+func (s *TaskListIsolationIntegrationSuite) startWorkflow(group string) *types.StartWorkflowExecutionResponse {
+	identity := "test"
+
+	request := &types.StartWorkflowExecutionRequest{
+		RequestID:  uuid.New(),
+		Domain:     s.domainName,
+		WorkflowID: s.T().Name(),
+		WorkflowType: &types.WorkflowType{
+			Name: "integration-task-list-isolation-type",
+		},
+		TaskList: &types.TaskList{
+			Name: tl,
+			Kind: types.TaskListKindNormal.Ptr(),
+		},
+		Input:                               nil,
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(10),
+		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Identity:                            identity,
+		WorkflowIDReusePolicy:               types.WorkflowIDReusePolicyAllowDuplicate.Ptr(),
+	}
+
+	ctx, cancel := createContext()
+	defer cancel()
+	result, err := s.engine.StartWorkflowExecution(ctx, request, withIsolationGroup(group))
+	s.Nil(err)
+
+	return result
+}
+
+func (s *TaskListIsolationIntegrationSuite) getWorkflowResult(runID string) (string, error) {
+	ctx, cancel := createContext()
+	historyResponse, err := s.engine.GetWorkflowExecutionHistory(ctx, &types.GetWorkflowExecutionHistoryRequest{
+		Domain: s.domainName,
+		Execution: &types.WorkflowExecution{
+			WorkflowID: s.T().Name(),
+			RunID:      runID,
+		},
+		HistoryEventFilterType: types.HistoryEventFilterTypeCloseEvent.Ptr(),
+		WaitForNewEvent:        true,
+	})
+	cancel()
+	if err != nil {
+		return "", err
+	}
+	history := historyResponse.History
+
+	lastEvent := history.Events[len(history.Events)-1]
+	if *lastEvent.EventType != types.EventTypeWorkflowExecutionCompleted {
+		return "", errors.New("workflow didn't complete")
+	}
+
+	return string(lastEvent.WorkflowExecutionCompletedEventAttributes.Result), nil
+
+}
+
+func withIsolationGroup(group string) yarpc.CallOption {
+	return yarpc.WithHeader(common.ClientIsolationGroupHeaderName, group)
+}

--- a/host/test_suites.go
+++ b/host/test_suites.go
@@ -75,4 +75,9 @@ type (
 		*require.Assertions
 		*IntegrationBase
 	}
+
+	TaskListIsolationIntegrationSuite struct {
+		*require.Assertions
+		*IntegrationBase
+	}
 )

--- a/host/testdata/matching_simulation_zonal_isolation.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation.yaml
@@ -16,6 +16,7 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
+    taskisolationduration: 1s
     tasks:
       - numtaskgenerators: 30
         taskspersecond: 500

--- a/host/testdata/matching_simulation_zonal_isolation_few_pollers.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_few_pollers.yaml
@@ -16,6 +16,7 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
+    taskisolationduration: 1s
     tasks:
       - numtaskgenerators: 30
         taskspersecond: 500

--- a/host/testdata/matching_simulation_zonal_isolation_many_pollers.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_many_pollers.yaml
@@ -16,6 +16,7 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
+    taskisolationduration: 1s
     tasks:
       - numtaskgenerators: 30
         taskspersecond: 500

--- a/host/testdata/matching_simulation_zonal_isolation_single_partition.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_single_partition.yaml
@@ -16,6 +16,7 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
+    taskisolationduration: 1s
     tasks:
       - numtaskgenerators: 30
         taskspersecond: 500

--- a/host/testdata/matching_simulation_zonal_isolation_skew.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_skew.yaml
@@ -16,6 +16,7 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
+    taskisolationduration: 1s
     tasks:
       - numtaskgenerators: 10
         taskspersecond: 180

--- a/host/testdata/matching_simulation_zonal_isolation_skew_extreme.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_skew_extreme.yaml
@@ -16,6 +16,7 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
+    taskisolationduration: 1s
     tasks:
       - numtaskgenerators: 3
         taskspersecond: 50

--- a/host/testdata/matching_simulation_zonal_isolation_skew_forwarding.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_skew_forwarding.yaml
@@ -16,6 +16,7 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
+    taskisolationduration: 1s
     tasks:
       - numtaskgenerators: 10
         taskspersecond: 180

--- a/host/testdata/task_list_isolation_test_cluster.yaml
+++ b/host/testdata/task_list_isolation_test_cluster.yaml
@@ -1,0 +1,13 @@
+enablearchival: false
+clusterno: 0
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+matchingconfig:
+  nummatchinghosts: 1
+workerconfig:
+  enablearchiver: false
+  enablereplicator: false
+  enableindexer: false

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -53,6 +53,8 @@ type (
 		AsyncTaskDispatchTimeout             dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		LocalPollWaitTime                    dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		LocalTaskWaitTime                    dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
+		TaskIsolationDuration                dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
+		TaskIsolationPollerWindow            dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		EnableGetNumberOfPartitionsFromCache dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
 		PartitionUpscaleRPS                  dynamicconfig.IntPropertyFnWithTaskListInfoFilters
 		PartitionDownscaleFactor             dynamicconfig.FloatPropertyFnWithTaskListInfoFilters
@@ -132,7 +134,9 @@ type (
 		// isolation configuration
 		EnableTasklistIsolation func() bool
 		// A function which returns all the isolation groups
-		AllIsolationGroups func() []string
+		AllIsolationGroups        func() []string
+		TaskIsolationDuration     func() time.Duration
+		TaskIsolationPollerWindow func() time.Duration
 		// hostname
 		HostName string
 		// rate limiter configuration
@@ -189,6 +193,8 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, getIsolationGroups
 		PartitionDownscaleSustainedDuration:  dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingPartitionDownscaleSustainedDuration),
 		AdaptiveScalerUpdateInterval:         dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingAdaptiveScalerUpdateInterval),
 		EnableAdaptiveScaler:                 dc.GetBoolPropertyFilteredByTaskListInfo(dynamicconfig.MatchingEnableAdaptiveScaler),
+		TaskIsolationDuration:                dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.TaskIsolationDuration),
+		TaskIsolationPollerWindow:            dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.TaskIsolationPollerWindow),
 		HostName:                             hostName,
 		TaskDispatchRPS:                      100000.0,
 		TaskDispatchRPSTTL:                   time.Minute,

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -89,6 +89,8 @@ func TestNewConfig(t *testing.T) {
 		"EnableAdaptiveScaler":                 {dynamicconfig.MatchingEnableAdaptiveScaler, true},
 		"EnableStandbyTaskCompletion":          {dynamicconfig.MatchingEnableStandbyTaskCompletion, false},
 		"EnableClientAutoConfig":               {dynamicconfig.MatchingEnableClientAutoConfig, false},
+		"TaskIsolationDuration":                {dynamicconfig.TaskIsolationDuration, time.Duration(35)},
+		"TaskIsolationPollerWindow":            {dynamicconfig.TaskIsolationPollerWindow, time.Duration(36)},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -1335,8 +1335,12 @@ func (e *matchingEngineImpl) emitTaskIsolationMetrics(
 	partitionConfig map[string]string,
 	pollerIsolationGroup string,
 ) {
-	if len(partitionConfig) > 0 {
-		scope.Tagged(metrics.PartitionConfigTags(partitionConfig)...).Tagged(metrics.PollerIsolationGroupTag(pollerIsolationGroup)).IncCounter(metrics.IsolationTaskMatchPerTaskListCounter)
+	if currentGroup, ok := partitionConfig[partition.IsolationGroupKey]; ok {
+		originalGroup, ok := partitionConfig[partition.OriginalIsolationGroupKey]
+		if !ok {
+			originalGroup = currentGroup
+		}
+		scope.Tagged(metrics.OriginalIsolationGroupTag(originalGroup), metrics.IsolationGroupTag(currentGroup), metrics.PollerIsolationGroupTag(pollerIsolationGroup)).IncCounter(metrics.IsolationTaskMatchPerTaskListCounter)
 	}
 }
 

--- a/service/matching/tasklist/task_test.go
+++ b/service/matching/tasklist/task_test.go
@@ -1,0 +1,163 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package tasklist
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/partition"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestNewInternalTask(t *testing.T) {
+	cases := []struct {
+		name                    string
+		partitionConfig         map[string]string
+		source                  types.TaskSource
+		forwardedFrom           string
+		forSyncMatch            bool
+		isolationGroup          string
+		expectedPartitionConfig map[string]string
+		additionalAssertions    func(t *testing.T, task *InternalTask)
+	}{
+		{
+			name:         "sync match",
+			source:       types.TaskSourceHistory,
+			forSyncMatch: true,
+			additionalAssertions: func(t *testing.T, task *InternalTask) {
+				// Only initialized for sync match
+				assert.NotNil(t, task.ResponseC)
+				assert.True(t, task.IsSyncMatch())
+			},
+		},
+		{
+			name:         "async match",
+			source:       types.TaskSourceDbBacklog,
+			forSyncMatch: false,
+			additionalAssertions: func(t *testing.T, task *InternalTask) {
+				// Only initialized for sync match
+				assert.Nil(t, task.ResponseC)
+				assert.False(t, task.IsSyncMatch())
+			},
+		},
+		{
+			name:          "forwarded from history",
+			source:        types.TaskSourceDbBacklog,
+			forSyncMatch:  true,
+			forwardedFrom: "elsewhere",
+			additionalAssertions: func(t *testing.T, task *InternalTask) {
+				assert.True(t, task.IsForwarded())
+				assert.True(t, task.IsSyncMatch())
+			},
+		},
+		{
+			name:          "forwarded from backlog",
+			source:        types.TaskSourceDbBacklog,
+			forSyncMatch:  true,
+			forwardedFrom: "elsewhere",
+			additionalAssertions: func(t *testing.T, task *InternalTask) {
+				assert.True(t, task.IsForwarded())
+				// Still technically sync match, just on a different host
+				assert.True(t, task.IsSyncMatch())
+			},
+		},
+		{
+			name:           "tasklist isolation",
+			source:         types.TaskSourceDbBacklog,
+			isolationGroup: "a",
+			partitionConfig: map[string]string{
+				partition.IsolationGroupKey: "a",
+				partition.WorkflowIDKey:     "workflowID",
+			},
+			expectedPartitionConfig: map[string]string{
+				partition.OriginalIsolationGroupKey: "a",
+				partition.IsolationGroupKey:         "a",
+				partition.WorkflowIDKey:             "workflowID",
+			},
+		},
+		{
+			name:           "tasklist isolation - leaked",
+			source:         types.TaskSourceDbBacklog,
+			isolationGroup: "",
+			partitionConfig: map[string]string{
+				partition.IsolationGroupKey: "a",
+				partition.WorkflowIDKey:     "workflowID",
+			},
+			expectedPartitionConfig: map[string]string{
+				partition.OriginalIsolationGroupKey: "a",
+				partition.IsolationGroupKey:         "",
+				partition.WorkflowIDKey:             "workflowID",
+			},
+		},
+		{
+			name:           "tasklist isolation - forwarded",
+			source:         types.TaskSourceDbBacklog,
+			isolationGroup: "",
+			partitionConfig: map[string]string{
+				partition.OriginalIsolationGroupKey: "a",
+				partition.IsolationGroupKey:         "",
+				partition.WorkflowIDKey:             "workflowID",
+			},
+			expectedPartitionConfig: map[string]string{
+				partition.OriginalIsolationGroupKey: "a",
+				partition.IsolationGroupKey:         "",
+				partition.WorkflowIDKey:             "workflowID",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			completionFunc := func(_ *persistence.TaskInfo, _ error) {}
+			taskInfo := defaultTaskInfo(tc.partitionConfig)
+			activityDispatchInfo := &types.ActivityTaskDispatchInfo{WorkflowDomain: "domain"}
+			task := newInternalTask(taskInfo, completionFunc, tc.source, tc.forwardedFrom, tc.forSyncMatch, activityDispatchInfo, tc.isolationGroup)
+			assert.Equal(t, defaultTaskInfo(tc.expectedPartitionConfig), task.Event.TaskInfo)
+			assert.NotNil(t, task.Event.completionFunc)
+			assert.Equal(t, tc.source, task.source)
+			assert.Equal(t, tc.forwardedFrom, task.forwardedFrom)
+			assert.Equal(t, tc.isolationGroup, task.isolationGroup)
+			assert.Equal(t, activityDispatchInfo, task.ActivityTaskDispatchInfo)
+			if tc.additionalAssertions != nil {
+				tc.additionalAssertions(t, task)
+			}
+		})
+	}
+}
+
+func defaultTaskInfo(partitionConfig map[string]string) *persistence.TaskInfo {
+	return &persistence.TaskInfo{
+		DomainID:                      "DomainID",
+		WorkflowID:                    "WorkflowID",
+		RunID:                         "RunID",
+		TaskID:                        1,
+		ScheduleID:                    2,
+		ScheduleToStartTimeoutSeconds: 3,
+		Expiry:                        time.UnixMicro(4),
+		CreatedTime:                   time.UnixMicro(5),
+		PartitionConfig:               partitionConfig,
+	}
+}


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
Add taskIsolationDuration, the time during which tasks will only be routed to pollers belonging to the same isolation group as them*.

Additionally replace the hardcoded constants of 1 minute and 10s for startup flexibilility and recent poller lookback respectively with a single value: TaskIsolationPollerWindow.

For the sake of measuring impact we now include the original partition group within the partition config prior to dispatching the task. This value isn't persisted within the tasks table and is only necessary so that a task that is forwarded after abandoning isolation will emit the correct metric. No behavior depends on this value, it is only used in metrics.

Add integration tests for tasklist isolation, as well as unit tests for getIsolationGroupForTask.

Update the matching simulator to include this new value.

<!-- Tell your future self why have you made these changes -->
**Why?**
-  Adding a failsafe for tasklist isolation to ensure latency doesn't exceed a configurable threshold.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit, integration, and simulation tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- This is a major change to tasklist isolation, but it's guarded behind a feature flag. Within Uber we've broadly disabled this feature and we're unaware of any major usage outside of Uber.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
