### PR TITLE
Fix default port for public client

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -302,7 +302,7 @@ kafka:
             dlq-topic: {{ default .Env.VISIBILITY_NAME "cadence-visibility-dev" }}-dlq
 
 publicClient:
-    hostPort: {{ default .Env.FRONTEND_SERVICE "cadence" }}:{{ default .Env.FRONTEND_PORT "7933" }}
+    hostPort: {{ default .Env.FRONTEND_SERVICE "cadence" }}:{{ default .Env.GRPC_FRONTEND_PORT "7833" }}
 
 dynamicconfig:
   client: filebased


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changing public client to use grpc port as the default.

<!-- Tell your future self why have you made these changes -->
**Why?**
The default transport is grpc ([set here](https://github.com/cadence-workflow/cadence/blob/d33ce7445850a293e2e2108b7e0e4ad7cecc9e42/common/config/config.go#L699-L701)) so grpc port should be used.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
After this change Cadence was able to start `cadence-sys-tl-scanner-workflow` workflow.


