### PR TITLE
[Wf-Diagnostics] fix the usage logs data emitted by wf diagnostics

### DIFF
--- a/service/worker/diagnostics/analytics/emitter.go
+++ b/service/worker/diagnostics/analytics/emitter.go
@@ -58,8 +58,8 @@ func (et *emitter) EmitUsageData(ctx context.Context, data WfDiagnosticsUsageDat
 	msg[DiagnosticsWfID] = data.DiagnosticsWorkflowID
 	msg[DiagnosticsWfRunID] = data.DiagnosticsRunID
 	msg[Environment] = data.Environment
-	msg[DiagnosticsStartTime] = data.DiagnosticsStartTime
-	msg[DiagnosticsEndTime] = data.DiagnosticsEndTime
+	msg[DiagnosticsStartTime] = data.DiagnosticsStartTime.UTC().UnixMilli()
+	msg[DiagnosticsEndTime] = data.DiagnosticsEndTime.UTC().UnixMilli()
 
 	serializedMsg, err := json.Marshal(msg)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
diagnostic start and end time are sent in millisecoonds

<!-- Tell your future self why have you made these changes -->
**Why?**
The message schema expects it in milliseconds 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
