### PR TITLE
Add sharddistributor outbounds

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -84,6 +84,10 @@ type (
 		// To use Async APIs for a domain first specify the queue using Admin API.
 		// Either refer to one of the predefined queues in this config or alternatively specify the queue details inline in the API call.
 		AsyncWorkflowQueues map[string]AsyncWorkflowQueueProvider `yaml:"asyncWorkflowQueues"`
+		// ShardDistributorClient is the config for shard distributor client
+		// Shard distributor is used to distribute shards across multiple cadence service instances
+		// Note: This is not recommended for use, it's still experimental
+		ShardDistributorClient ShardDistributorClient `yaml:"shardDistributorClient"`
 	}
 
 	// Membership holds peer provider configuration.
@@ -590,6 +594,12 @@ type (
 		Status string `yaml:"status"`
 		// URI is the domain default URI for visibility archiver
 		URI string `yaml:"URI"`
+	}
+
+	// ShardDistributorClient contains the config items for shard distributor
+	ShardDistributorClient struct {
+		// The host and port of the shard distributor server
+		HostPort string `yaml:"hostPort"`
 	}
 
 	// YamlNode is a lazy-unmarshaler, because *yaml.Node only exists in gopkg.in/yaml.v3, not v2,

--- a/common/constants.go
+++ b/common/constants.go
@@ -308,3 +308,8 @@ func (v FailoverType) String() string {
 		return "Unknown"
 	}
 }
+
+const (
+	ShardModeHashRing         = "hash-ring"
+	ShardModeShardDistributor = "shard-distributor"
+)

--- a/common/rpc/outbounds.go
+++ b/common/rpc/outbounds.go
@@ -263,3 +263,23 @@ func IsGRPCOutbound(config transport.ClientConfig) bool {
 	}
 	return namer.TransportName() == grpc.TransportName
 }
+func NewSingleGRPCOutboundBuilder(outboundName string, serviceName string, address string) OutboundsBuilder {
+	return singleGRPCOutbound{outboundName, serviceName, address}
+}
+
+type singleGRPCOutbound struct {
+	outboundName string
+	serviceName  string
+	address      string
+}
+
+func (b singleGRPCOutbound) Build(grpc *grpc.Transport, _ *tchannel.Transport) (*Outbounds, error) {
+	return &Outbounds{
+		Outbounds: yarpc.Outbounds{
+			b.outboundName: {
+				ServiceName: b.serviceName,
+				Unary:       grpc.NewSingleOutbound(b.address),
+			},
+		},
+	}, nil
+}

--- a/common/rpc/outbounds_test.go
+++ b/common/rpc/outbounds_test.go
@@ -180,6 +180,18 @@ func TestDirectOutbound(t *testing.T) {
 	assert.NotNil(t, outbounds["cadence-history"].Unary)
 }
 
+func TestSingleGRPCOutbound(t *testing.T) {
+	grpc := &grpc.Transport{}
+	tchannel := &tchannel.Transport{}
+
+	builder := NewSingleGRPCOutboundBuilder("grpc-only-out", "grpc-service-name", "http://example.com:1234")
+
+	outBound, err := builder.Build(grpc, tchannel)
+	assert.NoError(t, err)
+	assert.Equal(t, "grpc-service-name", outBound.Outbounds["grpc-only-out"].ServiceName)
+	assert.NotNil(t, outBound.Outbounds["grpc-only-out"].Unary)
+}
+
 func TestIsGRPCOutboud(t *testing.T) {
 	assert.True(t, IsGRPCOutbound(&transport.OutboundConfig{Outbounds: transport.Outbounds{Unary: (&grpc.Transport{}).NewSingleOutbound("localhost:1234")}}))
 	assert.False(t, IsGRPCOutbound(&transport.OutboundConfig{Outbounds: transport.Outbounds{Unary: (&tchannel.Transport{}).NewSingleOutbound("localhost:1234")}}))

--- a/common/rpc/params_test.go
+++ b/common/rpc/params_test.go
@@ -38,8 +38,9 @@ func TestNewParams(t *testing.T) {
 	dc := dynamicconfig.NewNopCollection()
 	makeConfig := func(svc config.Service) *config.Config {
 		return &config.Config{
-			PublicClient: config.PublicClient{HostPort: "localhost:9999"},
-			Services:     map[string]config.Service{"frontend": svc}}
+			PublicClient:           config.PublicClient{HostPort: "localhost:9999"},
+			ShardDistributorClient: config.ShardDistributorClient{HostPort: "localhost:9998"},
+			Services:               map[string]config.Service{"frontend": svc}}
 	}
 	logger := testlogger.New(t)
 	metricsCl := metrics.NewNoopMetricsClient()

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -144,3 +144,6 @@ dynamicconfig:
 blobstore:
   filestore:
     outputDirectory: "/tmp/blobstore"
+
+shardDistributorClient:
+  hostPort: "localhost:7943"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added outbounds and config for shard distributor

<!-- Tell your future self why have you made these changes -->
**Why?**
These outbounds will be used to instanciate the shard distributor. We use single grpc outbound as:
- We only support GRPC in shard distributor
- We only support unary outbounds for frontend in the OSS currently, so we do the same for shard distributor. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally and added some unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Should be very low risk, just adds some instanciations. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**