### PR TITLE
Update C* queries about execution table with timestamps

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -727,11 +727,12 @@ func (db *cdb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.R
 
 	shardID := shardCondition.ShardID
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	timeStamp := db.timeSrc.Now()
 	for _, task := range tasks {
-		createReplicationTasks(batch, shardID, task.DomainID, task.WorkflowID, []*nosqlplugin.ReplicationTask{task}, time.Now())
+		createReplicationTasks(batch, shardID, task.DomainID, task.WorkflowID, []*nosqlplugin.ReplicationTask{task}, timeStamp)
 	}
 
-	assertShardRangeID(batch, shardID, shardCondition.RangeID, time.Now())
+	assertShardRangeID(batch, shardID, shardCondition.RangeID, timeStamp)
 
 	previous := make(map[string]interface{})
 	applied, iter, err := db.session.MapExecuteBatchCAS(batch, previous)

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -50,28 +50,29 @@ func (db *cdb) InsertWorkflowExecutionWithTasks(
 	shardID := shardCondition.ShardID
 	domainID := execution.DomainID
 	workflowID := execution.WorkflowID
+	timeStamp := db.timeSrc.Now()
 
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 
-	err := insertOrUpsertWorkflowRequestRow(batch, requests)
+	err := insertOrUpsertWorkflowRequestRow(batch, requests, timeStamp)
 	if err != nil {
 		return err
 	}
-	err = createOrUpdateCurrentWorkflow(batch, shardID, domainID, workflowID, currentWorkflowRequest)
-	if err != nil {
-		return err
-	}
-
-	err = createWorkflowExecutionWithMergeMaps(batch, shardID, domainID, workflowID, execution)
+	err = createOrUpdateCurrentWorkflow(batch, shardID, domainID, workflowID, currentWorkflowRequest, timeStamp)
 	if err != nil {
 		return err
 	}
 
-	createTransferTasks(batch, shardID, domainID, workflowID, transferTasks)
-	createReplicationTasks(batch, shardID, domainID, workflowID, replicationTasks)
-	createCrossClusterTasks(batch, shardID, domainID, workflowID, crossClusterTasks)
-	createTimerTasks(batch, shardID, domainID, workflowID, timerTasks)
-	assertShardRangeID(batch, shardID, shardCondition.RangeID)
+	err = createWorkflowExecutionWithMergeMaps(batch, shardID, domainID, workflowID, execution, timeStamp)
+	if err != nil {
+		return err
+	}
+
+	createTransferTasks(batch, shardID, domainID, workflowID, transferTasks, timeStamp)
+	createReplicationTasks(batch, shardID, domainID, workflowID, replicationTasks, timeStamp)
+	createCrossClusterTasks(batch, shardID, domainID, workflowID, crossClusterTasks, timeStamp)
+	createTimerTasks(batch, shardID, domainID, workflowID, timerTasks, timeStamp)
+	assertShardRangeID(batch, shardID, shardCondition.RangeID, timeStamp)
 
 	return executeCreateWorkflowBatchTransaction(ctx, db.session, batch, currentWorkflowRequest, execution, shardCondition)
 }
@@ -129,6 +130,7 @@ func (db *cdb) UpdateWorkflowExecutionWithTasks(
 	shardID := shardCondition.ShardID
 	var domainID, workflowID string
 	var previousNextEventIDCondition int64
+	timeStamp := db.timeSrc.Now()
 	if mutatedExecution != nil {
 		domainID = mutatedExecution.DomainID
 		workflowID = mutatedExecution.WorkflowID
@@ -143,41 +145,41 @@ func (db *cdb) UpdateWorkflowExecutionWithTasks(
 
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 
-	err := insertOrUpsertWorkflowRequestRow(batch, requests)
+	err := insertOrUpsertWorkflowRequestRow(batch, requests, timeStamp)
 	if err != nil {
 		return err
 	}
-	err = createOrUpdateCurrentWorkflow(batch, shardID, domainID, workflowID, currentWorkflowRequest)
+	err = createOrUpdateCurrentWorkflow(batch, shardID, domainID, workflowID, currentWorkflowRequest, timeStamp)
 	if err != nil {
 		return err
 	}
 
 	if mutatedExecution != nil {
-		err = updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, shardID, domainID, workflowID, mutatedExecution)
+		err = updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, shardID, domainID, workflowID, mutatedExecution, timeStamp)
 		if err != nil {
 			return err
 		}
 	}
 
 	if insertedExecution != nil {
-		err = createWorkflowExecutionWithMergeMaps(batch, shardID, domainID, workflowID, insertedExecution)
+		err = createWorkflowExecutionWithMergeMaps(batch, shardID, domainID, workflowID, insertedExecution, timeStamp)
 		if err != nil {
 			return err
 		}
 	}
 
 	if resetExecution != nil {
-		err = resetWorkflowExecutionAndMapsAndEventBuffer(batch, shardID, domainID, workflowID, resetExecution)
+		err = resetWorkflowExecutionAndMapsAndEventBuffer(batch, shardID, domainID, workflowID, resetExecution, timeStamp)
 		if err != nil {
 			return err
 		}
 	}
 
-	createTransferTasks(batch, shardID, domainID, workflowID, transferTasks)
-	createReplicationTasks(batch, shardID, domainID, workflowID, replicationTasks)
-	createCrossClusterTasks(batch, shardID, domainID, workflowID, crossClusterTasks)
-	createTimerTasks(batch, shardID, domainID, workflowID, timerTasks)
-	assertShardRangeID(batch, shardID, shardCondition.RangeID)
+	createTransferTasks(batch, shardID, domainID, workflowID, transferTasks, timeStamp)
+	createReplicationTasks(batch, shardID, domainID, workflowID, replicationTasks, timeStamp)
+	createCrossClusterTasks(batch, shardID, domainID, workflowID, crossClusterTasks, timeStamp)
+	createTimerTasks(batch, shardID, domainID, workflowID, timerTasks, timeStamp)
+	assertShardRangeID(batch, shardID, shardCondition.RangeID, timeStamp)
 
 	return executeUpdateWorkflowBatchTransaction(ctx, db.session, batch, currentWorkflowRequest, previousNextEventIDCondition, shardCondition)
 }
@@ -648,6 +650,7 @@ func (db *cdb) InsertReplicationDLQTask(ctx context.Context, shardID int, source
 		defaultVisibilityTimestamp,
 		defaultVisibilityTimestamp,
 		task.TaskID,
+		db.timeSrc.Now(),
 	).WithContext(ctx)
 
 	return query.Exec()
@@ -725,10 +728,10 @@ func (db *cdb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.R
 	shardID := shardCondition.ShardID
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 	for _, task := range tasks {
-		createReplicationTasks(batch, shardID, task.DomainID, task.WorkflowID, []*nosqlplugin.ReplicationTask{task})
+		createReplicationTasks(batch, shardID, task.DomainID, task.WorkflowID, []*nosqlplugin.ReplicationTask{task}, time.Now())
 	}
 
-	assertShardRangeID(batch, shardID, shardCondition.RangeID)
+	assertShardRangeID(batch, shardID, shardCondition.RangeID, time.Now())
 
 	previous := make(map[string]interface{})
 	applied, iter, err := db.session.MapExecuteBatchCAS(batch, previous)

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
@@ -223,7 +223,8 @@ const (
 		`SET current_run_id = ?, ` +
 		`execution = {run_id: ?, create_request_id: ?, state: ?, close_status: ?}, ` +
 		`workflow_last_write_version = ?, ` +
-		`workflow_state = ? ` +
+		`workflow_state = ?, ` +
+		`last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -238,12 +239,12 @@ const (
 		`and workflow_state = ? `
 
 	templateInsertWorkflowRequestQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
-		`VALUES(?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS USING TTL ?`
+		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, created_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS USING TTL ?`
 
 	templateUpsertWorkflowRequestQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
-		`VALUES(?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?`
+		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, last_updated_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?`
 
 	templateGetLatestWorkflowRequestQuery = `SELECT current_run_id ` +
 		`FROM executions ` +
@@ -256,31 +257,32 @@ const (
 		`LIMIT 1`
 
 	templateCreateCurrentWorkflowExecutionQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, execution, workflow_last_write_version, workflow_state) ` +
-		`VALUES(?, ?, ?, ?, ?, ?, ?, ?, {run_id: ?, create_request_id: ?, state: ?, close_status: ?}, ?, ?) IF NOT EXISTS USING TTL 0 `
+		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, execution, workflow_last_write_version, workflow_state, created_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ?, ?, ?, {run_id: ?, create_request_id: ?, state: ?, close_status: ?}, ?, ?, ?) IF NOT EXISTS USING TTL 0 `
 
 	templateCreateWorkflowExecutionWithVersionHistoriesQuery = `INSERT INTO executions (` +
-		`shard_id, domain_id, workflow_id, run_id, type, execution, next_event_id, visibility_ts, task_id, version_histories, version_histories_encoding, checksum, workflow_last_write_version, workflow_state) ` +
-		`VALUES(?, ?, ?, ?, ?, ` + templateWorkflowExecutionType + `, ?, ?, ?, ?, ?, ` + templateChecksumType + `, ?, ?) IF NOT EXISTS `
+		`shard_id, domain_id, workflow_id, run_id, type, execution, next_event_id, visibility_ts, task_id, version_histories, version_histories_encoding, checksum, workflow_last_write_version, workflow_state, created_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ` + templateWorkflowExecutionType + `, ?, ?, ?, ?, ?, ` + templateChecksumType + `, ?, ?, ?) IF NOT EXISTS `
 
 	templateCreateTransferTaskQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, transfer, visibility_ts, task_id) ` +
-		`VALUES(?, ?, ?, ?, ?, ` + templateTransferTaskType + `, ?, ?)`
+		`shard_id, type, domain_id, workflow_id, run_id, transfer, visibility_ts, task_id, created_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ` + templateTransferTaskType + `, ?, ?, ?)`
 
 	templateCreateCrossClusterTaskQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, cross_cluster, visibility_ts, task_id) ` +
-		`VALUES(?, ?, ?, ?, ?, ` + templateCrossClusterTaskType + `, ?, ?)`
+		`shard_id, type, domain_id, workflow_id, run_id, cross_cluster, visibility_ts, task_id, created_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ` + templateCrossClusterTaskType + `, ?, ?, ?)`
 
 	templateCreateReplicationTaskQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, replication, visibility_ts, task_id) ` +
