### PR TITLE
Fix logging bug on task completer by adding nil check to error

### DIFF
--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -154,7 +154,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 
 	err := tc.throttleRetry.Do(ctx, op)
 
-	if !errors.Is(err, errDomainIsActive) && !errors.Is(err, errTaskNotStarted) {
+	if err != nil && !errors.Is(err, errDomainIsActive) && !errors.Is(err, errTaskNotStarted) {
 		tc.scope.IncCounter(metrics.StandbyClusterTasksCompletionFailurePerTaskList)
 		tc.logger.Error("Error completing task on domain's standby cluster", tag.Error(err))
 	}


### PR DESCRIPTION
**What changed?**
Add nil check to error before logging error on task completer.

**Why?**
The check was missing and metrics and logs were being recorded incorrectly

**How did you test it?**
Will verify on staging

**Potential risks**

**Release notes**

**Documentation Changes**
