### PR TITLE
Create naive isolation group matching loadbalancer

### DIFF
--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -60,10 +60,8 @@ func (c *clientImpl) AddActivityTask(
 	opts ...yarpc.CallOption,
 ) (*types.AddActivityTaskResponse, error) {
 	partition := c.loadBalancer.PickWritePartition(
-		request.GetDomainUUID(),
-		*request.GetTaskList(),
 		persistence.TaskListTypeActivity,
-		request.GetForwardedFrom(),
+		request,
 	)
 	originalTaskListName := request.TaskList.GetName()
 	request.TaskList.Name = partition
@@ -91,10 +89,8 @@ func (c *clientImpl) AddDecisionTask(
 	opts ...yarpc.CallOption,
 ) (*types.AddDecisionTaskResponse, error) {
 	partition := c.loadBalancer.PickWritePartition(
-		request.GetDomainUUID(),
-		*request.GetTaskList(),
 		persistence.TaskListTypeDecision,
-		request.GetForwardedFrom(),
+		request,
 	)
 	originalTaskListName := request.TaskList.GetName()
 	request.TaskList.Name = partition
@@ -122,10 +118,9 @@ func (c *clientImpl) PollForActivityTask(
 	opts ...yarpc.CallOption,
 ) (*types.MatchingPollForActivityTaskResponse, error) {
 	partition := c.loadBalancer.PickReadPartition(
-		request.GetDomainUUID(),
-		*request.PollRequest.GetTaskList(),
 		persistence.TaskListTypeActivity,
-		request.GetForwardedFrom(),
+		request,
+		request.GetIsolationGroup(),
 	)
 	originalTaskListName := request.PollRequest.GetTaskList().GetName()
 	request.PollRequest.TaskList.Name = partition
@@ -145,10 +140,8 @@ func (c *clientImpl) PollForActivityTask(
 		resp.PartitionConfig,
 	)
 	c.loadBalancer.UpdateWeight(
-		request.GetDomainUUID(),
-		*request.PollRequest.GetTaskList(),
 		persistence.TaskListTypeActivity,
-		request.GetForwardedFrom(),
+		request,
 		partition,
 		resp.LoadBalancerHints,
 	)
@@ -163,10 +156,9 @@ func (c *clientImpl) PollForDecisionTask(
 	opts ...yarpc.CallOption,
 ) (*types.MatchingPollForDecisionTaskResponse, error) {
 	partition := c.loadBalancer.PickReadPartition(
-		request.GetDomainUUID(),
-		*request.PollRequest.GetTaskList(),
 		persistence.TaskListTypeDecision,
-		request.GetForwardedFrom(),
+		request,
+		request.GetIsolationGroup(),
 	)
 	originalTaskListName := request.PollRequest.GetTaskList().GetName()
 	request.PollRequest.TaskList.Name = partition
@@ -186,10 +178,8 @@ func (c *clientImpl) PollForDecisionTask(
 		resp.PartitionConfig,
 	)
 	c.loadBalancer.UpdateWeight(
-		request.GetDomainUUID(),
-		*request.PollRequest.GetTaskList(),
 		persistence.TaskListTypeDecision,
-		request.GetForwardedFrom(),
+		request,
 		partition,
 		resp.LoadBalancerHints,
 	)
@@ -204,10 +194,9 @@ func (c *clientImpl) QueryWorkflow(
 	opts ...yarpc.CallOption,
 ) (*types.QueryWorkflowResponse, error) {
 	partition := c.loadBalancer.PickReadPartition(
-		request.GetDomainUUID(),
-		*request.GetTaskList(),
 		persistence.TaskListTypeDecision,
-		request.GetForwardedFrom(),
+		request,
+		"",
 	)
 	request.TaskList.Name = partition
 	peer, err := c.peerResolver.FromTaskList(request.TaskList.GetName())

--- a/client/matching/client_test.go
+++ b/client/matching/client_test.go
@@ -160,7 +160,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.AddActivityTask(context.Background(), testAddActivityTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickWritePartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, "").Return(_testPartition)
+				balancer.EXPECT().PickWritePartition(persistence.TaskListTypeActivity, testAddActivityTaskRequest()).Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().AddActivityTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(&types.AddActivityTaskResponse{}, nil)
 				mp.EXPECT().UpdatePartitionConfig(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, nil)
@@ -173,7 +173,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.AddActivityTask(context.Background(), testAddActivityTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickWritePartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, "").Return(_testPartition)
+				balancer.EXPECT().PickWritePartition(persistence.TaskListTypeActivity, testAddActivityTaskRequest()).Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", assert.AnError)
 			},
 			wantError: true,
@@ -184,7 +184,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.AddActivityTask(context.Background(), testAddActivityTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickWritePartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, "").Return(_testPartition)
+				balancer.EXPECT().PickWritePartition(persistence.TaskListTypeActivity, testAddActivityTaskRequest()).Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().AddActivityTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(nil, assert.AnError)
 			},
@@ -196,7 +196,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.AddDecisionTask(context.Background(), testAddDecisionTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickWritePartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickWritePartition(persistence.TaskListTypeDecision, testAddDecisionTaskRequest()).Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().AddDecisionTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(&types.AddDecisionTaskResponse{}, nil)
 				mp.EXPECT().UpdatePartitionConfig(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, nil)
@@ -209,7 +209,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.AddDecisionTask(context.Background(), testAddDecisionTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickWritePartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickWritePartition(persistence.TaskListTypeDecision, testAddDecisionTaskRequest()).Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", assert.AnError)
 			},
 			wantError: true,
@@ -220,7 +220,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.AddDecisionTask(context.Background(), testAddDecisionTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickWritePartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickWritePartition(persistence.TaskListTypeDecision, testAddDecisionTaskRequest()).Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().AddDecisionTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(nil, assert.AnError)
 			},
@@ -232,11 +232,11 @@ func TestClient_withResponse(t *testing.T) {
 				return c.PollForActivityTask(context.Background(), testMatchingPollForActivityTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeActivity, testMatchingPollForActivityTaskRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(&types.MatchingPollForActivityTaskResponse{}, nil)
 				mp.EXPECT().UpdatePartitionConfig(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, nil)
-				balancer.EXPECT().UpdateWeight(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, "", _testPartition, nil)
+				balancer.EXPECT().UpdateWeight(persistence.TaskListTypeActivity, testMatchingPollForActivityTaskRequest(), _testPartition, nil)
 			},
 			want: &types.MatchingPollForActivityTaskResponse{},
 		},
@@ -246,7 +246,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.PollForActivityTask(context.Background(), testMatchingPollForActivityTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeActivity, testMatchingPollForActivityTaskRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", assert.AnError)
 			},
 			want:      nil,
@@ -258,7 +258,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.PollForActivityTask(context.Background(), testMatchingPollForActivityTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeActivity, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeActivity, testMatchingPollForActivityTaskRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(nil, assert.AnError)
 			},
@@ -271,11 +271,11 @@ func TestClient_withResponse(t *testing.T) {
 				return c.PollForDecisionTask(context.Background(), testMatchingPollForDecisionTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeDecision, testMatchingPollForDecisionTaskRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(&types.MatchingPollForDecisionTaskResponse{}, nil)
 				mp.EXPECT().UpdatePartitionConfig(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, nil)
-				balancer.EXPECT().UpdateWeight(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "", _testPartition, nil)
+				balancer.EXPECT().UpdateWeight(persistence.TaskListTypeDecision, testMatchingPollForDecisionTaskRequest(), _testPartition, nil)
 			},
 			want: &types.MatchingPollForDecisionTaskResponse{},
 		},
@@ -285,7 +285,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.PollForDecisionTask(context.Background(), testMatchingPollForDecisionTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeDecision, testMatchingPollForDecisionTaskRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", assert.AnError)
 			},
 			want:      nil,
@@ -297,7 +297,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.PollForDecisionTask(context.Background(), testMatchingPollForDecisionTaskRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeDecision, testMatchingPollForDecisionTaskRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(nil, assert.AnError)
 			},
@@ -310,7 +310,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.QueryWorkflow(context.Background(), testMatchingQueryWorkflowRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeDecision, testMatchingQueryWorkflowRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(&types.QueryWorkflowResponse{}, nil)
 			},
@@ -322,7 +322,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.QueryWorkflow(context.Background(), testMatchingQueryWorkflowRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeDecision, testMatchingQueryWorkflowRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", assert.AnError)
 			},
 			want:      nil,
@@ -334,7 +334,7 @@ func TestClient_withResponse(t *testing.T) {
 				return c.QueryWorkflow(context.Background(), testMatchingQueryWorkflowRequest())
 			},
 			mock: func(p *MockPeerResolver, balancer *MockLoadBalancer, c *MockClient, mp *MockPartitionConfigProvider) {
-				balancer.EXPECT().PickReadPartition(_testDomainUUID, types.TaskList{Name: _testTaskList}, persistence.TaskListTypeDecision, "").Return(_testPartition)
+				balancer.EXPECT().PickReadPartition(persistence.TaskListTypeDecision, testMatchingQueryWorkflowRequest(), "").Return(_testPartition)
 				p.EXPECT().FromTaskList(_testPartition).Return("peer0", nil)
 				c.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any(), []yarpc.CallOption{yarpc.WithShardKey("peer0")}).Return(nil, assert.AnError)
 			},

--- a/client/matching/isolation_loadbalancer.go
+++ b/client/matching/isolation_loadbalancer.go
@@ -1,0 +1,147 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package matching
+
+import (
+	"math/rand"
+	"slices"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/uber/cadence/common/partition"
+	"github.com/uber/cadence/common/types"
+)
+
+type isolationLoadBalancer struct {
+	provider           PartitionConfigProvider
+	fallback           LoadBalancer
+	allIsolationGroups func() []string
+}
+
+func NewIsolationLoadBalancer(fallback LoadBalancer, provider PartitionConfigProvider, allIsolationGroups func() []string) LoadBalancer {
+	return &isolationLoadBalancer{
+		provider:           provider,
+		fallback:           fallback,
+		allIsolationGroups: allIsolationGroups,
+	}
+}
+
+func (i *isolationLoadBalancer) PickWritePartition(taskListType int, req WriteRequest) string {
+	taskList := *req.GetTaskList()
+	nPartitions := i.provider.GetNumberOfWritePartitions(req.GetDomainUUID(), taskList, taskListType)
+	taskListName := req.GetTaskList().Name
+
+	if nPartitions <= 1 {
+		return taskListName
+	}
+
+	taskGroup, ok := req.GetPartitionConfig()[partition.IsolationGroupKey]
+	if !ok {
+		return i.fallback.PickWritePartition(taskListType, req)
+	}
+
+	partitions, ok := i.getPartitionsForGroup(taskGroup, nPartitions)
+	if !ok {
+		return i.fallback.PickWritePartition(taskListType, req)
+	}
+
+	p := i.pickBetween(partitions)
+
+	return getPartitionTaskListName(taskList.GetName(), p)
+}
+
+func (i *isolationLoadBalancer) PickReadPartition(taskListType int, req ReadRequest, isolationGroup string) string {
+	taskList := *req.GetTaskList()
+	nRead := i.provider.GetNumberOfReadPartitions(req.GetDomainUUID(), taskList, taskListType)
+	taskListName := taskList.Name
+
+	if nRead <= 1 {
+		return taskListName
+	}
+
+	partitions, ok := i.getPartitionsForGroup(isolationGroup, nRead)
+	if !ok {
+		return i.fallback.PickReadPartition(taskListType, req, isolationGroup)
+	}
+
+	// Scaling down, we need to consider both sets of partitions
+	if numWrite := i.provider.GetNumberOfWritePartitions(req.GetDomainUUID(), taskList, taskListType); numWrite != nRead {
+		writePartitions, ok := i.getPartitionsForGroup(isolationGroup, numWrite)
+		if ok {
+			for p := range writePartitions {
+				partitions[p] = struct{}{}
+			}
+		}
+	}
+
+	p := i.pickBetween(partitions)
+
+	return getPartitionTaskListName(taskList.GetName(), p)
+}
+
+func (i *isolationLoadBalancer) UpdateWeight(taskListType int, req ReadRequest, partition string, info *types.LoadBalancerHints) {
+}
+
+func (i *isolationLoadBalancer) getPartitionsForGroup(taskGroup string, partitionCount int) (map[int]any, bool) {
+	if taskGroup == "" {
+		return nil, false
+	}
+	isolationGroups := slices.Clone(i.allIsolationGroups())
+	slices.Sort(isolationGroups)
+	index := slices.Index(isolationGroups, taskGroup)
+	if index == -1 {
+		return nil, false
+	}
+	partitions := make(map[int]any, 1)
+	// 3 groups [a, b, c] and 4 partitions gives us a mapping like this:
+	// 0, 3: a
+	// 1: b
+	// 2: c
+	// 4 groups [a, b, c, d] and 10 partitions gives us a mapping like this:
+	// 0, 4, 8: a
+	// 1, 5, 9: b
+	// 2, 6: c
+	// 3, 7: d
+	if len(isolationGroups) <= partitionCount {
+		for j := index; j < partitionCount; j += len(isolationGroups) {
+			partitions[j] = struct{}{}
+		}
+		// 4 groups [a,b,c,d] and 3 partitions gives us a mapping like this:
+		// 0: a, d
+		// 1: b
+		// 2: c
+	} else {
+		partitions[index%partitionCount] = struct{}{}
+	}
+	if len(partitions) == 0 {
+		return nil, false
+	}
+	return partitions, true
+}
+
+func (i *isolationLoadBalancer) pickBetween(partitions map[int]any) int {
+	// Could alternatively use backlog weights to make a smarter choice
+	total := len(partitions)
+	picked := rand.Intn(total)
+	return maps.Keys(partitions)[picked]
+}

--- a/client/matching/isolation_loadbalancer_test.go
+++ b/client/matching/isolation_loadbalancer_test.go
@@ -1,0 +1,283 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package matching
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/partition"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestIsolationPickWritePartition(t *testing.T) {
+	tl := "tl"
+	cases := []struct {
+		name            string
+		group           string
+		isolationGroups []string
+		numWrite        int
+		shouldFallback  bool
+		allowed         []string
+	}{
+		{
+			name:            "single partition",
+			group:           "a",
+			numWrite:        1,
+			isolationGroups: []string{"a"},
+			allowed:         []string{tl},
+		},
+		{
+			name:            "multiple partitions - single option",
+			group:           "b",
+			numWrite:        2,
+			isolationGroups: []string{"a", "b"},
+			allowed:         []string{getPartitionTaskListName(tl, 1)},
+		},
+		{
+			name:            "multiple partitions - multiple options",
+			group:           "a",
+			numWrite:        2,
+			isolationGroups: []string{"a"},
+			allowed:         []string{tl, getPartitionTaskListName(tl, 1)},
+		},
+		{
+			name:            "fallback - no group",
+			numWrite:        2,
+			isolationGroups: []string{"a"},
+			shouldFallback:  true,
+			allowed:         []string{"fallback"},
+		},
+		{
+			name:            "fallback - no groups",
+			group:           "a",
+			numWrite:        2,
+			isolationGroups: []string{""},
+			shouldFallback:  true,
+			allowed:         []string{"fallback"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lb, fallback := createWithMocks(t, tc.isolationGroups, tc.numWrite, tc.numWrite)
+			req := &types.AddDecisionTaskRequest{
+				DomainUUID: "domainId",
+				TaskList: &types.TaskList{
+					Name: tl,
+					Kind: types.TaskListKindSticky.Ptr(),
+				},
+			}
+			if tc.group != "" {
+				req.PartitionConfig = map[string]string{
+					partition.IsolationGroupKey: tc.group,
+				}
+			}
+			if tc.shouldFallback {
+				fallback.EXPECT().PickWritePartition(int(types.TaskListTypeDecision), req).Return("fallback").Times(1)
+			}
+			p := lb.PickWritePartition(0, req)
+			assert.Contains(t, tc.allowed, p)
+		})
+	}
+}
+
+func TestIsolationPickReadPartition(t *testing.T) {
+	tl := "tl"
+	cases := []struct {
+		name            string
+		group           string
+		isolationGroups []string
+		numRead         int
+		numWrite        int
+		shouldFallback  bool
+		allowed         []string
+	}{
+		{
+			name:            "single partition",
+			group:           "a",
+			numRead:         1,
+			numWrite:        1,
+			isolationGroups: []string{"a"},
+			allowed:         []string{tl},
+		},
+		{
+			name:            "multiple partitions - single option",
+			group:           "b",
+			numRead:         2,
+			numWrite:        2,
+			isolationGroups: []string{"a", "b"},
+			allowed:         []string{getPartitionTaskListName(tl, 1)},
+		},
+		{
+			name:            "multiple partitions - multiple options",
+			group:           "a",
+			numRead:         2,
+			numWrite:        2,
+			isolationGroups: []string{"a"},
+			allowed:         []string{tl, getPartitionTaskListName(tl, 1)},
+		},
+		{
+			name:            "scaling - multiple options",
+			group:           "d",
+			numRead:         4,
+			numWrite:        3,
+			isolationGroups: []string{"a", "b", "c", "d"},
+			// numRead = 4 means tasks for d could be in the last partition (idx=3)
+			// numWrite = 3 means new tasks  for d are being written to the root (idx=0)
+			allowed: []string{tl, getPartitionTaskListName(tl, 3)},
+		},
+		{
+			name:            "fallback - no group",
+			numRead:         2,
+			numWrite:        2,
+			isolationGroups: []string{"a"},
+			shouldFallback:  true,
+			allowed:         []string{"fallback"},
+		},
+		{
+			name:            "fallback - no groups",
+			group:           "a",
+			numRead:         2,
+			numWrite:        2,
+			isolationGroups: []string{""},
+			shouldFallback:  true,
+			allowed:         []string{"fallback"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lb, fallback := createWithMocks(t, tc.isolationGroups, tc.numWrite, tc.numRead)
+			req := &types.MatchingQueryWorkflowRequest{
+				DomainUUID: "domainId",
+				TaskList: &types.TaskList{
+					Name: tl,
+					Kind: types.TaskListKindSticky.Ptr(),
+				},
+			}
+			if tc.shouldFallback {
+				fallback.EXPECT().PickReadPartition(int(types.TaskListTypeDecision), req, tc.group).Return("fallback").Times(1)
+			}
+			p := lb.PickReadPartition(0, req, tc.group)
+			assert.Contains(t, tc.allowed, p)
+		})
+	}
+}
+
+func TestIsolationGetPartitionsForGroup(t *testing.T) {
+	cases := []struct {
+		name            string
+		group           string
+		isolationGroups []string
+		partitions      int
+		expected        []int
+	}{
+		{
+			name:            "single partition",
+			group:           "a",
+			isolationGroups: []string{"a", "b", "c"},
+			partitions:      1,
+			expected:        []int{0},
+		},
+		{
+			name:            "partitions less than groups",
+			group:           "b",
+			isolationGroups: []string{"a", "b", "c"},
+			partitions:      2,
+			expected:        []int{1},
+		},
+		{
+			name:            "partitions equals groups",
+			group:           "c",
+			isolationGroups: []string{"a", "b", "c"},
+			partitions:      3,
+			expected:        []int{2},
+		},
+		{
+			name:            "partitions greater than groups",
+			group:           "c",
+			isolationGroups: []string{"a", "b", "c"},
+			partitions:      4,
+			expected:        []int{2},
+		},
+		{
+			name:            "partitions greater than groups - multiple assigned",
+			group:           "a",
+			isolationGroups: []string{"a", "b", "c"},
+			partitions:      4,
+			expected:        []int{0, 3},
+		},
+		{
+			name:            "not ok - no isolation group",
+			group:           "",
+			isolationGroups: []string{"a"},
+			partitions:      4,
+		},
+		{
+			name:            "not ok - no isolation groups",
+			group:           "a",
+			isolationGroups: []string{},
+			partitions:      4,
+		},
+		{
+			name:            "not ok - unknown isolation group",
+			group:           "d",
+			isolationGroups: []string{"a", "b", "c"},
+			partitions:      4,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lb, _ := createWithMocks(t, tc.isolationGroups, tc.partitions, tc.partitions)
+			actual, ok := lb.getPartitionsForGroup(tc.group, tc.partitions)
+			if tc.expected == nil {
+				assert.Nil(t, actual)
+				assert.False(t, ok)
+			} else {
+				expectedSet := make(map[int]any, len(tc.expected))
+				for _, expectedPartition := range tc.expected {
+					expectedSet[expectedPartition] = struct{}{}
+				}
+				assert.Equal(t, expectedSet, actual)
+				assert.True(t, ok)
+			}
+		})
+	}
+}
+
+func createWithMocks(t *testing.T, isolationGroups []string, writePartitions, readPartitions int) (*isolationLoadBalancer, *MockLoadBalancer) {
+	ctrl := gomock.NewController(t)
+	fallback := NewMockLoadBalancer(ctrl)
+	cfg := NewMockPartitionConfigProvider(ctrl)
+	cfg.EXPECT().GetNumberOfWritePartitions(gomock.Any(), gomock.Any(), gomock.Any()).Return(writePartitions).AnyTimes()
+	cfg.EXPECT().GetNumberOfReadPartitions(gomock.Any(), gomock.Any(), gomock.Any()).Return(readPartitions).AnyTimes()
+	allIsolationGroups := func() []string {
+		return isolationGroups
+	}
+	return &isolationLoadBalancer{
+		provider:           cfg,
+		fallback:           fallback,
+		allIsolationGroups: allIsolationGroups,
+	}, fallback
+}

--- a/client/matching/loadbalancer_mock.go
+++ b/client/matching/loadbalancer_mock.go
@@ -34,6 +34,150 @@ import (
 	types "github.com/uber/cadence/common/types"
 )
 
+// MockWriteRequest is a mock of WriteRequest interface.
+type MockWriteRequest struct {
+	ctrl     *gomock.Controller
+	recorder *MockWriteRequestMockRecorder
+}
+
+// MockWriteRequestMockRecorder is the mock recorder for MockWriteRequest.
+type MockWriteRequestMockRecorder struct {
+	mock *MockWriteRequest
+}
+
+// NewMockWriteRequest creates a new mock instance.
+func NewMockWriteRequest(ctrl *gomock.Controller) *MockWriteRequest {
+	mock := &MockWriteRequest{ctrl: ctrl}
+	mock.recorder = &MockWriteRequestMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWriteRequest) EXPECT() *MockWriteRequestMockRecorder {
+	return m.recorder
+}
+
+// GetDomainUUID mocks base method.
+func (m *MockWriteRequest) GetDomainUUID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomainUUID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetDomainUUID indicates an expected call of GetDomainUUID.
+func (mr *MockWriteRequestMockRecorder) GetDomainUUID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomainUUID", reflect.TypeOf((*MockWriteRequest)(nil).GetDomainUUID))
+}
+
+// GetForwardedFrom mocks base method.
+func (m *MockWriteRequest) GetForwardedFrom() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetForwardedFrom")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetForwardedFrom indicates an expected call of GetForwardedFrom.
+func (mr *MockWriteRequestMockRecorder) GetForwardedFrom() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetForwardedFrom", reflect.TypeOf((*MockWriteRequest)(nil).GetForwardedFrom))
+}
+
+// GetPartitionConfig mocks base method.
+func (m *MockWriteRequest) GetPartitionConfig() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPartitionConfig")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetPartitionConfig indicates an expected call of GetPartitionConfig.
+func (mr *MockWriteRequestMockRecorder) GetPartitionConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPartitionConfig", reflect.TypeOf((*MockWriteRequest)(nil).GetPartitionConfig))
+}
+
+// GetTaskList mocks base method.
+func (m *MockWriteRequest) GetTaskList() *types.TaskList {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTaskList")
+	ret0, _ := ret[0].(*types.TaskList)
+	return ret0
+}
+
+// GetTaskList indicates an expected call of GetTaskList.
+func (mr *MockWriteRequestMockRecorder) GetTaskList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskList", reflect.TypeOf((*MockWriteRequest)(nil).GetTaskList))
+}
+
+// MockReadRequest is a mock of ReadRequest interface.
+type MockReadRequest struct {
+	ctrl     *gomock.Controller
+	recorder *MockReadRequestMockRecorder
+}
+
+// MockReadRequestMockRecorder is the mock recorder for MockReadRequest.
+type MockReadRequestMockRecorder struct {
+	mock *MockReadRequest
+}
+
+// NewMockReadRequest creates a new mock instance.
+func NewMockReadRequest(ctrl *gomock.Controller) *MockReadRequest {
+	mock := &MockReadRequest{ctrl: ctrl}
+	mock.recorder = &MockReadRequestMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockReadRequest) EXPECT() *MockReadRequestMockRecorder {
+	return m.recorder
+}
+
+// GetDomainUUID mocks base method.
+func (m *MockReadRequest) GetDomainUUID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomainUUID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetDomainUUID indicates an expected call of GetDomainUUID.
+func (mr *MockReadRequestMockRecorder) GetDomainUUID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomainUUID", reflect.TypeOf((*MockReadRequest)(nil).GetDomainUUID))
+}
+
+// GetForwardedFrom mocks base method.
+func (m *MockReadRequest) GetForwardedFrom() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetForwardedFrom")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetForwardedFrom indicates an expected call of GetForwardedFrom.
+func (mr *MockReadRequestMockRecorder) GetForwardedFrom() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetForwardedFrom", reflect.TypeOf((*MockReadRequest)(nil).GetForwardedFrom))
+}
+
+// GetTaskList mocks base method.
+func (m *MockReadRequest) GetTaskList() *types.TaskList {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTaskList")
+	ret0, _ := ret[0].(*types.TaskList)
+	return ret0
+}
+
+// GetTaskList indicates an expected call of GetTaskList.
+func (mr *MockReadRequestMockRecorder) GetTaskList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskList", reflect.TypeOf((*MockReadRequest)(nil).GetTaskList))
+}
+
 // MockLoadBalancer is a mock of LoadBalancer interface.
 type MockLoadBalancer struct {
 	ctrl     *gomock.Controller
@@ -58,41 +202,41 @@ func (m *MockLoadBalancer) EXPECT() *MockLoadBalancerMockRecorder {
 }
 
 // PickReadPartition mocks base method.
-func (m *MockLoadBalancer) PickReadPartition(domainID string, taskList types.TaskList, taskListType int, forwardedFrom string) string {
+func (m *MockLoadBalancer) PickReadPartition(taskListType int, request ReadRequest, isolationGroup string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PickReadPartition", domainID, taskList, taskListType, forwardedFrom)
+	ret := m.ctrl.Call(m, "PickReadPartition", taskListType, request, isolationGroup)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // PickReadPartition indicates an expected call of PickReadPartition.
-func (mr *MockLoadBalancerMockRecorder) PickReadPartition(domainID, taskList, taskListType, forwardedFrom interface{}) *gomock.Call {
+func (mr *MockLoadBalancerMockRecorder) PickReadPartition(taskListType, request, isolationGroup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PickReadPartition", reflect.TypeOf((*MockLoadBalancer)(nil).PickReadPartition), domainID, taskList, taskListType, forwardedFrom)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PickReadPartition", reflect.TypeOf((*MockLoadBalancer)(nil).PickReadPartition), taskListType, request, isolationGroup)
 }
 
 // PickWritePartition mocks base method.
-func (m *MockLoadBalancer) PickWritePartition(domainID string, taskList types.TaskList, taskListType int, forwardedFrom string) string {
+func (m *MockLoadBalancer) PickWritePartition(taskListType int, request WriteRequest) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PickWritePartition", domainID, taskList, taskListType, forwardedFrom)
+	ret := m.ctrl.Call(m, "PickWritePartition", taskListType, request)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // PickWritePartition indicates an expected call of PickWritePartition.
-func (mr *MockLoadBalancerMockRecorder) PickWritePartition(domainID, taskList, taskListType, forwardedFrom interface{}) *gomock.Call {
+func (mr *MockLoadBalancerMockRecorder) PickWritePartition(taskListType, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PickWritePartition", reflect.TypeOf((*MockLoadBalancer)(nil).PickWritePartition), domainID, taskList, taskListType, forwardedFrom)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PickWritePartition", reflect.TypeOf((*MockLoadBalancer)(nil).PickWritePartition), taskListType, request)
 }
 
 // UpdateWeight mocks base method.
-func (m *MockLoadBalancer) UpdateWeight(domainID string, taskList types.TaskList, taskListType int, forwardedFrom, partition string, info *types.LoadBalancerHints) {
+func (m *MockLoadBalancer) UpdateWeight(taskListType int, request ReadRequest, partition string, info *types.LoadBalancerHints) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateWeight", domainID, taskList, taskListType, forwardedFrom, partition, info)
+	m.ctrl.Call(m, "UpdateWeight", taskListType, request, partition, info)
 }
 
 // UpdateWeight indicates an expected call of UpdateWeight.
-func (mr *MockLoadBalancerMockRecorder) UpdateWeight(domainID, taskList, taskListType, forwardedFrom, partition, info interface{}) *gomock.Call {
+func (mr *MockLoadBalancerMockRecorder) UpdateWeight(taskListType, request, partition, info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWeight", reflect.TypeOf((*MockLoadBalancer)(nil).UpdateWeight), domainID, taskList, taskListType, forwardedFrom, partition, info)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWeight", reflect.TypeOf((*MockLoadBalancer)(nil).UpdateWeight), taskListType, request, partition, info)
 }

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -177,6 +177,7 @@ func New(
 			params.MetricsClient,
 			dynamicCollection,
 			numShards,
+			params.GetIsolationGroups,
 			logger,
 		),
 		params.RPCFactory.GetDispatcher(),

--- a/host/service.go
+++ b/host/service.go
@@ -80,6 +80,7 @@ type (
 		clientBean            client.Bean
 		timeSource            clock.TimeSource
 		numberOfHistoryShards int
+		allIsolationGroups    func() []string
 
 		logger          log.Logger
 		throttledLogger log.Logger
@@ -113,6 +114,7 @@ func NewService(params *resource.Params) Service {
 		timeSource:            clock.NewRealTimeSource(),
 		metricsScope:          params.MetricScope,
 		numberOfHistoryShards: params.PersistenceConfig.NumHistoryShards,
+		allIsolationGroups:    params.GetIsolationGroups,
 		clusterMetadata:       params.ClusterMetadata,
 		metricsClient:         params.MetricsClient,
 		messagingClient:       params.MessagingClient,
@@ -164,7 +166,7 @@ func (h *serviceImpl) Start() {
 	h.hostInfo = hostInfo
 
 	h.clientBean, err = client.NewClientBean(
-		client.NewRPCClientFactory(h.rpcFactory, h.membershipResolver, h.metricsClient, h.dynamicCollection, h.numberOfHistoryShards, h.logger),
+		client.NewRPCClientFactory(h.rpcFactory, h.membershipResolver, h.metricsClient, h.dynamicCollection, h.numberOfHistoryShards, h.allIsolationGroups, h.logger),
 		h.rpcFactory.GetDispatcher(),
 		h.clusterMetadata,
 	)


### PR DESCRIPTION
This is an intentionally naive implementation of a load balancer that assigns isolation groups to specific partitions and routes pollers/tasks to those partitions based on their isolation group. Any time there are multiple options one is picked randomly.

The goal of this implementation is to benchmark how significantly isolation-group-based routing improves task latencies and isolation group containment for non-extremely-skewed scenarios. It additionally provides a baseline to see how much a more sophisticated solution (storing the isolation group assignment with the partitions and dynamically rebalancing them) might improve these metrics.

This isn't intended to be used in production as-is.

<!-- Describe what has changed in this PR -->
**What changed?**
- Added a benchmarking-only implementation
- Refactoring related to matching client load balancers.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Allows for analyzing the impact of isolation group to partition assignment.
- Refactoring allows for implementing more sophisticated solutions in the future.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