-		`VALUES(?, ?, ?, ?, ?, ` + templateReplicationTaskType + `, ?, ?)`
+		`shard_id, type, domain_id, workflow_id, run_id, replication, visibility_ts, task_id, created_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ` + templateReplicationTaskType + `, ?, ?, ?)`
 
 	templateCreateTimerTaskQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, timer, visibility_ts, task_id) ` +
-		`VALUES(?, ?, ?, ?, ?, ` + templateTimerTaskType + `, ?, ?)`
+		`shard_id, type, domain_id, workflow_id, run_id, timer, visibility_ts, task_id, created_time) ` +
+		`VALUES(?, ?, ?, ?, ?, ` + templateTimerTaskType + `, ?, ?, ?)`
 
 	templateUpdateLeaseQuery = `UPDATE executions ` +
 		`SET range_id = ? ` +
+		`and last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -341,6 +343,7 @@ const (
 		`, checksum = ` + templateChecksumType +
 		`, workflow_last_write_version = ? ` +
 		`, workflow_state = ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -352,6 +355,7 @@ const (
 
 	templateUpdateActivityInfoQuery = `UPDATE executions ` +
 		`SET activity_map[ ? ] = ` + templateActivityInfoType + ` ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -362,6 +366,7 @@ const (
 
 	templateResetActivityInfoQuery = `UPDATE executions ` +
 		`SET activity_map = ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -372,6 +377,7 @@ const (
 
 	templateUpdateTimerInfoQuery = `UPDATE executions ` +
 		`SET timer_map[ ? ] = ` + templateTimerInfoType + ` ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -382,6 +388,7 @@ const (
 
 	templateResetTimerInfoQuery = `UPDATE executions ` +
 		`SET timer_map = ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -392,6 +399,7 @@ const (
 
 	templateUpdateChildExecutionInfoQuery = `UPDATE executions ` +
 		`SET child_executions_map[ ? ] = ` + templateChildExecutionInfoType + ` ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -402,6 +410,7 @@ const (
 
 	templateResetChildExecutionInfoQuery = `UPDATE executions ` +
 		`SET child_executions_map = ?` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -412,6 +421,7 @@ const (
 
 	templateUpdateRequestCancelInfoQuery = `UPDATE executions ` +
 		`SET request_cancel_map[ ? ] = ` + templateRequestCancelInfoType + ` ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -422,6 +432,7 @@ const (
 
 	templateResetRequestCancelInfoQuery = `UPDATE executions ` +
 		`SET request_cancel_map = ?` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -432,6 +443,7 @@ const (
 
 	templateUpdateSignalInfoQuery = `UPDATE executions ` +
 		`SET signal_map[ ? ] = ` + templateSignalInfoType + ` ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -442,6 +454,7 @@ const (
 
 	templateResetSignalInfoQuery = `UPDATE executions ` +
 		`SET signal_map = ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -452,6 +465,7 @@ const (
 
 	templateUpdateSignalRequestedQuery = `UPDATE executions ` +
 		`SET signal_requested = signal_requested + ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -462,6 +476,7 @@ const (
 
 	templateResetSignalRequestedQuery = `UPDATE executions ` +
 		`SET signal_requested = ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -472,6 +487,7 @@ const (
 
 	templateAppendBufferedEventsQuery = `UPDATE executions ` +
 		`SET buffered_events_list = buffered_events_list + ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -482,6 +498,7 @@ const (
 
 	templateDeleteBufferedEventsQuery = `UPDATE executions ` +
 		`SET buffered_events_list = [] ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +
@@ -553,6 +570,7 @@ const (
 
 	templateDeleteWorkflowExecutionSignalRequestedQuery = `UPDATE executions ` +
 		`SET signal_requested = signal_requested - ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
@@ -282,7 +282,7 @@ const (
 
 	templateUpdateLeaseQuery = `UPDATE executions ` +
 		`SET range_id = ? ` +
-		`and last_updated_time = ? ` +
+		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+var FixedTime time.Time = time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC)
+
 // fakeSession is fake implementation of gocql.Session
 type fakeSession struct {
 	// inputs
@@ -942,11 +944,11 @@ func TestInsertOrUpsertWorkflowRequestRow(t *testing.T) {
 			},
 			wantErr: false,
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
-					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, 1000, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, created_time) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, 1000, 25bd1013-0e79-4c45-8e55-08bb45886896, 2025-01-06T15:00:00Z) ` +
 					`IF NOT EXISTS USING TTL 10800`,
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
-					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, -100, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, created_time) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, -100, 25bd1013-0e79-4c45-8e55-08bb45886896, 2025-01-06T15:00:00Z) ` +
 					`IF NOT EXISTS USING TTL 10800`,
 			},
 		},
@@ -967,11 +969,11 @@ func TestInsertOrUpsertWorkflowRequestRow(t *testing.T) {
 			},
 			wantErr: false,
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
-					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, 1000, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, last_updated_time) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, 1000, 25bd1013-0e79-4c45-8e55-08bb45886896, 2025-01-06T15:00:00Z) ` +
 					`USING TTL 10800`,
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
-					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, -100, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, last_updated_time) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, -100, 25bd1013-0e79-4c45-8e55-08bb45886896, 2025-01-06T15:00:00Z) ` +
 					`USING TTL 10800`,
 			},
 		},
@@ -992,7 +994,7 @@ func TestInsertOrUpsertWorkflowRequestRow(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			batch := &fakeBatch{}
-			err := insertOrUpsertWorkflowRequestRow(batch, tc.request)
+			err := insertOrUpsertWorkflowRequestRow(batch, tc.request, FixedTime)
 			gotErr := (err != nil)
 			if gotErr != tc.wantErr {
 				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)
@@ -1051,14 +1053,14 @@ func TestCreateTimerTasks(t *testing.T) {
 				},
 			},
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, timer, visibility_ts, task_id) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, timer, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 3, 10000000-4000-f000-f000-000000000000, 20000000-4000-f000-f000-000000000000, 30000000-4000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_1, visibility_ts: 1702418921000, task_id: 1, type: 1, timeout_type: 1, event_id: 10, schedule_attempt: 0, version: 0}, ` +
-					`1702418921000, 1)`,
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, timer, visibility_ts, task_id) ` +
+					`1702418921000, 1, 2025-01-06T15:00:00Z)`,
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, timer, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 3, 10000000-4000-f000-f000-000000000000, 20000000-4000-f000-f000-000000000000, 30000000-4000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_1, visibility_ts: 1702418981000, task_id: 2, type: 1, timeout_type: 1, event_id: 11, schedule_attempt: 0, version: 0}, ` +
-					`1702418981000, 2)`,
+					`1702418981000, 2, 2025-01-06T15:00:00Z)`,
 			},
 		},
 	}
@@ -1066,7 +1068,7 @@ func TestCreateTimerTasks(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
-			err := createTimerTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.timerTasks)
+			err := createTimerTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.timerTasks, FixedTime)
 			if err != nil {
 				t.Fatalf("createTimerTasks failed: %v", err)
 			}
@@ -1123,16 +1125,16 @@ func TestReplicationTasks(t *testing.T) {
 				},
 			},
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, replication, visibility_ts, task_id) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, replication, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 4, 10000000-5000-f000-f000-000000000000, 20000000-5000-f000-f000-000000000000, 30000000-5000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_1, task_id: 644, type: 0, ` +
 					`first_event_id: 5,next_event_id: 8,version: 0,scheduled_id: -23, event_store_version: 2, branch_token: [], ` +
