### PR TITLE
[github-actions] Run master related actions only for the main repo

### DIFF
--- a/.github/workflows/codecov-on-master.yml
+++ b/.github/workflows/codecov-on-master.yml
@@ -1,27 +1,24 @@
 name: Workflow for Codecov integration
-on: [push, pull_request]
+on: push
 
 jobs:
   codecov:
+    if: github.repository == 'cadence-workflow/cadence'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.23.4
           cache: false
-
       - name: Download dependencies
         run: go mod download
-
       - name: Test and generate coverage report
         run: make cover_profile
-
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.5.0 # https://github.com/codecov/codecov-action
         with:

--- a/.github/workflows/codecov-on-pr.yml
+++ b/.github/workflows/codecov-on-pr.yml
@@ -1,0 +1,31 @@
+name: Workflow for Codecov integration
+on: pull_request
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23.4
+          cache: false
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Test and generate coverage report
+        run: make cover_profile
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.5.0 # https://github.com/codecov/codecov-action
+        with:
+          file: .build/coverage/unit_cover.out
+          exclude: ./
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: cadence-workflow/cadence

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -14,6 +14,7 @@ jobs:
   # This job exposes image_tag and push_enabled variables for other jobs.
   # Other jobs depends on this. see needs: meta in other jobs.
   meta:
+    if: github.repository == 'cadence-workflow/cadence'
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.determine-image-tag.outputs.image_tag }}

--- a/scripts/check-go-toolchain.sh
+++ b/scripts/check-go-toolchain.sh
@@ -31,13 +31,17 @@ while read file; do
   fi
 done < <( find "$root" -name Dockerfile )
 
-# check workflows
-codecov_file="$root/.github/workflows/codecov.yml"
-codecov_line="$(grep 'go-version:' "$codecov_file")"
-codecov_version="${codecov_line#*go-version: }"
-if [[ "$codecov_version" != "$target" ]]; then
-  bad "Wrong Go version in file $codecov_file:\n\t$codecov_line"
-fi
+declare -a codecov_files=( "$root/.github/workflows/codecov-on-pr.yml" "$root/.github/workflows/codecov-on-master.yml" );
+
+for codecov_file in "${codecov_files[@]}"; do
+  # check workflows
+  codecov_file="$root/.github/workflows/codecov-on-pr.yml"
+  codecov_line="$(grep 'go-version:' "$codecov_file")"
+  codecov_version="${codecov_line#*go-version: }"
+  if [[ "$codecov_version" != "$target" ]]; then
+    bad "Wrong Go version in file $codecov_file:\n\t$codecov_line"
+  fi
+done
 
 if [[ $fail == 1 ]]; then
   bad "Makefile pins Go to go${target}, Dockerfiles and GitHub workflows should too."


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updating github actions to run only for cadence-workflow/cadence.
I've separated actions related to PR and to master branch and added a condition to run them only on the main repo.

<!-- Tell your future self why have you made these changes -->
**Why?**
To avoid running some actions on forked repos.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Can break github actions on master

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
