### PR TITLE
Enable graceful shutdown of replication task fetcher by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1708,12 +1708,6 @@ const (
 	// Default value: false
 	// Allowed filters: N/A
 	QueueProcessorEnableGracefulSyncShutdown
-	// ReplicationTaskFetcherEnableGracefulSyncShutdown indicates whether task fetcher should be shutdown gracefully & synchronously
-	// KeyName: history.replicationTaskFetcherEnableGracefulSyncShutdown
-	// Value type: Bool
-	// Default value: false
-	// Allowed filters: N/A
-	ReplicationTaskFetcherEnableGracefulSyncShutdown
 	// TransferProcessorEnableValidator is whether validator should be enabled for transferQueueProcessor
 	// KeyName: history.transferProcessorEnableValidator
 	// Value type: Bool
@@ -4107,11 +4101,6 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	QueueProcessorEnableGracefulSyncShutdown: {
 		KeyName:      "history.queueProcessorEnableGracefulSyncShutdown",
 		Description:  "QueueProcessorEnableGracefulSyncShutdown indicates whether processing queue should be shutdown gracefully & synchronously",
-		DefaultValue: false,
-	},
-	ReplicationTaskFetcherEnableGracefulSyncShutdown: {
-		KeyName:      "history.replicationTaskFetcherEnableGracefulSyncShutdown",
-		Description:  "ReplicationTaskFetcherEnableGracefulSyncShutdown is whether we should gracefully drain replication task fetcher on shutdown",
 		DefaultValue: false,
 	},
 	TransferProcessorEnableValidator: {

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -242,7 +242,6 @@ type Config struct {
 	ReplicationTaskFetcherTimerJitterCoefficient       dynamicconfig.FloatPropertyFn
 	ReplicationTaskFetcherErrorRetryWait               dynamicconfig.DurationPropertyFn
 	ReplicationTaskFetcherServiceBusyWait              dynamicconfig.DurationPropertyFn
-	ReplicationTaskFetcherEnableGracefulSyncShutdown   dynamicconfig.BoolPropertyFn
 	ReplicationTaskProcessorErrorRetryWait             dynamicconfig.DurationPropertyFnWithShardIDFilter
 	ReplicationTaskProcessorErrorRetryMaxAttempts      dynamicconfig.IntPropertyFnWithShardIDFilter
 	ReplicationTaskProcessorErrorSecondRetryWait       dynamicconfig.DurationPropertyFnWithShardIDFilter
@@ -500,7 +499,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		ReplicationTaskFetcherTimerJitterCoefficient:       dc.GetFloat64Property(dynamicconfig.ReplicationTaskFetcherTimerJitterCoefficient),
 		ReplicationTaskFetcherErrorRetryWait:               dc.GetDurationProperty(dynamicconfig.ReplicationTaskFetcherErrorRetryWait),
 		ReplicationTaskFetcherServiceBusyWait:              dc.GetDurationProperty(dynamicconfig.ReplicationTaskFetcherServiceBusyWait),
-		ReplicationTaskFetcherEnableGracefulSyncShutdown:   dc.GetBoolProperty(dynamicconfig.ReplicationTaskFetcherEnableGracefulSyncShutdown),
 		ReplicationTaskProcessorErrorRetryWait:             dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryWait),
 		ReplicationTaskProcessorErrorRetryMaxAttempts:      dc.GetIntPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts),
 		ReplicationTaskProcessorErrorSecondRetryWait:       dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorSecondRetryWait),
@@ -606,7 +604,6 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 		"1": 50,
 	}))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.QueueProcessorRandomSplitProbability, 0.5))
-	panicIfErr(inMem.UpdateValue(dynamicconfig.ReplicationTaskFetcherEnableGracefulSyncShutdown, true))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.EnableStrongIdempotency, true))
 
 	dc := dynamicconfig.NewCollection(inMem, log.NewNoop())
@@ -631,7 +628,6 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	config.QueueProcessorPendingTaskSplitThreshold = dc.GetMapProperty(dynamicconfig.QueueProcessorPendingTaskSplitThreshold)
 	config.QueueProcessorStuckTaskSplitThreshold = dc.GetMapProperty(dynamicconfig.QueueProcessorStuckTaskSplitThreshold)
 	config.QueueProcessorRandomSplitProbability = dc.GetFloat64Property(dynamicconfig.QueueProcessorRandomSplitProbability)
-	config.ReplicationTaskFetcherEnableGracefulSyncShutdown = dc.GetBoolProperty(dynamicconfig.ReplicationTaskFetcherEnableGracefulSyncShutdown)
 	return config
 }
 

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -208,7 +208,6 @@ func TestNewConfig(t *testing.T) {
 		"ReplicationTaskFetcherTimerJitterCoefficient":         {dynamicconfig.ReplicationTaskFetcherTimerJitterCoefficient, 9.0},
 		"ReplicationTaskFetcherErrorRetryWait":                 {dynamicconfig.ReplicationTaskFetcherErrorRetryWait, time.Second},
 		"ReplicationTaskFetcherServiceBusyWait":                {dynamicconfig.ReplicationTaskFetcherServiceBusyWait, time.Second},
-		"ReplicationTaskFetcherEnableGracefulSyncShutdown":     {dynamicconfig.ReplicationTaskFetcherEnableGracefulSyncShutdown, true},
 		"ReplicationTaskProcessorErrorRetryWait":               {dynamicconfig.ReplicationTaskProcessorErrorRetryWait, time.Second},
 		"ReplicationTaskProcessorErrorRetryMaxAttempts":        {dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts, 86},
 		"ReplicationTaskProcessorErrorSecondRetryWait":         {dynamicconfig.ReplicationTaskProcessorErrorSecondRetryWait, time.Second},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replication task fetcher is not respecting shut down signal because it uses background context. This causes integration test flakiness ([example](https://buildkite.com/uberopensource/cadence-server/builds/21522#0193d665-65e8-4efb-b3d6-55be7986febd)). I have fixed the shutdown logic of this component last year in #5544 but it was behind a feature flag. 
When `Stop()` is called it will cancel internal context and rpc will terminate early. There's no side effect on replication ack levels.

<!-- Tell your future self why have you made these changes -->
**Why?**
Better shutdown handling and reduce test flakyness.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit and integration tests