-					`new_run_event_store_version: 2, new_run_branch_token: [97 98 99], created_time: 1702418921000000000 }, 946684800000, 644)`,
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, replication, visibility_ts, task_id) ` +
+					`new_run_event_store_version: 2, new_run_branch_token: [97 98 99], created_time: 1702418921000000000 }, 946684800000, 644, 2025-01-06T15:00:00Z)`,
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, replication, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 4, 10000000-5000-f000-f000-000000000000, 20000000-5000-f000-f000-000000000000, 30000000-5000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_1, task_id: 645, type: 0, ` +
 					`first_event_id: 25,next_event_id: 28,version: 0,scheduled_id: -23, event_store_version: 2, branch_token: [], ` +
-					`new_run_event_store_version: 2, new_run_branch_token: [97 98 99], created_time: 1702422521000000000 }, 946684800000, 645)`,
+					`new_run_event_store_version: 2, new_run_branch_token: [97 98 99], created_time: 1702422521000000000 }, 946684800000, 645, 2025-01-06T15:00:00Z)`,
 			},
 		},
 	}
@@ -1140,7 +1142,7 @@ func TestReplicationTasks(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
-			createReplicationTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.replTasks)
+			createReplicationTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.replTasks, FixedTime)
 			if diff := cmp.Diff(tc.wantQueries, batch.queries); diff != "" {
 				t.Fatalf("Query mismatch (-want +got):\n%s", diff)
 			}
