### PR TITLE
Fix multi-cluster domain register

### DIFF
--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -121,11 +121,7 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) error {
 
 	var clusters []*types.ClusterReplicationConfiguration
 	if c.IsSet(FlagClusters) {
-		clusterStr := c.String(FlagClusters)
-		clusters = append(clusters, &types.ClusterReplicationConfiguration{
-			ClusterName: clusterStr,
-		})
-		for _, clusterStr := range c.Args().Slice() {
+		for _, clusterStr := range c.StringSlice(FlagClusters) {
 			clusters = append(clusters, &types.ClusterReplicationConfiguration{
 				ClusterName: clusterStr,
 			})
@@ -231,11 +227,7 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) error {
 			retentionDays = int32(c.Int(FlagRetentionDays))
 		}
 		if c.IsSet(FlagClusters) {
-			clusterStr := c.String(FlagClusters)
-			clusters = append(clusters, &types.ClusterReplicationConfiguration{
-				ClusterName: clusterStr,
-			})
-			for _, clusterStr := range c.Args().Slice() {
+			for _, clusterStr := range c.StringSlice(FlagClusters) {
 				clusters = append(clusters, &types.ClusterReplicationConfiguration{
 					ClusterName: clusterStr,
 				})

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -59,7 +59,7 @@ func (s *cliAppSuite) TestDomainRegister() {
 		},
 		{
 			"domain with other options",
-			"cadence --do test-domain domain register --global_domain true --retention 5 --desc description --domain_data key1=value1,key2=value2 --active_cluster c1 --clusters c1 c2",
+			"cadence --do test-domain domain register --global_domain true --retention 5 --desc description --active_cluster c1 --clusters c1,c2 --domain_data key1=value1,key2=value2",
 			"",
 			func() {
 				s.serverFrontendClient.EXPECT().RegisterDomain(gomock.Any(), &types.RegisterDomainRequest{
@@ -73,12 +73,28 @@ func (s *cliAppSuite) TestDomainRegister() {
 					},
 					ActiveClusterName: "c1",
 					Clusters: []*types.ClusterReplicationConfiguration{
-						{
-							ClusterName: "c1",
-						},
-						{
-							ClusterName: "c2",
-						},
+						{ClusterName: "c1"}, {ClusterName: "c2"},
+					},
+				}).Return(nil)
+			},
+		},
+		{
+			"domain with other options and clusters mentioned as multiple options",
+			"cadence --do test-domain domain register --global_domain true --retention 5 --desc description --active_cluster c1 --cl c1 --cl c2 --domain_data key1=value1,key2=value2 --cl c3",
+			"",
+			func() {
+				s.serverFrontendClient.EXPECT().RegisterDomain(gomock.Any(), &types.RegisterDomainRequest{
+					Name:                                   "test-domain",
+					WorkflowExecutionRetentionPeriodInDays: 5,
+					IsGlobalDomain:                         true,
+					Description:                            "description",
+					Data: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+					ActiveClusterName: "c1",
+					Clusters: []*types.ClusterReplicationConfiguration{
+						{ClusterName: "c1"}, {ClusterName: "c2"}, {ClusterName: "c3"},
 					},
 				}).Return(nil)
 			},

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -72,11 +72,10 @@ var (
 			Aliases: []string{"ac"},
 			Usage:   "Active cluster name",
 		},
-		&cli.StringFlag{
-			// TODO use StringSliceFlag instead
+		&cli.StringSliceFlag{
 			Name:    FlagClusters,
 			Aliases: []string{"cl"},
-			Usage:   "Clusters",
+			Usage:   FlagClustersUsage,
 		},
 		&cli.StringFlag{
 			Name:    FlagIsGlobalDomain,
@@ -138,11 +137,10 @@ var (
 			Aliases: []string{"ac"},
 			Usage:   "Active cluster name",
 		},
-		&cli.StringFlag{
-			// TODO use StringSliceFlag instead
+		&cli.StringSliceFlag{
 			Name:    FlagClusters,
 			Aliases: []string{"cl"},
-			Usage:   "Clusters",
+			Usage:   FlagClustersUsage,
 		},
 		&cli.GenericFlag{
 			Name:  FlagDomainData,

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -222,6 +222,8 @@ const (
 	FlagSearchAttribute                = "search_attr"
 	FlagNumReadPartitions              = "num_read_partitions"
 	FlagNumWritePartitions             = "num_write_partitions"
+
+	FlagClustersUsage = "Clusters (example: --clusters clusterA,clusterB or --cl clusterA --cl clusterB)"
 )
 
 var flagsForExecution = []cli.Flag{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix multi-cluster domain register/update command in CLI


<!-- Tell your future self why have you made these changes -->
**Why?**
The commands which used cluster names (`domain register/update`) were
broken. Previously with urfave v1 we did a hack - we collected posional
arguments and implicitely took all of them as clusters.
Thus, these crazy invocations worked:
```
$ cadence domain register --clusters clusterA clusterB --other_opt ...
$ cadence domain register --clusters clusterA --other_opt ... clusterB
...
```
urfave v2 requires posional arguments to be at the end (makes sense!),
that's why the above invocations are not working. One could be very
confused with error-message cadence-cli gives in this case.

The solution is to make it explicit:
```
$ cadence domain register --clusters clusterA,clusterB
$ cadence domain register --clusters clusterA --clusters clusterB # a
bit weird IMO, I'd recommend the next example
$ cadence domain register --cl clusterA --cl clusterB
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit tests + added one more unit-test to capture `--cl A --cl B` semantics works

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
I don't think we mention this anywhere in documentation, but I think the
new approach is more obvious and, after all, it works!
In anyway, the command' --help explains it nicely:
"Clusters (example: --clusters clusterA,clusterB or --cl clusterA --cl clusterB)"
