### PR TITLE
[WIP] add cover profile parallel

### DIFF
--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -95,6 +95,52 @@ steps:
           run: unit-test
           config: docker/buildkite/docker-compose.yml
 
+  - label: ":golang: real unit test seq"
+    artifact_paths:
+      - ".build/coverage/*.out"
+      - ".build/coverage/metadata.txt"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                  - |-
+                    # ensure that we are not rebuilding binaries and not regenerating code
+                    make .just-build
+                    make cover_profile
+      - docker-compose#v3.0.0:
+          run: real-unit-test
+          config: docker/buildkite/docker-compose.yml
+
+  - label: ":golang: real unit test parallel"
+    artifact_paths:
+      - ".build/coverage/*.out"
+      - ".build/coverage/metadata.txt"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                  - |-
+                    # ensure that we are not rebuilding binaries and not regenerating code
+                    make .just-build
+                    make cover_profile_parallel
+      - docker-compose#v3.0.0:
+          run: real-unit-test
+          config: docker/buildkite/docker-compose.yml
+
   - label: ":lint: validate code is clean"
     artifact_paths: []
     retry:

--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -71,6 +71,30 @@ steps:
           run: unit-test
           config: docker/buildkite/docker-compose.yml
 
+  - label: ":golang: unit test parallel"
+    artifact_paths:
+      - ".build/coverage/*.out"
+      - ".build/coverage/metadata.txt"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                  - |-
+                    # ensure that we are not rebuilding binaries and not regenerating code
+                    make .just-build
+                    # make install-schema is needed for a server startup test. See main_test.go
+                    CASSANDRA_HOST=cassandra make install-schema && make cover_profile_parallel
+      - docker-compose#v3.0.0:
+          run: unit-test
+          config: docker/buildkite/docker-compose.yml
+
   - label: ":lint: validate code is clean"
     artifact_paths: []
     retry:

--- a/Makefile
+++ b/Makefile
@@ -661,6 +661,16 @@ cover_profile:
 		(cat $(BUILD)/"$$dir"/coverage.out | grep -v "^mode: \w\+" >> $(UNIT_COVER_FILE)) || true; \
 	done;
 
+cover_profile_parallel:
+	$Q mkdir -p $(BUILD)
+	$Q mkdir -p $(COVER_ROOT)
+	$Q echo "mode: atomic" > $(UNIT_COVER_FILE)
+
+	$Q echo Running special test cases without race detector:
+	$Q go test ./cmd/server/cadence/
+	$Q echo Running package tests:
+	$Q go test $(PKG_TEST_DIRS) $(TEST_ARG) -coverprofile=$(UNIT_COVER_FILE);
+
 cover_integration_profile:
 	$Q mkdir -p $(BUILD)
 	$Q mkdir -p $(COVER_ROOT)

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -114,6 +114,22 @@ services:
         aliases:
           - unit-test
 
+  real-unit-test:
+    build:
+      context: ../../
+      dockerfile: ./docker/buildkite/Dockerfile
+    environment:
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+    volumes:
+      - ../../:/cadence
+    networks:
+      services-network:
+        aliases:
+          - real-unit-test
+
   integration-test-cassandra:
     build:
       context: ../../


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
A new command `cover_profile_parallel` has been added to check how unit tests can be run in parallel

<!-- Tell your future self why have you made these changes -->
**Why?**
It can reduce the CI time if we get rid of dependencies like Cassandra in Unit tests


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No going to be merged, just to run in CI


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
