### PR TITLE
[WIP] Move time source from db layer to PersistenceManager

### DIFF
--- a/common/persistence/nosql/nosql_shard_store.go
+++ b/common/persistence/nosql/nosql_shard_store.go
@@ -23,6 +23,7 @@ package nosql
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
@@ -63,7 +64,7 @@ func (sh *nosqlShardStore) CreateShard(
 	if err != nil {
 		return err
 	}
-	err = storeShard.db.InsertShard(ctx, request.ShardInfo)
+	err = storeShard.db.InsertShard(ctx, request.ShardInfo, time.Now())
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
 		if ok {
@@ -161,7 +162,7 @@ func (sh *nosqlShardStore) UpdateShard(
 	if err != nil {
 		return err
 	}
-	err = storeShard.db.UpdateShard(ctx, request.ShardInfo, request.PreviousRangeID)
+	err = storeShard.db.UpdateShard(ctx, request.ShardInfo, request.PreviousRangeID, time.Now())
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
 		if ok {

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -225,7 +225,7 @@ func (t *nosqlTaskStore) UpdateTaskList(
 	}
 
 	if tli.Kind == persistence.TaskListKindSticky { // if task_list is sticky, then update with TTL
-		err = storeShard.db.UpdateTaskListWithTTL(ctx, stickyTaskListTTL, taskListToUpdate, tli.RangeID)
+		err = storeShard.db.UpdateTaskListWithTTL(ctx, stickyTaskListTTL, taskListToUpdate, tli.RangeID, time.Now())
 	} else {
 		err = storeShard.db.UpdateTaskList(ctx, taskListToUpdate, tli.RangeID)
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/db.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/db.go
@@ -21,7 +21,6 @@
 package cassandra
 
 import (
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -37,7 +36,6 @@ type cdb struct {
 	session gocql.Session
 	cfg     *config.NoSQL
 	dc      *persistence.DynamicConfiguration
-	timeSrc clock.TimeSource
 }
 
 var _ nosqlplugin.DB = (*cdb)(nil)
@@ -50,12 +48,6 @@ type cassandraDBOption func(*cdb)
 func dbWithClient(client gocql.Client) cassandraDBOption {
 	return func(db *cdb) {
 		db.client = client
-	}
-}
-
-func dbWithTimeSource(timeSrc clock.TimeSource) cassandraDBOption {
-	return func(db *cdb) {
-		db.timeSrc = timeSrc
 	}
 }
 
@@ -72,7 +64,6 @@ func newCassandraDBFromSession(
 		logger:  logger,
 		cfg:     cfg,
 		dc:      dc,
-		timeSrc: clock.NewRealTimeSource(),
 	}
 
 	for _, opt := range opts {

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard.go
@@ -33,8 +33,8 @@ import (
 
 // InsertShard creates a new shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
-func (db *cdb) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow) error {
-	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(db.timeSrc.Now().UnixNano())
+func (db *cdb) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow, timeStamp time.Time) error {
+	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(timeStamp.UnixNano())
 	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
 	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
 	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)
@@ -233,8 +233,8 @@ func (db *cdb) UpdateRangeID(ctx context.Context, shardID int, rangeID int64, pr
 
 // UpdateShard updates a shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
-func (db *cdb) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64) error {
-	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(db.timeSrc.Now().UnixNano())
+func (db *cdb) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64, timeStamp time.Time) error {
+	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(timeStamp.UnixNano())
 	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
 	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
 	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
@@ -112,11 +111,9 @@ func TestInsertShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
-			err := db.InsertShard(context.Background(), tc.row)
-
+			err := db.InsertShard(context.Background(), tc.row, ts)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("InsertShard() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -258,8 +255,8 @@ func TestSelectShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotRangeID, gotShardInfo, err := db.SelectShard(context.Background(), tc.shardID, tc.cluster)
 
@@ -287,11 +284,6 @@ func TestSelectShard(t *testing.T) {
 }
 
 func TestUpdateRangeID(t *testing.T) {
-	ts, err := time.Parse(time.RFC3339, "2024-04-02T18:00:00Z")
-	if err != nil {
-		t.Fatalf("Failed to parse time: %v", err)
-	}
-
 	tests := []struct {
 		name        string
 		shardID     int
@@ -365,8 +357,8 @@ func TestUpdateRangeID(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateRangeID(context.Background(), tc.shardID, tc.rangeID, tc.prevRangeID)
 
@@ -480,11 +472,9 @@ func TestUpdateShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
-			err := db.UpdateShard(context.Background(), tc.row, tc.prevRangeID)
-
+			err := db.UpdateShard(context.Background(), tc.row, tc.prevRangeID, ts)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("UpdateShard() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -261,6 +261,7 @@ func (db *cdb) UpdateTaskListWithTTL(
 	ttlSeconds int64,
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
+	timeStamp time.Time,
 ) error {
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 	// part 1 is used to set TTL on primary key as UPDATE can't set TTL for primary key
@@ -281,7 +282,7 @@ func (db *cdb) UpdateTaskListWithTTL(
 		row.TaskListType,
 		row.AckLevel,
 		row.TaskListKind,
-		db.timeSrc.Now(),
+		timeStamp,
 		fromTaskListPartitionConfig(row.AdaptivePartitionConfig),
 		row.DomainID,
 		row.TaskListName,

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
@@ -543,10 +542,9 @@ func TestUpdateTaskListWithTTL(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
-			err := db.UpdateTaskListWithTTL(context.Background(), tc.ttlSeconds, tc.row, tc.prevRangeID)
+			err := db.UpdateTaskListWithTTL(context.Background(), tc.ttlSeconds, tc.row, tc.prevRangeID, ts)
 
 			if (err != nil) != tc.wantErr {
 				t.Errorf("UpdateTaskListWithTTL() error = %v, wantErr %v", err, tc.wantErr)
@@ -823,8 +821,7 @@ func TestInsertTasks(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertTasks(context.Background(), tc.tasksToInsert, tc.tasklistCond)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
@@ -147,6 +147,7 @@ func TestInsertWorkflowExecutionWithTasks(t *testing.T) {
 				tc.replicationTasks,
 				tc.timerTasks,
 				tc.shardCondition,
+				time.Now(),
 			)
 
 			if (err != nil) != tc.wantErr {
@@ -458,6 +459,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 				tc.replicationTasks,
 				tc.timerTasks,
 				tc.shardCondition,
+				time.Now(),
 			)
 
 			if (err != nil) != tc.wantErr {
@@ -1942,7 +1944,7 @@ func TestInsertReplicationDLQTask(t *testing.T) {
 			logger := testlogger.New(t)
 			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
-			err := db.InsertReplicationDLQTask(context.Background(), tc.shardID, tc.sourceCluster, tc.task)
+			err := db.InsertReplicationDLQTask(context.Background(), tc.shardID, tc.sourceCluster, tc.task, time.Now())
 
 			if (err != nil) != tc.wantErr {
 				t.Errorf("RangeDeleteCrossClusterTasks() error: %v, wantErr: %v", err, tc.wantErr)
@@ -2315,7 +2317,7 @@ func TestInsertReplicationTask(t *testing.T) {
 			logger := testlogger.New(t)
 			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
-			err := db.InsertReplicationTask(context.Background(), tc.tasks, tc.shardCondition)
+			err := db.InsertReplicationTask(context.Background(), tc.tasks, tc.shardCondition, time.Now())
 
 			if (err != nil) != tc.wantErr {
 				t.Errorf("InsertReplicationTask() error: %v, wantErr: %v", err, tc.wantErr)

--- a/common/persistence/nosql/nosqlplugin/dynamodb/shard.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/shard.go
@@ -22,13 +22,14 @@ package dynamodb
 
 import (
 	"context"
+	"time"
 
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
 
 // InsertShard creates a new shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
-func (db *ddb) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow) error {
+func (db *ddb) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow, timeStamp time.Time) error {
 	panic("TODO")
 }
 
@@ -45,6 +46,6 @@ func (db *ddb) UpdateRangeID(ctx context.Context, shardID int, rangeID int64, pr
 
 // UpdateShard updates a shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
-func (db *ddb) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64) error {
+func (db *ddb) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64, timeStamp time.Time) error {
 	panic("TODO")
 }

--- a/common/persistence/nosql/nosqlplugin/dynamodb/task.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/task.go
@@ -22,6 +22,7 @@ package dynamodb
 
 import (
 	"context"
+	"time"
 
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
@@ -57,6 +58,7 @@ func (db *ddb) UpdateTaskListWithTTL(
 	ttlSeconds int64,
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
+	timeStamp time.Time,
 ) error {
 	panic("TODO")
 }

--- a/common/persistence/nosql/nosqlplugin/dynamodb/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/workflow.go
@@ -41,6 +41,7 @@ func (db *ddb) InsertWorkflowExecutionWithTasks(
 	replicationTasks []*nosqlplugin.ReplicationTask,
 	timerTasks []*nosqlplugin.TimerTask,
 	shardCondition *nosqlplugin.ShardCondition,
+	timeStamp time.Time,
 ) error {
 	panic("TODO")
 }
@@ -57,6 +58,7 @@ func (db *ddb) UpdateWorkflowExecutionWithTasks(
 	replicationTasks []*nosqlplugin.ReplicationTask,
 	timerTasks []*nosqlplugin.TimerTask,
 	shardCondition *nosqlplugin.ShardCondition,
+	timeStamp time.Time,
 ) error {
 	panic("TODO")
 }
@@ -125,7 +127,7 @@ func (db *ddb) RangeDeleteReplicationTasks(ctx context.Context, shardID int, inc
 	panic("TODO")
 }
 
-func (db *ddb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.ReplicationTask, condition nosqlplugin.ShardCondition) error {
+func (db *ddb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.ReplicationTask, condition nosqlplugin.ShardCondition, timeStamp time.Time) error {
 	panic("TODO")
 }
 
@@ -141,7 +143,7 @@ func (db *ddb) RangeDeleteCrossClusterTasks(ctx context.Context, shardID int, ta
 	panic("TODO")
 }
 
-func (db *ddb) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task nosqlplugin.ReplicationTask) error {
+func (db *ddb) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task nosqlplugin.ReplicationTask, timeStamp time.Time) error {
 	panic("TODO")
 }
 

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -205,7 +205,7 @@ type (
 		// InsertShard creates a new shard.
 		// Return error is there is any thing wrong
 		// Return the ShardOperationConditionFailure when doesn't meet the condition
-		InsertShard(ctx context.Context, row *ShardRow) error
+		InsertShard(ctx context.Context, row *ShardRow, timeStamp time.Time) error
 		// SelectShard gets a shard, rangeID is the current rangeID in shard row
 		SelectShard(ctx context.Context, shardID int, currentClusterName string) (rangeID int64, shard *ShardRow, err error)
 		// UpdateRangeID updates the rangeID
@@ -215,7 +215,7 @@ type (
 		// UpdateShard updates a shard
 		// Return error is there is any thing wrong
 		// Return the ShardOperationConditionFailure when doesn't meet the condition
-		UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64) error
+		UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64, timeStamp time.Time) error
 	}
 
 	/**
@@ -329,7 +329,7 @@ type (
 		// Return TaskOperationConditionFailure if the condition doesn't meet
 		// Ignore TTL if it's not supported, which becomes exactly the same as UpdateTaskList, but ListTaskList must be
 		// implemented for TaskListScavenger
-		UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64) error
+		UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64, timeStamp time.Time) error
 		// ListTaskList returns all tasklists.
 		// Noop if TTL is already implemented in other methods
 		ListTaskList(ctx context.Context, pageSize int, nextPageToken []byte) (*ListTaskListResult, error)
@@ -421,6 +421,7 @@ type (
 			replicationTasks []*ReplicationTask,
 			timerTasks []*TimerTask,
 			shardCondition *ShardCondition,
+			timeStamp time.Time,
 		) error
 
 		// UpdateWorkflowExecutionWithTasks is for updating a new workflow execution record.
@@ -451,6 +452,7 @@ type (
 			replicationTasks []*ReplicationTask,
 			timerTasks []*TimerTask,
 			shardCondition *ShardCondition,
+			timeStamp time.Time,
 		) error
 
 		// current_workflow table
@@ -495,7 +497,7 @@ type (
 		// delete a range of replication tasks
 		RangeDeleteReplicationTasks(ctx context.Context, shardID int, inclusiveEndTaskID int64) error
 		// insert replication task with shard condition check
-		InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition) error
+		InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition, timeStamp time.Time) error
 
 		// cross_cluster_task table
 		// within a shard, paging through replication tasks order by taskID(ASC), filtered by minTaskID(exclusive) and maxTaskID(inclusive)
@@ -507,7 +509,7 @@ type (
 
 		// replication_dlq_task
 		// insert a new replication task to DLQ
-		InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask) error
+		InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask, timeStamp time.Time) error
 		// within a shard, for a sourceCluster, paging through replication tasks order by taskID(ASC), filtered by minTaskID(exclusive) and maxTaskID(inclusive)
 		SelectReplicationDLQTasksOrderByTaskID(ctx context.Context, shardID int, sourceCluster string, pageSize int, pageToken []byte, exclusiveMinTaskID, inclusiveMaxTaskID int64) ([]*ReplicationTask, []byte, error)
 		// return the DLQ size

--- a/common/persistence/nosql/nosqlplugin/interfaces_mock.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces_mock.go
@@ -482,7 +482,7 @@ func (mr *MockDBMockRecorder) InsertQueueMetadata(ctx, queueType, version any) *
 }
 
 // InsertReplicationDLQTask mocks base method.
-func (m *MockDB) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask) error {
+func (m *MockDB) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertReplicationDLQTask", ctx, shardID, sourceCluster, task)
 	ret0, _ := ret[0].(error)
@@ -496,7 +496,7 @@ func (mr *MockDBMockRecorder) InsertReplicationDLQTask(ctx, shardID, sourceClust
 }
 
 // InsertReplicationTask mocks base method.
-func (m *MockDB) InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition) error {
+func (m *MockDB) InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertReplicationTask", ctx, tasks, condition)
 	ret0, _ := ret[0].(error)
@@ -510,7 +510,7 @@ func (mr *MockDBMockRecorder) InsertReplicationTask(ctx, tasks, condition any) *
 }
 
 // InsertShard mocks base method.
-func (m *MockDB) InsertShard(ctx context.Context, row *ShardRow) error {
+func (m *MockDB) InsertShard(ctx context.Context, row *ShardRow, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertShard", ctx, row)
 	ret0, _ := ret[0].(error)
@@ -566,7 +566,7 @@ func (mr *MockDBMockRecorder) InsertVisibility(ctx, ttlSeconds, row any) *gomock
 }
 
 // InsertWorkflowExecutionWithTasks mocks base method.
-func (m *MockDB) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockDB) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
@@ -1208,7 +1208,7 @@ func (mr *MockDBMockRecorder) UpdateRangeID(ctx, shardID, rangeID, previousRange
 }
 
 // UpdateShard mocks base method.
-func (m *MockDB) UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64) error {
+func (m *MockDB) UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateShard", ctx, row, previousRangeID)
 	ret0, _ := ret[0].(error)
@@ -1236,7 +1236,7 @@ func (mr *MockDBMockRecorder) UpdateTaskList(ctx, row, previousRangeID any) *gom
 }
 
 // UpdateTaskListWithTTL mocks base method.
-func (m *MockDB) UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64) error {
+func (m *MockDB) UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTaskListWithTTL", ctx, ttlSeconds, row, previousRangeID)
 	ret0, _ := ret[0].(error)
@@ -1264,7 +1264,7 @@ func (mr *MockDBMockRecorder) UpdateVisibility(ctx, ttlSeconds, row any) *gomock
 }
 
 // UpdateWorkflowExecutionWithTasks mocks base method.
-func (m *MockDB) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockDB) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
@@ -1598,7 +1598,7 @@ func (mr *MocktableCRUDMockRecorder) InsertQueueMetadata(ctx, queueType, version
 }
 
 // InsertReplicationDLQTask mocks base method.
-func (m *MocktableCRUD) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask) error {
+func (m *MocktableCRUD) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertReplicationDLQTask", ctx, shardID, sourceCluster, task)
 	ret0, _ := ret[0].(error)
@@ -1612,7 +1612,7 @@ func (mr *MocktableCRUDMockRecorder) InsertReplicationDLQTask(ctx, shardID, sour
 }
 
 // InsertReplicationTask mocks base method.
-func (m *MocktableCRUD) InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition) error {
+func (m *MocktableCRUD) InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertReplicationTask", ctx, tasks, condition)
 	ret0, _ := ret[0].(error)
@@ -1626,7 +1626,7 @@ func (mr *MocktableCRUDMockRecorder) InsertReplicationTask(ctx, tasks, condition
 }
 
 // InsertShard mocks base method.
-func (m *MocktableCRUD) InsertShard(ctx context.Context, row *ShardRow) error {
+func (m *MocktableCRUD) InsertShard(ctx context.Context, row *ShardRow, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertShard", ctx, row)
 	ret0, _ := ret[0].(error)
@@ -1682,7 +1682,7 @@ func (mr *MocktableCRUDMockRecorder) InsertVisibility(ctx, ttlSeconds, row any) 
 }
 
 // InsertWorkflowExecutionWithTasks mocks base method.
-func (m *MocktableCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MocktableCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
@@ -2254,7 +2254,7 @@ func (mr *MocktableCRUDMockRecorder) UpdateRangeID(ctx, shardID, rangeID, previo
 }
 
 // UpdateShard mocks base method.
-func (m *MocktableCRUD) UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64) error {
+func (m *MocktableCRUD) UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateShard", ctx, row, previousRangeID)
 	ret0, _ := ret[0].(error)
@@ -2282,7 +2282,7 @@ func (mr *MocktableCRUDMockRecorder) UpdateTaskList(ctx, row, previousRangeID an
 }
 
 // UpdateTaskListWithTTL mocks base method.
-func (m *MocktableCRUD) UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64) error {
+func (m *MocktableCRUD) UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTaskListWithTTL", ctx, ttlSeconds, row, previousRangeID)
 	ret0, _ := ret[0].(error)
@@ -2310,7 +2310,7 @@ func (mr *MocktableCRUDMockRecorder) UpdateVisibility(ctx, ttlSeconds, row any) 
 }
 
 // UpdateWorkflowExecutionWithTasks mocks base method.
-func (m *MocktableCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MocktableCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
@@ -2822,7 +2822,7 @@ func (m *MockShardCRUD) EXPECT() *MockShardCRUDMockRecorder {
 }
 
 // InsertShard mocks base method.
-func (m *MockShardCRUD) InsertShard(ctx context.Context, row *ShardRow) error {
+func (m *MockShardCRUD) InsertShard(ctx context.Context, row *ShardRow, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertShard", ctx, row)
 	ret0, _ := ret[0].(error)
@@ -2866,7 +2866,7 @@ func (mr *MockShardCRUDMockRecorder) UpdateRangeID(ctx, shardID, rangeID, previo
 }
 
 // UpdateShard mocks base method.
-func (m *MockShardCRUD) UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64) error {
+func (m *MockShardCRUD) UpdateShard(ctx context.Context, row *ShardRow, previousRangeID int64, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateShard", ctx, row, previousRangeID)
 	ret0, _ := ret[0].(error)
@@ -3131,7 +3131,7 @@ func (mr *MockTaskCRUDMockRecorder) UpdateTaskList(ctx, row, previousRangeID any
 }
 
 // UpdateTaskListWithTTL mocks base method.
-func (m *MockTaskCRUD) UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64) error {
+func (m *MockTaskCRUD) UpdateTaskListWithTTL(ctx context.Context, ttlSeconds int64, row *TaskListRow, previousRangeID int64, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTaskListWithTTL", ctx, ttlSeconds, row, previousRangeID)
 	ret0, _ := ret[0].(error)
@@ -3267,7 +3267,7 @@ func (mr *MockWorkflowCRUDMockRecorder) DeleteWorkflowExecution(ctx, shardID, do
 }
 
 // InsertReplicationDLQTask mocks base method.
-func (m *MockWorkflowCRUD) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask) error {
+func (m *MockWorkflowCRUD) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task ReplicationTask, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertReplicationDLQTask", ctx, shardID, sourceCluster, task)
 	ret0, _ := ret[0].(error)
@@ -3281,7 +3281,7 @@ func (mr *MockWorkflowCRUDMockRecorder) InsertReplicationDLQTask(ctx, shardID, s
 }
 
 // InsertReplicationTask mocks base method.
-func (m *MockWorkflowCRUD) InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition) error {
+func (m *MockWorkflowCRUD) InsertReplicationTask(ctx context.Context, tasks []*ReplicationTask, condition ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertReplicationTask", ctx, tasks, condition)
 	ret0, _ := ret[0].(error)
@@ -3295,7 +3295,7 @@ func (mr *MockWorkflowCRUDMockRecorder) InsertReplicationTask(ctx, tasks, condit
 }
 
 // InsertWorkflowExecutionWithTasks mocks base method.
-func (m *MockWorkflowCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockWorkflowCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
@@ -3551,7 +3551,7 @@ func (mr *MockWorkflowCRUDMockRecorder) SelectWorkflowExecution(ctx, shardID, do
 }
 
 // UpdateWorkflowExecutionWithTasks mocks base method.
-func (m *MockWorkflowCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockWorkflowCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition, timeStamp time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)

--- a/common/persistence/nosql/nosqlplugin/mongodb/shard.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/shard.go
@@ -23,13 +23,14 @@ package mongodb
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
 
 // InsertShard creates a new shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
-func (db *mdb) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow) error {
+func (db *mdb) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow, timeStamp time.Time) error {
 	log.Println("not implemented...ignore the error for testing...")
 	return nil
 }
@@ -47,6 +48,6 @@ func (db *mdb) UpdateRangeID(ctx context.Context, shardID int, rangeID int64, pr
 
 // UpdateShard updates a shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
-func (db *mdb) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64) error {
+func (db *mdb) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64, timeStamp time.Time) error {
 	panic("TODO")
 }

--- a/common/persistence/nosql/nosqlplugin/mongodb/task.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/task.go
@@ -22,6 +22,7 @@ package mongodb
 
 import (
 	"context"
+	"time"
 
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
@@ -57,6 +58,7 @@ func (db *mdb) UpdateTaskListWithTTL(
 	ttlSeconds int64,
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
+	timeStamp time.Time,
 ) error {
 	panic("TODO")
 }

--- a/common/persistence/nosql/nosqlplugin/mongodb/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/workflow.go
@@ -41,6 +41,7 @@ func (db *mdb) InsertWorkflowExecutionWithTasks(
 	replicationTasks []*nosqlplugin.ReplicationTask,
 	timerTasks []*nosqlplugin.TimerTask,
 	shardCondition *nosqlplugin.ShardCondition,
+	timeStamp time.Time,
 ) error {
 	panic("TODO")
 }
@@ -57,6 +58,7 @@ func (db *mdb) UpdateWorkflowExecutionWithTasks(
 	replicationTasks []*nosqlplugin.ReplicationTask,
 	timerTasks []*nosqlplugin.TimerTask,
 	shardCondition *nosqlplugin.ShardCondition,
+	timeStamp time.Time,
 ) error {
 	panic("TODO")
 }
@@ -125,7 +127,7 @@ func (db *mdb) RangeDeleteReplicationTasks(ctx context.Context, shardID int, inc
 	panic("TODO")
 }
 
-func (db *mdb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.ReplicationTask, condition nosqlplugin.ShardCondition) error {
+func (db *mdb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.ReplicationTask, condition nosqlplugin.ShardCondition, timeStamp time.Time) error {
 	panic("TODO")
 }
 
@@ -141,7 +143,7 @@ func (db *mdb) RangeDeleteCrossClusterTasks(ctx context.Context, shardID int, ta
 	panic("TODO")
 }
 
-func (db *mdb) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task nosqlplugin.ReplicationTask) error {
+func (db *mdb) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, task nosqlplugin.ReplicationTask, timeStamp time.Time) error {
 	panic("TODO")
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Refactored the system so that the PersistenceManager level handles the timestamp; 
- Removing the timeSrc logic from the DB layer;
- The DB layer only translate entity records into database queries without modifying or adding any additional information like timestamps;

<!-- Tell your future self why have you made these changes -->
**Why**
#6610 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
