### PR TITLE
[Wf-Diagnostics] create messaging client only if not initialised

### DIFF
--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -24,8 +24,8 @@ package diagnostics
 
 import (
 	"context"
-	"github.com/uber/cadence/common/log/tag"
 
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/common/log/tag"
 
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/types"
@@ -98,6 +99,7 @@ func (w *dw) rootCauseIssues(ctx context.Context, info rootCauseIssuesParams) ([
 func (w *dw) emitUsageLogs(ctx context.Context, info analytics.WfDiagnosticsUsageData) error {
 	if w.messagingClient == nil {
 		// skip emitting logs if messaging client is not provided since it is optional
+		w.logger.Error("messaging client is not provided, skipping emitting wf-diagnostics usage logs", tag.WorkflowDomainName(info.Domain))
 		return nil
 	}
 	return emit(ctx, info, w.messagingClient)

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -26,7 +26,6 @@ import (
 	"context"
 
 	"github.com/uber/cadence/common/messaging"
-	"github.com/uber/cadence/common/messaging/kafka"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
@@ -98,7 +97,8 @@ func (w *dw) rootCauseIssues(ctx context.Context, info rootCauseIssuesParams) ([
 
 func (w *dw) emitUsageLogs(ctx context.Context, info analytics.WfDiagnosticsUsageData) error {
 	if w.messagingClient == nil {
-		w.messagingClient = kafka.NewKafkaClient(&w.kafkaCfg, w.metricsClient, w.logger, w.tallyScope, true)
+		// skip emitting logs if messaging client is not provided since it is optional
+		return nil
 	}
 	return emit(ctx, info, w.messagingClient)
 }

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -102,13 +102,15 @@ func (w *dw) emitUsageLogs(ctx context.Context, info analytics.WfDiagnosticsUsag
 		w.logger.Error("messaging client is not provided, skipping emitting wf-diagnostics usage logs", tag.WorkflowDomainName(info.Domain))
 		return nil
 	}
-	return emit(ctx, info, w.messagingClient)
+	return w.emit(ctx, info, w.messagingClient)
 }
 
-func emit(ctx context.Context, info analytics.WfDiagnosticsUsageData, client messaging.Client) error {
+func (w *dw) emit(ctx context.Context, info analytics.WfDiagnosticsUsageData, client messaging.Client) error {
 	producer, err := client.NewProducer(WfDiagnosticsAppName)
 	if err != nil {
-		return err
+		// skip emitting logs if producer cannot be created since it is optional
+		w.logger.Error("producer creation failed, skipping emitting wf-diagnostics usage logs", tag.WorkflowDomainName(info.Domain))
+		return nil
 	}
 	emitter := analytics.NewEmitter(analytics.EmitterParams{
 		Producer: producer,

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -97,12 +97,10 @@ func (w *dw) rootCauseIssues(ctx context.Context, info rootCauseIssuesParams) ([
 }
 
 func (w *dw) emitUsageLogs(ctx context.Context, info analytics.WfDiagnosticsUsageData) error {
-	client := w.newMessagingClient()
-	return emit(ctx, info, client)
-}
-
-func (w *dw) newMessagingClient() messaging.Client {
-	return kafka.NewKafkaClient(&w.kafkaCfg, w.metricsClient, w.logger, w.tallyScope, true)
+	if w.messagingClient == nil {
+		w.messagingClient = kafka.NewKafkaClient(&w.kafkaCfg, w.metricsClient, w.logger, w.tallyScope, true)
+	}
+	return emit(ctx, info, w.messagingClient)
 }
 
 func emit(ctx context.Context, info analytics.WfDiagnosticsUsageData, client messaging.Client) error {

--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -140,11 +140,12 @@ func Test__rootCauseIssues(t *testing.T) {
 
 func Test__emit(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	dwtest := testDiagnosticWorkflow(t)
 	mockClient := messaging.NewMockClient(ctrl)
 	mockProducer := messaging.NewMockProducer(ctrl)
 	mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 	mockClient.EXPECT().NewProducer(WfDiagnosticsAppName).Return(mockProducer, nil)
-	err := emit(context.Background(), analytics.WfDiagnosticsUsageData{}, mockClient)
+	err := dwtest.emit(context.Background(), analytics.WfDiagnosticsUsageData{}, mockClient)
 	require.NoError(t, err)
 }
 

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
@@ -54,7 +53,6 @@ type dw struct {
 	logger          log.Logger
 	tallyScope      tally.Scope
 	worker          worker.Worker
-	kafkaCfg        config.KafkaConfig
 	invariants      []invariant.Invariant
 }
 
@@ -65,7 +63,6 @@ type Params struct {
 	MessagingClient messaging.Client
 	Logger          log.Logger
 	TallyScope      tally.Scope
-	KafkaCfg        config.KafkaConfig
 	Invariants      []invariant.Invariant
 }
 
@@ -78,7 +75,6 @@ func New(params Params) DiagnosticsWorkflow {
 		tallyScope:      params.TallyScope,
 		clientBean:      params.ClientBean,
 		logger:          params.Logger,
-		kafkaCfg:        params.KafkaCfg,
 		invariants:      params.Invariants,
 	}
 }

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/common/messaging"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
@@ -46,36 +47,39 @@ type DiagnosticsWorkflow interface {
 }
 
 type dw struct {
-	svcClient     workflowserviceclient.Interface
-	clientBean    client.Bean
-	metricsClient metrics.Client
-	logger        log.Logger
-	tallyScope    tally.Scope
-	worker        worker.Worker
-	kafkaCfg      config.KafkaConfig
-	invariants    []invariant.Invariant
+	svcClient       workflowserviceclient.Interface
+	clientBean      client.Bean
+	metricsClient   metrics.Client
+	messagingClient messaging.Client
+	logger          log.Logger
+	tallyScope      tally.Scope
+	worker          worker.Worker
+	kafkaCfg        config.KafkaConfig
+	invariants      []invariant.Invariant
 }
 
 type Params struct {
-	ServiceClient workflowserviceclient.Interface
-	ClientBean    client.Bean
-	MetricsClient metrics.Client
-	Logger        log.Logger
-	TallyScope    tally.Scope
-	KafkaCfg      config.KafkaConfig
-	Invariants    []invariant.Invariant
+	ServiceClient   workflowserviceclient.Interface
+	ClientBean      client.Bean
+	MetricsClient   metrics.Client
+	MessagingClient messaging.Client
+	Logger          log.Logger
+	TallyScope      tally.Scope
+	KafkaCfg        config.KafkaConfig
+	Invariants      []invariant.Invariant
 }
 
 // New creates a new diagnostics workflow.
 func New(params Params) DiagnosticsWorkflow {
 	return &dw{
-		svcClient:     params.ServiceClient,
-		metricsClient: params.MetricsClient,
-		tallyScope:    params.TallyScope,
-		clientBean:    params.ClientBean,
-		logger:        params.Logger,
-		kafkaCfg:      params.KafkaCfg,
-		invariants:    params.Invariants,
+		svcClient:       params.ServiceClient,
+		metricsClient:   params.MetricsClient,
+		messagingClient: params.MessagingClient,
+		tallyScope:      params.TallyScope,
+		clientBean:      params.ClientBean,
+		logger:          params.Logger,
+		kafkaCfg:        params.KafkaCfg,
+		invariants:      params.Invariants,
 	}
 }
 

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -24,7 +24,6 @@ package diagnostics
 
 import (
 	"context"
-	"github.com/uber/cadence/common/messaging"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
@@ -37,6 +36,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 )

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -84,7 +84,7 @@ func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params Diagnostics
 		StartToCloseTimeout:    time.Second * 5,
 	}
 	activityCtx := workflow.WithActivityOptions(ctx, activityOptions)
-	err = workflow.ExecuteActivity(activityCtx, w.emitUsageLogs, analytics.WfDiagnosticsUsageData{
+	err = workflow.ExecuteActivity(activityCtx, emitUsageLogsActivity, analytics.WfDiagnosticsUsageData{
 		Domain:                params.Domain,
 		WorkflowID:            params.WorkflowID,
 		RunID:                 params.RunID,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -343,13 +343,14 @@ func (s *Service) startFixerWorkflowWorker() {
 
 func (s *Service) startDiagnostics() {
 	params := diagnostics.Params{
-		ServiceClient: s.params.PublicClient,
-		MetricsClient: s.GetMetricsClient(),
-		TallyScope:    s.params.MetricScope,
-		ClientBean:    s.GetClientBean(),
-		Logger:        s.GetLogger(),
-		KafkaCfg:      s.params.KafkaConfig,
-		Invariants:    s.params.DiagnosticsInvariants,
+		ServiceClient:   s.params.PublicClient,
+		MetricsClient:   s.GetMetricsClient(),
+		MessagingClient: s.GetMessagingClient(),
+		TallyScope:      s.params.MetricScope,
+		ClientBean:      s.GetClientBean(),
+		Logger:          s.GetLogger(),
+		KafkaCfg:        s.params.KafkaConfig,
+		Invariants:      s.params.DiagnosticsInvariants,
 	}
 	if err := diagnostics.New(params).Start(); err != nil {
 		s.Stop()

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -349,7 +349,6 @@ func (s *Service) startDiagnostics() {
 		TallyScope:      s.params.MetricScope,
 		ClientBean:      s.GetClientBean(),
 		Logger:          s.GetLogger(),
-		KafkaCfg:        s.params.KafkaConfig,
 		Invariants:      s.params.DiagnosticsInvariants,
 	}
 	if err := diagnostics.New(params).Start(); err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Messaging client initialised on service startup will be used in workflow diagnostics as well

<!-- Tell your future self why have you made these changes -->
**Why?**
This helps with overriding internal client implementations on service start up

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
