### PR TITLE
[Wf-Diagnotics] Update Diagnostics workflow result to provide a completion signal

### DIFF
--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -141,10 +141,12 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 	s.NoError(s.workflowEnv.GetWorkflowResult(&result))
 	s.ElementsMatch(timeoutIssues, result.DiagnosticsResult.Timeouts.Issues)
 	s.ElementsMatch(timeoutRootCause, result.DiagnosticsResult.Timeouts.RootCause)
+	s.True(result.DiagnosticsCompleted)
 
 	queriedResult := s.queryDiagnostics()
 	s.ElementsMatch(queriedResult.DiagnosticsResult.Timeouts.Issues, result.DiagnosticsResult.Timeouts.Issues)
 	s.ElementsMatch(queriedResult.DiagnosticsResult.Timeouts.RootCause, result.DiagnosticsResult.Timeouts.RootCause)
+	s.True(queriedResult.DiagnosticsCompleted)
 }
 
 func (s *diagnosticsWorkflowTestSuite) TestWorkflow_Error() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Diagnostics workflow now provides a flag if the child workflow that runs diagnostics is completed

<!-- Tell your future self why have you made these changes -->
**Why?**
when the parent workflow is queried to get results, there is no signal on whether the result is empty because no issues were found or if diagnostics is still running

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
