### PR TITLE
Enable docker push from github workflows

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -65,9 +65,7 @@ jobs:
           context: .
           platforms: linux/amd64
           build-args: TARGET=server
-          # TODO: Uncomment below once image tags are validated after merging
-          # push: ${{ needs.meta.outputs.push_enabled == 'true' }}
-          push: false
+          push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}
       - name: Validate tag
         run: |
@@ -96,9 +94,7 @@ jobs:
           context: .
           platforms: linux/amd64
           build-args: TARGET=auto-setup
-          # TODO: Uncomment below once image tags are validated after merging
-          # push: ${{ needs.meta.outputs.push_enabled == 'true' }}
-          push: false
+          push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}-auto-setup
       - name: Validate tag
         run: |
@@ -128,9 +124,7 @@ jobs:
           context: .
           platforms: linux/amd64
           build-args: TARGET=cli
-          # TODO: Uncomment below once image tags are validated after merging
-          # push: ${{ needs.meta.outputs.push_enabled == 'true' }}
-          push: false
+          push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/cli:${{ needs.meta.outputs.image_tag }}
       - name: Validate tag
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -42,31 +42,6 @@ jobs:
             echo "enabled=true" >> $GITHUB_OUTPUT
           fi
 
-  # TODO: Delete below job below once image tags are validated after merging
-  check-meta:
-    needs: meta
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check meta
-        run: |
-          echo "Image tag: ${{ needs.meta.outputs.image_tag }}"
-          echo "Push enabled: ${{ needs.meta.outputs.push_enabled }}"
-      - name: This step should run if push is enabled
-        if: ${{ needs.meta.outputs.push_enabled == 'true' }}
-        run: |
-          echo "Push enabled: ${{ needs.meta.outputs.push_enabled }}"
-      - name: This step should run if push is disabled
-        if: ${{ needs.meta.outputs.push_enabled == 'false' }}
-        run: |
-          echo "Push enabled: ${{ needs.meta.outputs.push_enabled }}"
-      - name: Double check dockerhub secrets
-        env:
-          user: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
-          pw: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
-        run: |
-          echo "Dockerhub username first chars: ${user:0:2}, last char: ${user: -1}"
-          echo "Dockerhub token first chars: ${pw:0:2}, last char: ${pw: -1}"
-
   push_server_image:
     name: Push server image to Docker Hub
     needs: meta


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I was able to confirm the correct secrets are propagating to the actions now. Reverting debug steps and enabling push. Only master merges and releases will push images to docker hub. Pull requests will just build images for validation.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
via #6605 and #6606
