### PR TITLE
[Wf-Diagnostics] Failure of usage logs emission should'nt fail the workflow

### DIFF
--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"fmt"
+	"github.com/uber/cadence/common/log/tag"
 	"time"
 
 	"go.uber.org/cadence/workflow"
@@ -85,6 +86,7 @@ func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params Diagnostics
 	workflowResult.DiagnosticsCompleted = true
 	childWfEnd = workflow.Now(ctx)
 
+	info := workflow.GetInfo(ctx)
 	activityOptions := workflow.ActivityOptions{
 		ScheduleToCloseTimeout: time.Second * 10,
 		ScheduleToStartTimeout: time.Second * 5,
@@ -103,7 +105,10 @@ func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params Diagnostics
 		DiagnosticsEndTime:    childWfEnd,
 	}).Get(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("EmitUsageLogs: %w", err)
+		w.logger.Error("wf-diagnostics usage logs emission failed",
+			tag.Error(err),
+			tag.WorkflowID(info.WorkflowExecution.ID),
+			tag.WorkflowRunID(info.WorkflowExecution.RunID))
 	}
 
 	return &workflowResult, nil

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -24,11 +24,11 @@ package diagnostics
 
 import (
 	"fmt"
-	"github.com/uber/cadence/common/log/tag"
 	"time"
 
 	"go.uber.org/cadence/workflow"
 
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 )
 

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -63,6 +63,7 @@ func (s *diagnosticsWorkflowTestSuite) SetupTest() {
 	mockResource := resource.NewTest(s.T(), controller, metrics.Worker)
 	publicClient := mockResource.GetSDKClient()
 	s.dw = &dw{
+		logger:        mockResource.GetLogger(),
 		svcClient:     publicClient,
 		clientBean:    mockResource.ClientBean,
 		metricsClient: mockResource.GetMetricsClient(),
@@ -162,6 +163,21 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow_Error() {
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.Error(s.workflowEnv.GetWorkflowError())
 	s.EqualError(s.workflowEnv.GetWorkflowError(), errExpected.Error())
+}
+
+func (s *diagnosticsWorkflowTestSuite) TestWorkflow_NoErrorIfEmitLogsActivityFails() {
+	params := &DiagnosticsWorkflowInput{
+		Domain:     "test",
+		WorkflowID: "123",
+		RunID:      "abc",
+	}
+	mockErr := errors.New("mockErr")
+	s.workflowEnv.OnActivity(identifyIssuesActivity, mock.Anything, mock.Anything).Return(nil, nil)
+	s.workflowEnv.OnActivity(rootCauseIssuesActivity, mock.Anything, mock.Anything).Return(nil, nil)
+	s.workflowEnv.OnActivity(emitUsageLogsActivity, mock.Anything, mock.Anything).Return(mockErr)
+	s.workflowEnv.ExecuteWorkflow(diagnosticsStarterWorkflow, params)
+	s.True(s.workflowEnv.IsWorkflowCompleted())
+	s.NoError(s.workflowEnv.GetWorkflowError())
 }
 
 func (s *diagnosticsWorkflowTestSuite) queryDiagnostics() DiagnosticsStarterWorkflowResult {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When the emit usage logs activity fails, the workflow logs the error but doesnt fail the workflow

<!-- Tell your future self why have you made these changes -->
**Why?**
usage logs emission should be an optional step

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
