### PR TITLE
Fix liveness goroutine leak in TaskListManager

### DIFF
--- a/service/matching/liveness/liveness_test.go
+++ b/service/matching/liveness/liveness_test.go
@@ -58,7 +58,7 @@ func (s *livenessSuite) SetupTest() {
 	s.liveness = NewLiveness(s.timeSource, s.ttl, func() {
 		atomic.CompareAndSwapInt32(&s.shutdownFlag, 0, 1)
 		s.liveness.Stop()
-	 })
+	})
 }
 
 func (s *livenessSuite) TestIsAlive_No() {

--- a/service/matching/liveness/liveness_test.go
+++ b/service/matching/liveness/liveness_test.go
@@ -55,7 +55,10 @@ func (s *livenessSuite) SetupTest() {
 	s.ttl = 500 * time.Millisecond
 	s.timeSource = clock.NewMockedTimeSource()
 	s.shutdownFlag = 0
-	s.liveness = NewLiveness(s.timeSource, s.ttl, func() { atomic.CompareAndSwapInt32(&s.shutdownFlag, 0, 1) })
+	s.liveness = NewLiveness(s.timeSource, s.ttl, func() {
+		atomic.CompareAndSwapInt32(&s.shutdownFlag, 0, 1)
+		s.liveness.Stop()
+	 })
 }
 
 func (s *livenessSuite) TestIsAlive_No() {

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"go.uber.org/goleak"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/uber/cadence/client/history"
@@ -300,6 +301,7 @@ func TestDescribeTaskList(t *testing.T) {
 }
 
 func TestCheckIdleTaskList(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", getIsolationgroupsHelper)
 	cfg.IdleTasklistCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* `Liveness.Stop` should not call shutdownFn because there is not IsLive check. Even adding IsLive check in Stop would be confusing since the function literally means that shut down liveness only. 
* `Liveness.eventLoop` should not call Stop() which caused the deadlock (cyclic wait). 

<!-- Tell your future self why have you made these changes -->
**Why?**

Liveness can cause deadlock which caused a goroutine leak

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit Test with go routine leak detector

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

incorrect matching tasklistmanager lifecycle. We can monitor it in the test environments with canary tests.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