@@ -1197,20 +1199,20 @@ func TestTransferTasks(t *testing.T) {
 				},
 			},
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, transfer, visibility_ts, task_id) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, transfer, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 2, 10000000-3000-f000-f000-000000000000, 20000000-3000-f000-f000-000000000000, 30000000-3000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_1, visibility_ts: 2023-12-12T22:08:41Z, ` +
 					`task_id: 355, target_domain_id: e2bf2c8f-0ddf-4451-8840-27cfe8addd62, target_domain_ids: map[],` +
 					`target_workflow_id: 20000000-0000-f000-f000-000000000001, target_run_id: 30000000-0000-f000-f000-000000000002, ` +
 					`target_child_workflow_only: true, task_list: tasklist_1, type: 0, schedule_id: 14, record_visibility: false, version: 1}, ` +
-					`946684800000, 355)`,
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, transfer, visibility_ts, task_id) ` +
+					`946684800000, 355, 2025-01-06T15:00:00Z)`,
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, transfer, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 2, 10000000-3000-f000-f000-000000000000, 20000000-3000-f000-f000-000000000000, 30000000-3000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_2, visibility_ts: 2023-12-12T22:09:41Z, ` +
 					`task_id: 220, target_domain_id: e2bf2c8f-0ddf-4451-8840-27cfe8addd62, target_domain_ids: map[],` +
 					`target_workflow_id: 20000000-0000-f000-f000-000000000001, target_run_id: 30000000-0000-f000-f000-000000000002, ` +
 					`target_child_workflow_only: true, task_list: tasklist_2, type: 0, schedule_id: 3, record_visibility: false, version: 1}, ` +
-					`946684800000, 220)`,
+					`946684800000, 220, 2025-01-06T15:00:00Z)`,
 			},
 		},
 	}
@@ -1218,7 +1220,7 @@ func TestTransferTasks(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
-			createTransferTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.transferTasks)
+			createTransferTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.transferTasks, FixedTime)
 			if diff := cmp.Diff(tc.wantQueries, batch.queries); diff != "" {
 				t.Fatalf("Query mismatch (-want +got):\n%s", diff)
 			}
@@ -1264,13 +1266,13 @@ func TestCrossClusterTasks(t *testing.T) {
 				},
 			},
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, cross_cluster, visibility_ts, task_id) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, cross_cluster, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 6, 10000000-7000-f000-f000-000000000000, , 30000000-7000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_1, visibility_ts: 2023-12-12T22:08:41Z, ` +
 					`task_id: 355, target_domain_id: e2bf2c8f-0ddf-4451-8840-27cfe8addd62, target_domain_ids: map[],` +
 					`target_workflow_id: 20000000-0000-f000-f000-000000000001, target_run_id: 30000000-0000-f000-f000-000000000002, ` +
 					`target_child_workflow_only: true, task_list: tasklist_1, type: 0, schedule_id: 14, record_visibility: false, version: 1}, ` +
