### PR TITLE
Move time source from db layer to PersistenceManager

### DIFF
--- a/common/persistence/config_store_manager.go
+++ b/common/persistence/config_store_manager.go
@@ -22,9 +22,9 @@ package persistence
 
 import (
 	"context"
-	"time"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 )
 
@@ -35,6 +35,7 @@ type (
 		serializer  PayloadSerializer
 		persistence ConfigStore
 		logger      log.Logger
+		timeSrc     clock.TimeSource
 	}
 )
 
@@ -46,6 +47,7 @@ func NewConfigStoreManagerImpl(persistence ConfigStore, logger log.Logger) Confi
 		serializer:  NewPayloadSerializer(),
 		persistence: persistence,
 		logger:      logger,
+		timeSrc:     clock.NewRealTimeSource(),
 	}
 }
 
@@ -79,7 +81,7 @@ func (m *configStoreManagerImpl) UpdateDynamicConfig(ctx context.Context, reques
 	entry := &InternalConfigStoreEntry{
 		RowType:   int(cfgType),
 		Version:   request.Snapshot.Version,
-		Timestamp: time.Now(),
+		Timestamp: m.timeSrc.Now(),
 		Values:    blob,
 	}
 

--- a/common/persistence/config_store_manager_test.go
+++ b/common/persistence/config_store_manager_test.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/types"
 )
@@ -46,6 +47,7 @@ func setUpMocksForConfigStoreManager(t *testing.T) (*configStoreManagerImpl, *Mo
 		serializer:  mockSerializer,
 		persistence: mockStore,
 		logger:      logger,
+		timeSrc:     clock.NewRealTimeSource(),
 	}, mockStore, mockSerializer
 }
 

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1051,13 +1051,13 @@ type (
 
 	// LeaseTaskListRequest is used to request lease of a task list
 	LeaseTaskListRequest struct {
-		DomainID     string
-		DomainName   string
-		TaskList     string
-		TaskType     int
-		TaskListKind int
-		RangeID      int64
-		TimeStamp    time.Time
+		DomainID         string
+		DomainName       string
+		TaskList         string
+		TaskType         int
+		TaskListKind     int
+		RangeID          int64
+		CurrentTimeStamp time.Time
 	}
 
 	// LeaseTaskListResponse is response to LeaseTaskListRequest
@@ -1078,9 +1078,9 @@ type (
 
 	// UpdateTaskListRequest is used to update task list implementation information
 	UpdateTaskListRequest struct {
-		TaskListInfo *TaskListInfo
-		DomainName   string
-		UpdatedTime  time.Time
+		TaskListInfo     *TaskListInfo
+		DomainName       string
+		CurrentTimeStamp time.Time
 	}
 
 	// UpdateTaskListResponse is the response to UpdateTaskList
@@ -1122,10 +1122,10 @@ type (
 
 	// CreateTasksRequest is used to create a new task for a workflow exectution
 	CreateTasksRequest struct {
-		TaskListInfo *TaskListInfo
-		Tasks        []*CreateTaskInfo
-		DomainName   string
-		CreatedTime  time.Time
+		TaskListInfo     *TaskListInfo
+		Tasks            []*CreateTaskInfo
+		DomainName       string
+		CurrentTimeStamp time.Time
 	}
 
 	// CreateTaskInfo describes a task to be created in CreateTasksRequest
@@ -1396,8 +1396,6 @@ type (
 
 		// DomainName to get metrics created with the domain
 		DomainName string
-
-		CreatedTime time.Time
 	}
 
 	// AppendHistoryNodesResponse is a response to AppendHistoryNodesRequest
@@ -1479,8 +1477,6 @@ type (
 		ShardID *int
 		// DomainName to create metrics for Domain Cost Attribution
 		DomainName string
-
-		CreatedTime time.Time
 	}
 
 	// ForkHistoryBranchResponse is the response to ForkHistoryBranchRequest

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1057,6 +1057,7 @@ type (
 		TaskType     int
 		TaskListKind int
 		RangeID      int64
+		UpdatedTime  time.Time
 	}
 
 	// LeaseTaskListResponse is response to LeaseTaskListRequest
@@ -1079,6 +1080,7 @@ type (
 	UpdateTaskListRequest struct {
 		TaskListInfo *TaskListInfo
 		DomainName   string
+		UpdatedTime  time.Time
 	}
 
 	// UpdateTaskListResponse is the response to UpdateTaskList
@@ -1123,6 +1125,7 @@ type (
 		TaskListInfo *TaskListInfo
 		Tasks        []*CreateTaskInfo
 		DomainName   string
+		CreatedTime  time.Time
 	}
 
 	// CreateTaskInfo describes a task to be created in CreateTasksRequest

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1057,7 +1057,7 @@ type (
 		TaskType     int
 		TaskListKind int
 		RangeID      int64
-		UpdatedTime  time.Time
+		TimeStamp    time.Time
 	}
 
 	// LeaseTaskListResponse is response to LeaseTaskListRequest

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1549,8 +1549,9 @@ type (
 
 	// CreateFailoverMarkersRequest is request to create failover markers
 	CreateFailoverMarkersRequest struct {
-		RangeID int64
-		Markers []*FailoverMarkerTask
+		RangeID          int64
+		Markers          []*FailoverMarkerTask
+		CurrentTimeStamp time.Time
 	}
 
 	// FetchDynamicConfigResponse is a response to FetchDynamicConfigResponse

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1392,6 +1392,8 @@ type (
 
 		// DomainName to get metrics created with the domain
 		DomainName string
+
+		CreatedTime time.Time
 	}
 
 	// AppendHistoryNodesResponse is a response to AppendHistoryNodesRequest
@@ -1473,6 +1475,8 @@ type (
 		ShardID *int
 		// DomainName to create metrics for Domain Cost Attribution
 		DomainName string
+
+		CreatedTime time.Time
 	}
 
 	// ForkHistoryBranchResponse is the response to ForkHistoryBranchRequest

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1246,6 +1246,7 @@ type (
 		ConfigVersion     int64
 		FailoverVersion   int64
 		LastUpdatedTime   int64
+		CurrentTimeStamp  time.Time
 	}
 
 	// CreateDomainResponse is the response for CreateDomain

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -534,6 +534,8 @@ type (
 		TransactionID int64
 		// Used in sharded data stores to identify which shard to use
 		ShardID int
+
+		CreatedTime time.Time
 	}
 
 	// InternalGetWorkflowExecutionRequest is used to retrieve the info of a workflow execution
@@ -572,6 +574,8 @@ type (
 		Info string
 		// Used in sharded data stores to identify which shard to use
 		ShardID int
+
+		CreatedTime time.Time
 	}
 
 	// InternalForkHistoryBranchResponse is the response to ForkHistoryBranchRequest

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -271,6 +271,7 @@ type (
 		BranchToken       []byte
 		NewRunBranchToken []byte
 		CreationTime      time.Time
+		CurrentTimeStamp  time.Time
 	}
 
 	// InternalWorkflowExecutionInfo describes a workflow execution for Persistence Interface

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -876,11 +876,13 @@ type (
 		ClusterReplicationLevel       map[string]int64     `json:"cluster_replication_level"`
 		DomainNotificationVersion     int64                `json:"domain_notification_version"`
 		PendingFailoverMarkers        *DataBlob            `json:"pending_failover_markers"`
+		CurrentTimestamp              time.Time
 	}
 
 	// InternalCreateShardRequest is request to CreateShard
 	InternalCreateShardRequest struct {
-		ShardInfo *InternalShardInfo
+		ShardInfo        *InternalShardInfo
+		CurrentTimeStamp time.Time
 	}
 
 	// InternalGetShardRequest is used to get shard information
@@ -890,8 +892,9 @@ type (
 
 	// InternalUpdateShardRequest  is used to update shard information
 	InternalUpdateShardRequest struct {
-		ShardInfo       *InternalShardInfo
-		PreviousRangeID int64
+		ShardInfo        *InternalShardInfo
+		PreviousRangeID  int64
+		CurrentTimeStamp time.Time
 	}
 
 	// InternalGetShardResponse is the response to GetShard

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -820,6 +820,7 @@ type (
 		ConfigVersion     int64
 		FailoverVersion   int64
 		LastUpdatedTime   time.Time
+		CurrentTimeStamp  time.Time
 	}
 
 	// InternalGetDomainResponse is the response for GetDomain

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -238,6 +238,8 @@ type (
 		NewWorkflowSnapshot InternalWorkflowSnapshot
 
 		WorkflowRequestMode CreateWorkflowRequestMode
+
+		CreatedTime time.Time
 	}
 
 	// InternalGetReplicationTasksResponse is the response to GetReplicationTask
@@ -424,6 +426,8 @@ type (
 		NewWorkflowSnapshot *InternalWorkflowSnapshot
 
 		WorkflowRequestMode CreateWorkflowRequestMode
+
+		UpdatedTime time.Time
 	}
 
 	// InternalConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for Persistence Interface
@@ -442,6 +446,8 @@ type (
 		CurrentWorkflowMutation *InternalWorkflowMutation
 
 		WorkflowRequestMode CreateWorkflowRequestMode
+
+		UpdatedTime time.Time
 	}
 
 	// InternalWorkflowMutation is used as generic workflow execution state mutation for Persistence Interface

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -197,16 +197,16 @@ type (
 	// Queue is a store to enqueue and get messages
 	Queue interface {
 		Closeable
-		EnqueueMessage(ctx context.Context, messagePayload []byte) error
+		EnqueueMessage(ctx context.Context, messagePayload []byte, currentTimeStamp time.Time) error
 		ReadMessages(ctx context.Context, lastMessageID int64, maxCount int) ([]*InternalQueueMessage, error)
 		DeleteMessagesBefore(ctx context.Context, messageID int64) error
-		UpdateAckLevel(ctx context.Context, messageID int64, clusterName string, now time.Time) error
+		UpdateAckLevel(ctx context.Context, messageID int64, clusterName string, currentTimestamp time.Time) error
 		GetAckLevels(ctx context.Context) (map[string]int64, error)
-		EnqueueMessageToDLQ(ctx context.Context, messagePayload []byte) error
+		EnqueueMessageToDLQ(ctx context.Context, messagePayload []byte, currentTimeStamp time.Time) error
 		ReadMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*InternalQueueMessage, []byte, error)
 		DeleteMessageFromDLQ(ctx context.Context, messageID int64) error
 		RangeDeleteMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64) error
-		UpdateDLQAckLevel(ctx context.Context, messageID int64, clusterName string, now time.Time) error
+		UpdateDLQAckLevel(ctx context.Context, messageID int64, clusterName string, currentTimestamp time.Time) error
 		GetDLQAckLevels(ctx context.Context) (map[string]int64, error)
 		GetDLQSize(ctx context.Context) (int64, error)
 	}
@@ -239,7 +239,7 @@ type (
 
 		WorkflowRequestMode CreateWorkflowRequestMode
 
-		CreatedTime time.Time
+		CurrentTimeStamp time.Time
 	}
 
 	// InternalGetReplicationTasksResponse is the response to GetReplicationTask
@@ -427,7 +427,7 @@ type (
 
 		WorkflowRequestMode CreateWorkflowRequestMode
 
-		UpdatedTime time.Time
+		CurrentTimeStamp time.Time
 	}
 
 	// InternalConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for Persistence Interface
@@ -447,7 +447,7 @@ type (
 
 		WorkflowRequestMode CreateWorkflowRequestMode
 
-		UpdatedTime time.Time
+		CurrentTimeStamp time.Time
 	}
 
 	// InternalWorkflowMutation is used as generic workflow execution state mutation for Persistence Interface
@@ -535,7 +535,7 @@ type (
 		// Used in sharded data stores to identify which shard to use
 		ShardID int
 
-		CreatedTime time.Time
+		CurrentTimeStamp time.Time
 	}
 
 	// InternalGetWorkflowExecutionRequest is used to retrieve the info of a workflow execution
@@ -575,7 +575,7 @@ type (
 		// Used in sharded data stores to identify which shard to use
 		ShardID int
 
-		CreatedTime time.Time
+		CurrentTimeStamp time.Time
 	}
 
 	// InternalForkHistoryBranchResponse is the response to ForkHistoryBranchRequest

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -200,13 +200,13 @@ type (
 		EnqueueMessage(ctx context.Context, messagePayload []byte) error
 		ReadMessages(ctx context.Context, lastMessageID int64, maxCount int) ([]*InternalQueueMessage, error)
 		DeleteMessagesBefore(ctx context.Context, messageID int64) error
-		UpdateAckLevel(ctx context.Context, messageID int64, clusterName string) error
+		UpdateAckLevel(ctx context.Context, messageID int64, clusterName string, now time.Time) error
 		GetAckLevels(ctx context.Context) (map[string]int64, error)
 		EnqueueMessageToDLQ(ctx context.Context, messagePayload []byte) error
 		ReadMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*InternalQueueMessage, []byte, error)
 		DeleteMessageFromDLQ(ctx context.Context, messageID int64) error
 		RangeDeleteMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64) error
-		UpdateDLQAckLevel(ctx context.Context, messageID int64, clusterName string) error
+		UpdateDLQAckLevel(ctx context.Context, messageID int64, clusterName string, now time.Time) error
 		GetDLQAckLevels(ctx context.Context) (map[string]int64, error)
 		GetDLQSize(ctx context.Context) (int64, error)
 	}

--- a/common/persistence/domain_manager.go
+++ b/common/persistence/domain_manager.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/types"
 )
@@ -36,6 +37,7 @@ type (
 		serializer  PayloadSerializer
 		persistence DomainStore
 		logger      log.Logger
+		timeSrc     clock.TimeSource
 	}
 )
 
@@ -45,6 +47,7 @@ func NewDomainManagerImpl(persistence DomainStore, logger log.Logger, serializer
 		serializer:  serializer,
 		persistence: persistence,
 		logger:      logger,
+		timeSrc:     clock.NewRealTimeSource(),
 	}
 }
 
@@ -68,6 +71,7 @@ func (m *domainManagerImpl) CreateDomain(
 		ConfigVersion:     request.ConfigVersion,
 		FailoverVersion:   request.FailoverVersion,
 		LastUpdatedTime:   time.Unix(0, request.LastUpdatedTime),
+		CurrentTimeStamp:  m.timeSrc.Now(),
 	})
 }
 

--- a/common/persistence/domain_manager_test.go
+++ b/common/persistence/domain_manager_test.go
@@ -110,27 +110,34 @@ func TestCreateDomain(t *testing.T) {
 				mockSerializer.EXPECT().
 					SerializeAsyncWorkflowsConfig(&types.AsyncWorkflowConfiguration{Enabled: true, PredefinedQueueName: "q", QueueType: "kafka"}, common.EncodingTypeThriftRW).
 					Return(&DataBlob{Encoding: common.EncodingTypeThriftRW, Data: []byte("async-workflow-config")}, nil).Times(1)
+
+				expectedReq := &InternalCreateDomainRequest{
+					Info: testFixtureDomainInfo(),
+					Config: &InternalDomainConfig{
+						Retention:                common.DaysToDuration(1),
+						EmitMetric:               true,
+						HistoryArchivalStatus:    types.ArchivalStatusEnabled,
+						HistoryArchivalURI:       "s3://abc",
+						VisibilityArchivalStatus: types.ArchivalStatusEnabled,
+						VisibilityArchivalURI:    "s3://xyz",
+						BadBinaries:              &DataBlob{Encoding: common.EncodingTypeThriftRW, Data: []byte("bad-binaries")},
+						IsolationGroups:          &DataBlob{Encoding: common.EncodingTypeThriftRW, Data: []byte("isolation-groups")},
+						AsyncWorkflowsConfig:     &DataBlob{Encoding: common.EncodingTypeThriftRW, Data: []byte("async-workflow-config")},
+					},
+					ReplicationConfig: testFixtureDomainReplicationConfig(),
+					IsGlobalDomain:    true,
+					ConfigVersion:     1,
+					FailoverVersion:   10,
+					LastUpdatedTime:   time.Unix(0, 100),
+					CurrentTimeStamp:  time.Now(),
+				}
+
 				mockStore.EXPECT().
-					CreateDomain(gomock.Any(), &InternalCreateDomainRequest{
-						Info: testFixtureDomainInfo(),
-						Config: &InternalDomainConfig{
-							Retention:                common.DaysToDuration(1),
-							EmitMetric:               true,
-							HistoryArchivalStatus:    types.ArchivalStatusEnabled,
-							HistoryArchivalURI:       "s3://abc",
-							VisibilityArchivalStatus: types.ArchivalStatusEnabled,
-							VisibilityArchivalURI:    "s3://xyz",
-							BadBinaries:              &DataBlob{Encoding: common.EncodingTypeThriftRW, Data: []byte("bad-binaries")},
-							IsolationGroups:          &DataBlob{Encoding: common.EncodingTypeThriftRW, Data: []byte("isolation-groups")},
-							AsyncWorkflowsConfig:     &DataBlob{Encoding: common.EncodingTypeThriftRW, Data: []byte("async-workflow-config")},
-						},
-						ReplicationConfig: testFixtureDomainReplicationConfig(),
-						IsGlobalDomain:    true,
-						ConfigVersion:     1,
-						FailoverVersion:   10,
-						LastUpdatedTime:   time.Unix(0, 100),
-					}).
-					Return(&CreateDomainResponse{}, nil).Times(1)
+					CreateDomain(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, actualRequest *InternalCreateDomainRequest) (*CreateDomainResponse, error) {
+						assert.WithinDuration(t, expectedReq.CurrentTimeStamp, actualRequest.CurrentTimeStamp, time.Second)
+						return nil, nil
+					})
 			},
 			request: &CreateDomainRequest{
 				Info:              testFixtureDomainInfo(),

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -949,6 +949,7 @@ func (m *executionManagerImpl) CreateFailoverMarkerTasks(
 	ctx context.Context,
 	request *CreateFailoverMarkersRequest,
 ) error {
+	request.CurrentTimeStamp = m.timeSrc.Now()
 	return m.persistence.CreateFailoverMarkerTasks(ctx, request)
 }
 
@@ -1026,6 +1027,7 @@ func (m *executionManagerImpl) toInternalReplicationTaskInfo(info *ReplicationTa
 		BranchToken:       info.BranchToken,
 		NewRunBranchToken: info.NewRunBranchToken,
 		CreationTime:      time.Unix(0, info.CreationTime).UTC(),
+		CurrentTimeStamp:  m.timeSrc.Now(),
 	}
 }
 

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/types"
 )
