### PR TITLE
Use dual indexer and separate consumers for OpenSearch migration

### DIFF
--- a/common/config/elasticsearch.go
+++ b/common/config/elasticsearch.go
@@ -58,6 +58,8 @@ type (
 		// optional to add custom headers
 		CustomHeaders map[string]string   `yaml:"customHeaders,omitempty"`
 		Migration     VisibilityMigration `yaml:"migration"`
+		// optional to if not using default consumer name
+		ConsumerName string `yaml:"consumerName"`
 	}
 
 	// AWSSigning contains config to enable signing,

--- a/common/config/elasticsearch.go
+++ b/common/config/elasticsearch.go
@@ -58,7 +58,8 @@ type (
 		// optional to add custom headers
 		CustomHeaders map[string]string   `yaml:"customHeaders,omitempty"`
 		Migration     VisibilityMigration `yaml:"migration"`
-		// optional to if not using default consumer name
+		// optional, will use default consumer name if not provided
+		// default consumerName is topic + "-consumer"
 		ConsumerName string `yaml:"consumerName"`
 	}
 

--- a/config/development_es_opensearch_migration.yaml
+++ b/config/development_es_opensearch_migration.yaml
@@ -25,6 +25,7 @@ persistence:
           visibility: cadence-visibility-dev
         migration:
           enabled: true
+        consumerName: "cadence-visibility-dev-os-consumer"
 
 kafka:
   tls:

--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -2,6 +2,8 @@ frontend.enableClientVersionCheck:
   - value: true
 system.advancedVisibilityWritingMode:
   - value: "on"
+system.advancedVisibilityMigrationWritingMode:
+  - value: "source"
 system.enableReadVisibilityFromES:
   - value: true
 frontend.validSearchAttributes:
@@ -43,4 +45,3 @@ system.minRetentionDays:
 history.EnableConsistentQueryByDomain:
 - value: true
   constraints: {}
