### PR TITLE
Fix ListBatchJobs unit-test for Go 1.23+

### DIFF
--- a/tools/cli/utils.go
+++ b/tools/cli/utils.go
@@ -553,11 +553,11 @@ func timestampPtrToStringPtr(unixNanoPtr *int64, onlyTime bool) *string {
 	if unixNanoPtr == nil {
 		return nil
 	}
-	return common.StringPtr(convertTime(*unixNanoPtr, onlyTime))
+	return common.StringPtr(timestampToString(*unixNanoPtr, onlyTime))
 }
 
-func convertTime(unixNano int64, onlyTime bool) string {
-	t := time.Unix(0, unixNano)
+func timestampToString(unixNano int64, onlyTime bool) string {
+	t := time.Unix(0, unixNano).UTC()
 	var result string
 	if onlyTime {
 		result = t.Format(defaultTimeFormat)

--- a/tools/cli/workflow_batch_commands.go
+++ b/tools/cli/workflow_batch_commands.go
@@ -165,14 +165,14 @@ func ListBatchJobs(c *cli.Context) error {
 	for _, wf := range resp.Executions {
 		job := map[string]string{
 			"jobID":     wf.Execution.GetWorkflowID(),
-			"startTime": convertTime(wf.GetStartTime(), false),
+			"startTime": timestampToString(wf.GetStartTime(), false),
 			"reason":    string(wf.Memo.Fields["Reason"]),
 			"operator":  string(wf.SearchAttributes.IndexedFields["Operator"]),
 		}
 
 		if wf.CloseStatus != nil {
 			job["status"] = wf.CloseStatus.String()
-			job["closeTime"] = convertTime(wf.GetCloseTime(), false)
+			job["closeTime"] = timestampToString(wf.GetCloseTime(), false)
 		} else {
 			job["status"] = "RUNNING"
 		}

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -226,7 +226,7 @@ func showHistoryHelper(c *cli.Context, wid, rid string) error {
 			if printRawTime {
 				columns = append(columns, strconv.FormatInt(e.GetTimestamp(), 10))
 			} else if printDateTime {
-				columns = append(columns, convertTime(e.GetTimestamp(), false))
+				columns = append(columns, timestampToString(e.GetTimestamp(), false))
 			}
 			if printVersion {
 				columns = append(columns, fmt.Sprintf("(Version: %v)", e.Version))
@@ -604,9 +604,9 @@ func printWorkflowProgress(c *cli.Context, domain, wid, rid string) error {
 				isTimeElapseExist = false
 			}
 			if showDetails {
-				fmt.Printf("  %d, %s, %s, %s\n", event.ID, convertTime(event.GetTimestamp(), false), ColorEvent(event), HistoryEventToString(event, true, maxFieldLength))
+				fmt.Printf("  %d, %s, %s, %s\n", event.ID, timestampToString(event.GetTimestamp(), false), ColorEvent(event), HistoryEventToString(event, true, maxFieldLength))
 			} else {
-				fmt.Printf("  %d, %s, %s\n", event.ID, convertTime(event.GetTimestamp(), false), ColorEvent(event))
+				fmt.Printf("  %d, %s, %s\n", event.ID, timestampToString(event.GetTimestamp(), false), ColorEvent(event))
 			}
 			lastEvent = event
 		}
@@ -1177,8 +1177,8 @@ func convertDescribeWorkflowExecutionResponse(resp *types.DescribeWorkflowExecut
 	executionInfo := workflowExecutionInfo{
 		Execution:        info.Execution,
 		Type:             info.Type,
-		StartTime:        common.StringPtr(convertTime(info.GetStartTime(), false)),
-		CloseTime:        common.StringPtr(convertTime(info.GetCloseTime(), false)),
+		StartTime:        common.StringPtr(timestampToString(info.GetStartTime(), false)),
+		CloseTime:        common.StringPtr(timestampToString(info.GetCloseTime(), false)),
 		CloseStatus:      info.CloseStatus,
 		HistoryLength:    info.HistoryLength,
 		ParentDomainID:   info.ParentDomainID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed unit-tests running with Go 1.23

<!-- Tell your future self why have you made these changes -->
**Why?**
This happened because our assumption of dates in CLI is always UTC, but we
did't ask for this explicitely.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There is no risk, since the dates conversion is a) cli-only b) we always assume UTC format by this test

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
