### PR TITLE
Add metric when history replication message is too large

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1299,8 +1299,6 @@ const (
 	ReplicationTaskCleanupScope
 	// ReplicationDLQStatsScope is scope used by all metrics emitted related to replication DLQ
 	ReplicationDLQStatsScope
-	// ReplicationMessageTooLargeScope is scope used by all metrics emitted related to replication message size
-	ReplicationMessageTooLargeScope
 	// FailoverMarkerScope is scope used by all metrics emitted related to failover marker
 	FailoverMarkerScope
 	// HistoryReplicationV2TaskScope is the scope used by history task replication processing

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1299,6 +1299,8 @@ const (
 	ReplicationTaskCleanupScope
 	// ReplicationDLQStatsScope is scope used by all metrics emitted related to replication DLQ
 	ReplicationDLQStatsScope
+	// ReplicationMessageTooLargeScope is scope used by all metrics emitted related to replication message size
+	ReplicationMessageTooLargeScope
 	// FailoverMarkerScope is scope used by all metrics emitted related to failover marker
 	FailoverMarkerScope
 	// HistoryReplicationV2TaskScope is the scope used by history task replication processing
@@ -2523,6 +2525,7 @@ const (
 	ReplicationDLQProbeFailed
 	ReplicationDLQSize
 	ReplicationDLQValidationFailed
+	ReplicationMessageTooLargePerShard
 	GetReplicationMessagesForShardLatency
 	GetDLQReplicationMessagesLatency
 	EventReapplySkippedCount
@@ -3217,6 +3220,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ReplicationDLQProbeFailed:                                    {metricName: "replication_dlq_probe_failed", metricType: Counter},
 		ReplicationDLQSize:                                           {metricName: "replication_dlq_size", metricType: Gauge},
 		ReplicationDLQValidationFailed:                               {metricName: "replication_dlq_validation_failed", metricType: Counter},
+		ReplicationMessageTooLargePerShard:                           {metricName: "replication_message_too_large_per_shard", metricType: Counter},
 		GetReplicationMessagesForShardLatency:                        {metricName: "get_replication_messages_for_shard", metricType: Timer},
 		GetDLQReplicationMessagesLatency:                             {metricName: "get_dlq_replication_messages", metricType: Timer},
 		EventReapplySkippedCount:                                     {metricName: "event_reapply_skipped_count", metricType: Counter},

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -1601,8 +1601,7 @@ func (h *handlerImpl) GetReplicationMessages(
 
 		size := proto.FromReplicationMessages(tasks).Size()
 		if (responseSize + size) >= maxResponseSize {
-			metricsScope.Tagged(metrics.ShardIDTag(int(shardID)))
-			metricsScope.IncCounter(metrics.ReplicationMessageTooLargePerShard)
+			metricsScope.Tagged(metrics.ShardIDTag(int(shardID))).IncCounter(metrics.ReplicationMessageTooLargePerShard)
 
 			// Log shards that did not fit for debugging purposes
 			h.GetLogger().Warn("Replication messages did not fit in the response (history host)",

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -1601,6 +1601,9 @@ func (h *handlerImpl) GetReplicationMessages(
 
 		size := proto.FromReplicationMessages(tasks).Size()
 		if (responseSize + size) >= maxResponseSize {
+			metricsScope := h.GetMetricsClient().Scope(metrics.ReplicationMessageTooLargeScope, metrics.ShardIDTag(int(shardID)))
+			metricsScope.IncCounter(metrics.ReplicationMessageTooLargePerShard)
+
 			// Log shards that did not fit for debugging purposes
 			h.GetLogger().Warn("Replication messages did not fit in the response (history host)",
 				tag.ShardID(int(shardID)),

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -1555,7 +1555,7 @@ func (h *handlerImpl) GetReplicationMessages(
 
 	h.GetLogger().Debug("Received GetReplicationMessages call.")
 
-	_, sw := h.startRequestProfile(ctx, metrics.HistoryGetReplicationMessagesScope)
+	metricsScope, sw := h.startRequestProfile(ctx, metrics.HistoryGetReplicationMessagesScope)
 	defer sw.Stop()
 
 	if h.isShuttingDown() {
@@ -1601,7 +1601,7 @@ func (h *handlerImpl) GetReplicationMessages(
 
 		size := proto.FromReplicationMessages(tasks).Size()
 		if (responseSize + size) >= maxResponseSize {
-			metricsScope := h.GetMetricsClient().Scope(metrics.ReplicationMessageTooLargeScope, metrics.ShardIDTag(int(shardID)))
+			metricsScope.Tagged(metrics.ShardIDTag(int(shardID)))
 			metricsScope.IncCounter(metrics.ReplicationMessageTooLargePerShard)
 
 			// Log shards that did not fit for debugging purposes


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add metric when history replication message is too large

<!-- Tell your future self why have you made these changes -->
**Why?**
to catch a previous on-call issue

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
