### PR TITLE
Updated weighted round robin scheduler to be a generic type

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -5084,13 +5084,9 @@ var MapKeys = map[MapKey]DynamicMap{
 		DefaultValue: definition.GetDefaultIndexedKeys(),
 	},
 	TaskSchedulerRoundRobinWeights: {
-		KeyName:     "history.taskSchedulerRoundRobinWeight",
-		Description: "TaskSchedulerRoundRobinWeights is the priority weight for weighted round robin task scheduler",
-		DefaultValue: common.ConvertIntMapToDynamicConfigMapProperty(map[int]int{
-			common.GetTaskPriority(common.HighPriorityClass, common.DefaultPrioritySubclass):    500,
-			common.GetTaskPriority(common.DefaultPriorityClass, common.DefaultPrioritySubclass): 20,
-			common.GetTaskPriority(common.LowPriorityClass, common.DefaultPrioritySubclass):     5,
-		}),
+		KeyName:      "history.taskSchedulerRoundRobinWeight",
+		Description:  "TaskSchedulerRoundRobinWeights is the priority weight for weighted round robin task scheduler",
+		DefaultValue: common.ConvertIntMapToDynamicConfigMapProperty(DefaultTaskSchedulerRoundRobinWeights),
 	},
 	QueueProcessorPendingTaskSplitThreshold: {
 		KeyName:      "history.queueProcessorPendingTaskSplitThreshold",
@@ -5171,3 +5167,11 @@ func init() {
 		_keyNames[v.KeyName] = k
 	}
 }
+
+var (
+	DefaultTaskSchedulerRoundRobinWeights = map[int]int{
+		common.GetTaskPriority(common.HighPriorityClass, common.DefaultPrioritySubclass):    500,
+		common.GetTaskPriority(common.DefaultPriorityClass, common.DefaultPrioritySubclass): 20,
+		common.GetTaskPriority(common.LowPriorityClass, common.DefaultPrioritySubclass):     5,
+	}
+)

--- a/common/task/scheduler_options_test.go
+++ b/common/task/scheduler_options_test.go
@@ -33,7 +33,6 @@ func TestSchedulerOptionsString(t *testing.T) {
 		queueSize       int
 		workerCount     dynamicconfig.IntPropertyFn
 		dispatcherCount int
-		weights         dynamicconfig.MapPropertyFn
 		wantErr         bool
 		want            string
 	}{
@@ -51,11 +50,7 @@ func TestSchedulerOptionsString(t *testing.T) {
 			queueSize:       3,
 			workerCount:     dynamicconfig.GetIntPropertyFn(4),
 			dispatcherCount: 5,
-			weights: dynamicconfig.GetMapPropertyFn(map[string]interface{}{
-				"1": 500,
-				"9": 20,
-			}),
-			want: "{schedulerType:2, fifoSchedulerOptions:<nil>, wrrSchedulerOptions:{QueueSize: 3, WorkerCount: 4, DispatcherCount: 5, Weights: map[1:500 9:20]}}",
+			want:            "{schedulerType:2, fifoSchedulerOptions:<nil>, wrrSchedulerOptions:{QueueSize: 3, WorkerCount: 4, DispatcherCount: 5}}",
 		},
 		{
 			desc:          "InvalidSchedulerType",
@@ -66,7 +61,7 @@ func TestSchedulerOptionsString(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			o, err := NewSchedulerOptions(tc.schedulerType, tc.queueSize, tc.workerCount, tc.dispatcherCount, tc.weights)
+			o, err := NewSchedulerOptions[int](tc.schedulerType, tc.queueSize, tc.workerCount, tc.dispatcherCount, nil, nil)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Got error: %v, wantErr: %v", err, tc.wantErr)
 			}

--- a/common/task/weighted_round_robin_task_scheduler_options.go
+++ b/common/task/weighted_round_robin_task_scheduler_options.go
@@ -28,14 +28,15 @@ import (
 )
 
 // WeightedRoundRobinTaskSchedulerOptions configs WRR task scheduler
-type WeightedRoundRobinTaskSchedulerOptions struct {
-	Weights         dynamicconfig.MapPropertyFn
-	QueueSize       int
-	WorkerCount     dynamicconfig.IntPropertyFn
-	DispatcherCount int
-	RetryPolicy     backoff.RetryPolicy
+type WeightedRoundRobinTaskSchedulerOptions[K comparable] struct {
+	QueueSize            int
+	WorkerCount          dynamicconfig.IntPropertyFn
+	DispatcherCount      int
+	RetryPolicy          backoff.RetryPolicy
+	TaskToChannelKeyFn   func(PriorityTask) K
+	ChannelKeyToWeightFn func(K) int
 }
 
-func (o *WeightedRoundRobinTaskSchedulerOptions) String() string {
-	return fmt.Sprintf("{QueueSize: %v, WorkerCount: %v, DispatcherCount: %v, Weights: %v}", o.QueueSize, o.WorkerCount(), o.DispatcherCount, o.Weights())
+func (o *WeightedRoundRobinTaskSchedulerOptions[K]) String() string {
+	return fmt.Sprintf("{QueueSize: %v, WorkerCount: %v, DispatcherCount: %v}", o.QueueSize, o.WorkerCount(), o.DispatcherCount)
 }

--- a/service/history/task/processor_test.go
+++ b/service/history/task/processor_test.go
@@ -210,7 +210,7 @@ func (s *queueTaskProcessorSuite) TestTrySubmit_Fail() {
 }
 
 func (s *queueTaskProcessorSuite) TestNewSchedulerOptions_UnknownSchedulerType() {
-	options, err := task.NewSchedulerOptions(0, 100, dynamicconfig.GetIntPropertyFn(10), 1, nil)
+	options, err := task.NewSchedulerOptions[int](0, 100, dynamicconfig.GetIntPropertyFn(10), 1, func(task.PriorityTask) int { return 1 }, func(int) int { return 1 })
 	s.Error(err)
 	s.Nil(options)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated weighted round robin scheduler to be a generic type

<!-- Tell your future self why have you made these changes -->
**Why?**
To make the scheduler support scheduling tasks not only by priority but also custom properties.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing unit tests also tested in dev2 environment

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Scheduler may not work.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
