### PR TITLE
Complete tasks on stanbdy cluster for workflows that don't exist anymore

### DIFF
--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -26,6 +26,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -37,7 +39,6 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
-	"time"
 )
 
 type (

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -26,8 +26,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -39,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"time"
 )
 
 type (
@@ -117,7 +116,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 			tc.logger.Warn("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))
 
 			// this is a guard to prevent some race condition or quorum issue where the workflow is not found in the database
-			if tc.timeSource.Now().Add(-24 * time.Hour).After(task.Event.CreatedTime) {
+			if tc.timeSource.Since(task.Event.CreatedTime) > 24*time.Hour {
 				task.Finish(nil)
 
 				tc.scope.IncCounter(metrics.StandbyClusterTasksCompletedCounterPerTaskList)

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -26,11 +26,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -48,6 +50,7 @@ type (
 		scope           metrics.Scope
 		logger          log.Logger
 		throttleRetry   *backoff.ThrottleRetry
+		timeSource      clock.TimeSource
 	}
 )
 
@@ -62,11 +65,12 @@ func (e *DomainIsActiveInThisClusterError) Error() string {
 }
 
 var (
-	errWorkflowExecutionInfoIsNil      = errors.New("workflow execution info is nil")
-	errTaskTypeNotSupported            = errors.New("task type not supported")
-	errTaskNotStarted                  = errors.New("task not started")
-	errDomainIsActive                  = &DomainIsActiveInThisClusterError{Message: "domain is active"}
-	historyServiceOperationRetryPolicy = common.CreateTaskCompleterRetryPolicy()
+	errWorkflowExecutionInfoIsNil           = errors.New("workflow execution info is nil")
+	errTaskTypeNotSupported                 = errors.New("task type not supported")
+	errTaskNotStarted                       = errors.New("task not started")
+	errWaitTimeNotReachedForEntityNotExists = errors.New("wait time not reached for workflow EntityNotExistsError")
+	errDomainIsActive                       = &DomainIsActiveInThisClusterError{Message: "domain is active"}
+	historyServiceOperationRetryPolicy      = common.CreateTaskCompleterRetryPolicy()
 )
 
 func newTaskCompleter(tlMgr *taskListManagerImpl, retryPolicy backoff.RetryPolicy) TaskCompleter {
@@ -81,6 +85,7 @@ func newTaskCompleter(tlMgr *taskListManagerImpl, retryPolicy backoff.RetryPolic
 			backoff.WithRetryPolicy(retryPolicy),
 			backoff.WithRetryableError(isRetryableError),
 		),
+		timeSource: tlMgr.timeSource,
 	}
 }
 
@@ -111,11 +116,16 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 		if errors.As(err, new(*types.EntityNotExistsError)) {
 			tc.logger.Warn("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))
 
-			task.Finish(nil)
+			// this is a guard to prevent some race condition or quorum issue where the workflow is not found in the database
+			if tc.timeSource.Now().Add(-24 * time.Hour).After(task.Event.CreatedTime) {
+				task.Finish(nil)
 
-			tc.scope.IncCounter(metrics.StandbyClusterTasksCompletedCounterPerTaskList)
+				tc.scope.IncCounter(metrics.StandbyClusterTasksCompletedCounterPerTaskList)
 
-			return nil
+				return nil
+			}
+
+			return errWaitTimeNotReachedForEntityNotExists
 		} else if err != nil {
 			return fmt.Errorf("unable to fetch workflow execution from the history service: %w", err)
 		}

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -110,6 +110,11 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 
 		if errors.As(err, new(*types.EntityNotExistsError)) {
 			tc.logger.Warn("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))
+
+			task.Finish(nil)
+
+			tc.scope.IncCounter(metrics.StandbyClusterTasksCompletedCounterPerTaskList)
+
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("unable to fetch workflow execution from the history service: %w", err)

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -508,6 +508,12 @@ func (tr *taskReader) dispatchSingleTaskFromBuffer(taskInfo *persistence.TaskInf
 		return false, false
 	}
 
+	if errors.Is(err, errWaitTimeNotReachedForEntityNotExists) {
+		e.EventName = "Dispatch failed on completing task on the passive side because workflow could not be found and not enough time has passed to complete the task. Will retry dispatch"
+		event.Log(e)
+		return false, false
+	}
+
 	e.EventName = "Dispatch failed because of unknown error. Will retry dispatch"
 	e.Payload = map[string]any{
 		"error": err,


### PR DESCRIPTION
**What changed?**
Allow for completion of tasks on standby cluster if the workflow doesn't exist anymore

**Why?**
If the retention period after workflow completion has passed, the workflow will be deleted from the database. If tasks from these workflows were not already completed (because they were already there before the implementation of the feature) they will block completion of future tasks.

**How did you test it?**
Tested locally and will validate again in a staging environment.

**Potential risks**
Before tasks are pushed to the matching, it's checked to see if the workflow execution is present. Because we are checking for a specific error here, I don't think there is risk added.

**Release notes**

**Documentation Changes**
