### PR TITLE
Update caas schema with created_time and last_updated_time

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -342,7 +342,6 @@ CREATE TYPE checksum (
 );
 
 CREATE TABLE executions (
-  created_time                   timestamp,
   shard_id                       int,
   type                           int, -- enum RowType { Shard, Execution, TransferTask, TimerTask, ReplicationTask, CrossClusterTask}
   domain_id                      uuid,
@@ -373,19 +372,21 @@ CREATE TABLE executions (
   version_histories              blob, -- the metadata of history branching
   version_histories_encoding     text,
   checksum                       frozen<checksum>,
+  created_time                   timestamp,
+  last_updated_time              timestamp,
   PRIMARY KEY  (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
   };
 
 CREATE TABLE history_node (
-  created_time      timestamp,
   tree_id           uuid,
   branch_id         uuid,
   node_id           bigint, -- node_id: first eventID in a batch of events
   txn_id            bigint, -- for override the same node_id: bigger txn_id wins
   data                blob, -- Batch of workflow execution history events as a blob
   data_encoding       text, -- Protocol used for history serialization
+  created_time      timestamp,
   PRIMARY KEY ((tree_id), branch_id, node_id, txn_id )
   ) WITH CLUSTERING ORDER BY (branch_id ASC, node_id ASC, txn_id DESC)
     AND COMPACTION = {
@@ -393,12 +394,12 @@ CREATE TABLE history_node (
     };
 
 CREATE TABLE history_tree (
-  created_time      timestamp,
   tree_id           uuid,
   branch_id         uuid,
   ancestors         list<frozen<branch_range>>,
   fork_time         timestamp, -- For fork operation to prevent race condition to leak event data when forking branches
   info              text, -- For background cleanup when fork operation cannot finish self cleanup due to crash
+  created_time      timestamp,
   PRIMARY KEY ((tree_id), branch_id )
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
@@ -414,6 +415,8 @@ CREATE TABLE tasks (
   range_id         bigint, -- Used to ensure that only one process can write to the table
   task             frozen<task>,
   task_list        frozen<task_list>,
+  created_time       timestamp,
+  last_updated_time  timestamp,
   PRIMARY KEY ((domain_id, task_list_name, task_list_type), type, task_id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
@@ -421,17 +424,16 @@ CREATE TABLE tasks (
 
 -- this table is only used for storage of mapping of domain uuid to domain name
 CREATE TABLE domains (
-  created_time       timestamp,
   id     uuid,
   domain frozen<domain>,
   config frozen<domain_config>,
+  created_time       timestamp,
   PRIMARY KEY (id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
   };
 
 CREATE TABLE domains_by_name_v2 (
-  created_time                  timestamp,
   domains_partition             int,
   name                          text,
   domain                        frozen<domain>,
@@ -445,6 +447,7 @@ CREATE TABLE domains_by_name_v2 (
   failover_end_time             bigint, -- indicating domain failover state
   last_updated_time             bigint, -- indicating the domain last update timestamp
   notification_version          bigint,
+  created_time                  timestamp,
   PRIMARY KEY (domains_partition, name)
 )  WITH COMPACTION = {
      'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
@@ -491,21 +494,21 @@ INSERT INTO domains (
 ) IF NOT EXISTS;
 
 CREATE TABLE queue (
-  created_time    timestamp,
   queue_type      int,
   message_id      bigint,
   message_payload blob,
+  created_time    timestamp,
   PRIMARY KEY  (queue_type, message_id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
   };
 
 CREATE TABLE queue_metadata (
-  created_time      timestamp,
-  last_updated_time timestamp,
   queue_type        int,
   cluster_ack_level map<text, bigint>,
   version           bigint,
+  created_time      timestamp,
+  last_updated_time timestamp,
 PRIMARY KEY (queue_type)
 )  WITH COMPACTION = {
      'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -342,6 +342,7 @@ CREATE TYPE checksum (
 );
 
 CREATE TABLE executions (
+  created_time                   timestamp,
   shard_id                       int,
   type                           int, -- enum RowType { Shard, Execution, TransferTask, TimerTask, ReplicationTask, CrossClusterTask}
   domain_id                      uuid,
@@ -378,6 +379,7 @@ CREATE TABLE executions (
   };
 
 CREATE TABLE history_node (
+  created_time      timestamp,
   tree_id           uuid,
   branch_id         uuid,
   node_id           bigint, -- node_id: first eventID in a batch of events
@@ -391,6 +393,7 @@ CREATE TABLE history_node (
     };
 
 CREATE TABLE history_tree (
+  created_time      timestamp,
   tree_id           uuid,
   branch_id         uuid,
   ancestors         list<frozen<branch_range>>,
@@ -418,6 +421,7 @@ CREATE TABLE tasks (
 
 -- this table is only used for storage of mapping of domain uuid to domain name
 CREATE TABLE domains (
+  created_time       timestamp,
   id     uuid,
   domain frozen<domain>,
   config frozen<domain_config>,
@@ -427,6 +431,7 @@ CREATE TABLE domains (
   };
 
 CREATE TABLE domains_by_name_v2 (
+  created_time                  timestamp,
   domains_partition             int,
   name                          text,
   domain                        frozen<domain>,
@@ -486,6 +491,7 @@ INSERT INTO domains (
 ) IF NOT EXISTS;
 
 CREATE TABLE queue (
+  created_time    timestamp,
   queue_type      int,
   message_id      bigint,
   message_payload blob,
@@ -495,6 +501,8 @@ CREATE TABLE queue (
   };
 
 CREATE TABLE queue_metadata (
+  created_time      timestamp,
+  last_updated_time timestamp,
   queue_type        int,
   cluster_ack_level map<text, bigint>,
   version           bigint,

--- a/schema/cassandra/cadence/versioned/v0.39/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.39/manifest.json
@@ -3,6 +3,6 @@
   "MinCompatibleVersion": "0.39",
   "Description": "Adding create time and last update time for history tables",
   "SchemaUpdateCqlFiles": [
-    "task_list_partition_config.cql"
+    "timestamps.cql"
   ]
 }

--- a/schema/cassandra/cadence/versioned/v0.39/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.39/manifest.json
@@ -1,7 +1,7 @@
 {
   "CurrVersion": "0.39",
   "MinCompatibleVersion": "0.39",
-  "Description": "Adding create time and last update time for history tables",
+  "Description": "Adding create time and last update time for Cassandra tables",
   "SchemaUpdateCqlFiles": [
     "timestamps.cql"
   ]

--- a/schema/cassandra/cadence/versioned/v0.39/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.39/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.39",
+  "MinCompatibleVersion": "0.39",
+  "Description": "Adding create time and last update time for history tables",
+  "SchemaUpdateCqlFiles": [
+    "task_list_partition_config.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.39/task_list_partition_config.cql
+++ b/schema/cassandra/cadence/versioned/v0.39/task_list_partition_config.cql
@@ -1,0 +1,7 @@
+CREATE TYPE task_list_partition_config (
+  version              bigint,
+  num_read_partitions  int,
+  num_write_partitions int
+);
+
+ALTER TYPE task_list ADD adaptive_partition_config frozen<task_list_partition_config>;

--- a/schema/cassandra/cadence/versioned/v0.39/task_list_partition_config.cql
+++ b/schema/cassandra/cadence/versioned/v0.39/task_list_partition_config.cql
@@ -1,7 +1,0 @@
-CREATE TYPE task_list_partition_config (
-  version              bigint,
-  num_read_partitions  int,
-  num_write_partitions int
-);
-
-ALTER TYPE task_list ADD adaptive_partition_config frozen<task_list_partition_config>;

--- a/schema/cassandra/cadence/versioned/v0.39/timestamps.cql
+++ b/schema/cassandra/cadence/versioned/v0.39/timestamps.cql
@@ -1,8 +1,8 @@
-ALTER TYPE executions ADD created_time timestamp;
-ALTER TYPE history_node ADD created_time timestamp;
-ALTER TYPE history_tree ADD created_time timestamp;
-ALTER TYPE domains ADD created_time timestamp;
-ALTER TYPE domains_by_name_v2 ADD created_time timestamp;
-ALTER TYPE queue ADD created_time timestamp;
-ALTER TYPE queue_metadata ADD created_time timestamp;
-ALTER TYPE queue_metadata ADD last_updated_time timestamp;
+ALTER TABLE executions ADD created_time timestamp;
+ALTER TABLE history_node ADD created_time timestamp;
+ALTER TABLE history_tree ADD created_time timestamp;
+ALTER TABLE domains ADD created_time timestamp;
+ALTER TABLE domains_by_name_v2 ADD created_time timestamp;
+ALTER TABLE queue ADD created_time timestamp;
+ALTER TABLE queue_metadata ADD created_time timestamp;
+ALTER TABLE queue_metadata ADD last_updated_time timestamp;

--- a/schema/cassandra/cadence/versioned/v0.39/timestamps.cql
+++ b/schema/cassandra/cadence/versioned/v0.39/timestamps.cql
@@ -1,0 +1,8 @@
+ALTER TYPE executions ADD created_time timestamp;
+ALTER TYPE history_node ADD created_time timestamp;
+ALTER TYPE history_tree ADD created_time timestamp;
+ALTER TYPE domains ADD created_time timestamp;
+ALTER TYPE domains_by_name_v2 ADD created_time timestamp;
+ALTER TYPE queue ADD created_time timestamp;
+ALTER TYPE queue_metadata ADD created_time timestamp;
+ALTER TYPE queue_metadata ADD last_updated_time timestamp;

--- a/schema/cassandra/cadence/versioned/v0.39/timestamps.cql
+++ b/schema/cassandra/cadence/versioned/v0.39/timestamps.cql
@@ -1,6 +1,9 @@
 ALTER TABLE executions ADD created_time timestamp;
+ALTER TABLE executions ADD last_updated_time timestamp;
 ALTER TABLE history_node ADD created_time timestamp;
 ALTER TABLE history_tree ADD created_time timestamp;
+ALTER TABLE tasks ADD created_time timestamp;
+ALTER TABLE tasks ADD last_updated_time timestamp;
 ALTER TABLE domains ADD created_time timestamp;
 ALTER TABLE domains_by_name_v2 ADD created_time timestamp;
 ALTER TABLE queue ADD created_time timestamp;

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -23,7 +23,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.38"
+const Version = "0.39"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.9"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -114,7 +114,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
**Detailed Description**
Updated caas schema with created_time and last_updated_time. It was hard to determine the time at when a record was written for most tables in Cassandra because we don't add a timestamp when we write them.

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-d825e502-7fff-d2c2-c1b1-b427cf050f05"><div dir="ltr" style="margin-left:0pt;" align="left">
Table_Name | Is_immutable? | has created_time | has last_updated_time
-- | -- | -- | --
executions | no | Added in PR | Added in PR
history_node | Yes | Added in PR | no need
history_tree | Yes | Added in PR | no need
tasks | no | Yes (In type Task) | Added in PR
domains | no | Added in PR | no
domains_by_name_v2 | no | Added in PR | Yes (But it is type bigint)
queue | Might be | Added in PR | Might not need
queue_metadata | no | Added in PR | Added in PR
cluster_config | no | no | Has timestamp

</div></b>

Concerns: (All of those addressed offline with @davidporter-id-au )

- Domains table doesn’t have UPDATE operations in our code. Do we need last_update_time? Even if we add this col, it won’t be updated anyways. 
- Cluster_config table has a col called `timestamp`. And it only has INSERT operation called by a update_cluster_config function. I assume it uses insert as both create and update: this means created_time can’t be added. 
- Do we need to change the last_updated_time in domains_by_name_v2 to be timestamp instead of bigint?

**Impact Analysis**
- **Backward Compatibility**: 
  - Existing rows remain unchanged, as they do not automatically contain the new column's data.
  - Queries using old schema (not referencing the new column) continue to work without any issues.
  - Code using the old schema are unaffected since the new column is effectively ignored.
- **Forward Compatibility**: [Analysis of forward compatibility]
  - This change is for future auditing usage. We can't query old rows with newly added cols, but newly added data (row) can have this col for us to audit. 

**Testing Plan**
Ran manual test in docker:
First check schemas, then make install schema, then check the schemas again. 
There are no functional change in this PR, but those tests below will be running in the pipeline

- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan?
  - Can safely go to prod
- Does the order of deployment matter?
  - no
- Is it safe to rollback? Does the order of rollback matter?
  - it is safe.
- Is there a kill switch to mitigate the impact immediately?
  - roll back to v0.38

