### PR TITLE
A hack to fix the nil pointer issue of java client's sync workflow requests

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -5145,7 +5145,7 @@ func FromHistoryEventArray(t []*types.HistoryEvent) []*apiv1.HistoryEvent {
 
 func ToHistoryEventArray(t []*apiv1.HistoryEvent) []*types.HistoryEvent {
 	if t == nil {
-		return nil
+		return []*types.HistoryEvent{}
 	}
 	v := make([]*types.HistoryEvent, len(t))
 	for i := range t {

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -291,7 +291,7 @@ func TestHealthResponse(t *testing.T) {
 	}
 }
 func TestHistory(t *testing.T) {
-	for _, item := range []*types.History{nil, {}, &testdata.History} {
+	for _, item := range []*types.History{nil, &testdata.History} {
 		assert.Equal(t, item, ToHistory(FromHistory(item)))
 	}
 }
@@ -872,7 +872,7 @@ func TestDataBlobArray(t *testing.T) {
 	}
 }
 func TestHistoryEventArray(t *testing.T) {
-	for _, item := range [][]*types.HistoryEvent{nil, {}, testdata.HistoryEventArray} {
+	for _, item := range [][]*types.HistoryEvent{{}, testdata.HistoryEventArray} {
 		assert.Equal(t, item, ToHistoryEventArray(FromHistoryEventArray(item)))
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a hack to protobuf type converter to convert nil array to empty array to fix [a nil pointer issue in java client](https://github.com/cadence-workflow/cadence-java-client/blob/v3.12.4/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java#L305).

It is because in java client, we don't check if history.getEvents() return `nil pointer`. It doesn't return nil pointer if the client is using tchannel, but if the client is using grpc it can be `nil`. So in the long run we should fix the client.

We're migrating a domain between 2 clusters which is using tchannel. But the server internal cross cluster traffic is using grpc, so it can get `nil pointer` when auto-fowarding is involved during migration.


<!-- Tell your future self why have you made these changes -->
**Why?**
To unblock the migration of a domain

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests and verified locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
the risk of this change is low, and we'll revert this change later

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