-					`946684800000, 355)`,
+					`946684800000, 355, 2025-01-06T15:00:00Z)`,
 			},
 		},
 	}
@@ -1278,7 +1280,7 @@ func TestCrossClusterTasks(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
-			createCrossClusterTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.xClusterTasks)
+			createCrossClusterTasks(batch, tc.shardID, tc.domainID, tc.workflowID, tc.xClusterTasks, FixedTime)
 			if diff := cmp.Diff(tc.wantQueries, batch.queries); diff != "" {
 				t.Fatalf("Query mismatch (-want +got):\n%s", diff)
 			}
@@ -1305,7 +1307,7 @@ func TestResetSignalsRequested(t *testing.T) {
 			runID:        "runid_123",
 			signalReqIDs: []string{"signalReqID_1", "signalReqID_2"},
 			wantQueries: []string{
-				`UPDATE executions SET signal_requested = [signalReqID_1 signalReqID_2] WHERE ` +
+				`UPDATE executions SET signal_requested = [signalReqID_1 signalReqID_2] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain_123 and workflow_id = workflow_123 and ` +
 					`run_id = runid_123 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1315,7 +1317,7 @@ func TestResetSignalsRequested(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
-			err := resetSignalsRequested(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalReqIDs)
+			err := resetSignalsRequested(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalReqIDs, FixedTime)
 			if err != nil {
 				t.Fatalf("resetSignalsRequested failed: %v", err)
 			}
@@ -1348,7 +1350,7 @@ func TestUpdateSignalsRequested(t *testing.T) {
 			signalReqIDs:       []string{"signalReqID_3", "signalReqID_4"},
 			deleteSignalReqIDs: []string{},
 			wantQueries: []string{
-				`UPDATE executions SET signal_requested = signal_requested + [signalReqID_3 signalReqID_4] WHERE ` +
+				`UPDATE executions SET signal_requested = signal_requested + [signalReqID_3 signalReqID_4] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain_abc and workflow_id = workflow_abc and ` +
 					`run_id = runid_abc and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1362,7 +1364,7 @@ func TestUpdateSignalsRequested(t *testing.T) {
 			signalReqIDs:       []string{},
 			deleteSignalReqIDs: []string{"signalReqID_5", "signalReqID_6"},
 			wantQueries: []string{
-				`UPDATE executions SET signal_requested = signal_requested - [signalReqID_5 signalReqID_6] WHERE ` +
+				`UPDATE executions SET signal_requested = signal_requested - [signalReqID_5 signalReqID_6] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1001 and type = 1 and domain_id = domain_def and workflow_id = workflow_def and ` +
 					`run_id = runid_def and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1376,10 +1378,10 @@ func TestUpdateSignalsRequested(t *testing.T) {
 			signalReqIDs:       []string{"signalReqID_7"},
 			deleteSignalReqIDs: []string{"signalReqID_8"},
 			wantQueries: []string{
-				`UPDATE executions SET signal_requested = signal_requested + [signalReqID_7] WHERE ` +
+				`UPDATE executions SET signal_requested = signal_requested + [signalReqID_7] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1002 and type = 1 and domain_id = domain_ghi and workflow_id = workflow_ghi and ` +
 					`run_id = runid_ghi and visibility_ts = 946684800000 and task_id = -10 `,
-				`UPDATE executions SET signal_requested = signal_requested - [signalReqID_8] WHERE ` +
+				`UPDATE executions SET signal_requested = signal_requested - [signalReqID_8] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1002 and type = 1 and domain_id = domain_ghi and workflow_id = workflow_ghi and ` +
 					`run_id = runid_ghi and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1389,7 +1391,7 @@ func TestUpdateSignalsRequested(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
-			err := updateSignalsRequested(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalReqIDs, tc.deleteSignalReqIDs)
+			err := updateSignalsRequested(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalReqIDs, tc.deleteSignalReqIDs, FixedTime)
 			if err != nil {
 				t.Fatalf("updateSignalsRequested failed: %v", err)
 			}
@@ -1442,7 +1444,7 @@ func TestResetSignalInfos(t *testing.T) {
 				`UPDATE executions SET signal_map = map[` +
 					`1:map[control:[99 111 110 116 114 111 108 49] initiated_event_batch_id:2 initiated_id:1 input:[105 110 112 117 116 49] signal_name:signal1 signal_request_id:request1 version:1] ` +
 					`5:map[control:[99 111 110 116 114 111 108 50] initiated_event_batch_id:6 initiated_id:5 input:[105 110 112 117 116 50] signal_name:signal2 signal_request_id:request2 version:1]` +
-					`] WHERE ` +
+					`] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1453,7 +1455,7 @@ func TestResetSignalInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := resetSignalInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalInfos)
+			err := resetSignalInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("resetSignalInfos failed: %v", err)
 			}
@@ -1500,7 +1502,7 @@ func TestUpdateSignalInfos(t *testing.T) {
 					`version: 1, initiated_id: 1, initiated_event_batch_id: 2, signal_request_id: request1, ` +
 					`signal_name: signal1, input: [105 110 112 117 116 49], ` +
 					`control: [99 111 110 116 114 111 108 49]` +
-					`} WHERE ` +
+					`} , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and ` +
 					`workflow_id = workflow1 and run_id = runid1 and ` +
 					`visibility_ts = 946684800000 and task_id = -10 `,
@@ -1516,7 +1518,7 @@ func TestUpdateSignalInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateSignalInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalInfos, tc.deleteInfos)
+			err := updateSignalInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.signalInfos, tc.deleteInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("updateSignalInfos failed: %v", err)
 			}
@@ -1563,7 +1565,7 @@ func TestResetRequestCancelInfos(t *testing.T) {
 				`UPDATE executions SET request_cancel_map = map[` +
 					`1:map[cancel_request_id:cancelRequest1 initiated_event_batch_id:2 initiated_id:1 version:1] ` +
 					`3:map[cancel_request_id:cancelRequest3 initiated_event_batch_id:4 initiated_id:3 version:2]` +
-					`]WHERE shard_id = 1000 and type = 1 and domain_id = domain1 and ` +
+					`], last_updated_time = 2025-01-06T15:00:00Z WHERE shard_id = 1000 and type = 1 and domain_id = domain1 and ` +
 					`workflow_id = workflow1 and run_id = runid1 and ` +
 					`visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1574,7 +1576,7 @@ func TestResetRequestCancelInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := resetRequestCancelInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.requestCancelInfos)
+			err := resetRequestCancelInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.requestCancelInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("resetRequestCancelInfos failed: %v", err)
 			}
@@ -1615,7 +1617,7 @@ func TestUpdateRequestCancelInfos(t *testing.T) {
 			deleteInfos: []int64{2},
 			wantQueries: []string{
 				`UPDATE executions SET request_cancel_map[ 1 ] = ` +
-					`{version: 1,initiated_id: 1, initiated_event_batch_id: 2, cancel_request_id: cancelRequest1 } ` +
+					`{version: 1,initiated_id: 1, initiated_event_batch_id: 2, cancel_request_id: cancelRequest1 } , last_updated_time = 2025-01-06T15:00:00Z ` +
 					`WHERE shard_id = 1000 and type = 1 and domain_id = domain1 and ` +
 					`workflow_id = workflow1 and run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 				`DELETE request_cancel_map[ 2 ] FROM executions WHERE ` +
@@ -1629,7 +1631,7 @@ func TestUpdateRequestCancelInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateRequestCancelInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.requestCancelInfos, tc.deleteInfos)
+			err := updateRequestCancelInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.requestCancelInfos, tc.deleteInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("updateRequestCancelInfos failed: %v", err)
 			}
@@ -1686,7 +1688,7 @@ func TestResetChildExecutionInfos(t *testing.T) {
 					`initiated_event:[] initiated_event_batch_id:2 initiated_id:1 parent_close_policy:0 ` +
 					`started_event:[] started_id:3 started_run_id:startedRunID1 started_workflow_id:startedWorkflowID1 ` +
 					`version:1 workflow_type_name:workflowType1` +
-					`]]` +
+					`]], last_updated_time = 2025-01-06T15:00:00Z ` +
 					`WHERE shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1724,7 +1726,7 @@ func TestResetChildExecutionInfos(t *testing.T) {
 					`initiated_event:[] initiated_event_batch_id:2 initiated_id:1 parent_close_policy:0 ` +
 					`started_event:[] started_id:3 started_run_id:30000000-0000-f000-f000-000000000000 started_workflow_id:startedWorkflowID1 ` +
 					`version:1 workflow_type_name:workflowType1` +
-					`]]` +
+					`]], last_updated_time = 2025-01-06T15:00:00Z ` +
 					`WHERE shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = 30000000-0000-f000-f000-000000000000 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1735,7 +1737,7 @@ func TestResetChildExecutionInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := resetChildExecutionInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.childExecutionInfos)
+			err := resetChildExecutionInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.childExecutionInfos, FixedTime)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("resetChildExecutionInfos() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -1795,7 +1797,7 @@ func TestUpdateChildExecutionInfos(t *testing.T) {
 					`started_id: 3, started_workflow_id: startedWorkflowID1, started_run_id: startedRunID1, ` +
 					`started_event: [], create_request_id: createRequestID1, event_data_encoding: thriftrw, ` +
 					`domain_id: domain1, domain_name: , workflow_type_name: workflowType1, parent_close_policy: 0` +
-					`} WHERE ` +
+					`} , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 				`DELETE child_executions_map[ 2 ] FROM executions WHERE ` +
@@ -1809,7 +1811,7 @@ func TestUpdateChildExecutionInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateChildExecutionInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.childExecutionInfos, tc.deleteInfos)
+			err := updateChildExecutionInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.childExecutionInfos, tc.deleteInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("updateChildExecutionInfos failed: %v", err)
 			}
