### PR TITLE
Fix shutdown of replication task processor

### DIFF
--- a/service/worker/replicator/replicator.go
+++ b/service/worker/replicator/replicator.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/client"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/domain"
 	"github.com/uber/cadence/common/log"
@@ -92,6 +93,7 @@ func (r *Replicator) Start() error {
 			r.membershipResolver,
 			r.domainReplicationQueue,
 			r.replicationMaxRetry,
+			clock.NewRealTimeSource(),
 		)
 		r.domainProcessors = append(r.domainProcessors, processor)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Integration tests of my unrelated PR [failed](https://buildkite.com/uberopensource/cadence-server/builds/21478#0193b28b-b28c-428c-83fa-202d79e44d3e) due to replication task processor not respecting shut down signal. 
Updated it to use a context that gets canceled when `Stop()` is called. 

Note: I didn't change the place that adds tasks to DLQ. It will still use background context. I am not sure if skipping that during shut down would cause data loss so leaving it for now.

<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid using background context which hangs process during shut down.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added a start/stop test