@@ -37,6 +38,7 @@ type (
 		persistence   ExecutionStore
 		statsComputer statsComputer
 		logger        log.Logger
+		timeSrc       clock.TimeSource
 	}
 )
 
@@ -53,6 +55,7 @@ func NewExecutionManagerImpl(
 		persistence:   persistence,
 		statsComputer: statsComputer{},
 		logger:        logger,
+		timeSrc:       clock.NewRealTimeSource(),
 	}
 }
 
@@ -348,6 +351,8 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 		NewWorkflowSnapshot:    serializedNewWorkflowSnapshot,
 
 		WorkflowRequestMode: request.WorkflowRequestMode,
+
+		UpdatedTime: m.timeSrc.Now(),
 	}
 	msuss := m.statsComputer.computeMutableStateUpdateStats(newRequest)
 	err = m.persistence.UpdateWorkflowExecution(ctx, newRequest)
@@ -567,6 +572,8 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 		CurrentWorkflowMutation: serializedCurrentWorkflowMutation,
 
 		WorkflowRequestMode: request.WorkflowRequestMode,
+
+		UpdatedTime: m.timeSrc.Now(),
 	}
 	msuss := m.statsComputer.computeMutableStateConflictResolveStats(newRequest)
 	err = m.persistence.ConflictResolveWorkflowExecution(ctx, newRequest)
@@ -599,6 +606,8 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 		NewWorkflowSnapshot: *serializedNewWorkflowSnapshot,
 
 		WorkflowRequestMode: request.WorkflowRequestMode,
+
+		CreatedTime: m.timeSrc.Now(),
 	}
 
 	msuss := m.statsComputer.computeMutableStateCreateStats(newRequest)

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -352,7 +352,7 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 
 		WorkflowRequestMode: request.WorkflowRequestMode,
 
-		UpdatedTime: m.timeSrc.Now(),
+		CurrentTimeStamp: m.timeSrc.Now(),
 	}
 	msuss := m.statsComputer.computeMutableStateUpdateStats(newRequest)
 	err = m.persistence.UpdateWorkflowExecution(ctx, newRequest)
@@ -573,7 +573,7 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 
 		WorkflowRequestMode: request.WorkflowRequestMode,
 
-		UpdatedTime: m.timeSrc.Now(),
+		CurrentTimeStamp: m.timeSrc.Now(),
 	}
 	msuss := m.statsComputer.computeMutableStateConflictResolveStats(newRequest)
 	err = m.persistence.ConflictResolveWorkflowExecution(ctx, newRequest)
@@ -607,7 +607,7 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 
 		WorkflowRequestMode: request.WorkflowRequestMode,
 
-		CreatedTime: m.timeSrc.Now(),
+		CurrentTimeStamp: m.timeSrc.Now(),
 	}
 
 	msuss := m.statsComputer.computeMutableStateCreateStats(newRequest)

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -1002,7 +1002,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 					PreviousLastWriteVersion: 1,
 					NewWorkflowSnapshot:      *sampleInternalWorkflowSnapshot(),
 					WorkflowRequestMode:      CreateWorkflowRequestModeReplicated,
-					CreatedTime:              time.Now(),
+					CurrentTimeStamp:         time.Now(),
 				}
 				mockedStore.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, actualRequest *InternalCreateWorkflowExecutionRequest) (*CreateWorkflowExecutionResponse, error) {
@@ -1013,7 +1013,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 						assert.Equal(t, expectedRequest.WorkflowRequestMode, actualRequest.WorkflowRequestMode)
 						assert.Equal(t, expectedRequest.NewWorkflowSnapshot, actualRequest.NewWorkflowSnapshot)
 
-						assert.WithinDuration(t, expectedRequest.CreatedTime, actualRequest.CreatedTime, time.Second)
+						assert.WithinDuration(t, expectedRequest.CurrentTimeStamp, actualRequest.CurrentTimeStamp, time.Second)
 						return nil, nil
 					})
 
@@ -1118,7 +1118,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 					RangeID:               1,
 					Mode:                  ConflictResolveWorkflowModeBypassCurrent,
 					ResetWorkflowSnapshot: *sampleInternalWorkflowSnapshot(),
-					UpdatedTime:           time.Now(),
+					CurrentTimeStamp:      time.Now(),
 				}
 				mockedStore.EXPECT().ConflictResolveWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, actualRequest *InternalConflictResolveWorkflowExecutionRequest) error {
@@ -1126,7 +1126,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 						assert.Equal(t, expectedRequest.Mode, actualRequest.Mode)
 						assert.Equal(t, expectedRequest.ResetWorkflowSnapshot, actualRequest.ResetWorkflowSnapshot)
 
-						assert.WithinDuration(t, expectedRequest.UpdatedTime, actualRequest.UpdatedTime, time.Second)
+						assert.WithinDuration(t, expectedRequest.CurrentTimeStamp, actualRequest.CurrentTimeStamp, time.Second)
 						return nil
 					})
 
@@ -1186,7 +1186,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 					Mode:                    ConflictResolveWorkflowModeBypassCurrent,
 					ResetWorkflowSnapshot:   *sampleInternalWorkflowSnapshot(),
 					CurrentWorkflowMutation: sampleInternalWorkflowMutation(),
-					UpdatedTime:             time.Now(),
+					CurrentTimeStamp:        time.Now(),
 				}
 
 				mockedStore.EXPECT().ConflictResolveWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, actualRequest *InternalConflictResolveWorkflowExecutionRequest) error {
@@ -1194,7 +1194,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 					assert.Equal(t, expectedRequest.Mode, actualRequest.Mode)
 					assert.Equal(t, expectedRequest.ResetWorkflowSnapshot, actualRequest.ResetWorkflowSnapshot)
 
-					assert.WithinDuration(t, expectedRequest.UpdatedTime, actualRequest.UpdatedTime, time.Second)
+					assert.WithinDuration(t, expectedRequest.CurrentTimeStamp, actualRequest.CurrentTimeStamp, time.Second)
 					return nil
 				})
 

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -132,12 +132,12 @@ func (m *historyV2ManagerImpl) ForkHistoryBranch(
 		return nil, err
 	}
 	req := &InternalForkHistoryBranchRequest{
-		ForkBranchInfo: *thrift.ToHistoryBranch(&forkBranch),
-		ForkNodeID:     request.ForkNodeID,
-		NewBranchID:    uuid.New(),
-		Info:           request.Info,
-		ShardID:        shardID,
-		CreatedTime:    m.timeSrc.Now(),
+		ForkBranchInfo:   *thrift.ToHistoryBranch(&forkBranch),
+		ForkNodeID:       request.ForkNodeID,
+		NewBranchID:      uuid.New(),
+		Info:             request.Info,
+		ShardID:          shardID,
+		CurrentTimeStamp: m.timeSrc.Now(),
 	}
 
 	resp, err := m.persistence.ForkHistoryBranch(ctx, req)
@@ -269,14 +269,14 @@ func (m *historyV2ManagerImpl) AppendHistoryNodes(
 		}
 	}
 	req := &InternalAppendHistoryNodesRequest{
-		IsNewBranch:   request.IsNewBranch,
-		Info:          request.Info,
-		BranchInfo:    *thrift.ToHistoryBranch(&branch),
-		NodeID:        nodeID,
-		Events:        blob,
-		TransactionID: request.TransactionID,
-		ShardID:       shardID,
-		CreatedTime:   m.timeSrc.Now(),
+		IsNewBranch:      request.IsNewBranch,
+		Info:             request.Info,
+		BranchInfo:       *thrift.ToHistoryBranch(&branch),
+		NodeID:           nodeID,
+		Events:           blob,
+		TransactionID:    request.TransactionID,
+		ShardID:          shardID,
+		CurrentTimeStamp: m.timeSrc.Now(),
 	}
 
 	err = m.persistence.AppendHistoryNodes(ctx, req)

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -29,6 +29,7 @@ import (
 
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/codec"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
@@ -65,6 +66,7 @@ type (
 		deserializeTokenFn     func([]byte, int64) (*historyV2PagingToken, error)
 		readRawHistoryBranchFn func(context.Context, *ReadHistoryBranchRequest) ([]*DataBlob, *historyV2PagingToken, int, log.Logger, error)
 		readHistoryBranchFn    func(context.Context, bool, *ReadHistoryBranchRequest) ([]*types.HistoryEvent, []*types.History, []byte, int, int64, error)
+		timeSrc                clock.TimeSource
 	}
 )
 
@@ -96,6 +98,7 @@ func NewHistoryV2ManagerImpl(
 		transactionSizeLimit: transactionSizeLimit,
 		serializeTokenFn:     serializeToken,
 		deserializeTokenFn:   deserializeToken,
+		timeSrc:              clock.NewRealTimeSource(),
 	}
 	hm.readRawHistoryBranchFn = hm.readRawHistoryBranch
 	hm.readHistoryBranchFn = hm.readHistoryBranch
@@ -134,6 +137,7 @@ func (m *historyV2ManagerImpl) ForkHistoryBranch(
 		NewBranchID:    uuid.New(),
 		Info:           request.Info,
 		ShardID:        shardID,
+		CreatedTime:    m.timeSrc.Now(),
 	}
 
 	resp, err := m.persistence.ForkHistoryBranch(ctx, req)
@@ -272,6 +276,7 @@ func (m *historyV2ManagerImpl) AppendHistoryNodes(
 		Events:        blob,
 		TransactionID: request.TransactionID,
 		ShardID:       shardID,
+		CreatedTime:   m.timeSrc.Now(),
 	}
 
 	err = m.persistence.AppendHistoryNodes(ctx, req)

--- a/common/persistence/nosql/nosql_domain_store.go
+++ b/common/persistence/nosql/nosql_domain_store.go
@@ -75,6 +75,7 @@ func (m *nosqlDomainStore) CreateDomain(
 		FailoverEndTime:             nil,
 		IsGlobalDomain:              request.IsGlobalDomain,
 		LastUpdatedTime:             request.LastUpdatedTime,
+		CurrentTimeStamp:            request.CurrentTimeStamp,
 	}
 
 	err := m.db.InsertDomain(ctx, row)

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -834,18 +834,15 @@ func (d *nosqlExecutionStore) CreateFailoverMarkerTasks(
 ) error {
 
 	var nosqlTasks []*nosqlplugin.HistoryMigrationTask
-	for _, task := range request.Markers {
-	//var nosqlTasks []*nosqlplugin.ReplicationTask
-	//for i, task := range request.Markers {
+	for i, task := range request.Markers {
 		ts := []persistence.Task{task}
 
 		tasks, err := d.prepareReplicationTasksForWorkflowTxn(task.DomainID, rowTypeReplicationWorkflowID, rowTypeReplicationRunID, ts)
 		if err != nil {
 			return err
 		}
+		tasks[i].Replication.CurrentTimeStamp = request.CurrentTimeStamp
 		nosqlTasks = append(nosqlTasks, tasks...)
-		//tasks[i].CurrentTimeStamp = request.CurrentTimeStamp
-		//nosqlTasks = append(nosqlTasks, tasks...)
 	}
 
 	err := d.db.InsertReplicationTask(ctx, nosqlTasks, nosqlplugin.ShardCondition{

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -91,7 +91,7 @@ func (d *nosqlExecutionStore) CreateWorkflowExecution(
 		return nil, err
 	}
 
-	workflowExecutionWriteReq, err := d.prepareCreateWorkflowExecutionRequestWithMaps(&newWorkflow)
+	workflowExecutionWriteReq, err := d.prepareCreateWorkflowExecutionRequestWithMaps(&newWorkflow, request.CreatedTime)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func (d *nosqlExecutionStore) UpdateWorkflowExecution(
 
 	// 2. new
 	if newWorkflow != nil {
-		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow)
+		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow, request.UpdatedTime)
 		if err != nil {
 			return err
 		}
@@ -463,7 +463,7 @@ func (d *nosqlExecutionStore) ConflictResolveWorkflowExecution(
 
 	// 3. new
 	if newWorkflow != nil {
-		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow)
+		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow, request.UpdatedTime)
 		if err != nil {
 			return err
 		}

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -91,7 +91,7 @@ func (d *nosqlExecutionStore) CreateWorkflowExecution(
 		return nil, err
 	}
 
-	workflowExecutionWriteReq, err := d.prepareCreateWorkflowExecutionRequestWithMaps(&newWorkflow, request.CreatedTime)
+	workflowExecutionWriteReq, err := d.prepareCreateWorkflowExecutionRequestWithMaps(&newWorkflow, request.CurrentTimeStamp)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func (d *nosqlExecutionStore) UpdateWorkflowExecution(
 
 	// 2. new
 	if newWorkflow != nil {
-		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow, request.UpdatedTime)
+		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow, request.CurrentTimeStamp)
 		if err != nil {
 			return err
 		}
@@ -463,7 +463,7 @@ func (d *nosqlExecutionStore) ConflictResolveWorkflowExecution(
 
 	// 3. new
 	if newWorkflow != nil {
-		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow, request.UpdatedTime)
+		insertExecution, err = d.prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow, request.CurrentTimeStamp)
 		if err != nil {
 			return err
 		}

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -298,7 +298,7 @@ func (d *nosqlExecutionStore) UpdateWorkflowExecution(
 	tasksByCategory := map[persistence.HistoryTaskCategory][]*nosqlplugin.HistoryMigrationTask{}
 
 	// 1. current
-	mutateExecution, err = d.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(&updateWorkflow)
+	mutateExecution, err = d.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(&updateWorkflow, request.CurrentTimeStamp)
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (d *nosqlExecutionStore) ConflictResolveWorkflowExecution(
 
 	// 1. current
 	if currentWorkflow != nil {
-		mutateExecution, err = d.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(currentWorkflow)
+		mutateExecution, err = d.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(currentWorkflow, request.CurrentTimeStamp)
 		if err != nil {
 			return err
 		}
@@ -447,7 +447,7 @@ func (d *nosqlExecutionStore) ConflictResolveWorkflowExecution(
 	}
 
 	// 2. reset
-	resetExecution, err = d.prepareResetWorkflowExecutionRequestWithMapsAndEventBuffer(&resetWorkflow)
+	resetExecution, err = d.prepareResetWorkflowExecutionRequestWithMapsAndEventBuffer(&resetWorkflow, request.CurrentTimeStamp)
 	if err != nil {
 		return err
 	}

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -835,6 +835,8 @@ func (d *nosqlExecutionStore) CreateFailoverMarkerTasks(
 
 	var nosqlTasks []*nosqlplugin.HistoryMigrationTask
 	for _, task := range request.Markers {
+	//var nosqlTasks []*nosqlplugin.ReplicationTask
+	//for i, task := range request.Markers {
 		ts := []persistence.Task{task}
 
 		tasks, err := d.prepareReplicationTasksForWorkflowTxn(task.DomainID, rowTypeReplicationWorkflowID, rowTypeReplicationRunID, ts)
@@ -842,6 +844,8 @@ func (d *nosqlExecutionStore) CreateFailoverMarkerTasks(
 			return err
 		}
 		nosqlTasks = append(nosqlTasks, tasks...)
+		//tasks[i].CurrentTimeStamp = request.CurrentTimeStamp
+		//nosqlTasks = append(nosqlTasks, tasks...)
 	}
 
 	err := d.db.InsertReplicationTask(ctx, nosqlTasks, nosqlplugin.ShardCondition{

--- a/common/persistence/nosql/nosql_execution_store_util.go
+++ b/common/persistence/nosql/nosql_execution_store_util.go
@@ -34,16 +34,15 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func (d *nosqlExecutionStore) prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow *persistence.InternalWorkflowSnapshot) (*nosqlplugin.WorkflowExecutionRequest, error) {
+func (d *nosqlExecutionStore) prepareCreateWorkflowExecutionRequestWithMaps(newWorkflow *persistence.InternalWorkflowSnapshot, timeStamp time.Time) (*nosqlplugin.WorkflowExecutionRequest, error) {
 	executionInfo := newWorkflow.ExecutionInfo
 	lastWriteVersion := newWorkflow.LastWriteVersion
 	checkSum := newWorkflow.Checksum
 	versionHistories := newWorkflow.VersionHistories
-	nowTimestamp := time.Now()
 
 	executionRequest, err := d.prepareCreateWorkflowExecutionTxn(
 		executionInfo, versionHistories, checkSum,
-		nowTimestamp, lastWriteVersion,
+		timeStamp, lastWriteVersion,
 	)
 	if err != nil {
 		return nil, err

--- a/common/persistence/nosql/nosql_execution_store_util.go
+++ b/common/persistence/nosql/nosql_execution_store_util.go
@@ -531,7 +531,6 @@ func (d *nosqlExecutionStore) prepareUpdateWorkflowExecutionTxn(
 	executionInfo *persistence.InternalWorkflowExecutionInfo,
 	versionHistories *persistence.DataBlob,
 	checksum checksum.Checksum,
-	// TODO: nowTimestamp is not used. Remove it?
 	nowTimestamp time.Time,
 	lastWriteVersion int64,
 ) (*nosqlplugin.WorkflowExecutionRequest, error) {
@@ -563,6 +562,7 @@ func (d *nosqlExecutionStore) prepareUpdateWorkflowExecutionTxn(
 		VersionHistories:              versionHistories,
 		Checksums:                     &checksum,
 		LastWriteVersion:              lastWriteVersion,
+		CurrentTimeStamp:              nowTimestamp,
 	}, nil
 }
 

--- a/common/persistence/nosql/nosql_execution_store_util_test.go
+++ b/common/persistence/nosql/nosql_execution_store_util_test.go
@@ -40,6 +40,8 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+var FixedTime = time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC)
+
 func newTestNosqlExecutionStoreWithTaskSerializer(db nosqlplugin.DB, logger log.Logger, taskSerializer serialization.TaskSerializer) *nosqlExecutionStore {
 	return &nosqlExecutionStore{
 		shardID:        1,
@@ -69,7 +71,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 						Data:     []byte(`[{"Branches":[{"BranchID":"test-branch-id","BeginNodeID":1,"EndNodeID":2}]}]`),
 					},
 				}
-				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, time.Now())
+				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, FixedTime)
 			},
 			input: &persistence.InternalWorkflowSnapshot{},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
@@ -94,7 +96,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 					},
 					Checksum: checksum.Checksum{Value: nil},
 				}
-				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, time.Now())
+				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, FixedTime)
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)
@@ -117,7 +119,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 						Data:     []byte("[]"), // Empty VersionHistories
 					},
 				}
-				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, time.Now())
+				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, FixedTime)
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)