@@ -1854,7 +1856,7 @@ func TestResetTimerInfos(t *testing.T) {
 			wantQueries: []string{
 				`UPDATE executions SET timer_map = map[` +
 					`timer1:map[expiry_time:2023-12-12 22:08:41 +0000 UTC started_id:2 task_id:1 timer_id:timer1 version:1]` +
-					`] WHERE ` +
+					`] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -1865,7 +1867,7 @@ func TestResetTimerInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := resetTimerInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.timerInfos)
+			err := resetTimerInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.timerInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("resetTimerInfos() error = %v", err)
 			}
@@ -1913,7 +1915,7 @@ func TestUpdateTimerInfos(t *testing.T) {
 			wantQueries: []string{
 				`UPDATE executions SET timer_map[ timer1 ] = {` +
 					`version: 1, timer_id: timer1, started_id: 2, expiry_time: 2023-12-19T22:08:41Z, task_id: 1` +
-					`} WHERE ` +
+					`} , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 				`DELETE timer_map[ timer2 ] FROM executions WHERE ` +
@@ -1927,7 +1929,7 @@ func TestUpdateTimerInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateTimerInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.timerInfos, tc.deleteInfos)
+			err := updateTimerInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.timerInfos, tc.deleteInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("updateTimerInfos() error = %v", err)
 			}
