### PR TITLE
[Wf-Diagnostics] Refactor the workflow diagnostics initialisation code

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -21,6 +21,10 @@
 package cadence
 
 import (
+	diagnosticsInvariant "github.com/uber/cadence/service/worker/diagnostics/invariant"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
 	"log"
 	"time"
 
@@ -258,6 +262,7 @@ func (s *server) startService() common.Daemon {
 	}
 
 	params.KafkaConfig = s.cfg.Kafka
+	params.DiagnosticsInvariants = []diagnosticsInvariant.Invariant{timeout.NewInvariant(timeout.NewTimeoutParams{Client: params.PublicClient}), failure.NewInvariant(), retry.NewInvariant()}
 
 	params.Logger.Info("Starting service " + s.name)
 

--- a/common/resource/params.go
+++ b/common/resource/params.go
@@ -22,6 +22,7 @@ package resource
 
 import (
 	"github.com/uber-go/tally"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 
 	"github.com/uber/cadence/client/history"
@@ -92,6 +93,7 @@ type (
 		// HistoryClientFn is used by integration tests to mock a history client
 		HistoryClientFn func() history.Client
 		// NewPersistenceBeanFn can be used to override the default persistence bean creation in unit tests to avoid DB setup
-		NewPersistenceBeanFn func(persistenceClient.Factory, *persistenceClient.Params, *service.Config) (persistenceClient.Bean, error)
+		NewPersistenceBeanFn  func(persistenceClient.Factory, *persistenceClient.Params, *service.Config) (persistenceClient.Bean, error)
+		DiagnosticsInvariants []invariant.Invariant
 	}
 )

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -30,9 +30,6 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
-	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
-	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
-	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
 )
 
 const (
@@ -63,66 +60,38 @@ type identifyIssuesParams struct {
 func (w *dw) identifyIssues(ctx context.Context, info identifyIssuesParams) ([]invariant.InvariantCheckResult, error) {
 	result := make([]invariant.InvariantCheckResult, 0)
 
-	timeoutInvariant := timeout.NewInvariant(timeout.NewTimeoutParams{
-		WorkflowExecutionHistory: info.History,
-		Domain:                   info.Domain,
-		ClientBean:               w.clientBean,
-	})
-	timeoutIssues, err := timeoutInvariant.Check(ctx)
-	if err != nil {
-		return nil, err
+	for _, inv := range w.invariants {
+		issues, err := inv.Check(ctx, invariant.InvariantCheckInput{
+			WorkflowExecutionHistory: info.History,
+			Domain:                   info.Domain,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, issues...)
 	}
-	result = append(result, timeoutIssues...)
-
-	failureInvariant := failure.NewInvariant(failure.Params{
-		WorkflowExecutionHistory: info.History,
-		Domain:                   info.Domain,
-	})
-	failureIssues, err := failureInvariant.Check(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result = append(result, failureIssues...)
-
-	retryInvariant := retry.NewInvariant(retry.Params{
-		WorkflowExecutionHistory: info.History,
-	})
-	retryIssues, err := retryInvariant.Check(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result = append(result, retryIssues...)
 
 	return result, nil
 }
 
 type rootCauseIssuesParams struct {
-	History *types.GetWorkflowExecutionHistoryResponse
-	Domain  string
-	Issues  []invariant.InvariantCheckResult
+	Domain string
+	Issues []invariant.InvariantCheckResult
 }
 
 func (w *dw) rootCauseIssues(ctx context.Context, info rootCauseIssuesParams) ([]invariant.InvariantRootCauseResult, error) {
 	result := make([]invariant.InvariantRootCauseResult, 0)
-	timeoutInvariant := timeout.NewInvariant(timeout.NewTimeoutParams{
-		WorkflowExecutionHistory: info.History,
-		ClientBean:               w.clientBean,
-		Domain:                   info.Domain,
-	})
-	timeoutRC, err := timeoutInvariant.RootCause(ctx, info.Issues)
-	if err != nil {
-		return nil, err
+
+	for _, inv := range w.invariants {
+		rootCause, err := inv.RootCause(ctx, invariant.InvariantRootCauseInput{
+			Domain: info.Domain,
+			Issues: info.Issues,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, rootCause...)
 	}
-	result = append(result, timeoutRC...)
-	failureInvariant := failure.NewInvariant(failure.Params{
-		WorkflowExecutionHistory: info.History,
-		Domain:                   info.Domain,
-	})
-	failureRC, err := failureInvariant.RootCause(ctx, info.Issues)
-	if err != nil {
-		return nil, err
-	}
-	result = append(result, failureRC...)
 
 	return result, nil
 }

--- a/service/worker/diagnostics/invariant/failure/failure_test.go
+++ b/service/worker/diagnostics/invariant/failure/failure_test.go
@@ -109,11 +109,11 @@ func Test__Check(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		inv := NewInvariant(Params{
+		inv := NewInvariant()
+		result, err := inv.Check(context.Background(), invariant.InvariantCheckInput{
 			WorkflowExecutionHistory: tc.testData,
 			Domain:                   testDomain,
 		})
-		result, err := inv.Check(context.Background())
 		require.Equal(t, tc.err, err)
 		require.Equal(t, len(tc.expectedResult), len(result))
 		require.ElementsMatch(t, tc.expectedResult, result)
@@ -283,9 +283,11 @@ func Test__RootCause(t *testing.T) {
 			err: nil,
 		},
 	}
-	inv := NewInvariant(Params{})
+	inv := NewInvariant()
 	for _, tc := range testCases {
-		result, err := inv.RootCause(context.Background(), tc.input)
+		result, err := inv.RootCause(context.Background(), invariant.InvariantRootCauseInput{
+			Issues: tc.input,
+		})
 		require.Equal(t, tc.err, err)
 		require.Equal(t, len(tc.expectedResult), len(result))
 		require.ElementsMatch(t, tc.expectedResult, result)

--- a/service/worker/diagnostics/invariant/interface.go
+++ b/service/worker/diagnostics/invariant/interface.go
@@ -25,6 +25,7 @@ package invariant
 import (
 	"context"
 	"encoding/json"
+	"github.com/uber/cadence/common/types"
 )
 
 // InvariantCheckResult is the result from the invariant check
@@ -40,6 +41,15 @@ type InvariantRootCauseResult struct {
 	Metadata  []byte
 }
 
+type InvariantCheckInput struct {
+	WorkflowExecutionHistory *types.GetWorkflowExecutionHistoryResponse
+	Domain                   string
+}
+
+type InvariantRootCauseInput struct {
+	Domain string
+	Issues []InvariantCheckResult
+}
 type RootCause string
 
 const (
@@ -61,8 +71,8 @@ func (r RootCause) String() string {
 
 // Invariant represents a condition of a workflow execution.
 type Invariant interface {
-	Check(context.Context) ([]InvariantCheckResult, error)
-	RootCause(context.Context, []InvariantCheckResult) ([]InvariantRootCauseResult, error)
+	Check(context.Context, InvariantCheckInput) ([]InvariantCheckResult, error)
+	RootCause(context.Context, InvariantRootCauseInput) ([]InvariantRootCauseResult, error)
 }
 
 func MarshalData(rc any) []byte {

--- a/service/worker/diagnostics/invariant/retry/retry.go
+++ b/service/worker/diagnostics/invariant/retry/retry.go
@@ -34,22 +34,15 @@ import (
 type Retry invariant.Invariant
 
 type retry struct {
-	workflowExecutionHistory *types.GetWorkflowExecutionHistoryResponse
 }
 
-type Params struct {
-	WorkflowExecutionHistory *types.GetWorkflowExecutionHistoryResponse
+func NewInvariant() Retry {
+	return &retry{}
 }
 
-func NewInvariant(p Params) Retry {
-	return &retry{
-		workflowExecutionHistory: p.WorkflowExecutionHistory,
-	}
-}
-
-func (r *retry) Check(context.Context) ([]invariant.InvariantCheckResult, error) {
+func (r *retry) Check(ctx context.Context, params invariant.InvariantCheckInput) ([]invariant.InvariantCheckResult, error) {
 	result := make([]invariant.InvariantCheckResult, 0)
-	events := r.workflowExecutionHistory.GetHistory().GetEvents()
+	events := params.WorkflowExecutionHistory.GetHistory().GetEvents()
 
 	lastEvent := fetchContinuedAsNewEvent(events)
 	startedEvent := fetchWfStartedEvent(events)
@@ -122,7 +115,7 @@ func checkRetryPolicy(policy *types.RetryPolicy) IssueType {
 	return ""
 }
 
-func (r *retry) RootCause(ctx context.Context, issues []invariant.InvariantCheckResult) ([]invariant.InvariantRootCauseResult, error) {
+func (r *retry) RootCause(ctx context.Context, params invariant.InvariantRootCauseInput) ([]invariant.InvariantRootCauseResult, error) {
 	// Not implemented since this invariant does not have any root cause.
 	// Issue identified in Check() are the root cause.
 	result := make([]invariant.InvariantRootCauseResult, 0)

--- a/service/worker/diagnostics/invariant/retry/retry_test.go
+++ b/service/worker/diagnostics/invariant/retry/retry_test.go
@@ -96,10 +96,10 @@ func Test__Check(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		inv := NewInvariant(Params{
+		inv := NewInvariant()
+		result, err := inv.Check(context.Background(), invariant.InvariantCheckInput{
 			WorkflowExecutionHistory: tc.testData,
 		})
-		result, err := inv.Check(context.Background())
 		require.Equal(t, tc.err, err)
 		require.Equal(t, len(tc.expectedResult), len(result))
 		require.ElementsMatch(t, tc.expectedResult, result)

--- a/service/worker/diagnostics/invariant/timeout/timeout_test.go
+++ b/service/worker/diagnostics/invariant/timeout/timeout_test.go
@@ -25,14 +25,14 @@ package timeout
 import (
 	"context"
 	"encoding/json"
+	publicservicetest "go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
+	"go.uber.org/cadence/.gen/go/shared"
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/client"
-	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
@@ -118,14 +118,15 @@ func Test__Check(t *testing.T) {
 		},
 	}
 	ctrl := gomock.NewController(t)
-	mockClientBean := client.NewMockBean(ctrl)
+	mockClient := publicservicetest.NewMockClient(ctrl)
 	for _, tc := range testCases {
 		inv := NewInvariant(NewTimeoutParams{
+			Client: mockClient,
+		})
+		result, err := inv.Check(context.Background(), invariant.InvariantCheckInput{
 			WorkflowExecutionHistory: tc.testData,
 			Domain:                   testDomain,
-			ClientBean:               mockClientBean,
 		})
-		result, err := inv.Check(context.Background())
 		require.Equal(t, tc.err, err)
 		require.Equal(t, len(tc.expectedResult), len(result))
 		for i := range result {
@@ -399,7 +400,7 @@ func Test__RootCause(t *testing.T) {
 	testCases := []struct {
 		name           string
 		input          []invariant.InvariantCheckResult
-		clientExpects  func(*frontend.MockClient)
+		clientExpects  func(client *publicservicetest.MockClient)
 		expectedResult []invariant.InvariantRootCauseResult
 		err            error
 	}{
@@ -412,11 +413,11 @@ func Test__RootCause(t *testing.T) {
 					Metadata:      wfTimeoutDataInBytes(t),
 				},
 			},
-			clientExpects: func(client *frontend.MockClient) {
-				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&types.DescribeTaskListResponse{
+			clientExpects: func(client *publicservicetest.MockClient) {
+				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&shared.DescribeTaskListResponse{
 					Pollers: nil,
-					TaskListStatus: &types.TaskListStatus{
-						BacklogCountHint: testTaskListBacklog,
+					TaskListStatus: &shared.TaskListStatus{
+						BacklogCountHint: common.Int64Ptr(testTaskListBacklog),
 					},
 				}, nil)
 			},
@@ -437,15 +438,15 @@ func Test__RootCause(t *testing.T) {
 					Metadata:      wfTimeoutDataInBytes(t),
 				},
 			},
-			clientExpects: func(client *frontend.MockClient) {
-				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&types.DescribeTaskListResponse{
-					Pollers: []*types.PollerInfo{
+			clientExpects: func(client *publicservicetest.MockClient) {
+				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&shared.DescribeTaskListResponse{
+					Pollers: []*shared.PollerInfo{
 						{
-							Identity: "dca24-xy",
+							Identity: common.StringPtr("dca24-xy"),
 						},
 					},
-					TaskListStatus: &types.TaskListStatus{
-						BacklogCountHint: testTaskListBacklog,
+					TaskListStatus: &shared.TaskListStatus{
+						BacklogCountHint: common.Int64Ptr(testTaskListBacklog),
 					},
 				}, nil)
 			},
@@ -466,15 +467,15 @@ func Test__RootCause(t *testing.T) {
 					Metadata:      activityStartToCloseTimeoutDataInBytes(t),
 				},
 			},
-			clientExpects: func(client *frontend.MockClient) {
-				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&types.DescribeTaskListResponse{
-					Pollers: []*types.PollerInfo{
+			clientExpects: func(client *publicservicetest.MockClient) {
+				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&shared.DescribeTaskListResponse{
+					Pollers: []*shared.PollerInfo{
 						{
-							Identity: "dca24-xy",
+							Identity: common.StringPtr("dca24-xy"),
 						},
 					},
-					TaskListStatus: &types.TaskListStatus{
-						BacklogCountHint: testTaskListBacklog,
+					TaskListStatus: &shared.TaskListStatus{
+						BacklogCountHint: common.Int64Ptr(testTaskListBacklog),
 					},
 				}, nil)
 			},
@@ -499,15 +500,15 @@ func Test__RootCause(t *testing.T) {
 					Metadata:      activityScheduleToStartTimeoutDataInBytes(t),
 				},
 			},
-			clientExpects: func(client *frontend.MockClient) {
-				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&types.DescribeTaskListResponse{
-					Pollers: []*types.PollerInfo{
+			clientExpects: func(client *publicservicetest.MockClient) {
+				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&shared.DescribeTaskListResponse{
+					Pollers: []*shared.PollerInfo{
 						{
-							Identity: "dca24-xy",
+							Identity: common.StringPtr("dca24-xy"),
 						},
 					},
-					TaskListStatus: &types.TaskListStatus{
-						BacklogCountHint: testTaskListBacklog,
+					TaskListStatus: &shared.TaskListStatus{
+						BacklogCountHint: common.Int64Ptr(testTaskListBacklog),
 					},
 				}, nil)
 			},
@@ -528,15 +529,15 @@ func Test__RootCause(t *testing.T) {
 					Metadata:      activityHeartBeatTimeoutDataWithRetryPolicyInBytes(t),
 				},
 			},
-			clientExpects: func(client *frontend.MockClient) {
-				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&types.DescribeTaskListResponse{
-					Pollers: []*types.PollerInfo{
+			clientExpects: func(client *publicservicetest.MockClient) {
+				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&shared.DescribeTaskListResponse{
+					Pollers: []*shared.PollerInfo{
 						{
-							Identity: "dca24-xy",
+							Identity: common.StringPtr("dca24-xy"),
 						},
 					},
-					TaskListStatus: &types.TaskListStatus{
-						BacklogCountHint: testTaskListBacklog,
+					TaskListStatus: &shared.TaskListStatus{
+						BacklogCountHint: common.Int64Ptr(testTaskListBacklog),
 					},
 				}, nil)
 			},
@@ -561,15 +562,15 @@ func Test__RootCause(t *testing.T) {
 					Metadata:      activityHeartBeatTimeoutDataInBytes(t),
 				},
 			},
-			clientExpects: func(client *frontend.MockClient) {
-				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&types.DescribeTaskListResponse{
-					Pollers: []*types.PollerInfo{
+			clientExpects: func(client *publicservicetest.MockClient) {
+				client.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(&shared.DescribeTaskListResponse{
+					Pollers: []*shared.PollerInfo{
 						{
-							Identity: "dca24-xy",
+							Identity: common.StringPtr("dca24-xy"),
 						},
 					},
-					TaskListStatus: &types.TaskListStatus{
-						BacklogCountHint: testTaskListBacklog,
+					TaskListStatus: &shared.TaskListStatus{
+						BacklogCountHint: common.Int64Ptr(testTaskListBacklog),
 					},
 				}, nil)
 			},
@@ -587,16 +588,16 @@ func Test__RootCause(t *testing.T) {
 		},
 	}
 	ctrl := gomock.NewController(t)
-	mockClientBean := client.NewMockBean(ctrl)
-	mockFrontendClient := frontend.NewMockClient(ctrl)
-	mockClientBean.EXPECT().GetFrontendClient().Return(mockFrontendClient).AnyTimes()
+	mockClient := publicservicetest.NewMockClient(ctrl)
 	inv := NewInvariant(NewTimeoutParams{
-		Domain:     testDomain,
-		ClientBean: mockClientBean,
+		Client: mockClient,
 	})
 	for _, tc := range testCases {
-		tc.clientExpects(mockFrontendClient)
-		result, err := inv.RootCause(context.Background(), tc.input)
+		tc.clientExpects(mockClient)
+		result, err := inv.RootCause(context.Background(), invariant.InvariantRootCauseInput{
+			Domain: testDomain,
+			Issues: tc.input,
+		})
 		require.Equal(t, tc.err, err)
 		require.Equal(t, len(tc.expectedResult), len(result))
 		for i := range result {

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
@@ -52,6 +53,7 @@ type dw struct {
 	tallyScope    tally.Scope
 	worker        worker.Worker
 	kafkaCfg      config.KafkaConfig
+	invariants    []invariant.Invariant
 }
 
 type Params struct {
@@ -61,6 +63,7 @@ type Params struct {
 	Logger        log.Logger
 	TallyScope    tally.Scope
 	KafkaCfg      config.KafkaConfig
+	Invariants    []invariant.Invariant
 }
 
 // New creates a new diagnostics workflow.
@@ -72,6 +75,7 @@ func New(params Params) DiagnosticsWorkflow {
 		clientBean:    params.ClientBean,
 		logger:        params.Logger,
 		kafkaCfg:      params.KafkaCfg,
+		invariants:    params.Invariants,
 	}
 }
 

--- a/service/worker/diagnostics/module_test.go
+++ b/service/worker/diagnostics/module_test.go
@@ -23,6 +23,8 @@
 package diagnostics
 
 import (
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,5 +58,6 @@ func setuptest(t *testing.T) (DiagnosticsWorkflow, *resource.Test) {
 		ClientBean:    mockClientBean,
 		MetricsClient: nil,
 		TallyScope:    tally.TestScope(nil),
+		Invariants:    []invariant.Invariant{failure.NewInvariant()},
 	}), mockResource
 }

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -148,9 +148,8 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	}
 
 	err = workflow.ExecuteActivity(activityCtx, w.rootCauseIssues, rootCauseIssuesParams{
-		History: wfExecutionHistory,
-		Domain:  params.Domain,
-		Issues:  checkResult,
+		Domain: params.Domain,
+		Issues: checkResult,
 	}).Get(ctx, &rootCauseResult)
 	if err != nil {
 		return nil, fmt.Errorf("RootCauseIssues: %w", err)

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -61,11 +61,12 @@ func (s *diagnosticsWorkflowTestSuite) SetupTest() {
 	s.workflowEnv = s.NewTestWorkflowEnvironment()
 	controller := gomock.NewController(s.T())
 	mockResource := resource.NewTest(s.T(), controller, metrics.Worker)
-
+	publicClient := mockResource.GetSDKClient()
 	s.dw = &dw{
-		svcClient:     mockResource.GetSDKClient(),
+		svcClient:     publicClient,
 		clientBean:    mockResource.ClientBean,
 		metricsClient: mockResource.GetMetricsClient(),
+		invariants:    []invariant.Invariant{timeout.NewInvariant(timeout.NewTimeoutParams{Client: publicClient}), failure.NewInvariant(), retry.NewInvariant()},
 	}
 
 	s.T().Cleanup(func() {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -349,6 +349,7 @@ func (s *Service) startDiagnostics() {
 		ClientBean:    s.GetClientBean(),
 		Logger:        s.GetLogger(),
 		KafkaCfg:      s.params.KafkaConfig,
+		Invariants:    s.params.DiagnosticsInvariants,
 	}
 	if err := diagnostics.New(params).Start(); err != nil {
 		s.Stop()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Invariants are initialised outside the service and provided as inputs before starting worker service or diagnostics. As a result, the diagnostics workflow is generic and performs the same checks and rootcause across all invariants

<!-- Tell your future self why have you made these changes -->
**Why?**
The invariants used in workflow diagnostics were initialised within the service and as a result was hard to setup overrides for alternative implementations of the same invariant

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Invariant interface has been modified so when this PR is merged with alternate implementations within Uber, they need to be modified accordingly

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
