### PR TITLE
Fixed usage of RatelimitExternal/InternalPerWorkflowID

### DIFF
--- a/service/history/service.go
+++ b/service/history/service.go
@@ -108,8 +108,8 @@ func (s *Service) Start() {
 		DomainCache:                    s.Resource.GetDomainCache(),
 		Logger:                         s.Resource.GetLogger(),
 		MetricsClient:                  s.Resource.GetMetricsClient(),
-		RatelimitExternalPerWorkflowID: s.config.WorkflowIDCacheExternalEnabled,
-		RatelimitInternalPerWorkflowID: s.config.WorkflowIDCacheInternalEnabled,
+		RatelimitExternalPerWorkflowID: s.config.WorkflowIDExternalRateLimitEnabled,
+		RatelimitInternalPerWorkflowID: s.config.WorkflowIDInternalRateLimitEnabled,
 	})
 
 	rawHandler := handler.NewHandler(s.Resource, s.config, wfIDCache, s.config.WorkflowIDInternalRateLimitEnabled)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set initialization of `workflowcache` to  appropriate properties `WorkflowIDExternalRateLimitEnabled` and `WorkflowIDInternalRateLimitEnabled`


<!-- Tell your future self why have you made these changes -->
**Why?**
`WorkflowIDCacheExternalEnabled` and `WorkflowIDCacheInternalEnabled` are supposed to be removed, however they're used to emit metrics in the workflow rate limiter. It's not correct.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The log field `mode` will contain `enabled` instead of `shadow` for `HistoryClientWfIDCache` metrics