@@ -2035,7 +2037,7 @@ func TestResetActivityInfos(t *testing.T) {
 					`started_event:[116 104 114 105 102 116 45 101 110 99 111 100 101 100 45 115 116 97 114 116 101 100 45 101 118 101 110 116 45 100 97 116 97] ` +
 					`started_id:3 started_identity: started_time:0001-01-01 00:00:00 +0000 UTC task_list:tasklist1 timer_task_status:0 version:1` +
 					`]` +
-					`] WHERE ` +
+					`] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
@@ -2046,7 +2048,7 @@ func TestResetActivityInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := resetActivityInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.activityInfos)
+			err := resetActivityInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.activityInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("resetActivityInfos() error = %v", err)
 			}
@@ -2121,7 +2123,7 @@ func TestUpdateActivityInfos(t *testing.T) {
 					`init_interval: 0, backoff_coefficient: 0, max_interval: 0, expiration_time: 0001-01-01T00:00:00Z, ` +
 					`max_attempts: 5, non_retriable_errors: [], last_failure_reason: retry reason, last_worker_identity: , ` +
 					`last_failure_details: [], event_data_encoding: thriftrw` +
-					`} WHERE ` +
+					`} , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 				`DELETE activity_map[ 2 ] FROM executions ` +
@@ -2135,7 +2137,7 @@ func TestUpdateActivityInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateActivityInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.activityInfos, tc.deleteInfos)
+			err := updateActivityInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.activityInfos, tc.deleteInfos, FixedTime)
 			if err != nil {
 				t.Fatalf("updateActivityInfos() error = %v", err)
 			}
