### PR TITLE
Support adaptive tasklist partitioner in matching simulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ test_eventsV2.log
 test_eventsV2_xdc
 test_eventsV2_xdc.log
 matching-simulator-output/
-simulation_comparison.csv
 
 # Executables produced by cadence repo
 /cadence

--- a/common/stats/stats_benchmark_test.go
+++ b/common/stats/stats_benchmark_test.go
@@ -28,13 +28,14 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/service/matching/event"
 )
 
 // Benchmark the ReportCounter function to see how it handles frequent updates
 func BenchmarkReportCounter(b *testing.B) {
 	timeSource := clock.NewRealTimeSource()
 	// Initialize the QPS reporter with a smoothing factor and a 1 second bucket interval
-	reporter := NewEmaFixedWindowQPSTracker(timeSource, 0.5, time.Second)
+	reporter := NewEmaFixedWindowQPSTracker(timeSource, 0.5, time.Second, event.E{})
 	reporter.Start()
 
 	// Run the benchmark for b.N iterations
@@ -52,7 +53,7 @@ func BenchmarkReportCounter(b *testing.B) {
 func BenchmarkQPS(b *testing.B) {
 	timeSource := clock.NewRealTimeSource()
 	// Initialize the QPS reporter
-	reporter := NewEmaFixedWindowQPSTracker(timeSource, 0.5, time.Second)
+	reporter := NewEmaFixedWindowQPSTracker(timeSource, 0.5, time.Second, event.E{})
 	reporter.Start()
 
 	// Simulate a number of report updates before calling QPS
@@ -75,7 +76,7 @@ func BenchmarkQPS(b *testing.B) {
 func BenchmarkFullReport(b *testing.B) {
 	timeSource := clock.NewRealTimeSource()
 	// Initialize the QPS reporter
-	reporter := NewEmaFixedWindowQPSTracker(timeSource, 0.5, time.Millisecond*100) // 100ms bucket interval
+	reporter := NewEmaFixedWindowQPSTracker(timeSource, 0.5, time.Millisecond*100, event.E{}) // 100ms bucket interval
 	reporter.Start()
 
 	var wg sync.WaitGroup

--- a/common/stats/stats_test.go
+++ b/common/stats/stats_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/service/matching/event"
 )
 
 const floatResolution = 1e-6
@@ -37,7 +38,7 @@ func TestEmaFixedWindowQPSTracker(t *testing.T) {
 	exp := 0.4
 	bucketInterval := time.Second
 
-	r := NewEmaFixedWindowQPSTracker(timeSource, exp, bucketInterval)
+	r := NewEmaFixedWindowQPSTracker(timeSource, exp, bucketInterval, event.E{})
 	r.Start()
 	defer r.Stop()
 

--- a/host/matching_simulation_test.go
+++ b/host/matching_simulation_test.go
@@ -32,7 +32,7 @@ To run locally:
 Full test logs can be found at test.log file. Event json logs can be found at matching-simulator-output folder.
 See the run_matching_simulator.sh script for more details about how to parse events.
 
-If you want to run all the scenarios and compare them refer to tools/matchingsimulationcomparison/README.md
+If you want to run multiple scenarios and compare them refer to tools/matchingsimulationcomparison/README.md
 */
 package host
 
@@ -119,6 +119,12 @@ func TestMatchingSimulationSuite(t *testing.T) {
 		dynamicconfig.AllIsolationGroups:                           isolationGroups,
 		dynamicconfig.TasklistLoadBalancerStrategy:                 getTasklistLoadBalancerStrategy(clusterConfig.MatchingConfig.SimulationConfig.TasklistLoadBalancerStrategy),
 		dynamicconfig.MatchingEnableGetNumberOfPartitionsFromCache: clusterConfig.MatchingConfig.SimulationConfig.GetPartitionConfigFromDB,
+		dynamicconfig.MatchingEnableAdaptiveScaler:                 clusterConfig.MatchingConfig.SimulationConfig.EnableAdaptiveScaler,
+		dynamicconfig.MatchingPartitionDownscaleFactor:             clusterConfig.MatchingConfig.SimulationConfig.PartitionDownscaleFactor,
+		dynamicconfig.MatchingPartitionUpscaleRPS:                  clusterConfig.MatchingConfig.SimulationConfig.PartitionUpscaleRPS,
+		dynamicconfig.MatchingPartitionUpscaleSustainedDuration:    clusterConfig.MatchingConfig.SimulationConfig.PartitionUpscaleSustainedDuration,
+		dynamicconfig.MatchingPartitionDownscaleSustainedDuration:  clusterConfig.MatchingConfig.SimulationConfig.PartitionDownscaleSustainedDuration,
+		dynamicconfig.MatchingAdaptiveScalerUpdateInterval:         clusterConfig.MatchingConfig.SimulationConfig.AdaptiveScalerUpdateInterval,
 	}
 
 	ctrl := gomock.NewController(t)
@@ -190,7 +196,8 @@ func (s *MatchingSimulationSuite) TestMatchingSimulation() {
 	domainID := s.domainID(ctx)
 	tasklist := "my-tasklist"
 
-	if s.testClusterConfig.MatchingConfig.SimulationConfig.GetPartitionConfigFromDB {
+	if s.testClusterConfig.MatchingConfig.SimulationConfig.GetPartitionConfigFromDB &&
+		!s.testClusterConfig.MatchingConfig.SimulationConfig.EnableAdaptiveScaler {
 		_, err := s.testCluster.GetMatchingClient().UpdateTaskListPartitionConfig(ctx, &types.MatchingUpdateTaskListPartitionConfigRequest{
 			DomainUUID:   domainID,
 			TaskList:     &types.TaskList{Name: tasklist, Kind: types.TaskListKindNormal.Ptr()},

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -192,7 +192,17 @@ type (
 
 		Backlogs []SimulationBacklogConfiguration
 
+		// GetPartitionConfigFromDB indicates whether to get the partition config from DB or not.
+		// This is a prerequisite for adaptive scaler.
 		GetPartitionConfigFromDB bool
+
+		// Adaptive scaler configurations
+		EnableAdaptiveScaler                bool
+		PartitionDownscaleFactor            float64
+		PartitionUpscaleRPS                 float64
+		PartitionUpscaleSustainedDuration   time.Duration
+		PartitionDownscaleSustainedDuration time.Duration
+		AdaptiveScalerUpdateInterval        time.Duration
 	}
 
 	SimulationPollerConfiguration struct {

--- a/host/testdata/matching_simulation_burst_adaptive.yaml
+++ b/host/testdata/matching_simulation_burst_adaptive.yaml
@@ -28,8 +28,8 @@ matchingconfig:
     enableadaptivescaler: true
     partitiondownscalefactor: 0.75
     partitionupscalerps: 200
-    partitionupscalesustainedduration: 1m
-    partitiondownscalesustainedduration: 1m
-    adaptivescalerupdateinterval: 2s
+    partitionupscalesustainedduration: 5s
+    partitiondownscalesustainedduration: 5s
+    adaptivescalerupdateinterval: 1s
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_burst_adaptive.yaml
+++ b/host/testdata/matching_simulation_burst_adaptive.yaml
@@ -1,0 +1,35 @@
+enablearchival: false
+clusterno: 1
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+matchingconfig:
+  nummatchinghosts: 4
+  simulationconfig:
+    tasklistwritepartitions: 0 # this doesn't matter. adaptive scaler will start from 1
+    tasklistreadpartitions: 0  # this doesn't matter. adaptive scaler will start from 1
+    forwardermaxoutstandingpolls: 1
+    forwardermaxoutstandingtasks: 1
+    forwardermaxratepersecond: 10
+    forwardermaxchildrenpernode: 20
+    localpollwaittime: 10ms
+    localtaskwaittime: 10ms
+    tasks:
+      - numtaskgenerators: 10
+        taskspersecond: 500
+        maxtasktogenerate: 10000
+    pollers:
+      - taskprocesstime: 1ms
+        numpollers: 8
+        polltimeout: 60s
+    getpartitionconfigfromdb: true
+    enableadaptivescaler: true
+    partitiondownscalefactor: 0.75
+    partitionupscalerps: 200
+    partitionupscalesustainedduration: 1m
+    partitiondownscalesustainedduration: 1m
+    adaptivescalerupdateinterval: 2s
+workerconfig:
+  enableasyncwfconsumer: false

--- a/scripts/run_matching_simulator.sh
+++ b/scripts/run_matching_simulator.sh
@@ -12,7 +12,7 @@ timestamp="${2:-$now}"
 testName="test-$testCase-$timestamp"
 resultFolder="matching-simulator-output"
 mkdir -p "$resultFolder"
-eventLogsFile="$resultFolder/events.json"
+eventLogsFile="$resultFolder/$testName-events.json"
 testSummaryFile="$resultFolder/$testName-summary.txt"
 
 echo "Building test image"

--- a/service/matching/tasklist/adaptive_scaler_test.go
+++ b/service/matching/tasklist/adaptive_scaler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/stats"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/matching/config"
+	"github.com/uber/cadence/service/matching/event"
 )
 
 type mockAdaptiveScalerDeps struct {
@@ -73,7 +74,7 @@ func setupMocksForAdaptiveScaler(t *testing.T, taskListID *Identifier) (*adaptiv
 	}
 
 	cfg := newTaskListConfig(taskListID, config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), "test-host", func() []string { return nil }), "test-domain")
-	scaler := NewAdaptiveScaler(taskListID, mockManager, mockQPSTracker, cfg, mockTimeSource, logger, scope, mockMatchingClient).(*adaptiveScalerImpl)
+	scaler := NewAdaptiveScaler(taskListID, mockManager, mockQPSTracker, cfg, mockTimeSource, logger, scope, mockMatchingClient, event.E{}).(*adaptiveScalerImpl)
 	return scaler, deps
 }
 

--- a/tools/matchingsimulationcomparison/README.md
+++ b/tools/matchingsimulationcomparison/README.md
@@ -6,12 +6,18 @@ Note: The parsing logic might break in the future if the `run_matching_simulator
 
 Run all the scenarios and compare:
 ```
-go run tools/matchingsimulationcomparison/*.go --out simulation_comparison.csv
+go run tools/matchingsimulationcomparison/*.go
 ```
 
-If you have already run some scenarios before and made changes in the output/comparison then run in Compare mode
+Run subset of scenarios and compare:
 ```
-go run tools/matchingsimulationcomparison/*.go --out simulation_comparison.csv \
-    --ts 2024-09-12-18-16-44 \
+go run tools/matchingsimulationcomparison/*.go \
+    --scenarios "burst"
+```
+
+If you have already run some scenarios before and made changes in the csv output then run in Compare mode
+```
+go run tools/matchingsimulationcomparison/*.go \
+    --ts 2024-11-27-21-29-55 \
     --mode Compare
 ```

--- a/tools/matchingsimulationcomparison/main.go
+++ b/tools/matchingsimulationcomparison/main.go
@@ -25,6 +25,7 @@ package main
 import (
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -35,15 +36,20 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/uber/cadence/service/matching/event"
 )
 
 var (
 	scenarioFilter = flag.String("scenarios", ".*", "Regex to filter the tests to execute by name")
-	outputFile     = flag.String("out", "simulation_comparison.csv", "Output file")
 	mode           = flag.String("mode", "RunAndCompare", "Mode to run the tool in. Options: RunAndCompare, Compare. "+
 		"RunAndCompare runs the simulation and compares the results. "+
 		"Compare only compares the results of previously run results. Compare requires --ts flag to be set.")
 	timestamp = flag.String("ts", "", "Timestamp of the simulation run to compare in following format '2006-01-02-15-04-05'. Required when mode is Compare")
+)
+
+const (
+	outputFolder = "matching-simulator-output"
 )
 
 var (
@@ -86,32 +92,37 @@ func main() {
 		}
 	}
 
-	mustGenerateComparisonCSV(root, scenarios, ts, *outputFile)
+	mustGenerateReports(root, scenarios, ts)
 }
 
-func mustGenerateComparisonCSV(root string, scenarios []string, ts, outputFile string) {
+func mustGenerateReports(root string, scenarios []string, ts string) {
 	// outer key is scenario name, inner key is stat name, value is stat value
 	csvData := make(map[string]map[string]string)
 
 	var missingScenarios []string
+	var missingScenariosReasons []string
 	for _, scenario := range scenarios {
-		summaryFile := scenarioSummaryFile(root, scenario, ts)
-		if !scenarioHasRun(summaryFile) {
+		if reason, ok := scenarioHasRun(root, scenario, ts); !ok {
 			missingScenarios = append(missingScenarios, scenario)
+			missingScenariosReasons = append(missingScenariosReasons, reason)
 			continue
 		}
 
+		summaryFile := scenarioSummaryFile(root, scenario, ts)
 		csvData[scenario] = mustParseSummaryFile(summaryFile, scenario)
+
+		mustGenerateGraphs(root, scenario, ts)
 	}
 
 	if len(missingScenarios) == len(scenarios) {
-		log.Fatalf("No simulation results found for any of the scenarios for timestamp: %s", ts)
+		log.Fatalf("No simulation results found for any of the scenarios for timestamp: %s, reasons:\n%s", ts, strings.Join(missingScenariosReasons, "\n"))
 	}
 
 	allStatKeys := mustGetAllStatKeys(csvData)
 	headers := append([]string{"scenario"}, allStatKeys...)
 	var data [][]string
-	writer := mustNewCSVWriter(outputFile)
+	outputFile := csvFilePath(root)
+	writer := mustNewCSVWriter(csvFilePath(root))
 	for scenario, stats := range csvData {
 		row := []string{scenario}
 		for _, key := range allStatKeys {
@@ -132,6 +143,29 @@ func mustGenerateComparisonCSV(root string, scenarios []string, ts, outputFile s
 	}
 
 	fmt.Printf("Comparison CSV generated at: %s\n", outputFile)
+}
+
+func mustGenerateGraphs(root, scenario, ts string) {
+	eventFile := scenarioRawEventsFile(root, scenario, ts)
+	reader, err := os.Open(eventFile)
+	if err != nil {
+		log.Fatalf("Could not open event file %s, err: %v", eventFile, err)
+	}
+	defer reader.Close()
+
+	d := json.NewDecoder(reader)
+	for d.More() {
+		var e event.E
+		if err := d.Decode(&e); err != nil {
+			log.Fatalf("Could not decode event from file %s, err: %v", eventFile, err)
+		}
+
+		// TODO: use echarts to grab stuff from events and generate html
+	}
+}
+
+func csvFilePath(root string) string {
+	return path.Join(root, outputFolder, "comparison.csv")
 }
 
 func mustGetAllStatKeys(csvData map[string]map[string]string) []string {
@@ -210,8 +244,13 @@ func scenarioSummaryFile(root, scenario, ts string) string {
 	return path.Join(root, fmt.Sprintf("matching-simulator-output/test-%s-%s-summary.txt", scenario, ts))
 }
 
+func scenarioRawEventsFile(root, scenario, ts string) string {
+	// e.g. matching-simulator-output/test-default-2024-09-12-18-16-44-events.json
+	return path.Join(root, fmt.Sprintf("matching-simulator-output/test-%s-%s-events.json", scenario, ts))
+}
+
 func mustRunScenario(root, scenario, ts string) {
-	if scenarioHasRun(scenarioSummaryFile(root, scenario, ts)) {
+	if _, ok := scenarioHasRun(root, scenario, ts); ok {
 		fmt.Printf("Scenario %s already ran for timestamp %s, skipping\n", scenario, ts)
 		return
 	}
@@ -225,7 +264,7 @@ func mustRunScenario(root, scenario, ts string) {
 	err := cmd.Run()
 
 	if err != nil {
-		log.Fatalf("Could not run scenario %s, err: %v,\n-----stdout:-----\n%s\n----stderr:----\n%s", scenario, err, stdout.String(), stderr.String())
+		log.Fatalf("Could not run scenario %s, err: %v,\n-----stdout:-----\n%s\n----stderr:----\n%s\nMore details can be found in test.log file.\n", scenario, err, stdout.String(), stderr.String())
 	}
 
 	fmt.Printf("Finished running scenario: %s in %v seconds\n", scenario, time.Since(start).Seconds())
@@ -269,11 +308,6 @@ func mustGetSimulationScenarios(root string) []string {
 func validateAndParseFlags() {
 	flag.Parse()
 
-	if *outputFile == "" {
-		fmt.Println("--output is required")
-		os.Exit(1)
-	}
-
 	if *mode != "RunAndCompare" && *mode != "Compare" {
 		fmt.Println("--mode must be RunAndCompare or Compare")
 		os.Exit(1)
@@ -285,18 +319,31 @@ func validateAndParseFlags() {
 	}
 }
 
-func scenarioHasRun(path string) bool {
-	_, err := os.Stat(path)
+func scenarioHasRun(root, scenario, ts string) (string, bool) {
+	// check if summary file exists and complete
+	summaryFilePath := scenarioSummaryFile(root, scenario, ts)
+	_, err := os.Stat(summaryFilePath)
 	if os.IsNotExist(err) {
-		return false
+		return fmt.Sprintf("summary file %s doesn't exist", summaryFilePath), false
 	}
 
-	content, err := os.ReadFile(path)
+	content, err := os.ReadFile(summaryFilePath)
 	if err != nil {
-		log.Fatalf("Could not read file %s, err: %v", path, err)
+		log.Fatalf("Could not read summary file %s, err: %v", summaryFilePath, err)
 	}
 
-	return strings.Contains(string(content), "End of summary")
+	if !strings.Contains(string(content), "End of summary") {
+		return fmt.Sprintf("summary file %s doesn't contain 'End of summary'", summaryFilePath), false
+	}
+
+	// check if raw events file exists
+	eventFilePath := scenarioRawEventsFile(root, scenario, ts)
+	_, err = os.Stat(eventFilePath)
+	if os.IsNotExist(err) {
+		return fmt.Sprintf("event file %s doesn't exist", eventFilePath), false
+	}
+
+	return "", true
 }
 
 func mustGetRootDir() string {

--- a/tools/matchingsimulationcomparison/main.go
+++ b/tools/matchingsimulationcomparison/main.go
@@ -25,7 +25,6 @@ package main
 import (
 	"bytes"
 	"encoding/csv"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -36,8 +35,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/uber/cadence/service/matching/event"
 )
 
 var (
@@ -110,8 +107,6 @@ func mustGenerateReports(root string, scenarios []string, ts string) {
 
 		summaryFile := scenarioSummaryFile(root, scenario, ts)
 		csvData[scenario] = mustParseSummaryFile(summaryFile, scenario)
-
-		mustGenerateGraphs(root, scenario, ts)
 	}
 
 	if len(missingScenarios) == len(scenarios) {
@@ -143,25 +138,6 @@ func mustGenerateReports(root string, scenarios []string, ts string) {
 	}
 
 	fmt.Printf("Comparison CSV generated at: %s\n", outputFile)
-}
-
-func mustGenerateGraphs(root, scenario, ts string) {
-	eventFile := scenarioRawEventsFile(root, scenario, ts)
-	reader, err := os.Open(eventFile)
-	if err != nil {
-		log.Fatalf("Could not open event file %s, err: %v", eventFile, err)
-	}
-	defer reader.Close()
-
-	d := json.NewDecoder(reader)
-	for d.More() {
-		var e event.E
-		if err := d.Decode(&e); err != nil {
-			log.Fatalf("Could not decode event from file %s, err: %v", eventFile, err)
-		}
-
-		// TODO: use echarts to grab stuff from events and generate html
-	}
 }
 
 func csvFilePath(root string) string {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding support for adaptive tasklist partitioner in matching simulations

<!-- Tell your future self why have you made these changes -->
**Why?**
Test and validate the behavior in local simulations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go run tools/matchingsimulationcomparison/*.go --scenarios "burst"
```

Above command runs following scenarios
- burst (4 read and 4 write partitions)
- burst_adaptive (1 read/write partition with adaptive scaler enabled)

Checked [CSV Output](https://gist.github.com/taylanisikdemir/4c1eafafe3c7ee5efe1d024414751bde). It shows that adaptive partitioner scaled up to 2 partitions and have much better task latencies compared to fixed 4 partitions. 
I will be adding support for visualizing metrics in a follow up PR to help us get more insights on what is happening during simulation.