-

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -1006,6 +1006,7 @@ func (c *cadenceImpl) startWorkerIndexer(params *resource.Params, service Servic
 		c.messagingClient,
 		c.esClient,
 		c.esConfig.Indices[common.VisibilityAppName],
+		c.esConfig.ConsumerName,
 		c.logger,
 		service.GetMetricsClient())
 	if err := c.indexer.Start(); err != nil {

--- a/service/worker/indexer/indexer.go
+++ b/service/worker/indexer/indexer.go
@@ -97,6 +97,7 @@ func NewIndexer(
 	client messaging.Client,
 	visibilityClient es.GenericClient,
 	visibilityName string,
+	consumerName string,
 	logger log.Logger,
 	metricsClient metrics.Client,
 ) *Indexer {
@@ -107,7 +108,11 @@ func NewIndexer(
 		logger.Fatal("Index ES processor state changed", tag.LifeCycleStartFailed, tag.Error(err))
 	}
 
-	consumer, err := client.NewConsumer(common.VisibilityAppName, getConsumerName(visibilityName))
+	if consumerName == "" {
+		consumerName = getConsumerName(visibilityName)
+	}
+
+	consumer, err := client.NewConsumer(common.VisibilityAppName, consumerName)
 	if err != nil {
 		logger.Fatal("Index consumer state changed", tag.LifeCycleStartFailed, tag.Error(err))
 	}

--- a/service/worker/indexer/indexer.go
+++ b/service/worker/indexer/indexer.go
@@ -74,6 +74,11 @@ type (
 		shutdownCh chan struct{}
 	}
 
+	DualIndexer struct {
+		SourceIndexer *Indexer
+		DestIndexer   *Indexer
+	}
+
 	// Config contains all configs for indexer
 	Config struct {
 		IndexerConcurrency             dynamicconfig.IntPropertyFn

--- a/service/worker/indexer/indexer.go
+++ b/service/worker/indexer/indexer.go
@@ -44,8 +44,9 @@ import (
 )
 
 const (
-	versionTypeExternal = "external"
-	processorName       = "visibility-processor"
+	versionTypeExternal    = "external"
+	processorName          = "visibility-processor"
+	migrationProcessorName = "migration-visibility-processor"
 )
 
 var (

--- a/service/worker/indexer/indexer_test.go
+++ b/service/worker/indexer/indexer_test.go
@@ -54,7 +54,7 @@ func TestNewDualIndexer(t *testing.T) {
 		ESProcessorFlushInterval: dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 	}
 	processorName := "test-bulkProcessor"
-	consumerName := "test-consumer"
+	consumerName := "test-bulkProcessor-os-consumer"
 	mockESClient := &esMocks.GenericClient{}
 	mockESClient.On("RunBulkProcessor", mock.Anything, mock.MatchedBy(func(input *bulk.BulkProcessorParameters) bool {
 		return true
@@ -64,7 +64,7 @@ func TestNewDualIndexer(t *testing.T) {
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-consumer").Return(nil, nil).Times(1)
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-os-consumer").Return(nil, nil).Times(1)
 
-	indexer := NewMigrationDualIndexer(config, mockMessagingClient, mockESClient, mockESClient, processorName, processorName, consumerName, consumerName, testlogger.New(t), metrics.NewNoopMetricsClient())
+	indexer := NewMigrationDualIndexer(config, mockMessagingClient, mockESClient, mockESClient, processorName, processorName, "", consumerName, testlogger.New(t), metrics.NewNoopMetricsClient())
 	assert.NotNil(t, indexer)
 }
 
@@ -79,7 +79,6 @@ func TestNewIndexer(t *testing.T) {
 		ESProcessorFlushInterval: dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 	}
 	processorName := "test-bulkProcessor"
-	consumerName := "test-consumer"
 	mockESClient := &esMocks.GenericClient{}
 	mockESClient.On("RunBulkProcessor", mock.Anything, mock.MatchedBy(func(input *bulk.BulkProcessorParameters) bool {
 		return true
@@ -88,7 +87,7 @@ func TestNewIndexer(t *testing.T) {
 	mockMessagingClient := messaging.NewMockClient(ctrl)
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-consumer").Return(nil, nil).Times(1)
 
-	indexer := NewIndexer(config, mockMessagingClient, mockESClient, processorName, consumerName, testlogger.New(t), metrics.NewNoopMetricsClient())
+	indexer := NewIndexer(config, mockMessagingClient, mockESClient, processorName, "", testlogger.New(t), metrics.NewNoopMetricsClient())
 	assert.NotNil(t, indexer)
 }
 

--- a/service/worker/indexer/indexer_test.go
+++ b/service/worker/indexer/indexer_test.go
@@ -61,6 +61,7 @@ func TestNewDualIndexer(t *testing.T) {
 
 	mockMessagingClient := messaging.NewMockClient(ctrl)
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-consumer").Return(nil, nil).Times(1)
+	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-os-consumer").Return(nil, nil).Times(1)
 
 	indexer := NewMigrationDualIndexer(config, mockMessagingClient, mockESClient, mockESClient, processorName, processorName, testlogger.New(t), metrics.NewNoopMetricsClient())
 	assert.NotNil(t, indexer)

--- a/service/worker/indexer/indexer_test.go
+++ b/service/worker/indexer/indexer_test.go
@@ -54,6 +54,7 @@ func TestNewDualIndexer(t *testing.T) {
 		ESProcessorFlushInterval: dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 	}
 	processorName := "test-bulkProcessor"
+	consumerName := "test-consumer"
 	mockESClient := &esMocks.GenericClient{}
 	mockESClient.On("RunBulkProcessor", mock.Anything, mock.MatchedBy(func(input *bulk.BulkProcessorParameters) bool {
 		return true
@@ -63,7 +64,7 @@ func TestNewDualIndexer(t *testing.T) {
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-consumer").Return(nil, nil).Times(1)
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-os-consumer").Return(nil, nil).Times(1)
 
-	indexer := NewMigrationDualIndexer(config, mockMessagingClient, mockESClient, mockESClient, processorName, processorName, testlogger.New(t), metrics.NewNoopMetricsClient())
+	indexer := NewMigrationDualIndexer(config, mockMessagingClient, mockESClient, mockESClient, processorName, processorName, consumerName, consumerName, testlogger.New(t), metrics.NewNoopMetricsClient())
 	assert.NotNil(t, indexer)
 }
 
@@ -78,6 +79,7 @@ func TestNewIndexer(t *testing.T) {
 		ESProcessorFlushInterval: dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 	}
 	processorName := "test-bulkProcessor"
+	consumerName := "test-consumer"
 	mockESClient := &esMocks.GenericClient{}
 	mockESClient.On("RunBulkProcessor", mock.Anything, mock.MatchedBy(func(input *bulk.BulkProcessorParameters) bool {
 		return true
@@ -86,7 +88,7 @@ func TestNewIndexer(t *testing.T) {
 	mockMessagingClient := messaging.NewMockClient(ctrl)
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-consumer").Return(nil, nil).Times(1)
 
-	indexer := NewIndexer(config, mockMessagingClient, mockESClient, processorName, testlogger.New(t), metrics.NewNoopMetricsClient())
+	indexer := NewIndexer(config, mockMessagingClient, mockESClient, processorName, consumerName, testlogger.New(t), metrics.NewNoopMetricsClient())
 	assert.NotNil(t, indexer)
 }
 

--- a/service/worker/indexer/indexer_test.go
+++ b/service/worker/indexer/indexer_test.go
@@ -62,7 +62,7 @@ func TestNewDualIndexer(t *testing.T) {
 	mockMessagingClient := messaging.NewMockClient(ctrl)
 	mockMessagingClient.EXPECT().NewConsumer("visibility", "test-bulkProcessor-consumer").Return(nil, nil).Times(1)
 
-	indexer := NewMigrationIndexer(config, mockMessagingClient, mockESClient, mockESClient, processorName, testlogger.New(t), metrics.NewNoopMetricsClient())
+	indexer := NewMigrationDualIndexer(config, mockMessagingClient, mockESClient, mockESClient, processorName, processorName, testlogger.New(t), metrics.NewNoopMetricsClient())
 	assert.NotNil(t, indexer)
 }
 

--- a/service/worker/indexer/migration_indexer.go
+++ b/service/worker/indexer/migration_indexer.go
@@ -29,36 +29,63 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
-// NewMigrationIndexer create a new Indexer that can index to both ES and OS
-func NewMigrationIndexer(
-	config *Config,
+// NewMigrationDualIndexer create a new Indexer that will be used during visibility migration
+// When migrate from ES to OS, we will have this indexer to index to both ES and OS
+func NewMigrationDualIndexer(config *Config,
 	client messaging.Client,
 	primaryClient es.GenericClient,
 	secondaryClient es.GenericClient,
-	visibilityName string,
+	primaryVisibilityName string,
+	secondaryVisibilityName string,
 	logger log.Logger,
-	metricsClient metrics.Client,
-) *Indexer {
+	metricsClient metrics.Client) *DualIndexer {
+
 	logger = logger.WithTags(tag.ComponentIndexer)
 
-	visibilityProcessor, err := newESDualProcessor(processorName, config, primaryClient, secondaryClient, logger, metricsClient)
+	visibilityProcessor, err := newESProcessor(processorName, config, primaryClient, logger, metricsClient)
 	if err != nil {
 		logger.Fatal("Index ES processor state changed", tag.LifeCycleStartFailed, tag.Error(err))
 	}
 
-	consumer, err := client.NewConsumer(common.VisibilityAppName, getConsumerName(visibilityName))
+	consumer, err := client.NewConsumer(common.VisibilityAppName, getConsumerName(primaryVisibilityName))
 	if err != nil {
 		logger.Fatal("Index consumer state changed", tag.LifeCycleStartFailed, tag.Error(err))
 	}
 
-	return &Indexer{
+	sourceIndexer := &Indexer{
 		config:              config,
-		esIndexName:         visibilityName,
+		esIndexName:         primaryVisibilityName,
 		consumer:            consumer,
 		logger:              logger.WithTags(tag.ComponentIndexerProcessor),
 		scope:               metricsClient.Scope(metrics.IndexProcessorScope),
 		shutdownCh:          make(chan struct{}),
 		visibilityProcessor: visibilityProcessor,
 		msgEncoder:          defaultEncoder,
+	}
+
+	secondaryVisibilityProcessor, err := newESProcessor(processorName, config, secondaryClient, logger, metricsClient)
+	if err != nil {
+		logger.Fatal("Secondary Index ES processor state changed", tag.LifeCycleStartFailed, tag.Error(err))
+	}
+
+	secondaryConsumer, err := client.NewConsumer(common.VisibilityAppName, getConsumerName(secondaryVisibilityName+"-os"))
+	if err != nil {
+		logger.Fatal("Secondary Index consumer state changed", tag.LifeCycleStartFailed, tag.Error(err))
+	}
+
+	destIndexer := &Indexer{
+		config:              config,
+		esIndexName:         secondaryVisibilityName,
+		consumer:            secondaryConsumer,
+		logger:              logger.WithTags(tag.ComponentIndexerProcessor),
+		scope:               metricsClient.Scope(metrics.IndexProcessorScope),
+		shutdownCh:          make(chan struct{}),
+		visibilityProcessor: secondaryVisibilityProcessor,
+		msgEncoder:          defaultEncoder,
+	}
+
+	return &DualIndexer{
+		SourceIndexer: sourceIndexer,
+		DestIndexer:   destIndexer,
 	}
 }

--- a/service/worker/indexer/migration_indexer.go
+++ b/service/worker/indexer/migration_indexer.go
@@ -68,7 +68,7 @@ func NewMigrationDualIndexer(config *Config,
 		msgEncoder:          defaultEncoder,
 	}
 
-	secondaryVisibilityProcessor, err := newESProcessor(processorName, config, secondaryClient, logger, metricsClient)
+	secondaryVisibilityProcessor, err := newESProcessor(migrationProcessorName, config, secondaryClient, logger, metricsClient)
 	if err != nil {
 		logger.Fatal("Migration Index ES processor state changed", tag.LifeCycleStartFailed, tag.Error(err))
 	}
@@ -96,4 +96,23 @@ func NewMigrationDualIndexer(config *Config,
 		SourceIndexer: sourceIndexer,
 		DestIndexer:   destIndexer,
 	}
+}
+
+func (i *DualIndexer) Start() error {
+	if err := i.SourceIndexer.Start(); err != nil {
+		i.SourceIndexer.Stop()
+		return err
+	}
+
+	if err := i.DestIndexer.Start(); err != nil {
+		i.DestIndexer.Stop()
+		return err
+	}
+
+	return nil
+}
+
+func (i *DualIndexer) Stop() {
+	i.SourceIndexer.Stop()
+	i.DestIndexer.Stop()
 }

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -385,6 +385,7 @@ func (s *Service) startIndexer() {
 		s.GetMessagingClient(),
 		s.params.ESClient,
 		s.params.ESConfig.Indices[common.VisibilityAppName],
+		s.params.ESConfig.ConsumerName,
 		s.GetLogger(),
 		s.GetMetricsClient(),
 	)
@@ -402,6 +403,8 @@ func (s *Service) startMigrationDualIndexer() {
 		s.params.OSClient,
 		s.params.ESConfig.Indices[common.VisibilityAppName],
 		s.params.OSConfig.Indices[common.VisibilityAppName],
+		s.params.ESConfig.ConsumerName,
+		s.params.OSConfig.ConsumerName,
 		s.GetLogger(),
 		s.GetMetricsClient(),
 	)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -410,12 +410,12 @@ func (s *Service) startMigrationDualIndexer() {
 	)
 	if err := visibilityDualIndexer.SourceIndexer.Start(); err != nil {
 		visibilityDualIndexer.SourceIndexer.Stop()
-		s.GetLogger().Fatal("fail to start source indexer", tag.Error(err))
+		s.GetLogger().Fatal("fail to start indexer", tag.Error(err))
 	}
 
 	if err := visibilityDualIndexer.DestIndexer.Start(); err != nil {
 		visibilityDualIndexer.DestIndexer.Stop()
-		s.GetLogger().Fatal("fail to start dest indexer", tag.Error(err))
+		s.GetLogger().Fatal("fail to start indexer", tag.Error(err))
 	}
 }
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -408,13 +408,8 @@ func (s *Service) startMigrationDualIndexer() {
 		s.GetLogger(),
 		s.GetMetricsClient(),
 	)
-	if err := visibilityDualIndexer.SourceIndexer.Start(); err != nil {
-		visibilityDualIndexer.SourceIndexer.Stop()
-		s.GetLogger().Fatal("fail to start indexer", tag.Error(err))
-	}
-
-	if err := visibilityDualIndexer.DestIndexer.Start(); err != nil {
-		visibilityDualIndexer.DestIndexer.Stop()
+	if err := visibilityDualIndexer.Start(); err != nil {
+		// not need to call visibilityDualIndexer.Stop() since it has been called inside Start()
 		s.GetLogger().Fatal("fail to start indexer", tag.Error(err))
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added dual indexer which contains 2 indexer to handle write operation to ES/OS 
Each indexer will has its own consumer, so ES and OS can ack/nack kafka messages independently
Remove the migration indexer
Fixed a bug in the retry logic for es processor, which nacks the massges which are already acked.

Will land this after the changes in monorepo

<!-- Tell your future self why have you made these changes -->
**Why?**
OpenSearch migration

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test to verify
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