--- a/common/persistence/nosql/nosql_execution_store_util_test.go
+++ b/common/persistence/nosql/nosql_execution_store_util_test.go
@@ -149,7 +149,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 					SignalRequestedIDs: []string{"signalRequestedID"},
 					Condition:          999,
 				}
-				return store.prepareResetWorkflowExecutionRequestWithMapsAndEventBuffer(resetWorkflow)
+				return store.prepareResetWorkflowExecutionRequestWithMapsAndEventBuffer(resetWorkflow, FixedTime)
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 					Checksum:         checksum.Checksum{Version: 1},
 					VersionHistories: &persistence.DataBlob{Encoding: common.EncodingTypeJSON, Data: []byte("{malformed}")},
 				}
-				return store.prepareResetWorkflowExecutionRequestWithMapsAndEventBuffer(resetWorkflow)
+				return store.prepareResetWorkflowExecutionRequestWithMapsAndEventBuffer(resetWorkflow, FixedTime)
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)
@@ -189,7 +189,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 						RunID:      "runID-success",
 					},
 				}
-				return store.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(workflowMutation)
+				return store.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(workflowMutation, FixedTime)
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)
@@ -204,7 +204,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 						DomainID: "domainID-incomplete",
 					},
 				}
-				return store.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(workflowMutation)
+				return store.prepareUpdateWorkflowExecutionRequestWithMapsAndEventBuffer(workflowMutation, FixedTime)
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)

--- a/common/persistence/nosql/nosql_execution_store_util_test.go
+++ b/common/persistence/nosql/nosql_execution_store_util_test.go
@@ -69,7 +69,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 						Data:     []byte(`[{"Branches":[{"BranchID":"test-branch-id","BeginNodeID":1,"EndNodeID":2}]}]`),
 					},
 				}
-				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot)
+				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, time.Now())
 			},
 			input: &persistence.InternalWorkflowSnapshot{},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
@@ -94,7 +94,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 					},
 					Checksum: checksum.Checksum{Value: nil},
 				}
-				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot)
+				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, time.Now())
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)
@@ -117,7 +117,7 @@ func TestNosqlExecutionStoreUtils(t *testing.T) {
 						Data:     []byte("[]"), // Empty VersionHistories
 					},
 				}
-				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot)
+				return store.prepareCreateWorkflowExecutionRequestWithMaps(workflowSnapshot, time.Now())
 			},
 			validate: func(t *testing.T, req *nosqlplugin.WorkflowExecutionRequest, err error) {
 				assert.NoError(t, err)

--- a/common/persistence/nosql/nosql_history_store.go
+++ b/common/persistence/nosql/nosql_history_store.go
@@ -75,7 +75,7 @@ func (h *nosqlHistoryStore) AppendHistoryNodes(
 			TreeID:          branchInfo.TreeID,
 			BranchID:        branchInfo.BranchID,
 			Ancestors:       ancestors,
-			CreateTimestamp: request.CreatedTime,
+			CreateTimestamp: request.CurrentTimeStamp,
 			Info:            request.Info,
 		}
 	}
@@ -87,7 +87,7 @@ func (h *nosqlHistoryStore) AppendHistoryNodes(
 		Data:            request.Events.Data,
 		DataEncoding:    string(request.Events.Encoding),
 		ShardID:         request.ShardID,
-		CreateTimestamp: request.CreatedTime,
+		CreateTimestamp: request.CurrentTimeStamp,
 	}
 
 	storeShard, err := h.GetStoreShardByHistoryShard(request.ShardID)
@@ -283,7 +283,7 @@ func (h *nosqlHistoryStore) ForkHistoryBranch(
 		TreeID:          treeID,
 		BranchID:        request.NewBranchID,
 		Ancestors:       ancestors,
-		CreateTimestamp: request.CreatedTime,
+		CreateTimestamp: request.CurrentTimeStamp,
 		Info:            request.Info,
 	}
 

--- a/common/persistence/nosql/nosql_history_store.go
+++ b/common/persistence/nosql/nosql_history_store.go
@@ -22,7 +22,6 @@ package nosql
 
 import (
 	"context"
-	"time"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
@@ -76,18 +75,19 @@ func (h *nosqlHistoryStore) AppendHistoryNodes(
 			TreeID:          branchInfo.TreeID,
 			BranchID:        branchInfo.BranchID,
 			Ancestors:       ancestors,
-			CreateTimestamp: time.Now(),
+			CreateTimestamp: request.CreatedTime,
 			Info:            request.Info,
 		}
 	}
 	nodeRow := &nosqlplugin.HistoryNodeRow{
-		TreeID:       branchInfo.TreeID,
-		BranchID:     branchInfo.BranchID,
-		NodeID:       request.NodeID,
-		TxnID:        &request.TransactionID,
-		Data:         request.Events.Data,
-		DataEncoding: string(request.Events.Encoding),
-		ShardID:      request.ShardID,
+		TreeID:          branchInfo.TreeID,
+		BranchID:        branchInfo.BranchID,
+		NodeID:          request.NodeID,
+		TxnID:           &request.TransactionID,
+		Data:            request.Events.Data,
+		DataEncoding:    string(request.Events.Encoding),
+		ShardID:         request.ShardID,
+		CreateTimestamp: request.CreatedTime,
 	}
 
 	storeShard, err := h.GetStoreShardByHistoryShard(request.ShardID)
@@ -283,7 +283,7 @@ func (h *nosqlHistoryStore) ForkHistoryBranch(
 		TreeID:          treeID,
 		BranchID:        request.NewBranchID,
 		Ancestors:       ancestors,
-		CreateTimestamp: time.Now(),
+		CreateTimestamp: request.CreatedTime,
 		Info:            request.Info,
 	}
 

--- a/common/persistence/nosql/nosql_history_store_test.go
+++ b/common/persistence/nosql/nosql_history_store_test.go
@@ -167,7 +167,7 @@ func TestAppendHistoryNodes_NewBranch(t *testing.T) {
 			assert.Equal(t, "TestBranchID", treeRow.BranchID)
 			assert.Equal(t, request.BranchInfo.Ancestors, treeRow.Ancestors)
 			assert.Equal(t, request.Info, treeRow.Info)
-			assert.Equal(t, FixedTime, treeRow.CreateTimestamp, time.Second)
+			assert.Equal(t, FixedTime, treeRow.CreateTimestamp)
 
 			return nil
 		})

--- a/common/persistence/nosql/nosql_history_store_test.go
+++ b/common/persistence/nosql/nosql_history_store_test.go
@@ -68,18 +68,20 @@ func validInternalAppendHistoryNodesRequest() *persistence.InternalAppendHistory
 		},
 		TransactionID: testTransactionID,
 		ShardID:       testShardID,
+		CreatedTime:   FixedTime,
 	}
 }
 
 func validHistoryNodeRow() *nosqlplugin.HistoryNodeRow {
 	expectedNodeRow := &nosqlplugin.HistoryNodeRow{
-		TreeID:       "TestTreeID",
-		BranchID:     "TestBranchID",
-		NodeID:       testNodeID,
-		TxnID:        common.Ptr[int64](123),
-		Data:         []byte("TestEvents"),
-		DataEncoding: string(common.EncodingTypeThriftRW),
-		ShardID:      testShardID,
+		TreeID:          "TestTreeID",
+		BranchID:        "TestBranchID",
+		NodeID:          testNodeID,
+		TxnID:           common.Ptr[int64](123),
+		Data:            []byte("TestEvents"),
+		DataEncoding:    string(common.EncodingTypeThriftRW),
+		ShardID:         testShardID,
+		CreateTimestamp: FixedTime,
 	}
 	return expectedNodeRow
 }
@@ -159,14 +161,14 @@ func TestAppendHistoryNodes_NewBranch(t *testing.T) {
 	// Expect to insert the node into the history tree and node, as this is a new branch expect treeRow to be set
 	dbMock.EXPECT().InsertIntoHistoryTreeAndNode(gomock.Any(), gomock.Any(), validHistoryNodeRow()).
 		DoAndReturn(func(ctx ctx.Context, treeRow *nosqlplugin.HistoryTreeRow, nodeRow *nosqlplugin.HistoryNodeRow) error {
-			// Assert that the treeRow is as expected, we have to check this here because the treeRow has time.Now() in it
+			// Assert that the treeRow is as expected
 			assert.Equal(t, testShardID, treeRow.ShardID)
 			assert.Equal(t, "TestTreeID", treeRow.TreeID)
 			assert.Equal(t, "TestBranchID", treeRow.BranchID)
 			assert.Equal(t, request.BranchInfo.Ancestors, treeRow.Ancestors)
 			assert.Equal(t, request.Info, treeRow.Info)
+			assert.Equal(t, FixedTime, treeRow.CreateTimestamp, time.Second)
 
-			assert.WithinDuration(t, time.Now(), treeRow.CreateTimestamp, time.Second)
 			return nil
 		})
 
@@ -349,6 +351,7 @@ func validInternalForkHistoryBranchRequest(forkNodeID int64) *persistence.Intern
 		NewBranchID: "TestNewBranchID",
 		Info:        "TestInfo",
 		ShardID:     testShardID,
+		CreatedTime: FixedTime,
 	}
 }
 
@@ -388,19 +391,20 @@ func expectedTreeRow() *nosqlplugin.HistoryTreeRow {
 				EndNodeID: 10,
 			},
 		},
-		CreateTimestamp: time.Now(),
+		CreateTimestamp: FixedTime,
 		Info:            "TestInfo",
 	}
 }
 
 func treeRowEqual(t *testing.T, expected, actual *nosqlplugin.HistoryTreeRow) {
+	t.Helper()
+
 	assert.Equal(t, expected.ShardID, actual.ShardID)
 	assert.Equal(t, expected.TreeID, actual.TreeID)
 	assert.Equal(t, expected.BranchID, actual.BranchID)
 	assert.Equal(t, expected.Ancestors, actual.Ancestors)
 	assert.Equal(t, expected.Info, actual.Info)
-
-	assert.WithinDuration(t, time.Now(), actual.CreateTimestamp, time.Second)
+	assert.Equal(t, FixedTime, actual.CreateTimestamp)
 }
 
 func TestForkHistoryBranch_NotAllAncestors(t *testing.T) {
@@ -417,7 +421,7 @@ func TestForkHistoryBranch_NotAllAncestors(t *testing.T) {
 	// Expect to insert the new branch into the history tree
 	dbMock.EXPECT().InsertIntoHistoryTreeAndNode(gomock.Any(), gomock.Any(), nil).
 		DoAndReturn(func(ctx ctx.Context, treeRow *nosqlplugin.HistoryTreeRow, nodeRow *nosqlplugin.HistoryNodeRow) error {
-			// Assert that the treeRow is as expected, we have to check this here because the treeRow has time.Now() in it
+			// Assert that the treeRow is as expected
 			treeRowEqual(t, expTreeRow, treeRow)
 			return nil
 		}).Times(1)
@@ -448,7 +452,7 @@ func TestForkHistoryBranch_AllAncestors(t *testing.T) {
 	// Expect to insert the new branch into the history tree
 	dbMock.EXPECT().InsertIntoHistoryTreeAndNode(gomock.Any(), gomock.Any(), nil).
 		DoAndReturn(func(ctx ctx.Context, treeRow *nosqlplugin.HistoryTreeRow, nodeRow *nosqlplugin.HistoryNodeRow) error {
-			// Assert that the treeRow is as expected, we have to check this here because the treeRow has time.Now() in it
+			// Assert that the treeRow is as expected
 			treeRowEqual(t, expTreeRow, treeRow)
 			return nil
 		}).Times(1)

--- a/common/persistence/nosql/nosql_history_store_test.go
+++ b/common/persistence/nosql/nosql_history_store_test.go
@@ -66,9 +66,9 @@ func validInternalAppendHistoryNodesRequest() *persistence.InternalAppendHistory
 			Encoding: common.EncodingTypeThriftRW,
 			Data:     []byte("TestEvents"),
 		},
-		TransactionID: testTransactionID,
-		ShardID:       testShardID,
-		CreatedTime:   FixedTime,
+		TransactionID:    testTransactionID,
+		ShardID:          testShardID,
+		CurrentTimeStamp: FixedTime,
 	}
 }
 
@@ -347,11 +347,11 @@ func validInternalForkHistoryBranchRequest(forkNodeID int64) *persistence.Intern
 				},
 			},
 		},
-		ForkNodeID:  forkNodeID,
-		NewBranchID: "TestNewBranchID",
-		Info:        "TestInfo",
-		ShardID:     testShardID,
-		CreatedTime: FixedTime,
+		ForkNodeID:       forkNodeID,
+		NewBranchID:      "TestNewBranchID",
+		Info:             "TestInfo",
+		ShardID:          testShardID,
+		CurrentTimeStamp: FixedTime,
 	}
 }
 

--- a/common/persistence/nosql/nosql_queue_store_test.go
+++ b/common/persistence/nosql/nosql_queue_store_test.go
@@ -219,9 +219,10 @@ func TestEnqueueMessage_Succeeds(t *testing.T) {
 			assert.Equal(
 				t,
 				&nosqlplugin.QueueMessageRow{
-					QueueType: testQueueType,
-					ID:        lastMessageID + 20 + 1, // should be the max of cluster AckLevels + 1
-					Payload:   testPayload,
+					QueueType:        testQueueType,
+					ID:               lastMessageID + 20 + 1, // should be the max of cluster AckLevels + 1
+					Payload:          testPayload,
+					CurrentTimeStamp: FixedTime,
 				},
 				row,
 			)
@@ -286,9 +287,10 @@ func TestEnqueueMessageToDLQ_Succeeds(t *testing.T) {
 			assert.Equal(
 				t,
 				&nosqlplugin.QueueMessageRow{
-					QueueType: dlqMessageType,
-					ID:        lastMessageID + 1,
-					Payload:   testPayload,
+					QueueType:        dlqMessageType,
+					ID:               lastMessageID + 1,
+					Payload:          testPayload,
+					CurrentTimeStamp: FixedTime,
 				},
 				row,
 			)
@@ -545,7 +547,7 @@ func TestUpdateAckLevel_Succeeds(t *testing.T) {
 			assert.Equal(t, expectedClusterAckLevels, newMeta.ClusterAckLevels)
 		}).Return(nil)
 
-	assert.NoError(t, store.UpdateDLQAckLevel(ctx, messageID, clusterName, FixedTime))
+	assert.NoError(t, store.UpdateAckLevel(ctx, messageID, clusterName, FixedTime))
 }
 
 func TestUpdateAckLevel_FailsIfSelectMetadataFails(t *testing.T) {

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -98,7 +98,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 			Message: "LeaseTaskList requires non empty task list",
 		}
 	}
-	now := request.UpdatedTime
+	now := request.TimeStamp
 	var err, selectErr error
 	var currTL *nosqlplugin.TaskListRow
 	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskList, request.TaskType)
@@ -122,6 +122,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 				TaskListKind:    request.TaskListKind,
 				AckLevel:        initialAckLevel,
 				LastUpdatedTime: now,
+				TimeStamp:       now,
 			}
 			err = storeShard.db.InsertTaskList(ctx, currTL)
 		} else {
@@ -149,6 +150,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 			TaskListKind:            currTL.TaskListKind,
 			AckLevel:                currTL.AckLevel,
 			LastUpdatedTime:         now,
+			TimeStamp:               now,
 			AdaptivePartitionConfig: currTL.AdaptivePartitionConfig,
 		}, currTL.RangeID-1)
 	}