@@ -2302,7 +2304,7 @@ func TestCreateWorkflowExecutionWithMergeMaps(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := createWorkflowExecutionWithMergeMaps(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution)
+			err := createWorkflowExecutionWithMergeMaps(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, FixedTime)
 			gotErr := (err != nil)
 			if gotErr != tc.wantErr {
 				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)
@@ -2395,7 +2397,7 @@ func TestResetWorkflowExecutionAndMapsAndEventBuffer(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := resetWorkflowExecutionAndMapsAndEventBuffer(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution)
+			err := resetWorkflowExecutionAndMapsAndEventBuffer(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, FixedTime)
 			gotErr := (err != nil)
 			if gotErr != tc.wantErr {
 				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)
@@ -2551,7 +2553,7 @@ func TestUpdateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(t *testing.
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution)
+			err := updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, FixedTime)
 			gotErr := (err != nil)
 			if gotErr != tc.wantErr {
 				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)
@@ -2623,7 +2625,7 @@ func TestUpdateWorkflowExecution(t *testing.T) {
 					`init_interval: 0, backoff_coefficient: 0, max_interval: 0, expiration_time: 0001-01-01T00:00:00Z, max_attempts: 0, ` +
 					`non_retriable_errors: [], event_store_version: 2, branch_token: [], cron_schedule: , expiration_seconds: 0, search_attributes: map[], ` +
 					`memo: map[], partition_config: map[] ` +
-					`}, next_event_id = 0 , version_histories = [] , version_histories_encoding =  , checksum = {version: 0, flavor: 0, value: [] }, workflow_last_write_version = 0 , workflow_state = 0 ` +
+					`}, next_event_id = 0 , version_histories = [] , version_histories_encoding =  , checksum = {version: 0, flavor: 0, value: [] }, workflow_last_write_version = 0 , workflow_state = 0 , last_updated_time = 2025-01-06T15:00:00Z ` +
 					`WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 ` +
@@ -2636,7 +2638,7 @@ func TestUpdateWorkflowExecution(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateWorkflowExecution(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution)
+			err := updateWorkflowExecution(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, FixedTime)
 			if err != nil {
 				t.Fatalf("updateWorkflowExecution failed, err: %v", err)
 			}
@@ -2689,7 +2691,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 				Checksums:                    &checksum.Checksum{},
 			},
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, domain_id, workflow_id, run_id, type, execution, next_event_id, visibility_ts, task_id, version_histories, version_histories_encoding, checksum, workflow_last_write_version, workflow_state) ` +
+				`INSERT INTO executions (shard_id, domain_id, workflow_id, run_id, type, execution, next_event_id, visibility_ts, task_id, version_histories, version_histories_encoding, checksum, workflow_last_write_version, workflow_state, created_time) ` +
 					`VALUES(1000, domain1, workflow1, runid1, 1, ` +
 					`{domain_id: domain1, workflow_id: workflow1, run_id: runid1, first_run_id: , parent_domain_id: , parent_workflow_id: , ` +
 					`parent_run_id: parentRunID1, initiated_id: 0, completion_event_batch_id: 0, completion_event: [], completion_event_data_encoding: , ` +
@@ -2702,7 +2704,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 					`client_impl: , auto_reset_points: [], auto_reset_points_encoding: , attempt: 0, has_retry_policy: false, init_interval: 0, ` +
 					`backoff_coefficient: 0, max_interval: 0, expiration_time: 0001-01-01T00:00:00Z, max_attempts: 0, non_retriable_errors: [], ` +
 					`event_store_version: 2, branch_token: [], cron_schedule: , expiration_seconds: 0, search_attributes: map[], memo: map[], partition_config: map[] ` +
-					`}, 0, 946684800000, -10, [], , {version: 0, flavor: 0, value: [] }, 0, 0) IF NOT EXISTS `,
+					`}, 0, 946684800000, -10, [], , {version: 0, flavor: 0, value: [] }, 0, 0, 2025-01-06T15:00:00Z) IF NOT EXISTS `,
 			},
 		},
 	}
@@ -2711,7 +2713,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := createWorkflowExecution(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution)
+			err := createWorkflowExecution(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, FixedTime)
 			if err != nil {
 				t.Fatalf("createWorkflowExecution failed, err: %v", err)
 			}
@@ -2769,9 +2771,9 @@ func TestCreateOrUpdateWorkflowExecution(t *testing.T) {
 				},
 			},
 			wantQueries: []string{
-				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, execution, workflow_last_write_version, workflow_state) ` +
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, execution, workflow_last_write_version, workflow_state, created_time) ` +
 					`VALUES(1000, 1, domain1, workflow1, 30000000-0000-f000-f000-000000000001, 946684800000, -10, runid1, ` +
-					`{run_id: runid1, create_request_id: createRequestID1, state: 0, close_status: 0}, 0, 0) ` +
+					`{run_id: runid1, create_request_id: createRequestID1, state: 0, close_status: 0}, 0, 0, 2025-01-06T15:00:00Z) ` +
 					`IF NOT EXISTS USING TTL 0 `,
 			},
 		},
@@ -2833,7 +2835,7 @@ func TestCreateOrUpdateWorkflowExecution(t *testing.T) {
 				`UPDATE executions USING TTL 0 SET ` +
 					`current_run_id = runid1, ` +
 					`execution = {run_id: runid1, create_request_id: createRequestID1, state: 0, close_status: 0}, ` +
-					`workflow_last_write_version = 0, workflow_state = 0 ` +
+					`workflow_last_write_version = 0, workflow_state = 0, last_updated_time = 2025-01-06T15:00:00Z ` +
 					`WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = 30000000-0000-f000-f000-000000000001 and visibility_ts = 946684800000 and task_id = -10 ` +
@@ -2861,7 +2863,7 @@ func TestCreateOrUpdateWorkflowExecution(t *testing.T) {
 				`UPDATE executions USING TTL 0 SET ` +
 					`current_run_id = runid1, ` +
 					`execution = {run_id: runid1, create_request_id: createRequestID1, state: 0, close_status: 0}, ` +
-					`workflow_last_write_version = 0, workflow_state = 0 ` +
+					`workflow_last_write_version = 0, workflow_state = 0, last_updated_time = 2025-01-06T15:00:00Z ` +
 					`WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = 30000000-0000-f000-f000-000000000001 and visibility_ts = 946684800000 and task_id = -10 ` +
@@ -2874,7 +2876,7 @@ func TestCreateOrUpdateWorkflowExecution(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := createOrUpdateCurrentWorkflow(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution)
+			err := createOrUpdateCurrentWorkflow(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, FixedTime)
 			gotErr := (err != nil)
 			if gotErr != tc.wantErr {
 				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-var FixedTime time.Time = time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC)
+var FixedTime = time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC)
 
 // fakeSession is fake implementation of gocql.Session
 type fakeSession struct {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update queries about execution table with created_time and last_updated_time
Updated unit test accordingly

<!-- Tell your future self why have you made these changes -->
**Why?**
to make rows in Cassandra easier to debug

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test
manually tested in mono repo

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
