### PR TITLE
Update redispatcher to respect task redispatch time

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2106,11 +2106,6 @@ const (
 
 	// key for history
 
-	// TaskRedispatchIntervalJitterCoefficient is the task redispatch interval jitter coefficient
-	// KeyName: history.taskRedispatchIntervalJitterCoefficient
-	// Value type: Float64
-	// Default value: 0.15
-	// Allowed filters: N/A
 	TaskRedispatchIntervalJitterCoefficient
 	// QueueProcessorRandomSplitProbability is the probability for a domain to be split to a new processing queue
 	// KeyName: history.queueProcessorRandomSplitProbability
@@ -4432,7 +4427,7 @@ var FloatKeys = map[FloatKey]DynamicFloat{
 	},
 	TaskRedispatchIntervalJitterCoefficient: {
 		KeyName:      "history.taskRedispatchIntervalJitterCoefficient",
-		Description:  "TaskRedispatchIntervalJitterCoefficient is the task redispatch interval jitter coefficient",
+		Description:  "Deprecated",
 		DefaultValue: 0.15,
 	},
 	QueueProcessorRandomSplitProbability: {

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -89,21 +89,20 @@ type Config struct {
 	StandbyTaskMissingEventsDiscardDelay dynamicconfig.DurationPropertyFn
 
 	// Task process settings
-	TaskProcessRPS                          dynamicconfig.IntPropertyFnWithDomainFilter
-	TaskSchedulerType                       dynamicconfig.IntPropertyFn
-	TaskSchedulerWorkerCount                dynamicconfig.IntPropertyFn
-	TaskSchedulerShardWorkerCount           dynamicconfig.IntPropertyFn
-	TaskSchedulerQueueSize                  dynamicconfig.IntPropertyFn
-	TaskSchedulerShardQueueSize             dynamicconfig.IntPropertyFn
-	TaskSchedulerDispatcherCount            dynamicconfig.IntPropertyFn
-	TaskSchedulerRoundRobinWeights          dynamicconfig.MapPropertyFn
-	TaskCriticalRetryCount                  dynamicconfig.IntPropertyFn
-	ActiveTaskRedispatchInterval            dynamicconfig.DurationPropertyFn
-	StandbyTaskRedispatchInterval           dynamicconfig.DurationPropertyFn
-	TaskRedispatchIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
-	StandbyTaskReReplicationContextTimeout  dynamicconfig.DurationPropertyFnWithDomainIDFilter
-	EnableDropStuckTaskByDomainID           dynamicconfig.BoolPropertyFnWithDomainIDFilter
-	ResurrectionCheckMinDelay               dynamicconfig.DurationPropertyFnWithDomainFilter
+	TaskProcessRPS                         dynamicconfig.IntPropertyFnWithDomainFilter
+	TaskSchedulerType                      dynamicconfig.IntPropertyFn
+	TaskSchedulerWorkerCount               dynamicconfig.IntPropertyFn
+	TaskSchedulerShardWorkerCount          dynamicconfig.IntPropertyFn
+	TaskSchedulerQueueSize                 dynamicconfig.IntPropertyFn
+	TaskSchedulerShardQueueSize            dynamicconfig.IntPropertyFn
+	TaskSchedulerDispatcherCount           dynamicconfig.IntPropertyFn
+	TaskSchedulerRoundRobinWeights         dynamicconfig.MapPropertyFn
+	TaskCriticalRetryCount                 dynamicconfig.IntPropertyFn
+	ActiveTaskRedispatchInterval           dynamicconfig.DurationPropertyFn
+	StandbyTaskRedispatchInterval          dynamicconfig.DurationPropertyFn
+	StandbyTaskReReplicationContextTimeout dynamicconfig.DurationPropertyFnWithDomainIDFilter
+	EnableDropStuckTaskByDomainID          dynamicconfig.BoolPropertyFnWithDomainIDFilter
+	ResurrectionCheckMinDelay              dynamicconfig.DurationPropertyFnWithDomainFilter
 
 	// QueueProcessor settings
 	QueueProcessorEnableSplit                          dynamicconfig.BoolPropertyFn
@@ -368,21 +367,20 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		DeleteHistoryEventContextTimeout:       dc.GetIntProperty(dynamicconfig.DeleteHistoryEventContextTimeout),
 		MaxResponseSize:                        maxMessageSize,
 
-		TaskProcessRPS:                          dc.GetIntPropertyFilteredByDomain(dynamicconfig.TaskProcessRPS),
-		TaskSchedulerType:                       dc.GetIntProperty(dynamicconfig.TaskSchedulerType),
-		TaskSchedulerWorkerCount:                dc.GetIntProperty(dynamicconfig.TaskSchedulerWorkerCount),
-		TaskSchedulerShardWorkerCount:           dc.GetIntProperty(dynamicconfig.TaskSchedulerShardWorkerCount),
-		TaskSchedulerQueueSize:                  dc.GetIntProperty(dynamicconfig.TaskSchedulerQueueSize),
-		TaskSchedulerShardQueueSize:             dc.GetIntProperty(dynamicconfig.TaskSchedulerShardQueueSize),
-		TaskSchedulerDispatcherCount:            dc.GetIntProperty(dynamicconfig.TaskSchedulerDispatcherCount),
-		TaskSchedulerRoundRobinWeights:          dc.GetMapProperty(dynamicconfig.TaskSchedulerRoundRobinWeights),
-		TaskCriticalRetryCount:                  dc.GetIntProperty(dynamicconfig.TaskCriticalRetryCount),
-		ActiveTaskRedispatchInterval:            dc.GetDurationProperty(dynamicconfig.ActiveTaskRedispatchInterval),
-		StandbyTaskRedispatchInterval:           dc.GetDurationProperty(dynamicconfig.StandbyTaskRedispatchInterval),
-		TaskRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TaskRedispatchIntervalJitterCoefficient),
-		StandbyTaskReReplicationContextTimeout:  dc.GetDurationPropertyFilteredByDomainID(dynamicconfig.StandbyTaskReReplicationContextTimeout),
-		EnableDropStuckTaskByDomainID:           dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.EnableDropStuckTaskByDomainID),
-		ResurrectionCheckMinDelay:               dc.GetDurationPropertyFilteredByDomain(dynamicconfig.ResurrectionCheckMinDelay),
+		TaskProcessRPS:                         dc.GetIntPropertyFilteredByDomain(dynamicconfig.TaskProcessRPS),
+		TaskSchedulerType:                      dc.GetIntProperty(dynamicconfig.TaskSchedulerType),
+		TaskSchedulerWorkerCount:               dc.GetIntProperty(dynamicconfig.TaskSchedulerWorkerCount),
+		TaskSchedulerShardWorkerCount:          dc.GetIntProperty(dynamicconfig.TaskSchedulerShardWorkerCount),
+		TaskSchedulerQueueSize:                 dc.GetIntProperty(dynamicconfig.TaskSchedulerQueueSize),
+		TaskSchedulerShardQueueSize:            dc.GetIntProperty(dynamicconfig.TaskSchedulerShardQueueSize),
+		TaskSchedulerDispatcherCount:           dc.GetIntProperty(dynamicconfig.TaskSchedulerDispatcherCount),
+		TaskSchedulerRoundRobinWeights:         dc.GetMapProperty(dynamicconfig.TaskSchedulerRoundRobinWeights),
+		TaskCriticalRetryCount:                 dc.GetIntProperty(dynamicconfig.TaskCriticalRetryCount),
+		ActiveTaskRedispatchInterval:           dc.GetDurationProperty(dynamicconfig.ActiveTaskRedispatchInterval),
+		StandbyTaskRedispatchInterval:          dc.GetDurationProperty(dynamicconfig.StandbyTaskRedispatchInterval),
+		StandbyTaskReReplicationContextTimeout: dc.GetDurationPropertyFilteredByDomainID(dynamicconfig.StandbyTaskReReplicationContextTimeout),
+		EnableDropStuckTaskByDomainID:          dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.EnableDropStuckTaskByDomainID),
+		ResurrectionCheckMinDelay:              dc.GetDurationPropertyFilteredByDomain(dynamicconfig.ResurrectionCheckMinDelay),
 
 		QueueProcessorEnableSplit:                          dc.GetBoolProperty(dynamicconfig.QueueProcessorEnableSplit),
 		QueueProcessorSplitMaxLevel:                        dc.GetIntProperty(dynamicconfig.QueueProcessorSplitMaxLevel),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -103,7 +103,6 @@ func TestNewConfig(t *testing.T) {
 		"TaskCriticalRetryCount":                               {dynamicconfig.TaskCriticalRetryCount, 37},
 		"ActiveTaskRedispatchInterval":                         {dynamicconfig.ActiveTaskRedispatchInterval, time.Second},
 		"StandbyTaskRedispatchInterval":                        {dynamicconfig.StandbyTaskRedispatchInterval, time.Second},
-		"TaskRedispatchIntervalJitterCoefficient":              {dynamicconfig.TaskRedispatchIntervalJitterCoefficient, 1.0},
 		"StandbyTaskReReplicationContextTimeout":               {dynamicconfig.StandbyTaskReReplicationContextTimeout, time.Second},
 		"EnableDropStuckTaskByDomainID":                        {dynamicconfig.EnableDropStuckTaskByDomainID, true},
 		"ResurrectionCheckMinDelay":                            {dynamicconfig.ResurrectionCheckMinDelay, time.Second},

--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -102,8 +102,7 @@ func newProcessorBase(
 			taskProcessor,
 			shard.GetTimeSource(),
 			&task.RedispatcherOptions{
-				TaskRedispatchInterval:                  options.RedispatchInterval,
-				TaskRedispatchIntervalJitterCoefficient: options.RedispatchIntervalJitterCoefficient,
+				TaskRedispatchInterval: options.RedispatchInterval,
 			},
 			logger,
 			metricsScope,

--- a/service/history/queue/processor_options.go
+++ b/service/history/queue/processor_options.go
@@ -31,7 +31,6 @@ type queueProcessorOptions struct {
 	UpdateAckInterval                    dynamicconfig.DurationPropertyFn
 	UpdateAckIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
 	RedispatchInterval                   dynamicconfig.DurationPropertyFn
-	RedispatchIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
 	MaxRedispatchQueueSize               dynamicconfig.IntPropertyFn
 	MaxStartJitterInterval               dynamicconfig.DurationPropertyFn
 	SplitQueueInterval                   dynamicconfig.DurationPropertyFn

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -672,7 +672,6 @@ func newTimerQueueProcessorOptions(
 		MaxPollIntervalJitterCoefficient:     config.TimerProcessorMaxPollIntervalJitterCoefficient,
 		UpdateAckInterval:                    config.TimerProcessorUpdateAckInterval,
 		UpdateAckIntervalJitterCoefficient:   config.TimerProcessorUpdateAckIntervalJitterCoefficient,
-		RedispatchIntervalJitterCoefficient:  config.TaskRedispatchIntervalJitterCoefficient,
 		MaxRedispatchQueueSize:               config.TimerProcessorMaxRedispatchQueueSize,
 		SplitQueueInterval:                   config.TimerProcessorSplitQueueInterval,
 		SplitQueueIntervalJitterCoefficient:  config.TimerProcessorSplitQueueIntervalJitterCoefficient,

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -573,7 +573,6 @@ func newTransferQueueProcessorOptions(
 		MaxPollIntervalJitterCoefficient:     config.TransferProcessorMaxPollIntervalJitterCoefficient,
 		UpdateAckInterval:                    config.TransferProcessorUpdateAckInterval,
 		UpdateAckIntervalJitterCoefficient:   config.TransferProcessorUpdateAckIntervalJitterCoefficient,
-		RedispatchIntervalJitterCoefficient:  config.TaskRedispatchIntervalJitterCoefficient,
 		MaxRedispatchQueueSize:               config.TransferProcessorMaxRedispatchQueueSize,
 		SplitQueueInterval:                   config.TransferProcessorSplitQueueInterval,
 		SplitQueueIntervalJitterCoefficient:  config.TransferProcessorSplitQueueIntervalJitterCoefficient,

--- a/service/history/task/redispatcher_test.go
+++ b/service/history/task/redispatcher_test.go
@@ -46,6 +46,7 @@ type (
 		controller     *gomock.Controller
 		mockProcessor  *MockProcessor
 		mockTimeSource clock.MockedTimeSource
+		options        *RedispatcherOptions
 
 		metricsScope metrics.Scope
 		logger       log.Logger
@@ -65,19 +66,24 @@ func (s *redispatcherSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockProcessor = NewMockProcessor(s.controller)
 	s.mockTimeSource = clock.NewMockedTimeSource()
+	s.options = &RedispatcherOptions{
+		TaskRedispatchInterval: dynamicconfig.GetDurationPropertyFn(time.Millisecond * 50),
+	}
 
 	s.metricsScope = metrics.NewClient(tally.NoopScope, metrics.History).Scope(0)
-	s.logger = testlogger.New(s.Suite.T())
+	s.logger = testlogger.New(s.T())
 
-	s.redispatcher = s.newTestRedispatcher()
+	s.redispatcher = NewRedispatcher(
+		s.mockProcessor,
+		s.mockTimeSource,
+		s.options,
+		s.logger,
+		s.metricsScope,
+	).(*redispatcherImpl)
 }
 
 func (s *redispatcherSuite) TearDownTest() {
 	s.redispatcher.Stop()
-	s.redispatcher.Lock()
-	s.Nil(s.redispatcher.redispatchTimer)
-	s.redispatcher.Unlock()
-	s.controller.Finish()
 }
 
 func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
@@ -96,7 +102,7 @@ func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
 		return false, errors.New("processor shutdown")
 	}).Times(1)
 
-	for i := 0; i != numTasks; i++ {
+	for i := 0; i < numTasks; i++ {
 		mockTask := NewMockTask(s.controller)
 		mockTask.EXPECT().Priority().Return(rand.Intn(5)).AnyTimes()
 		mockTask.EXPECT().GetAttempt().Return(0).Times(1)
@@ -104,7 +110,7 @@ func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
 	}
 
 	s.Equal(numTasks, s.redispatcher.Size())
-	s.mockTimeSource.Advance(2 * s.redispatcher.options.TaskRedispatchInterval())
+	s.mockTimeSource.Advance(2 * s.options.TaskRedispatchInterval())
 	s.redispatcher.Start()
 	<-s.redispatcher.shutdownCh
 	<-stopDoneCh
@@ -116,28 +122,37 @@ func (s *redispatcherSuite) TestRedispatch_WithTargetSize() {
 	numTasks := defaultBufferSize + 20
 	targetSize := defaultBufferSize + 10
 
-	for i := 0; i != numTasks; i++ {
+	for i := 0; i < numTasks; i++ {
 		mockTask := NewMockTask(s.controller)
 		mockTask.EXPECT().Priority().Return(rand.Intn(5)).AnyTimes()
 		mockTask.EXPECT().GetAttempt().Return(0).Times(1)
 		s.redispatcher.AddTask(mockTask)
-		s.mockProcessor.EXPECT().TrySubmit(gomock.Any()).Return(true, nil).MaxTimes(1)
 	}
 
-	s.mockTimeSource.Advance(2 * s.redispatcher.options.TaskRedispatchInterval())
 	s.redispatcher.Start()
+	s.redispatcher.timerGate.Stop()
+	s.mockProcessor.EXPECT().TrySubmit(gomock.Any()).Return(true, nil).Times(numTasks + defaultBufferSize - targetSize)
+	s.mockProcessor.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(_ interface{}) (bool, error) {
+		go func() {
+			s.redispatcher.Stop()
+		}()
+
+		<-s.redispatcher.shutdownCh
+		return false, errors.New("processor shutdown")
+	}).Times(1)
+	s.mockTimeSource.Advance(2 * s.options.TaskRedispatchInterval())
 	s.redispatcher.Redispatch(targetSize)
 
 	// implementation can choose to redispatch more tasks than needed
-	s.True(s.redispatcher.Size() <= targetSize)
-	s.True(s.redispatcher.Size() > 0)
+	sz := s.redispatcher.Size()
+	s.Equal(targetSize-defaultBufferSize, sz)
 }
 
 func (s *redispatcherSuite) TestRedispatch_Backoff() {
 	numTasks := 50
 	numLowAttemptTasks := 0
 	numHighAttemptTasks := 0
-	for i := 0; i != numTasks; i++ {
+	for i := 0; i < numTasks; i++ {
 		attempt := 100
 		if rand.Intn(2) == 0 {
 			numLowAttemptTasks++
@@ -153,8 +168,9 @@ func (s *redispatcherSuite) TestRedispatch_Backoff() {
 		s.mockProcessor.EXPECT().TrySubmit(NewMockTaskMatcher(mockTask)).Return(true, nil).MaxTimes(1)
 	}
 
-	s.mockTimeSource.Advance(2 * s.redispatcher.options.TaskRedispatchInterval())
 	s.redispatcher.Start()
+	s.redispatcher.timerGate.Stop()
+	s.mockTimeSource.Advance(2 * s.options.TaskRedispatchInterval())
 	s.redispatcher.Redispatch(0)
 
 	s.Equal(numHighAttemptTasks, s.redispatcher.Size())
@@ -182,23 +198,11 @@ func (s *redispatcherSuite) TestRedispatch_Random() {
 		s.mockProcessor.EXPECT().TrySubmit(NewMockTaskMatcher(mockTask)).Return(submitted, nil).MaxTimes(1)
 	}
 
-	s.mockTimeSource.Advance(2 * s.redispatcher.options.TaskRedispatchInterval())
 	s.redispatcher.Start()
+	s.redispatcher.timerGate.Stop()
+	s.mockTimeSource.Advance(2 * s.options.TaskRedispatchInterval())
 	s.redispatcher.Redispatch(0)
 
 	// implementation can choose to stop redispatch for a certain priority when previous submit has failed
 	s.True(s.redispatcher.Size() >= numTasks-dispatched)
-}
-
-func (s *redispatcherSuite) newTestRedispatcher() *redispatcherImpl {
-	return NewRedispatcher(
-		s.mockProcessor,
-		s.mockTimeSource,
-		&RedispatcherOptions{
-			TaskRedispatchInterval:                  dynamicconfig.GetDurationPropertyFn(time.Millisecond * 50),
-			TaskRedispatchIntervalJitterCoefficient: dynamicconfig.GetFloatPropertyFn(0.15),
-		},
-		s.logger,
-		s.metricsScope,
-	).(*redispatcherImpl)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update redispatcher to use timer gate instead of timer
- Set the timer gate to fire at the earliest redispatch time of all tasks
- Deprecate TaskRedispatchIntervalJitterCoefficient dynamicconfig

<!-- Tell your future self why have you made these changes -->
**Why?**
Redispatcher previously was triggered periodically in the background and send all the tasks that should be redispatched before now to the task scheduler. This creates 2 issues:
- When there is no task to be redispatched, it's still waken up by the timer
- When there are tasks to be redispatched, it might be waken up by the timer too late, in which case the redispatch time of the task is not respected.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Redispatcher not working
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