@@ -218,6 +220,7 @@ func (t *nosqlTaskStore) UpdateTaskList(
 		TaskListKind:            tli.Kind,
 		AckLevel:                tli.AckLevel,
 		LastUpdatedTime:         request.UpdatedTime,
+		TimeStamp:               request.UpdatedTime,
 		AdaptivePartitionConfig: tli.AdaptivePartitionConfig,
 	}
 	storeShard, err := t.GetStoreShardByTaskList(tli.DomainID, tli.Name, tli.TaskType)
@@ -331,6 +334,7 @@ func (t *nosqlTaskStore) CreateTasks(
 		TaskListType:    request.TaskListInfo.TaskType,
 		RangeID:         request.TaskListInfo.RangeID,
 		LastUpdatedTime: now,
+		TimeStamp:       now,
 	}
 
 	tli := request.TaskListInfo

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -98,7 +98,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 			Message: "LeaseTaskList requires non empty task list",
 		}
 	}
-	now := request.TimeStamp
+	now := request.CurrentTimeStamp
 	var err, selectErr error
 	var currTL *nosqlplugin.TaskListRow
 	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskList, request.TaskType)
@@ -219,8 +219,8 @@ func (t *nosqlTaskStore) UpdateTaskList(
 		RangeID:                 tli.RangeID,
 		TaskListKind:            tli.Kind,
 		AckLevel:                tli.AckLevel,
-		LastUpdatedTime:         request.UpdatedTime,
-		TimeStamp:               request.UpdatedTime,
+		LastUpdatedTime:         request.CurrentTimeStamp,
+		TimeStamp:               request.CurrentTimeStamp,
 		AdaptivePartitionConfig: tli.AdaptivePartitionConfig,
 	}
 	storeShard, err := t.GetStoreShardByTaskList(tli.DomainID, tli.Name, tli.TaskType)
@@ -290,7 +290,7 @@ func (t *nosqlTaskStore) CreateTasks(
 	ctx context.Context,
 	request *persistence.CreateTasksRequest,
 ) (*persistence.CreateTasksResponse, error) {
-	now := request.CreatedTime
+	now := request.CurrentTimeStamp
 	var tasks []*nosqlplugin.TaskRowForInsert
 	for _, taskRequest := range request.Tasks {
 		task := &nosqlplugin.TaskRow{

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -115,14 +115,14 @@ func (t *nosqlTaskStore) LeaseTaskList(
 	if selectErr != nil {
 		if storeShard.db.IsNotFoundError(selectErr) { // First time task list is used
 			currTL = &nosqlplugin.TaskListRow{
-				DomainID:        request.DomainID,
-				TaskListName:    request.TaskList,
-				TaskListType:    request.TaskType,
-				RangeID:         initialRangeID,
-				TaskListKind:    request.TaskListKind,
-				AckLevel:        initialAckLevel,
-				LastUpdatedTime: now,
-				TimeStamp:       now,
+				DomainID:         request.DomainID,
+				TaskListName:     request.TaskList,
+				TaskListType:     request.TaskType,
+				RangeID:          initialRangeID,
+				TaskListKind:     request.TaskListKind,
+				AckLevel:         initialAckLevel,
+				LastUpdatedTime:  now,
+				CurrentTimeStamp: now,
 			}
 			err = storeShard.db.InsertTaskList(ctx, currTL)
 		} else {
@@ -150,7 +150,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 			TaskListKind:            currTL.TaskListKind,
 			AckLevel:                currTL.AckLevel,
 			LastUpdatedTime:         now,
-			TimeStamp:               now,
+			CurrentTimeStamp:        now,
 			AdaptivePartitionConfig: currTL.AdaptivePartitionConfig,
 		}, currTL.RangeID-1)
 	}
@@ -220,7 +220,7 @@ func (t *nosqlTaskStore) UpdateTaskList(
 		TaskListKind:            tli.Kind,
 		AckLevel:                tli.AckLevel,
 		LastUpdatedTime:         request.CurrentTimeStamp,
-		TimeStamp:               request.CurrentTimeStamp,
+		CurrentTimeStamp:        request.CurrentTimeStamp,
 		AdaptivePartitionConfig: tli.AdaptivePartitionConfig,
 	}
 	storeShard, err := t.GetStoreShardByTaskList(tli.DomainID, tli.Name, tli.TaskType)
@@ -329,12 +329,12 @@ func (t *nosqlTaskStore) CreateTasks(
 	}
 
 	tasklistCondition := &nosqlplugin.TaskListRow{
-		DomainID:        request.TaskListInfo.DomainID,
-		TaskListName:    request.TaskListInfo.Name,
-		TaskListType:    request.TaskListInfo.TaskType,
-		RangeID:         request.TaskListInfo.RangeID,
-		LastUpdatedTime: now,
-		TimeStamp:       now,
+		DomainID:         request.TaskListInfo.DomainID,
+		TaskListName:     request.TaskListInfo.Name,
+		TaskListType:     request.TaskListInfo.TaskType,
+		RangeID:          request.TaskListInfo.RangeID,
+		LastUpdatedTime:  now,
+		CurrentTimeStamp: now,
 	}
 
 	tli := request.TaskListInfo

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -98,7 +98,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 			Message: "LeaseTaskList requires non empty task list",
 		}
 	}
-	now := time.Now()
+	now := request.UpdatedTime
 	var err, selectErr error
 	var currTL *nosqlplugin.TaskListRow
 	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskList, request.TaskType)
@@ -217,7 +217,7 @@ func (t *nosqlTaskStore) UpdateTaskList(
 		RangeID:                 tli.RangeID,
 		TaskListKind:            tli.Kind,
 		AckLevel:                tli.AckLevel,
-		LastUpdatedTime:         time.Now(),
+		LastUpdatedTime:         request.UpdatedTime,
 		AdaptivePartitionConfig: tli.AdaptivePartitionConfig,
 	}
 	storeShard, err := t.GetStoreShardByTaskList(tli.DomainID, tli.Name, tli.TaskType)
@@ -287,7 +287,7 @@ func (t *nosqlTaskStore) CreateTasks(
 	ctx context.Context,
 	request *persistence.CreateTasksRequest,
 ) (*persistence.CreateTasksResponse, error) {
-	now := time.Now()
+	now := request.CreatedTime
 	var tasks []*nosqlplugin.TaskRowForInsert
 	for _, taskRequest := range request.Tasks {
 		task := &nosqlplugin.TaskRow{
@@ -326,10 +326,11 @@ func (t *nosqlTaskStore) CreateTasks(
 	}
 
 	tasklistCondition := &nosqlplugin.TaskListRow{
-		DomainID:     request.TaskListInfo.DomainID,
-		TaskListName: request.TaskListInfo.Name,
-		TaskListType: request.TaskListInfo.TaskType,
-		RangeID:      request.TaskListInfo.RangeID,
+		DomainID:        request.TaskListInfo.DomainID,
+		TaskListName:    request.TaskListInfo.Name,
+		TaskListType:    request.TaskListInfo.TaskType,
+		RangeID:         request.TaskListInfo.RangeID,
+		LastUpdatedTime: now,
 	}
 
 	tli := request.TaskListInfo

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -98,7 +98,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 			Message: "LeaseTaskList requires non empty task list",
 		}
 	}
-	now := request.CurrentTimeStamp
+	currentTimeStamp := request.CurrentTimeStamp
 	var err, selectErr error
 	var currTL *nosqlplugin.TaskListRow
 	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskList, request.TaskType)
@@ -121,8 +121,8 @@ func (t *nosqlTaskStore) LeaseTaskList(
 				RangeID:          initialRangeID,
 				TaskListKind:     request.TaskListKind,
 				AckLevel:         initialAckLevel,
-				LastUpdatedTime:  now,
-				CurrentTimeStamp: now,
+				LastUpdatedTime:  currentTimeStamp,
+				CurrentTimeStamp: currentTimeStamp,
 			}
 			err = storeShard.db.InsertTaskList(ctx, currTL)
 		} else {
@@ -149,8 +149,8 @@ func (t *nosqlTaskStore) LeaseTaskList(
 			RangeID:                 currTL.RangeID,
 			TaskListKind:            currTL.TaskListKind,
 			AckLevel:                currTL.AckLevel,
-			LastUpdatedTime:         now,
-			CurrentTimeStamp:        now,
+			LastUpdatedTime:         currentTimeStamp,
+			CurrentTimeStamp:        currentTimeStamp,
 			AdaptivePartitionConfig: currTL.AdaptivePartitionConfig,
 		}, currTL.RangeID-1)
 	}
@@ -171,7 +171,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 		RangeID:                 currTL.RangeID,
 		AckLevel:                currTL.AckLevel,
 		Kind:                    request.TaskListKind,
-		LastUpdated:             now,
+		LastUpdated:             currentTimeStamp,
 		AdaptivePartitionConfig: currTL.AdaptivePartitionConfig,
 	}
 	return &persistence.LeaseTaskListResponse{TaskListInfo: tli}, nil
