### PR TITLE
Use taskAckManager's BacklogCount for DescribeTaskList

### DIFF
--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -726,12 +726,7 @@ func (c *taskListManagerImpl) DescribeTaskList(includeTaskListStatus bool) *type
 		return response
 	}
 
-	taskIDBlock := rangeIDToTaskIDBlock(c.db.RangeID(), c.config.RangeSize)
-	backlogCount, err := c.db.GetTaskListSize(c.taskAckManager.GetAckLevel())
-	if err != nil {
-		// fallback to im-memory backlog, if failed to get count from db
-		backlogCount = c.taskAckManager.GetBacklogCount()
-	}
+	idBlock := rangeIDToTaskIDBlock(c.db.RangeID(), c.config.RangeSize)
 	isolationGroups := c.config.AllIsolationGroups()
 	pollerCounts := c.getRecentPollersByIsolationGroup()
 	isolationGroupMetrics := make(map[string]*types.IsolationGroupMetrics, len(isolationGroups))
@@ -744,11 +739,11 @@ func (c *taskListManagerImpl) DescribeTaskList(includeTaskListStatus bool) *type
 	response.TaskListStatus = &types.TaskListStatus{
 		ReadLevel:        c.taskAckManager.GetReadLevel(),
 		AckLevel:         c.taskAckManager.GetAckLevel(),
-		BacklogCountHint: backlogCount,
+		BacklogCountHint: c.taskAckManager.GetBacklogCount(),
 		RatePerSecond:    c.matcher.Rate(),
 		TaskIDBlock: &types.TaskIDBlock{
-			StartID: taskIDBlock.start,
-			EndID:   taskIDBlock.end,
+			StartID: idBlock.start,
+			EndID:   idBlock.end,
 		},
 		IsolationGroupMetrics: isolationGroupMetrics,
 		NewTasksPerSecond:     c.qpsTracker.QPS(),

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -307,13 +307,18 @@ func TestDescribeTaskList(t *testing.T) {
 			name:          "with status, tasks completed",
 			includeStatus: true,
 			allowance: func(_ *gomock.Controller, tlm *taskListManagerImpl) {
-				tlm.taskAckManager.SetAckLevel(5)
-				tlm.taskAckManager.SetReadLevel(10)
+				for i := startedID; i < 11; i++ {
+					err := tlm.taskAckManager.ReadItem(i)
+					require.NoError(t, err)
+				}
+				for i := startedID; i < 5; i++ {
+					tlm.taskAckManager.AckItem(i)
+				}
 			},
 			expectedStatus: &types.TaskListStatus{
-				BacklogCountHint: 0,
+				BacklogCountHint: 6,
 				ReadLevel:        10,
-				AckLevel:         5,
+				AckLevel:         4,
 				RatePerSecond:    defaultRps,
 				TaskIDBlock:      firstIDBlock,
 				IsolationGroupMetrics: map[string]*types.IsolationGroupMetrics{


### PR DESCRIPTION
In all other contexts we use the taskAckManager's BacklogCount as the BacklogCountHint, such as the LoadBalancerHints and task poll responses. This definition aligns with those and removes the error-prone logic to use another value, silently falling back to this value.

This additionally ensures that DescribeTaskList is responsive as all values returned are stored in memory. This method is used by the UI, CLI, and in the future will be used for automated tasklist partition scaling.

<!-- Describe what has changed in this PR -->
**What changed?**
- DescribeTaskList's BacklogCount will use the backlog count from the ackManager, rather than reading the number of tasks in the database. 

<!-- Tell your future self why have you made these changes -->
**Why?**
- This caps the value at the size of batches we read but ensures it returns a consistent value and does so quickly. Counting the number of tasks is slow when the backlog is large, and if it fails to do so it silently falls back to this value.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit Tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- This is low risk as this value is only used by the CLI for debugging purposes. The task_reader continues to publish the original metric value, which is the primary mechanism we use for examining and alerting on backlogs.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
