### PR TITLE
Don't fail the workflow when failed to emit metrics for one domain

### DIFF
--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -158,7 +158,7 @@ func (w *Workflow) emitWorkflowTypeCountMetrics(ctx context.Context) error {
 				err = w.emitWorkflowTypeCountMetricsES(ctx, domainName, logger)
 			}
 			if err != nil {
-				return err
+				logger.Error(fmt.Sprintf("Failed to emit workflow type metrics for domain %s", domainName), zap.Error(err))
 			}
 		}
 	}

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -148,6 +148,7 @@ func (w *Workflow) emitWorkflowTypeCountMetrics(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		var failedDomains []string
 		for _, domainName := range workflowMetricDomainNames {
 			switch w.analyzer.readMode {
 			case ES:
@@ -159,7 +160,11 @@ func (w *Workflow) emitWorkflowTypeCountMetrics(ctx context.Context) error {
 			}
 			if err != nil {
 				logger.Error(fmt.Sprintf("Failed to emit workflow type metrics for domain %s", domainName), zap.Error(err))
+				failedDomains = append(failedDomains, domainName)
 			}
+		}
+		if len(failedDomains) == len(workflowMetricDomainNames) {
+			return fmt.Errorf("Failed to emit workflow type metrics for all domains.")
 		}
 	}
 	return nil

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -159,12 +159,12 @@ func (w *Workflow) emitWorkflowTypeCountMetrics(ctx context.Context) error {
 				err = w.emitWorkflowTypeCountMetricsES(ctx, domainName, logger)
 			}
 			if err != nil {
-				logger.Error(fmt.Sprintf("Failed to emit workflow type metrics for domain %s", domainName), zap.Error(err))
+				logger.Error(fmt.Sprintf("failed to emit workflow type metrics for domain %s", domainName), zap.Error(err))
 				failedDomains = append(failedDomains, domainName)
 			}
 		}
 		if len(failedDomains) == len(workflowMetricDomainNames) {
-			return fmt.Errorf("Failed to emit workflow type metrics for all domains.")
+			return fmt.Errorf("failed to emit workflow type metrics for all domains")
 		}
 	}
 	return nil

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -197,6 +197,7 @@ func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		var failedDomains []string
 		for _, domainName := range workflowMetricDomainNames {
 			switch w.analyzer.readMode {
 			case ES:
@@ -208,7 +209,11 @@ func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 			}
 			if err != nil {
 				logger.Error(fmt.Sprintf("Failed to emit workflow version metrics for domain %s", domainName), zap.Error(err))
+				failedDomains = append(failedDomains, domainName)
 			}
+		}
+		if len(failedDomains) == len(workflowMetricDomainNames) {
+			return fmt.Errorf("Failed to emit workflow version metrics for all domains.")
 		}
 	}
 	return nil

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -208,12 +208,12 @@ func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 				err = w.emitWorkflowVersionMetricsES(ctx, domainName, logger)
 			}
 			if err != nil {
-				logger.Error(fmt.Sprintf("Failed to emit workflow version metrics for domain %s", domainName), zap.Error(err))
+				logger.Error(fmt.Sprintf("failed to emit workflow version metrics for domain %s", domainName), zap.Error(err))
 				failedDomains = append(failedDomains, domainName)
 			}
 		}
 		if len(failedDomains) == len(workflowMetricDomainNames) {
-			return fmt.Errorf("Failed to emit workflow version metrics for all domains.")
+			return fmt.Errorf("failed to emit workflow version metrics for all domains")
 		}
 	}
 	return nil

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -207,7 +207,7 @@ func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 				err = w.emitWorkflowVersionMetricsES(ctx, domainName, logger)
 			}
 			if err != nil {
-				return err
+				logger.Error(fmt.Sprintf("Failed to emit workflow version metrics for domain %s", domainName), zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We have workflows in ES analyzer to emit workflow count metrics per workflow type/version. Currently the workflow will fail entirely when it failed to get the domain info and block emitting metrics for other domains.

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