@@ -290,7 +290,7 @@ func (t *nosqlTaskStore) CreateTasks(
 	ctx context.Context,
 	request *persistence.CreateTasksRequest,
 ) (*persistence.CreateTasksResponse, error) {
-	now := request.CurrentTimeStamp
+	currentTimeStamp := request.CurrentTimeStamp
 	var tasks []*nosqlplugin.TaskRowForInsert
 	for _, taskRequest := range request.Tasks {
 		task := &nosqlplugin.TaskRow{
@@ -301,7 +301,7 @@ func (t *nosqlTaskStore) CreateTasks(
 			WorkflowID:      taskRequest.Data.WorkflowID,
 			RunID:           taskRequest.Data.RunID,
 			ScheduledID:     taskRequest.Data.ScheduleID,
-			CreatedTime:     now,
+			CreatedTime:     currentTimeStamp,
 			PartitionConfig: taskRequest.Data.PartitionConfig,
 		}
 
@@ -309,7 +309,7 @@ func (t *nosqlTaskStore) CreateTasks(
 		// If the Data has a non-zero Expiry value, means that the ask is being re-added to the tasks table.
 		// If that's the case, use the Expiry value to calculate the new TTL value to match history's timeout value.
 		if !taskRequest.Data.Expiry.IsZero() {
-			scheduleToStartTimeoutSeconds := int(taskRequest.Data.Expiry.Sub(now).Seconds())
+			scheduleToStartTimeoutSeconds := int(taskRequest.Data.Expiry.Sub(currentTimeStamp).Seconds())
 
 			if scheduleToStartTimeoutSeconds > 0 {
 				ttl = scheduleToStartTimeoutSeconds
@@ -333,8 +333,8 @@ func (t *nosqlTaskStore) CreateTasks(
 		TaskListName:     request.TaskListInfo.Name,
 		TaskListType:     request.TaskListInfo.TaskType,
 		RangeID:          request.TaskListInfo.RangeID,
-		LastUpdatedTime:  now,
-		CurrentTimeStamp: now,
+		LastUpdatedTime:  currentTimeStamp,
+		CurrentTimeStamp: currentTimeStamp,
 	}
 
 	tli := request.TaskListInfo

--- a/common/persistence/nosql/nosql_task_store_test.go
+++ b/common/persistence/nosql/nosql_task_store_test.go
@@ -279,8 +279,8 @@ func TestUpdateTaskList(t *testing.T) {
 	)
 
 	resp, err := store.UpdateTaskList(context.Background(), &persistence.UpdateTaskListRequest{
-		TaskListInfo: getExpectedTaskListInfo(),
-		UpdatedTime:  FixedTime,
+		TaskListInfo:     getExpectedTaskListInfo(),
+		CurrentTimeStamp: FixedTime,
 	})
 
 	assert.NoError(t, err)
@@ -303,8 +303,8 @@ func TestUpdateTaskList_Sticky(t *testing.T) {
 	taskListInfo.Kind = int(types.TaskListKindSticky)
 
 	resp, err := store.UpdateTaskList(context.Background(), &persistence.UpdateTaskListRequest{
-		TaskListInfo: taskListInfo,
-		UpdatedTime:  FixedTime,
+		TaskListInfo:     taskListInfo,
+		CurrentTimeStamp: FixedTime,
 	})
 
 	assert.NoError(t, err)
@@ -322,8 +322,8 @@ func TestUpdateTaskList_ConditionFailure(t *testing.T) {
 	)
 
 	_, err := store.UpdateTaskList(context.Background(), &persistence.UpdateTaskListRequest{
-		TaskListInfo: getExpectedTaskListInfo(),
-		UpdatedTime:  FixedTime,
+		TaskListInfo:     getExpectedTaskListInfo(),
+		CurrentTimeStamp: FixedTime,
 	})
 
 	var expectedErr *persistence.ConditionFailedError
@@ -564,7 +564,7 @@ func TestCreateTasks(t *testing.T) {
 					TaskType: TestTaskType,
 					RangeID:  1,
 				},
-				CreatedTime: now,
+				CurrentTimeStamp: now,
 				Tasks: []*persistence.CreateTaskInfo{
 					{
 						TaskID: 100,
@@ -666,13 +666,13 @@ func TestCreateTasks(t *testing.T) {
 
 func getValidLeaseTaskListRequest() *persistence.LeaseTaskListRequest {
 	return &persistence.LeaseTaskListRequest{
-		DomainID:     TestDomainID,
-		DomainName:   TestDomainName,
-		TaskList:     TestTaskListName,
-		TaskType:     int(types.TaskListTypeDecision),
-		TaskListKind: int(types.TaskListKindNormal),
-		RangeID:      0,
-		TimeStamp:    FixedTime,
+		DomainID:         TestDomainID,
+		DomainName:       TestDomainName,
+		TaskList:         TestTaskListName,
+		TaskType:         int(types.TaskListTypeDecision),
+		TaskListKind:     int(types.TaskListKindNormal),
+		RangeID:          0,
+		CurrentTimeStamp: FixedTime,
 	}
 }
 
@@ -692,7 +692,7 @@ func checkTaskListInfoExpected(t *testing.T, taskListInfo *persistence.TaskListI
 	assert.Equal(t, initialRangeID, taskListInfo.RangeID)
 	assert.Equal(t, initialAckLevel, taskListInfo.AckLevel)
 	assert.Equal(t, int(types.TaskListKindNormal), taskListInfo.Kind)
-	assert.WithinDuration(t, FixedTime, taskListInfo.LastUpdated, time.Second)
+	assert.Equal(t, FixedTime, taskListInfo.LastUpdated)
 }
 
 func taskRowEqualTaskInfo(t *testing.T, taskrow1 nosqlplugin.TaskRow, taskInfo1 *persistence.TaskInfo) {

--- a/common/persistence/nosql/nosql_task_store_test.go
+++ b/common/persistence/nosql/nosql_task_store_test.go
@@ -547,12 +547,12 @@ func TestCreateTasks(t *testing.T) {
 			name: "success - skipping task with Expiry expired",
 			setupMock: func(dbMock *nosqlplugin.MockDB) {
 				dbMock.EXPECT().InsertTasks(gomock.Any(), gomock.Any(), &nosqlplugin.TaskListRow{
-					DomainID:        TestDomainID,
-					TaskListName:    TestTaskListName,
-					TaskListType:    TestTaskType,
-					RangeID:         1,
-					LastUpdatedTime: FixedTime,
-					TimeStamp:       FixedTime,
+					DomainID:         TestDomainID,
+					TaskListName:     TestTaskListName,
+					TaskListType:     TestTaskType,
+					RangeID:          1,
+					LastUpdatedTime:  FixedTime,
+					CurrentTimeStamp: FixedTime,
 				}).Do(func(_ context.Context, tasks []*nosqlplugin.TaskRowForInsert, _ *nosqlplugin.TaskListRow) {
 					assert.Len(t, tasks, 0)
 				}).Return(nil).Times(1)
@@ -728,27 +728,27 @@ func getDecisionTaskListFilter() *nosqlplugin.TaskListFilter {
 
 func getExpectedTaskListRow() *nosqlplugin.TaskListRow {
 	return &nosqlplugin.TaskListRow{
-		DomainID:        TestDomainID,
-		TaskListName:    TestTaskListName,
-		TaskListType:    int(types.TaskListTypeDecision),
-		RangeID:         initialRangeID,
-		TaskListKind:    int(types.TaskListKindNormal),
-		AckLevel:        initialAckLevel,
-		LastUpdatedTime: FixedTime,
-		TimeStamp:       FixedTime,
+		DomainID:         TestDomainID,
+		TaskListName:     TestTaskListName,
+		TaskListType:     int(types.TaskListTypeDecision),
+		RangeID:          initialRangeID,
+		TaskListKind:     int(types.TaskListKindNormal),
+		AckLevel:         initialAckLevel,
+		LastUpdatedTime:  FixedTime,
+		CurrentTimeStamp: FixedTime,
 	}
 }
 
 func getExpectedTaskListRowWithPartitionConfig() *nosqlplugin.TaskListRow {
 	return &nosqlplugin.TaskListRow{
-		DomainID:        TestDomainID,
-		TaskListName:    TestTaskListName,
-		TaskListType:    int(types.TaskListTypeDecision),
-		RangeID:         initialRangeID,
-		TaskListKind:    int(types.TaskListKindNormal),
-		AckLevel:        initialAckLevel,
-		LastUpdatedTime: FixedTime,
-		TimeStamp:       FixedTime,
+		DomainID:         TestDomainID,
+		TaskListName:     TestTaskListName,
+		TaskListType:     int(types.TaskListTypeDecision),
+		RangeID:          initialRangeID,
+		TaskListKind:     int(types.TaskListKindNormal),
+		AckLevel:         initialAckLevel,
+		LastUpdatedTime:  FixedTime,
+		CurrentTimeStamp: FixedTime,
 		AdaptivePartitionConfig: &persistence.TaskListPartitionConfig{
 			Version: 1,
 			ReadPartitions: map[int]*persistence.TaskListPartition{

--- a/common/persistence/nosql/nosql_task_store_test.go
+++ b/common/persistence/nosql/nosql_task_store_test.go
@@ -551,7 +551,8 @@ func TestCreateTasks(t *testing.T) {
 					TaskListName:    TestTaskListName,
 					TaskListType:    TestTaskType,
 					RangeID:         1,
-					LastUpdatedTime: now,
+					LastUpdatedTime: FixedTime,
+					TimeStamp:       FixedTime,
 				}).Do(func(_ context.Context, tasks []*nosqlplugin.TaskRowForInsert, _ *nosqlplugin.TaskListRow) {
 					assert.Len(t, tasks, 0)
 				}).Return(nil).Times(1)
@@ -671,7 +672,7 @@ func getValidLeaseTaskListRequest() *persistence.LeaseTaskListRequest {
 		TaskType:     int(types.TaskListTypeDecision),
 		TaskListKind: int(types.TaskListKindNormal),
 		RangeID:      0,
-		UpdatedTime:  FixedTime,
+		TimeStamp:    FixedTime,
 	}
 }
 
@@ -734,6 +735,7 @@ func getExpectedTaskListRow() *nosqlplugin.TaskListRow {
 		TaskListKind:    int(types.TaskListKindNormal),
 		AckLevel:        initialAckLevel,
 		LastUpdatedTime: FixedTime,
+		TimeStamp:       FixedTime,
 	}
 }
 
@@ -746,6 +748,7 @@ func getExpectedTaskListRowWithPartitionConfig() *nosqlplugin.TaskListRow {
 		TaskListKind:    int(types.TaskListKindNormal),
 		AckLevel:        initialAckLevel,
 		LastUpdatedTime: FixedTime,
+		TimeStamp:       FixedTime,
 		AdaptivePartitionConfig: &persistence.TaskListPartitionConfig{
 			Version: 1,
 			ReadPartitions: map[int]*persistence.TaskListPartition{

--- a/common/persistence/nosql/nosql_task_store_test.go
+++ b/common/persistence/nosql/nosql_task_store_test.go
@@ -280,6 +280,7 @@ func TestUpdateTaskList(t *testing.T) {
 
 	resp, err := store.UpdateTaskList(context.Background(), &persistence.UpdateTaskListRequest{
 		TaskListInfo: getExpectedTaskListInfo(),
+		UpdatedTime:  FixedTime,
 	})
 
 	assert.NoError(t, err)
@@ -303,6 +304,7 @@ func TestUpdateTaskList_Sticky(t *testing.T) {
 
 	resp, err := store.UpdateTaskList(context.Background(), &persistence.UpdateTaskListRequest{
 		TaskListInfo: taskListInfo,
+		UpdatedTime:  FixedTime,
 	})
 
 	assert.NoError(t, err)
@@ -321,6 +323,7 @@ func TestUpdateTaskList_ConditionFailure(t *testing.T) {
 
 	_, err := store.UpdateTaskList(context.Background(), &persistence.UpdateTaskListRequest{
 		TaskListInfo: getExpectedTaskListInfo(),
+		UpdatedTime:  FixedTime,
 	})
 
 	var expectedErr *persistence.ConditionFailedError
@@ -447,7 +450,7 @@ func TestCompleteTasksLessThan(t *testing.T) {
 }
 
 func TestCreateTasks(t *testing.T) {
-	now := time.Now()
+	now := FixedTime
 
 	testCases := []struct {
 		name          string
@@ -544,10 +547,11 @@ func TestCreateTasks(t *testing.T) {
 			name: "success - skipping task with Expiry expired",
 			setupMock: func(dbMock *nosqlplugin.MockDB) {
 				dbMock.EXPECT().InsertTasks(gomock.Any(), gomock.Any(), &nosqlplugin.TaskListRow{
-					DomainID:     TestDomainID,
-					TaskListName: TestTaskListName,
-					TaskListType: TestTaskType,
-					RangeID:      1,
+					DomainID:        TestDomainID,
+					TaskListName:    TestTaskListName,
+					TaskListType:    TestTaskType,
+					RangeID:         1,
+					LastUpdatedTime: now,
 				}).Do(func(_ context.Context, tasks []*nosqlplugin.TaskRowForInsert, _ *nosqlplugin.TaskListRow) {
 					assert.Len(t, tasks, 0)
 				}).Return(nil).Times(1)
@@ -559,6 +563,7 @@ func TestCreateTasks(t *testing.T) {
 					TaskType: TestTaskType,
 					RangeID:  1,
 				},
+				CreatedTime: now,
 				Tasks: []*persistence.CreateTaskInfo{
 					{
 						TaskID: 100,
@@ -666,6 +671,7 @@ func getValidLeaseTaskListRequest() *persistence.LeaseTaskListRequest {
 		TaskType:     int(types.TaskListTypeDecision),
 		TaskListKind: int(types.TaskListKindNormal),
 		RangeID:      0,
+		UpdatedTime:  FixedTime,
 	}
 }
 
@@ -685,7 +691,7 @@ func checkTaskListInfoExpected(t *testing.T, taskListInfo *persistence.TaskListI
 	assert.Equal(t, initialRangeID, taskListInfo.RangeID)
 	assert.Equal(t, initialAckLevel, taskListInfo.AckLevel)
 	assert.Equal(t, int(types.TaskListKindNormal), taskListInfo.Kind)
-	assert.WithinDuration(t, time.Now(), taskListInfo.LastUpdated, time.Second)
+	assert.WithinDuration(t, FixedTime, taskListInfo.LastUpdated, time.Second)
 }
 
 func taskRowEqualTaskInfo(t *testing.T, taskrow1 nosqlplugin.TaskRow, taskInfo1 *persistence.TaskInfo) {
@@ -727,7 +733,7 @@ func getExpectedTaskListRow() *nosqlplugin.TaskListRow {
 		RangeID:         initialRangeID,
 		TaskListKind:    int(types.TaskListKindNormal),
 		AckLevel:        initialAckLevel,
-		LastUpdatedTime: time.Now(),
+		LastUpdatedTime: FixedTime,
 	}
 }
 
@@ -739,7 +745,7 @@ func getExpectedTaskListRowWithPartitionConfig() *nosqlplugin.TaskListRow {
 		RangeID:         initialRangeID,
 		TaskListKind:    int(types.TaskListKindNormal),
 		AckLevel:        initialAckLevel,
-		LastUpdatedTime: time.Now(),
+		LastUpdatedTime: FixedTime,
 		AdaptivePartitionConfig: &persistence.TaskListPartitionConfig{
 			Version: 1,
 			ReadPartitions: map[int]*persistence.TaskListPartition{
@@ -760,11 +766,8 @@ func getExpectedTaskListRowWithPartitionConfig() *nosqlplugin.TaskListRow {
 }
 
 func checkTaskListRowExpected(t *testing.T, expectedRow *nosqlplugin.TaskListRow, taskList *nosqlplugin.TaskListRow) {
-	// Check the duration
-	assert.WithinDuration(t, expectedRow.LastUpdatedTime, taskList.LastUpdatedTime, time.Second)
+	t.Helper()
 
-	// Set the expected time to the actual time to make the comparison work
-	expectedRow.LastUpdatedTime = taskList.LastUpdatedTime
 	assert.Equal(t, expectedRow, taskList)
 }
 
@@ -776,7 +779,7 @@ func getExpectedTaskListInfo() *persistence.TaskListInfo {
 		RangeID:     initialRangeID,
 		AckLevel:    initialAckLevel,
 		Kind:        int(types.TaskListKindNormal),
-		LastUpdated: time.Now(),
+		LastUpdated: FixedTime,
 		AdaptivePartitionConfig: &persistence.TaskListPartitionConfig{
 			Version: 1,
 			ReadPartitions: map[int]*persistence.TaskListPartition{

--- a/common/persistence/nosql/nosqlplugin/cassandra/db.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/db.go
@@ -21,7 +21,6 @@
 package cassandra
 
 import (
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -37,7 +36,6 @@ type cdb struct {
 	session gocql.Session
 	cfg     *config.NoSQL
 	dc      *persistence.DynamicConfiguration
-	timeSrc clock.TimeSource
 }
 
 var _ nosqlplugin.DB = (*cdb)(nil)
@@ -50,12 +48,6 @@ type cassandraDBOption func(*cdb)
 func dbWithClient(client gocql.Client) cassandraDBOption {
 	return func(db *cdb) {
 		db.client = client
-	}
-}
-
-func dbWithTimeSource(timeSrc clock.TimeSource) cassandraDBOption {
-	return func(db *cdb) {
-		db.timeSrc = timeSrc
 	}
 }
 
@@ -72,7 +64,6 @@ func newCassandraDBFromSession(
 		logger:  logger,
 		cfg:     cfg,
 		dc:      dc,
-		timeSrc: clock.NewRealTimeSource(),
 	}
 
 	for _, opt := range opts {

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain.go
@@ -43,7 +43,7 @@ const (
 // return types.DomainAlreadyExistsError error if failed or already exists
 // Must return ConditionFailure error if other condition doesn't match
 func (db *cdb) InsertDomain(ctx context.Context, row *nosqlplugin.DomainRow) error {
-	timeStamp := db.timeSrc.Now()
+	timeStamp := row.CurrentTimeStamp
 	query := db.session.Query(templateCreateDomainQuery, row.Info.ID, row.Info.Name, timeStamp).WithContext(ctx)
 	applied, err := query.MapScanCAS(make(map[string]interface{}))
 	if err != nil {

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain_test.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -250,7 +249,6 @@ func TestInsertDomain(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
-			db.timeSrc = clock.NewMockedTimeSourceAt(FixedTime)
 
 			err := db.InsertDomain(context.Background(), tc.row)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/history_events.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/history_events.go
@@ -53,7 +53,6 @@ func (db *cdb) InsertIntoHistoryTreeAndNode(ctx context.Context, treeRow *nosqlp
 		// Note: for perf, prefer using batch for inserting more than one records
 		batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 		batch.Query(v2templateInsertTree,
-			// TODO: Should the `persistence.UnixNanoToDBTimestamp(treeRow.CreateTimestamp.UnixNano())` logic be handled by `persistenceManager` as well, or should it remain as is?
 			treeRow.TreeID, treeRow.BranchID, ancs, persistence.UnixNanoToDBTimestamp(treeRow.CreateTimestamp.UnixNano()), treeRow.Info, treeRow.CreateTimestamp)
 		batch.Query(v2templateUpsertData,
 			nodeRow.TreeID, nodeRow.BranchID, nodeRow.NodeID, nodeRow.TxnID, nodeRow.Data, nodeRow.DataEncoding, nodeRow.CreateTimestamp)

--- a/common/persistence/nosql/nosqlplugin/cassandra/history_events.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/history_events.go
@@ -34,7 +34,6 @@ import (
 
 // InsertIntoHistoryTreeAndNode inserts one or two rows: tree row and node row(at least one of them)
 func (db *cdb) InsertIntoHistoryTreeAndNode(ctx context.Context, treeRow *nosqlplugin.HistoryTreeRow, nodeRow *nosqlplugin.HistoryNodeRow) error {
-	timeStamp := db.timeSrc.Now()
 	if treeRow == nil && nodeRow == nil {
 		return fmt.Errorf("require at least a tree row or a node row to insert")
 	}
@@ -54,19 +53,20 @@ func (db *cdb) InsertIntoHistoryTreeAndNode(ctx context.Context, treeRow *nosqlp
 		// Note: for perf, prefer using batch for inserting more than one records
 		batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 		batch.Query(v2templateInsertTree,
-			treeRow.TreeID, treeRow.BranchID, ancs, persistence.UnixNanoToDBTimestamp(treeRow.CreateTimestamp.UnixNano()), treeRow.Info, timeStamp)
+			// TODO: Should the `persistence.UnixNanoToDBTimestamp(treeRow.CreateTimestamp.UnixNano())` logic be handled by `persistenceManager` as well, or should it remain as is?
+			treeRow.TreeID, treeRow.BranchID, ancs, persistence.UnixNanoToDBTimestamp(treeRow.CreateTimestamp.UnixNano()), treeRow.Info, treeRow.CreateTimestamp)
 		batch.Query(v2templateUpsertData,
-			nodeRow.TreeID, nodeRow.BranchID, nodeRow.NodeID, nodeRow.TxnID, nodeRow.Data, nodeRow.DataEncoding, timeStamp)
+			nodeRow.TreeID, nodeRow.BranchID, nodeRow.NodeID, nodeRow.TxnID, nodeRow.Data, nodeRow.DataEncoding, nodeRow.CreateTimestamp)
 		err = db.session.ExecuteBatch(batch)
 	} else {
 		var query gocql.Query
 		if treeRow != nil {
 			query = db.session.Query(v2templateInsertTree,
-				treeRow.TreeID, treeRow.BranchID, ancs, persistence.UnixNanoToDBTimestamp(treeRow.CreateTimestamp.UnixNano()), treeRow.Info, timeStamp).WithContext(ctx)
+				treeRow.TreeID, treeRow.BranchID, ancs, persistence.UnixNanoToDBTimestamp(treeRow.CreateTimestamp.UnixNano()), treeRow.Info, treeRow.CreateTimestamp).WithContext(ctx)
 		}
 		if nodeRow != nil {
 			query = db.session.Query(v2templateUpsertData,
-				nodeRow.TreeID, nodeRow.BranchID, nodeRow.NodeID, nodeRow.TxnID, nodeRow.Data, nodeRow.DataEncoding, timeStamp).WithContext(ctx)
+				nodeRow.TreeID, nodeRow.BranchID, nodeRow.NodeID, nodeRow.TxnID, nodeRow.Data, nodeRow.DataEncoding, nodeRow.CreateTimestamp).WithContext(ctx)
 		}
 		err = query.Exec()
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/history_events_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/history_events_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/common/types"
@@ -121,7 +120,7 @@ func TestInsertIntoHistoryTreeAndNode(t *testing.T) {
 				tt.setupMocks(ctrl, session)
 			}
 
-			db := &cdb{session: session, timeSrc: clock.NewMockedTimeSourceAt(FixedTime)}
+			db := &cdb{session: session}
 			err := db.InsertIntoHistoryTreeAndNode(context.Background(), tt.treeRow, tt.nodeRow)
 			if tt.expectError {
 				assert.Error(t, err, "Expected an error but got none")

--- a/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
@@ -831,7 +831,12 @@ func TestInsertQueueMetadata(t *testing.T) {
 			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 			db.timeSrc = clock.NewMockedTimeSourceAt(FixedTime)
 
-			err := db.InsertQueueMetadata(context.Background(), tc.queueType, tc.version)
+			row := nosqlplugin.QueueMetadataRow{
+				QueueType:        tc.queueType,
+				Version:          tc.version,
+				CurrentTimeStamp: FixedTime,
+			}
+			err := db.InsertQueueMetadata(context.Background(), row)
 
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Got error = %v, wantErr %v", err, tc.wantErr)
@@ -862,6 +867,7 @@ func TestUpdateQueueMetadataCas(t *testing.T) {
 				QueueType:        persistence.QueueType(2),
 				ClusterAckLevels: map[string]int64{"cluster1": 1000, "cluster2": 2000},
 				Version:          25,
+				CurrentTimeStamp: FixedTime,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -933,8 +939,9 @@ func TestUpdateQueueMetadataCas(t *testing.T) {
 }
 func queueMessageRow(id int64) *nosqlplugin.QueueMessageRow {
 	return &nosqlplugin.QueueMessageRow{
-		QueueType: persistence.DomainReplicationQueueType,
-		ID:        id,
-		Payload:   []byte(fmt.Sprintf("test-payload-%d", id)),
+		QueueType:        persistence.DomainReplicationQueueType,
+		ID:               id,
+		Payload:          []byte(fmt.Sprintf("test-payload-%d", id)),
+		CurrentTimeStamp: FixedTime,
 	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
@@ -96,7 +95,6 @@ func TestInsertIntoQueue(t *testing.T) {
 			dc := &persistence.DynamicConfiguration{}
 
 			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
-			db.timeSrc = clock.NewMockedTimeSourceAt(FixedTime)
 
 			err := db.InsertIntoQueue(context.Background(), tc.row)
 
@@ -829,7 +827,6 @@ func TestInsertQueueMetadata(t *testing.T) {
 			dc := &persistence.DynamicConfiguration{}
 
 			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
-			db.timeSrc = clock.NewMockedTimeSourceAt(FixedTime)
 
 			row := nosqlplugin.QueueMetadataRow{
 				QueueType:        tc.queueType,
@@ -919,7 +916,6 @@ func TestUpdateQueueMetadataCas(t *testing.T) {
 			dc := &persistence.DynamicConfiguration{}
 
 			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
-			db.timeSrc = clock.NewMockedTimeSourceAt(FixedTime)
 
 			err := db.UpdateQueueMetadataCas(context.Background(), tc.row)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard.go
@@ -34,7 +34,7 @@ import (
 // InsertShard creates a new shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
 func (db *cdb) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow) error {
-	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(db.timeSrc.Now().UnixNano())
+	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(row.CurrentTimestamp.UnixNano())
 	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
 	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
 	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)
@@ -234,7 +234,7 @@ func (db *cdb) UpdateRangeID(ctx context.Context, shardID int, rangeID int64, pr
 // UpdateShard updates a shard, return error is there is any.
 // Return ShardOperationConditionFailure if the condition doesn't meet
 func (db *cdb) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64) error {
-	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(db.timeSrc.Now().UnixNano())
+	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(row.CurrentTimestamp.UnixNano())
 	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
 	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
 	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
@@ -112,8 +111,7 @@ func TestInsertShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertShard(context.Background(), tc.row)
 
@@ -258,8 +256,7 @@ func TestSelectShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotRangeID, gotShardInfo, err := db.SelectShard(context.Background(), tc.shardID, tc.cluster)
 
@@ -287,11 +284,6 @@ func TestSelectShard(t *testing.T) {
 }
 
 func TestUpdateRangeID(t *testing.T) {
-	ts, err := time.Parse(time.RFC3339, "2024-04-02T18:00:00Z")
-	if err != nil {
-		t.Fatalf("Failed to parse time: %v", err)
-	}
-
 	tests := []struct {
 		name        string
 		shardID     int
@@ -365,8 +357,7 @@ func TestUpdateRangeID(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateRangeID(context.Background(), tc.shardID, tc.rangeID, tc.prevRangeID)
 
@@ -480,8 +471,7 @@ func TestUpdateShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateShard(context.Background(), tc.row, tc.prevRangeID)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -178,7 +178,7 @@ func fromTaskListPartition(partition *persistence.TaskListPartition) any {
 // InsertTaskList insert a single tasklist row
 // Return TaskOperationConditionFailure if the condition doesn't meet
 func (db *cdb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow) error {
-	timeStamp := row.LastUpdatedTime
+	timeStamp := row.TimeStamp
 	query := db.session.Query(templateInsertTaskListQuery,
 		row.DomainID,
 		row.TaskListName,
@@ -212,7 +212,7 @@ func (db *cdb) UpdateTaskList(
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
 ) error {
-	timeStamp := row.LastUpdatedTime
+	timeStamp := row.TimeStamp
 	query := db.session.Query(templateUpdateTaskListQuery,
 		row.RangeID,
 		row.DomainID,
@@ -266,7 +266,7 @@ func (db *cdb) UpdateTaskListWithTTL(
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
 ) error {
-	timeStamp := row.LastUpdatedTime
+	timeStamp := row.TimeStamp
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 	// part 1 is used to set TTL on primary key as UPDATE can't set TTL for primary key
 	batch.Query(templateUpdateTaskListQueryWithTTLPart1,
@@ -350,7 +350,7 @@ func (db *cdb) InsertTasks(
 	domainID := tasklistCondition.DomainID
 	taskListName := tasklistCondition.TaskListName
 	taskListType := tasklistCondition.TaskListType
-	timeStamp := tasklistCondition.LastUpdatedTime
+	timeStamp := tasklistCondition.TimeStamp
 
 	for _, task := range tasksToInsert {
 		scheduleID := task.ScheduledID
@@ -456,24 +456,24 @@ PopulateTasks:
 		}
 
 		// TODO: no usage of ttl
-		//// Extract the TTL value
-		//ttlValue, ttlExists := task["ttl"]
-		//
-		//// Check if TTL is null or an integer
-		//var ttl *int
-		//if ttlExists && ttlValue != nil {
-		//	if ttlInt, ok := ttlValue.(int); ok {
-		//		ttl = &ttlInt // TTL is an integer
-		//	}
-		//}
+		// Extract the TTL value
+		ttlValue, ttlExists := task["ttl"]
+
+		// Check if TTL is null or an integer
+		var ttl *int
+		if ttlExists && ttlValue != nil {
+			if ttlInt, ok := ttlValue.(int); ok {
+				ttl = &ttlInt // TTL is an integer
+			}
+		}
 
 		t := createTaskInfo(task["task"].(map[string]interface{}))
 		t.TaskID = taskID.(int64)
 
-		// TODO: removing this, because there is no usage of it
-		//if ttl != nil {
-		//	t.Expiry = db.timeSrc.Now().Add(time.Duration(*ttl) * time.Second)
-		//}
+		// TODO: any computations on such level is not recommended, move to higher level
+		if ttl != nil {
+			t.Expiry = time.Now().Add(time.Duration(*ttl) * time.Second)
+		}
 
 		response = append(response, t)
 		if len(response) == filter.BatchSize {

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -178,7 +178,7 @@ func fromTaskListPartition(partition *persistence.TaskListPartition) any {
 // InsertTaskList insert a single tasklist row
 // Return TaskOperationConditionFailure if the condition doesn't meet
 func (db *cdb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow) error {
-	timeStamp := row.TimeStamp
+	timeStamp := row.CurrentTimeStamp
 	query := db.session.Query(templateInsertTaskListQuery,
 		row.DomainID,
 		row.TaskListName,
@@ -212,7 +212,7 @@ func (db *cdb) UpdateTaskList(
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
 ) error {
-	timeStamp := row.TimeStamp
+	timeStamp := row.CurrentTimeStamp
 	query := db.session.Query(templateUpdateTaskListQuery,
 		row.RangeID,
 		row.DomainID,
@@ -266,7 +266,7 @@ func (db *cdb) UpdateTaskListWithTTL(
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
 ) error {
-	timeStamp := row.TimeStamp
+	timeStamp := row.CurrentTimeStamp
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 	// part 1 is used to set TTL on primary key as UPDATE can't set TTL for primary key
 	batch.Query(templateUpdateTaskListQueryWithTTLPart1,
@@ -350,7 +350,7 @@ func (db *cdb) InsertTasks(
 	domainID := tasklistCondition.DomainID
 	taskListName := tasklistCondition.TaskListName
 	taskListType := tasklistCondition.TaskListType
-	timeStamp := tasklistCondition.TimeStamp
+	timeStamp := tasklistCondition.CurrentTimeStamp
 
 	for _, task := range tasksToInsert {
 		scheduleID := task.ScheduledID

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
@@ -340,7 +339,6 @@ func TestInsertTaskList(t *testing.T) {
 			dc := &persistence.DynamicConfiguration{}
 
 			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
-			db.timeSrc = clock.NewMockedTimeSourceAt(FixedTime)
 
 			err := db.InsertTaskList(context.Background(), tc.row)
 
@@ -453,7 +451,6 @@ func TestUpdateTaskList(t *testing.T) {
 			dc := &persistence.DynamicConfiguration{}
 
 			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
-			db.timeSrc = clock.NewMockedTimeSourceAt(FixedTime)
 
 			err := db.UpdateTaskList(context.Background(), tc.row, tc.prevRangeID)
 
@@ -554,8 +551,7 @@ func TestUpdateTaskListWithTTL(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 			err := db.UpdateTaskListWithTTL(context.Background(), tc.ttlSeconds, tc.row, tc.prevRangeID)
 
 			if (err != nil) != tc.wantErr {
@@ -834,8 +830,7 @@ func TestInsertTasks(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			timeSrc := clock.NewMockedTimeSourceAt(ts)
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client), dbWithTimeSource(timeSrc))
+			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertTasks(context.Background(), tc.tasksToInsert, tc.tasklistCond)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
@@ -226,14 +226,14 @@ func TestInsertTaskList(t *testing.T) {
 		{
 			name: "successfully applied - nil partition_config",
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -251,14 +251,14 @@ func TestInsertTaskList(t *testing.T) {
 		{
 			name: "successfully applied - non-nil partition_config",
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 				AdaptivePartitionConfig: &persistence.TaskListPartitionConfig{
 					Version: 1,
 					ReadPartitions: map[int]*persistence.TaskListPartition{
@@ -286,14 +286,14 @@ func TestInsertTaskList(t *testing.T) {
 		{
 			name: "not applied",
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -307,14 +307,14 @@ func TestInsertTaskList(t *testing.T) {
 		{
 			name: "mapscan failed",
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -377,14 +377,14 @@ func TestUpdateTaskList(t *testing.T) {
 			name:        "successfully applied",
 			prevRangeID: 25,
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -399,14 +399,14 @@ func TestUpdateTaskList(t *testing.T) {
 		{
 			name: "not applied",
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -420,14 +420,14 @@ func TestUpdateTaskList(t *testing.T) {
 		{
 			name: "mapscan failed",
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -494,14 +494,14 @@ func TestUpdateTaskListWithTTL(t *testing.T) {
 			ttlSeconds:  180,
 			prevRangeID: 25,
 			row: &nosqlplugin.TaskListRow{
-				DomainID:        "domain1",
-				TaskListName:    "tasklist1",
-				TaskListType:    1,
-				TaskListKind:    2,
-				AckLevel:        1000,
-				RangeID:         25,
-				LastUpdatedTime: ts,
-				TimeStamp:       ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				TaskListKind:     2,
+				AckLevel:         1000,
+				RangeID:          25,
+				LastUpdatedTime:  ts,
+				CurrentTimeStamp: ts,
 			},
 			mapExecuteBatchCASApplied: true,
 			wantQueries: []string{
@@ -783,11 +783,11 @@ func TestInsertTasks(t *testing.T) {
 				},
 			},
 			tasklistCond: &nosqlplugin.TaskListRow{
-				DomainID:     "domain1",
-				TaskListName: "tasklist1",
-				TaskListType: 1,
-				RangeID:      25,
-				TimeStamp:    ts,
+				DomainID:         "domain1",
+				TaskListName:     "tasklist1",
+				TaskListType:     1,
+				RangeID:          25,
+				CurrentTimeStamp: ts,
 			},
 			mapExecuteBatchCASApplied: true,
 			wantQueries: []string{

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
@@ -233,6 +233,7 @@ func TestInsertTaskList(t *testing.T) {
 				AckLevel:        1000,
 				RangeID:         25,
 				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -244,7 +245,7 @@ func TestInsertTaskList(t *testing.T) {
 				`INSERT INTO tasks (domain_id, task_list_name, task_list_type, type, task_id, range_id, task_list, created_time ) ` +
 					`VALUES (domain1, tasklist1, 1, 1, -12345, 1, ` +
 					`{domain_id: domain1, name: tasklist1, type: 1, ack_level: 0, kind: 2, last_updated: 2024-04-01T22:08:41Z, adaptive_partition_config: map[] }` +
-					`, 2025-01-06T15:00:00Z) IF NOT EXISTS`,
+					`, 2024-04-01T22:08:41Z) IF NOT EXISTS`,
 			},
 		},
 		{
@@ -257,6 +258,7 @@ func TestInsertTaskList(t *testing.T) {
 				AckLevel:        1000,
 				RangeID:         25,
 				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 				AdaptivePartitionConfig: &persistence.TaskListPartitionConfig{
 					Version: 1,
 					ReadPartitions: map[int]*persistence.TaskListPartition{
@@ -278,7 +280,7 @@ func TestInsertTaskList(t *testing.T) {
 					`VALUES (domain1, tasklist1, 1, 1, -12345, 1, ` +
 					`{domain_id: domain1, name: tasklist1, type: 1, ack_level: 0, kind: 2, last_updated: 2024-04-01T22:08:41Z, ` +
 					`adaptive_partition_config: map[num_read_partitions:1 num_write_partitions:1 read_partitions:map[0:map[isolation_groups:[]]] version:1 write_partitions:map[0:map[isolation_groups:[]]]] }` +
-					`, 2025-01-06T15:00:00Z) IF NOT EXISTS`,
+					`, 2024-04-01T22:08:41Z) IF NOT EXISTS`,
 			},
 		},
 		{
@@ -291,6 +293,7 @@ func TestInsertTaskList(t *testing.T) {
 				AckLevel:        1000,
 				RangeID:         25,
 				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -311,6 +314,7 @@ func TestInsertTaskList(t *testing.T) {
 				AckLevel:        1000,
 				RangeID:         25,
 				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -380,6 +384,7 @@ func TestUpdateTaskList(t *testing.T) {
 				AckLevel:        1000,
 				RangeID:         25,
 				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -388,7 +393,7 @@ func TestUpdateTaskList(t *testing.T) {
 				}).Times(1)
 			},
 			wantQueries: []string{
-				`UPDATE tasks SET range_id = 25, task_list = {domain_id: domain1, name: tasklist1, type: 1, ack_level: 1000, kind: 2, last_updated: 2024-04-01T22:08:41Z, adaptive_partition_config: map[] } , last_updated_time = 2025-01-06T15:00:00Z WHERE domain_id = domain1 and task_list_name = tasklist1 and task_list_type = 1 and type = 1 and task_id = -12345 IF range_id = 25`,
+				`UPDATE tasks SET range_id = 25, task_list = {domain_id: domain1, name: tasklist1, type: 1, ack_level: 1000, kind: 2, last_updated: 2024-04-01T22:08:41Z, adaptive_partition_config: map[] } , last_updated_time = 2024-04-01T22:08:41Z WHERE domain_id = domain1 and task_list_name = tasklist1 and task_list_type = 1 and type = 1 and task_id = -12345 IF range_id = 25`,
 			},
 		},
 		{
@@ -401,6 +406,7 @@ func TestUpdateTaskList(t *testing.T) {
 				AckLevel:        1000,
 				RangeID:         25,
 				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -421,6 +427,7 @@ func TestUpdateTaskList(t *testing.T) {
 				AckLevel:        1000,
 				RangeID:         25,
 				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 			},
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
@@ -487,12 +494,14 @@ func TestUpdateTaskListWithTTL(t *testing.T) {
 			ttlSeconds:  180,
 			prevRangeID: 25,
 			row: &nosqlplugin.TaskListRow{
-				DomainID:     "domain1",
-				TaskListName: "tasklist1",
-				TaskListType: 1,
-				TaskListKind: 2,
-				AckLevel:     1000,
-				RangeID:      25,
+				DomainID:        "domain1",
+				TaskListName:    "tasklist1",
+				TaskListType:    1,
+				TaskListKind:    2,
+				AckLevel:        1000,
+				RangeID:         25,
+				LastUpdatedTime: ts,
+				TimeStamp:       ts,
 			},
 			mapExecuteBatchCASApplied: true,
 			wantQueries: []string{
@@ -778,6 +787,7 @@ func TestInsertTasks(t *testing.T) {
 				TaskListName: "tasklist1",
 				TaskListType: 1,
 				RangeID:      25,
+				TimeStamp:    ts,
 			},
 			mapExecuteBatchCASApplied: true,
 			wantQueries: []string{

--- a/common/persistence/nosql/nosqlplugin/cassandra/testdata/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/testdata/domain.go
@@ -67,6 +67,6 @@ func NewDomainRow(ts time.Time) *nosqlplugin.DomainRow {
 		FailoverEndTime:     &ts,
 		LastUpdatedTime:     ts,
 		NotificationVersion: 5,
-		CurrentTimeStamp:    time.Now(),
+		CurrentTimeStamp:    time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC),
 	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/testdata/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/testdata/domain.go
@@ -67,5 +67,6 @@ func NewDomainRow(ts time.Time) *nosqlplugin.DomainRow {
 		FailoverEndTime:     &ts,
 		LastUpdatedTime:     ts,
 		NotificationVersion: 5,
+		CurrentTimeStamp:    time.Now(),
 	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/testdata/shard.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/testdata/shard.go
@@ -45,6 +45,7 @@ func NewShardRow(ts time.Time) *nosqlplugin.ShardRow {
 		PendingFailoverMarkers:        &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("failovermarkers")},
 		TransferProcessingQueueStates: &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("transferqueue")},
 		TimerProcessingQueueStates:    &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("timerqueue")},
+		CurrentTimestamp:              ts,
 	}
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/testdata/workflow_execution.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/testdata/workflow_execution.go
@@ -23,6 +23,8 @@
 package testdata
 
 import (
+	"time"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/checksum"
 	"github.com/uber/cadence/common/persistence"
@@ -44,6 +46,7 @@ func WFExecRequestWithEventBufferWriteMode(mode nosqlplugin.EventBufferWriteMode
 }
 
 func WFExecRequest(opts ...WFExecRequestOption) *nosqlplugin.WorkflowExecutionRequest {
+	ts := time.Now()
 	req := &nosqlplugin.WorkflowExecutionRequest{
 		InternalWorkflowExecutionInfo: persistence.InternalWorkflowExecutionInfo{
 			DomainID:   "test-domain-id",
@@ -67,6 +70,8 @@ func WFExecRequest(opts ...WFExecRequestOption) *nosqlplugin.WorkflowExecutionRe
 			Value:   []byte("test-checksum"),
 		},
 		PreviousNextEventIDCondition: common.Int64Ptr(123),
+		CreatedTime:                  ts,
+		UpdatedTime:                  ts,
 	}
 
 	for _, opt := range opts {

--- a/common/persistence/nosql/nosqlplugin/cassandra/testdata/workflow_execution.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/testdata/workflow_execution.go
@@ -70,8 +70,7 @@ func WFExecRequest(opts ...WFExecRequestOption) *nosqlplugin.WorkflowExecutionRe
 			Value:   []byte("test-checksum"),
 		},
 		PreviousNextEventIDCondition: common.Int64Ptr(123),
-		CreatedTime:                  ts,
-		UpdatedTime:                  ts,
+		CurrentTimeStamp:             ts,
 	}
 
 	for _, opt := range opts {

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -122,15 +122,17 @@ func (db *cdb) UpdateWorkflowExecutionWithTasks(
 	shardID := shardCondition.ShardID
 	var domainID, workflowID string
 	var previousNextEventIDCondition int64
-	timeStamp := insertedExecution.CurrentTimeStamp
+	var timeStamp time.Time
 	if mutatedExecution != nil {
 		domainID = mutatedExecution.DomainID
 		workflowID = mutatedExecution.WorkflowID
 		previousNextEventIDCondition = *mutatedExecution.PreviousNextEventIDCondition
+		timeStamp = mutatedExecution.CurrentTimeStamp
 	} else if resetExecution != nil {
 		domainID = resetExecution.DomainID
 		workflowID = resetExecution.WorkflowID
 		previousNextEventIDCondition = *resetExecution.PreviousNextEventIDCondition
+		timeStamp = resetExecution.CurrentTimeStamp
 	} else {
 		return fmt.Errorf("at least one of mutatedExecution and resetExecution should be provided")
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -47,7 +47,7 @@ func (db *cdb) InsertWorkflowExecutionWithTasks(
 	shardID := shardCondition.ShardID
 	domainID := execution.DomainID
 	workflowID := execution.WorkflowID
-	timeStamp := execution.CreatedTime
+	timeStamp := execution.CurrentTimeStamp
 
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 
@@ -122,7 +122,7 @@ func (db *cdb) UpdateWorkflowExecutionWithTasks(
 	shardID := shardCondition.ShardID
 	var domainID, workflowID string
 	var previousNextEventIDCondition int64
-	timeStamp := insertedExecution.UpdatedTime
+	timeStamp := insertedExecution.CurrentTimeStamp
 	if mutatedExecution != nil {
 		domainID = mutatedExecution.DomainID
 		workflowID = mutatedExecution.WorkflowID
@@ -721,7 +721,7 @@ func (db *cdb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.H
 
 	shardID := shardCondition.ShardID
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
-	timeStamp := tasks[0].CurrentTimeStamp
+	timeStamp := tasks[0].Replication.CurrentTimeStamp
 	for _, task := range tasks {
 		createReplicationTasks(batch, shardID, task.Replication.DomainID, task.Replication.WorkflowID, []*nosqlplugin.HistoryMigrationTask{task}, timeStamp)
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -644,7 +644,7 @@ func (db *cdb) InsertReplicationDLQTask(ctx context.Context, shardID int, source
 		taskEncoding,
 		defaultVisibilityTimestamp,
 		task.TaskID,
-		db.timeSrc.Now(),
+		task.CurrentTimeStamp,
 	).WithContext(ctx)
 
 	return query.Exec()
@@ -721,7 +721,7 @@ func (db *cdb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.H
 
 	shardID := shardCondition.ShardID
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
-	timeStamp := db.timeSrc.Now()
+	timeStamp := tasks[0].CurrentTimeStamp
 	for _, task := range tasks {
 		createReplicationTasks(batch, shardID, task.Replication.DomainID, task.Replication.WorkflowID, []*nosqlplugin.HistoryMigrationTask{task}, timeStamp)
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -47,7 +47,7 @@ func (db *cdb) InsertWorkflowExecutionWithTasks(
 	shardID := shardCondition.ShardID
 	domainID := execution.DomainID
 	workflowID := execution.WorkflowID
-	timeStamp := db.timeSrc.Now()
+	timeStamp := execution.CreatedTime
 
 	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 
@@ -122,7 +122,7 @@ func (db *cdb) UpdateWorkflowExecutionWithTasks(
 	shardID := shardCondition.ShardID
 	var domainID, workflowID string
 	var previousNextEventIDCondition int64
-	timeStamp := db.timeSrc.Now()
+	timeStamp := insertedExecution.UpdatedTime
 	if mutatedExecution != nil {
 		domainID = mutatedExecution.DomainID
 		workflowID = mutatedExecution.WorkflowID

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
@@ -317,7 +317,8 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 			mutatedExecution: testdata.WFExecRequest(
 				testdata.WFExecRequestWithMapsWriteMode(nosqlplugin.WorkflowExecutionMapsWriteModeUpdate),
 			),
-			wantErr: true,
+			insertedExecution: testdata.WFExecRequest(),
+			wantErr:           true,
 		},
 		{
 			name: "mutatedExecution provided - success",
@@ -330,6 +331,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 			mutatedExecution: testdata.WFExecRequest(
 				testdata.WFExecRequestWithMapsWriteMode(nosqlplugin.WorkflowExecutionMapsWriteModeUpdate),
 			),
+			insertedExecution: testdata.WFExecRequest(),
 		},
 		{
 			name:    "mutatedExecution provided - update fails",
@@ -343,6 +345,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 			mutatedExecution: testdata.WFExecRequest(
 				testdata.WFExecRequestWithMapsWriteMode(nosqlplugin.WorkflowExecutionMapsWriteModeCreate), // this will cause failure
 			),
+			insertedExecution: testdata.WFExecRequest(),
 		},
 		{
 			name: "resetExecution provided - success",
@@ -356,6 +359,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 				testdata.WFExecRequestWithEventBufferWriteMode(nosqlplugin.EventBufferWriteModeClear),
 				testdata.WFExecRequestWithMapsWriteMode(nosqlplugin.WorkflowExecutionMapsWriteModeReset),
 			),
+			insertedExecution: testdata.WFExecRequest(),
 		},
 		{
 			name:    "resetExecution provided - reset fails",
@@ -370,6 +374,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 				testdata.WFExecRequestWithEventBufferWriteMode(nosqlplugin.EventBufferWriteModeNone), // this will cause failure
 				testdata.WFExecRequestWithMapsWriteMode(nosqlplugin.WorkflowExecutionMapsWriteModeReset),
 			),
+			insertedExecution: testdata.WFExecRequest(),
 		},
 		{
 			name: "resetExecution and insertedExecution provided - success",
@@ -420,6 +425,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 				testdata.WFExecRequestWithEventBufferWriteMode(nosqlplugin.EventBufferWriteModeClear),
 				testdata.WFExecRequestWithMapsWriteMode(nosqlplugin.WorkflowExecutionMapsWriteModeReset),
 			),
+			insertedExecution: testdata.WFExecRequest(),
 		},
 	}
 

--- a/common/persistence/nosql/nosqlplugin/dynamodb/queue.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/queue.go
@@ -91,11 +91,7 @@ func (db *ddb) DeleteMessage(
 }
 
 // Insert an empty metadata row, starting from a version
-func (db *ddb) InsertQueueMetadata(
-	ctx context.Context,
-	queueType persistence.QueueType,
-	version int64,
-) error {
+func (db *ddb) InsertQueueMetadata(ctx context.Context, row nosqlplugin.QueueMetadataRow) error {
 	panic("TODO")
 }
 

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -136,7 +136,7 @@ type (
 		DeleteMessage(ctx context.Context, queueType persistence.QueueType, messageID int64) error
 
 		// Insert an empty metadata row, starting from a version
-		InsertQueueMetadata(ctx context.Context, queueType persistence.QueueType, version int64) error
+		InsertQueueMetadata(ctx context.Context, row QueueMetadataRow) error
 		// **Conditionally** update a queue metadata row, if current version is matched(meaning current == row.Version - 1),
 		// then the current version will increase by one when updating the metadata row
 		// Must return conditionFailed error if the condition is not met

--- a/common/persistence/nosql/nosqlplugin/interfaces_mock.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces_mock.go
@@ -468,17 +468,17 @@ func (mr *MockDBMockRecorder) InsertIntoQueue(ctx, row any) *gomock.Call {
 }
 
 // InsertQueueMetadata mocks base method.
-func (m *MockDB) InsertQueueMetadata(ctx context.Context, queueType persistence.QueueType, version int64) error {
+func (m *MockDB) InsertQueueMetadata(ctx context.Context, row QueueMetadataRow) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertQueueMetadata", ctx, queueType, version)
+	ret := m.ctrl.Call(m, "InsertQueueMetadata", ctx, row)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertQueueMetadata indicates an expected call of InsertQueueMetadata.
-func (mr *MockDBMockRecorder) InsertQueueMetadata(ctx, queueType, version any) *gomock.Call {
+func (mr *MockDBMockRecorder) InsertQueueMetadata(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertQueueMetadata", reflect.TypeOf((*MockDB)(nil).InsertQueueMetadata), ctx, queueType, version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertQueueMetadata", reflect.TypeOf((*MockDB)(nil).InsertQueueMetadata), ctx, row)
 }
 
 // InsertReplicationDLQTask mocks base method.
@@ -1584,17 +1584,17 @@ func (mr *MocktableCRUDMockRecorder) InsertIntoQueue(ctx, row any) *gomock.Call 
 }
 
 // InsertQueueMetadata mocks base method.
-func (m *MocktableCRUD) InsertQueueMetadata(ctx context.Context, queueType persistence.QueueType, version int64) error {
+func (m *MocktableCRUD) InsertQueueMetadata(ctx context.Context, row QueueMetadataRow) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertQueueMetadata", ctx, queueType, version)
+	ret := m.ctrl.Call(m, "InsertQueueMetadata", ctx, row)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertQueueMetadata indicates an expected call of InsertQueueMetadata.
-func (mr *MocktableCRUDMockRecorder) InsertQueueMetadata(ctx, queueType, version any) *gomock.Call {
+func (mr *MocktableCRUDMockRecorder) InsertQueueMetadata(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertQueueMetadata", reflect.TypeOf((*MocktableCRUD)(nil).InsertQueueMetadata), ctx, queueType, version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertQueueMetadata", reflect.TypeOf((*MocktableCRUD)(nil).InsertQueueMetadata), ctx, row)
 }
 
 // InsertReplicationDLQTask mocks base method.
@@ -2598,17 +2598,17 @@ func (mr *MockMessageQueueCRUDMockRecorder) InsertIntoQueue(ctx, row any) *gomoc
 }
 
 // InsertQueueMetadata mocks base method.
-func (m *MockMessageQueueCRUD) InsertQueueMetadata(ctx context.Context, queueType persistence.QueueType, version int64) error {
+func (m *MockMessageQueueCRUD) InsertQueueMetadata(ctx context.Context, row QueueMetadataRow) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertQueueMetadata", ctx, queueType, version)
+	ret := m.ctrl.Call(m, "InsertQueueMetadata", ctx, row)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertQueueMetadata indicates an expected call of InsertQueueMetadata.
-func (mr *MockMessageQueueCRUDMockRecorder) InsertQueueMetadata(ctx, queueType, version any) *gomock.Call {
+func (mr *MockMessageQueueCRUDMockRecorder) InsertQueueMetadata(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertQueueMetadata", reflect.TypeOf((*MockMessageQueueCRUD)(nil).InsertQueueMetadata), ctx, queueType, version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertQueueMetadata", reflect.TypeOf((*MockMessageQueueCRUD)(nil).InsertQueueMetadata), ctx, row)
 }
 
 // SelectLastEnqueuedMessageID mocks base method.

--- a/common/persistence/nosql/nosqlplugin/mongodb/queue.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/queue.go
@@ -92,11 +92,7 @@ func (db *mdb) DeleteMessage(
 }
 
 // Insert an empty metadata row, starting from a version
-func (db *mdb) InsertQueueMetadata(
-	ctx context.Context,
-	queueType persistence.QueueType,
-	version int64,
-) error {
+func (db *mdb) InsertQueueMetadata(ctx context.Context, row nosqlplugin.QueueMetadataRow) error {
 	fmt.Println("not implemented, ignore the eror for testing")
 	return nil
 }

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -198,6 +198,7 @@ type (
 		RangeID                 int64
 		TaskListKind            int
 		AckLevel                int64
+		TimeStamp               time.Time
 		LastUpdatedTime         time.Time
 		AdaptivePartitionConfig *persistence.TaskListPartitionConfig
 	}

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -39,6 +39,8 @@ type (
 		VersionHistories *persistence.DataBlob
 		Checksums        *checksum.Checksum
 		LastWriteVersion int64
+		CreatedTime      time.Time
+		UpdatedTime      time.Time
 		// condition checking for updating execution info
 		PreviousNextEventIDCondition *int64
 

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -235,6 +235,7 @@ type (
 		NotificationVersion         int64
 		LastUpdatedTime             time.Time
 		IsGlobalDomain              bool
+		CurrentTimeStamp            time.Time
 	}
 
 	// SelectMessagesBetweenRequest is a request struct for SelectMessagesBetween

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -198,7 +198,7 @@ type (
 		RangeID                 int64
 		TaskListKind            int
 		AckLevel                int64
-		TimeStamp               time.Time
+		CurrentTimeStamp        time.Time
 		LastUpdatedTime         time.Time
 		AdaptivePartitionConfig *persistence.TaskListPartitionConfig
 	}

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -255,9 +255,10 @@ type (
 
 	// QueueMessageRow defines the row struct for queue message
 	QueueMessageRow struct {
-		QueueType persistence.QueueType
-		ID        int64
-		Payload   []byte
+		QueueType        persistence.QueueType
+		ID               int64
+		Payload          []byte
+		CurrentTimeStamp time.Time
 	}
 
 	// QueueMetadataRow defines the row struct for metadata
@@ -265,6 +266,7 @@ type (
 		QueueType        persistence.QueueType
 		ClusterAckLevels map[string]int64
 		Version          int64
+		CurrentTimeStamp time.Time
 	}
 
 	// HistoryNodeRow represents a row in history_node table

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -272,9 +272,10 @@ type (
 		BranchID string
 		NodeID   int64
 		// Note: use pointer so that it's easier to multiple by -1 if needed
-		TxnID        *int64
-		Data         []byte
-		DataEncoding string
+		TxnID           *int64
+		Data            []byte
+		DataEncoding    string
+		CreateTimestamp time.Time
 	}
 
 	// HistoryNodeFilter contains the column names within history_node table that

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -39,8 +39,7 @@ type (
 		VersionHistories *persistence.DataBlob
 		Checksums        *checksum.Checksum
 		LastWriteVersion int64
-		CreatedTime      time.Time
-		UpdatedTime      time.Time
+		CurrentTimeStamp time.Time
 		// condition checking for updating execution info
 		PreviousNextEventIDCondition *int64
 

--- a/common/persistence/queue_manager.go
+++ b/common/persistence/queue_manager.go
@@ -22,11 +22,16 @@
 
 package persistence
 
-import "context"
+import (
+	"context"
+
+	"github.com/uber/cadence/common/clock"
+)
 
 type (
 	queueManager struct {
 		persistence Queue
+		timeSrc     clock.TimeSource
 	}
 )
 
@@ -38,6 +43,7 @@ func NewQueueManager(
 ) QueueManager {
 	return &queueManager{
 		persistence: persistence,
+		timeSrc:     clock.NewRealTimeSource(),
 	}
 }
 
@@ -66,7 +72,7 @@ func (q *queueManager) DeleteMessagesBefore(ctx context.Context, messageID int64
 }
 
 func (q *queueManager) UpdateAckLevel(ctx context.Context, messageID int64, clusterName string) error {
-	return q.persistence.UpdateAckLevel(ctx, messageID, clusterName)
+	return q.persistence.UpdateAckLevel(ctx, messageID, clusterName, q.timeSrc.Now())
 }
 
 func (q *queueManager) GetAckLevels(ctx context.Context) (map[string]int64, error) {
@@ -98,7 +104,7 @@ func (q *queueManager) RangeDeleteMessagesFromDLQ(ctx context.Context, firstMess
 }
 
 func (q *queueManager) UpdateDLQAckLevel(ctx context.Context, messageID int64, clusterName string) error {
-	return q.persistence.UpdateDLQAckLevel(ctx, messageID, clusterName)
+	return q.persistence.UpdateDLQAckLevel(ctx, messageID, clusterName, q.timeSrc.Now())
 }
 
 func (q *queueManager) GetDLQAckLevels(ctx context.Context) (map[string]int64, error) {

--- a/common/persistence/queue_manager.go
+++ b/common/persistence/queue_manager.go
@@ -52,7 +52,8 @@ func (q *queueManager) Close() {
 }
 
 func (q *queueManager) EnqueueMessage(ctx context.Context, messagePayload []byte) error {
-	return q.persistence.EnqueueMessage(ctx, messagePayload)
+	currentTimestamp := q.timeSrc.Now()
+	return q.persistence.EnqueueMessage(ctx, messagePayload, currentTimestamp)
 }
 
 func (q *queueManager) ReadMessages(ctx context.Context, lastMessageID int64, maxCount int) (QueueMessageList, error) {
@@ -72,7 +73,8 @@ func (q *queueManager) DeleteMessagesBefore(ctx context.Context, messageID int64
 }
 
 func (q *queueManager) UpdateAckLevel(ctx context.Context, messageID int64, clusterName string) error {
-	return q.persistence.UpdateAckLevel(ctx, messageID, clusterName, q.timeSrc.Now())
+	currentTimestamp := q.timeSrc.Now()
+	return q.persistence.UpdateAckLevel(ctx, messageID, clusterName, currentTimestamp)
 }
 
 func (q *queueManager) GetAckLevels(ctx context.Context) (map[string]int64, error) {
@@ -80,7 +82,8 @@ func (q *queueManager) GetAckLevels(ctx context.Context) (map[string]int64, erro
 }
 
 func (q *queueManager) EnqueueMessageToDLQ(ctx context.Context, messagePayload []byte) error {
-	return q.persistence.EnqueueMessageToDLQ(ctx, messagePayload)
+	currentTimestamp := q.timeSrc.Now()
+	return q.persistence.EnqueueMessageToDLQ(ctx, messagePayload, currentTimestamp)
 }
 
 func (q *queueManager) ReadMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error) {
@@ -104,7 +107,8 @@ func (q *queueManager) RangeDeleteMessagesFromDLQ(ctx context.Context, firstMess
 }
 
 func (q *queueManager) UpdateDLQAckLevel(ctx context.Context, messageID int64, clusterName string) error {
-	return q.persistence.UpdateDLQAckLevel(ctx, messageID, clusterName, q.timeSrc.Now())
+	currentTimestamp := q.timeSrc.Now()
+	return q.persistence.UpdateDLQAckLevel(ctx, messageID, clusterName, currentTimestamp)
 }
 
 func (q *queueManager) GetDLQAckLevels(ctx context.Context) (map[string]int64, error) {

--- a/common/persistence/shard_manager.go
+++ b/common/persistence/shard_manager.go
@@ -26,12 +26,14 @@ import (
 	"context"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 )
 
 type (
 	shardManager struct {
 		persistence ShardStore
 		serializer  PayloadSerializer
+		timeSrc     clock.TimeSource
 	}
 )
 
@@ -55,6 +57,7 @@ func NewShardManager(
 	manager := &shardManager{
 		persistence: persistence,
 		serializer:  NewPayloadSerializer(),
+		timeSrc:     clock.NewRealTimeSource(),
 	}
 	for _, option := range options {
 		option(manager)
@@ -76,7 +79,8 @@ func (m *shardManager) CreateShard(ctx context.Context, request *CreateShardRequ
 		return err
 	}
 	internalRequest := &InternalCreateShardRequest{
-		ShardInfo: shardInfo,
+		ShardInfo:        shardInfo,
+		CurrentTimeStamp: m.timeSrc.Now(),
 	}
 	return m.persistence.CreateShard(ctx, internalRequest)
 }
@@ -105,8 +109,9 @@ func (m *shardManager) UpdateShard(ctx context.Context, request *UpdateShardRequ
 		return err
 	}
 	internalRequest := &InternalUpdateShardRequest{
-		ShardInfo:       shardInfo,
-		PreviousRangeID: request.PreviousRangeID,
+		ShardInfo:        shardInfo,
+		PreviousRangeID:  request.PreviousRangeID,
+		CurrentTimeStamp: m.timeSrc.Now(),
 	}
 	return m.persistence.UpdateShard(ctx, internalRequest)
 }

--- a/common/persistence/shard_manager_test.go
+++ b/common/persistence/shard_manager_test.go
@@ -97,7 +97,12 @@ func TestShardManagerCreateShard(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			store := NewMockShardStore(ctrl)
 			if test.internalRequest != nil {
-				store.EXPECT().CreateShard(gomock.Any(), gomock.Eq(test.internalRequest)).Return(test.internalResponse)
+				store.EXPECT().CreateShard(gomock.Any(), gomock.Any()).
+					Do(func(ctx context.Context, req *InternalCreateShardRequest) {
+						assert.Equal(t, test.internalRequest.ShardInfo, req.ShardInfo)
+
+						assert.WithinDuration(t, time.Now(), req.CurrentTimeStamp, time.Second)
+					}).Return(test.internalResponse)
 			}
 
 			manager := NewShardManager(store, WithSerializer(test.serializer))
@@ -237,7 +242,13 @@ func TestShardManagerUpdateShard(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			store := NewMockShardStore(ctrl)
 			if test.internalRequest != nil {
-				store.EXPECT().UpdateShard(gomock.Any(), gomock.Eq(test.internalRequest)).Return(test.internalResponse)
+				store.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
+					Do(func(ctx context.Context, req *InternalUpdateShardRequest) {
+						assert.Equal(t, test.internalRequest.PreviousRangeID, req.PreviousRangeID)
+						assert.Equal(t, test.internalRequest.ShardInfo, req.ShardInfo)
+
+						assert.WithinDuration(t, time.Now(), req.CurrentTimeStamp, time.Second)
+					}).Return(test.internalResponse)
 			}
 
 			manager := NewShardManager(store, WithSerializer(test.serializer))

--- a/common/persistence/sql/sql_queue_store.go
+++ b/common/persistence/sql/sql_queue_store.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
@@ -117,11 +118,7 @@ func (q *sqlQueueStore) DeleteMessagesBefore(
 	return nil
 }
 
-func (q *sqlQueueStore) UpdateAckLevel(
-	ctx context.Context,
-	messageID int64,
-	clusterName string,
-) error {
+func (q *sqlQueueStore) UpdateAckLevel(ctx context.Context, messageID int64, clusterName string, now time.Time) error {
 	return q.txExecute(ctx, sqlplugin.DbDefaultShard, "UpdateAckLevel", func(tx sqlplugin.Tx) error {
 		clusterAckLevels, err := tx.GetAckLevels(ctx, q.queueType, true)
 		if err != nil {
@@ -229,11 +226,7 @@ func (q *sqlQueueStore) RangeDeleteMessagesFromDLQ(
 	return nil
 }
 
-func (q *sqlQueueStore) UpdateDLQAckLevel(
-	ctx context.Context,
-	messageID int64,
-	clusterName string,
-) error {
+func (q *sqlQueueStore) UpdateDLQAckLevel(ctx context.Context, messageID int64, clusterName string, now time.Time) error {
 	return q.txExecute(ctx, sqlplugin.DbDefaultShard, "UpdateDLQAckLevel", func(tx sqlplugin.Tx) error {
 		clusterAckLevels, err := tx.GetAckLevels(ctx, q.getDLQTypeFromQueueType(), true)
 		if err != nil {

--- a/common/persistence/sql/sql_queue_store.go
+++ b/common/persistence/sql/sql_queue_store.go
@@ -55,10 +55,7 @@ func newQueueStore(
 	}, nil
 }
 
-func (q *sqlQueueStore) EnqueueMessage(
-	ctx context.Context,
-	messagePayload []byte,
-) error {
+func (q *sqlQueueStore) EnqueueMessage(ctx context.Context, messagePayload []byte, currentTimeStamp time.Time) error {
 	return q.txExecute(ctx, sqlplugin.DbDefaultShard, "EnqueueMessage", func(tx sqlplugin.Tx) error {
 		lastMessageID, err := tx.GetLastEnqueuedMessageIDForUpdate(ctx, q.queueType)
 		if err != nil {
@@ -149,10 +146,7 @@ func (q *sqlQueueStore) GetAckLevels(
 	return result, nil
 }
 
-func (q *sqlQueueStore) EnqueueMessageToDLQ(
-	ctx context.Context,
-	messagePayload []byte,
-) error {
+func (q *sqlQueueStore) EnqueueMessageToDLQ(ctx context.Context, messagePayload []byte, currentTimeStamp time.Time) error {
 	return q.txExecute(ctx, sqlplugin.DbDefaultShard, "EnqueueMessageToDLQ", func(tx sqlplugin.Tx) error {
 		var err error
 		lastMessageID, err := tx.GetLastEnqueuedMessageIDForUpdate(ctx, q.getDLQTypeFromQueueType())

--- a/common/persistence/sql/sql_queue_store_test.go
+++ b/common/persistence/sql/sql_queue_store_test.go
@@ -27,6 +27,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -352,7 +353,7 @@ func TestUpdateAckLevel(t *testing.T) {
 			require.NoError(t, err, "Failed to create sql queue store")
 
 			tc.mockSetup(mockDB, mockTx)
-			err = store.UpdateAckLevel(context.Background(), 0, tc.clusterName)
+			err = store.UpdateAckLevel(context.Background(), 0, tc.clusterName, time.Now())
 			if tc.wantErr {
 				assert.Error(t, err, "Expected an error for test case")
 			} else {
@@ -719,7 +720,7 @@ func TestUpdateDLQAckLevel(t *testing.T) {
 			require.NoError(t, err, "Failed to create sql queue store")
 
 			tc.mockSetup(mockDB, mockTx)
-			err = store.UpdateDLQAckLevel(context.Background(), 0, tc.clusterName)
+			err = store.UpdateDLQAckLevel(context.Background(), 0, tc.clusterName, time.Now())
 			if tc.wantErr {
 				assert.Error(t, err, "Expected an error for test case")
 			} else {

--- a/common/persistence/sql/sql_queue_store_test.go
+++ b/common/persistence/sql/sql_queue_store_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
 
+var fixedTime = time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
 func TestGetNextID(t *testing.T) {
 	tests := map[string]struct {
 		acks     map[string]int64
@@ -138,7 +140,7 @@ func TestEnqueueMessage(t *testing.T) {
 			require.NoError(t, err, "Failed to create sql queue store")
 
 			tc.mockSetup(mockDB, mockTx)
-			err = store.EnqueueMessage(context.Background(), nil)
+			err = store.EnqueueMessage(context.Background(), nil, fixedTime)
 			if tc.wantErr {
 				assert.Error(t, err, "Expected an error for test case")
 			} else {
@@ -353,7 +355,7 @@ func TestUpdateAckLevel(t *testing.T) {
 			require.NoError(t, err, "Failed to create sql queue store")
 
 			tc.mockSetup(mockDB, mockTx)
-			err = store.UpdateAckLevel(context.Background(), 0, tc.clusterName, time.Now())
+			err = store.UpdateAckLevel(context.Background(), 0, tc.clusterName, fixedTime)
 			if tc.wantErr {
 				assert.Error(t, err, "Expected an error for test case")
 			} else {
@@ -469,7 +471,7 @@ func TestEnqueueMessageToDLQ(t *testing.T) {
 			require.NoError(t, err, "Failed to create sql queue store")
 
 			tc.mockSetup(mockDB, mockTx)
-			err = store.EnqueueMessageToDLQ(context.Background(), nil)
+			err = store.EnqueueMessageToDLQ(context.Background(), nil, fixedTime)
 			if tc.wantErr {
 				assert.Error(t, err, "Expected an error for test case")
 			} else {
@@ -720,7 +722,7 @@ func TestUpdateDLQAckLevel(t *testing.T) {
 			require.NoError(t, err, "Failed to create sql queue store")
 
 			tc.mockSetup(mockDB, mockTx)
-			err = store.UpdateDLQAckLevel(context.Background(), 0, tc.clusterName, time.Now())
+			err = store.UpdateDLQAckLevel(context.Background(), 0, tc.clusterName, fixedTime)
 			if tc.wantErr {
 				assert.Error(t, err, "Expected an error for test case")
 			} else {

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -24,11 +24,14 @@ package persistence
 
 import (
 	"context"
+
+	"github.com/uber/cadence/common/clock"
 )
 
 type (
 	taskManager struct {
 		persistence TaskStore
+		timeSrc     clock.TimeSource
 	}
 )
 
@@ -40,6 +43,7 @@ func NewTaskManager(
 ) TaskManager {
 	return &taskManager{
 		persistence: persistence,
+		timeSrc:     clock.NewRealTimeSource(),
 	}
 }
 
@@ -52,6 +56,7 @@ func (t *taskManager) Close() {
 }
 
 func (t *taskManager) LeaseTaskList(ctx context.Context, request *LeaseTaskListRequest) (*LeaseTaskListResponse, error) {
+	request.UpdatedTime = t.timeSrc.Now()
 	return t.persistence.LeaseTaskList(ctx, request)
 }
 
@@ -60,6 +65,7 @@ func (t *taskManager) GetTaskList(ctx context.Context, request *GetTaskListReque
 }
 
 func (t *taskManager) UpdateTaskList(ctx context.Context, request *UpdateTaskListRequest) (*UpdateTaskListResponse, error) {
+	request.UpdatedTime = t.timeSrc.Now()
 	return t.persistence.UpdateTaskList(ctx, request)
 }
 
@@ -76,6 +82,7 @@ func (t *taskManager) GetTaskListSize(ctx context.Context, request *GetTaskListS
 }
 
 func (t *taskManager) CreateTasks(ctx context.Context, request *CreateTasksRequest) (*CreateTasksResponse, error) {
+	request.CreatedTime = t.timeSrc.Now()
 	return t.persistence.CreateTasks(ctx, request)
 }
 

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -56,7 +56,7 @@ func (t *taskManager) Close() {
 }
 
 func (t *taskManager) LeaseTaskList(ctx context.Context, request *LeaseTaskListRequest) (*LeaseTaskListResponse, error) {
-	request.TimeStamp = t.timeSrc.Now()
+	request.CurrentTimeStamp = t.timeSrc.Now()
 	return t.persistence.LeaseTaskList(ctx, request)
 }
 
@@ -65,7 +65,7 @@ func (t *taskManager) GetTaskList(ctx context.Context, request *GetTaskListReque
 }
 
 func (t *taskManager) UpdateTaskList(ctx context.Context, request *UpdateTaskListRequest) (*UpdateTaskListResponse, error) {
-	request.UpdatedTime = t.timeSrc.Now()
+	request.CurrentTimeStamp = t.timeSrc.Now()
 	return t.persistence.UpdateTaskList(ctx, request)
 }
 
@@ -82,7 +82,7 @@ func (t *taskManager) GetTaskListSize(ctx context.Context, request *GetTaskListS
 }
 
 func (t *taskManager) CreateTasks(ctx context.Context, request *CreateTasksRequest) (*CreateTasksResponse, error) {
-	request.CreatedTime = t.timeSrc.Now()
+	request.CurrentTimeStamp = t.timeSrc.Now()
 	return t.persistence.CreateTasks(ctx, request)
 }
 

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -56,7 +56,7 @@ func (t *taskManager) Close() {
 }
 
 func (t *taskManager) LeaseTaskList(ctx context.Context, request *LeaseTaskListRequest) (*LeaseTaskListResponse, error) {
-	request.UpdatedTime = t.timeSrc.Now()
+	request.TimeStamp = t.timeSrc.Now()
 	return t.persistence.LeaseTaskList(ctx, request)
 }
 

--- a/service/matching/tasklist/db.go
+++ b/service/matching/tasklist/db.go
@@ -106,7 +106,7 @@ func (db *taskListDB) RenewLease() (taskListState, error) {
 		TaskListKind: db.taskListKind,
 		RangeID:      atomic.LoadInt64(&db.rangeID),
 		DomainName:   db.domainName,
-		UpdatedTime:  db.timeSrc.Now(),
+		TimeStamp:    db.timeSrc.Now(),
 	})
 	if err != nil {
 		return taskListState{}, err

--- a/service/matching/tasklist/db.go
+++ b/service/matching/tasklist/db.go
@@ -100,13 +100,13 @@ func (db *taskListDB) RenewLease() (taskListState, error) {
 	db.Lock()
 	defer db.Unlock()
 	resp, err := db.store.LeaseTaskList(context.Background(), &persistence.LeaseTaskListRequest{
-		DomainID:     db.domainID,
-		TaskList:     db.taskListName,
-		TaskType:     db.taskType,
-		TaskListKind: db.taskListKind,
-		RangeID:      atomic.LoadInt64(&db.rangeID),
-		DomainName:   db.domainName,
-		TimeStamp:    db.timeSrc.Now(),
+		DomainID:         db.domainID,
+		TaskList:         db.taskListName,
+		TaskType:         db.taskType,
+		TaskListKind:     db.taskListKind,
+		RangeID:          atomic.LoadInt64(&db.rangeID),
+		DomainName:       db.domainName,
+		CurrentTimeStamp: db.timeSrc.Now(),
 	})
 	if err != nil {
 		return taskListState{}, err
@@ -131,8 +131,8 @@ func (db *taskListDB) UpdateState(ackLevel int64) error {
 			Kind:                    db.taskListKind,
 			AdaptivePartitionConfig: db.partitionConfig,
 		},
-		DomainName:  db.domainName,
-		UpdatedTime: db.timeSrc.Now(),
+		DomainName:       db.domainName,
+		CurrentTimeStamp: db.timeSrc.Now(),
 	})
 	if err != nil {
 		return err
@@ -154,8 +154,8 @@ func (db *taskListDB) UpdateTaskListPartitionConfig(partitionConfig *persistence
 			Kind:                    db.taskListKind,
 			AdaptivePartitionConfig: partitionConfig,
 		},
-		DomainName:  db.domainName,
-		UpdatedTime: db.timeSrc.Now(),
+		DomainName:       db.domainName,
+		CurrentTimeStamp: db.timeSrc.Now(),
 	})
 	if err != nil {
 		return err
@@ -175,9 +175,9 @@ func (db *taskListDB) CreateTasks(tasks []*persistence.CreateTaskInfo) (*persist
 			TaskType: db.taskType,
 			RangeID:  db.rangeID,
 		},
-		Tasks:       tasks,
-		DomainName:  db.domainName,
-		CreatedTime: db.timeSrc.Now(),
+		Tasks:            tasks,
+		DomainName:       db.domainName,
+		CurrentTimeStamp: db.timeSrc.Now(),
 	})
 }
 


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
Refactored the system so that the PersistenceManager level handles the timestamp;
Removing the timeSrc logic from the DB layer;
The DB layer only translate entity records into database queries without modifying or adding any additional information like timestamps;

<!-- Tell your future self why have you made these changes -->
**Why?**
#6610 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests
integration tests
smoke tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
