### PR TITLE
Don't treat missing PartitionConfig data as an error

### DIFF
--- a/common/partition/default-partitioner.go
+++ b/common/partition/default-partitioner.go
@@ -84,7 +84,7 @@ func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, sc
 	}
 	wfPartition := mapPartitionConfigToDefaultPartitionConfig(wfPartitionData)
 	if wfPartition.WorkflowStartIsolationGroup == "" || wfPartition.WFID == "" {
-		return "", ErrInvalidPartitionConfig
+		return "", nil
 	}
 
 	isolationGroups, err := r.isolationGroupState.IsolationGroupsByDomainID(ctx, pollerInfo.DomainID)

--- a/common/partition/default-partitioner_test.go
+++ b/common/partition/default-partitioner_test.go
@@ -112,7 +112,7 @@ func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 			stateAffordance:      func(state *isolationgroup.MockState) {},
 			incomingContext:      context.Background(),
 			expectedValue:        "",
-			expectedError:        errors.New("invalid partition config"),
+			expectedError:        nil,
 		},
 		"Error condition - No isolation-group information passed in 2": {
 			partitionKeyPassedIn: nil,

--- a/host/matching_simulation_test.go
+++ b/host/matching_simulation_test.go
@@ -128,7 +128,7 @@ func TestMatchingSimulation(t *testing.T) {
 		dynamicconfig.MatchingPartitionUpscaleSustainedDuration:    clusterConfig.MatchingConfig.SimulationConfig.PartitionUpscaleSustainedDuration,
 		dynamicconfig.MatchingPartitionDownscaleSustainedDuration:  clusterConfig.MatchingConfig.SimulationConfig.PartitionDownscaleSustainedDuration,
 		dynamicconfig.MatchingAdaptiveScalerUpdateInterval:         clusterConfig.MatchingConfig.SimulationConfig.AdaptiveScalerUpdateInterval,
-		dynamicconfig.MatchingQPSTrackerInterval:                   clusterConfig.MatchingConfig.SimulationConfig.QPSTrackerInterval,
+		dynamicconfig.MatchingQPSTrackerInterval:                   getQpsTrackerInterval(clusterConfig.MatchingConfig.SimulationConfig.QPSTrackerInterval),
 		dynamicconfig.TaskIsolationDuration:                        clusterConfig.MatchingConfig.SimulationConfig.TaskIsolationDuration,
 	}
 
@@ -426,6 +426,7 @@ func (s *MatchingSimulationSuite) poll(
 						Name: tasklist,
 						Kind: types.TaskListKindNormal.Ptr(),
 					},
+					Identity: pollerID,
 				},
 				IsolationGroup: pollerConfig.getIsolationGroup(),
 			})
@@ -670,6 +671,13 @@ func getPartitionTaskListName(root string, partition int) string {
 		return root
 	}
 	return fmt.Sprintf("%v%v/%v", common.ReservedTaskListPrefix, root, partition)
+}
+
+func getQpsTrackerInterval(duration time.Duration) time.Duration {
+	if duration == 0 {
+		return 10 * time.Second
+	}
+	return duration
 }
 
 func randomlyPickKey(weights map[string]int) string {

--- a/host/testdata/matching_simulation_zonal_isolation_few_pollers.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_few_pollers.yaml
@@ -17,6 +17,7 @@ matchingconfig:
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
     taskisolationduration: 1s
+    tasklistloadbalancerstrategy: isolation
     tasks:
       - numtaskgenerators: 30
         taskspersecond: 500

--- a/host/testdata/matching_simulation_zonal_isolation_many_pollers.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_many_pollers.yaml
@@ -17,6 +17,7 @@ matchingconfig:
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
     taskisolationduration: 1s
+    tasklistloadbalancerstrategy: isolation
     tasks:
       - numtaskgenerators: 30
         taskspersecond: 500

--- a/host/testdata/matching_simulation_zonal_isolation_single_partition.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_single_partition.yaml
@@ -17,6 +17,7 @@ matchingconfig:
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
     taskisolationduration: 1s
+    tasklistloadbalancerstrategy: isolation
     tasks:
       - numtaskgenerators: 30
         taskspersecond: 500

--- a/host/testdata/matching_simulation_zonal_isolation_skew.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_skew.yaml
@@ -17,6 +17,7 @@ matchingconfig:
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
     taskisolationduration: 1s
+    tasklistloadbalancerstrategy: isolation
     tasks:
       - numtaskgenerators: 10
         taskspersecond: 180

--- a/host/testdata/matching_simulation_zonal_isolation_skew_extreme.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_skew_extreme.yaml
@@ -17,6 +17,7 @@ matchingconfig:
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
     taskisolationduration: 1s
+    tasklistloadbalancerstrategy: isolation
     tasks:
       - numtaskgenerators: 3
         taskspersecond: 50

--- a/host/testdata/matching_simulation_zonal_isolation_skew_forwarding.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation_skew_forwarding.yaml
@@ -17,6 +17,7 @@ matchingconfig:
     localpollwaittime: 10ms
     localtaskwaittime: 10ms
     taskisolationduration: 1s
+    tasklistloadbalancerstrategy: isolation
     tasks:
       - numtaskgenerators: 10
         taskspersecond: 180


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
We intentionally set the isolation group to "" when we leak tasks, which causes forwarded tasks to report an error resolving the isolation group. Don't return an error in this case, or if the task happens not to have a PartitionConfig.

Additionally update the matching simulation to use the isolation group based load balancer and provide a default for the QpsTrackerInterval. 0s results in a panic on service startup.

Additionally specify an Identity on requests in the matching simulation so that poller history is tracked.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Reduce noise in metrics caused by an expected scenario

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
