### PR TITLE
[Wf-Diagnostics] generate workflow id for diagnostics from domain and runid

### DIFF
--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -6095,6 +6095,14 @@ func (v *DiagnoseWorkflowExecutionRequest) GetWorkflowExecution() (o *WorkflowEx
 	return
 }
 
+// GetIdentity returns the identity
+func (v *DiagnoseWorkflowExecutionRequest) GetIdentity() (o string) {
+	if v != nil {
+		return v.Identity
+	}
+	return
+}
+
 type DiagnoseWorkflowExecutionResponse struct {
 	Domain                      string             `json:"domain,omitempty"`
 	DiagnosticWorkflowExecution *WorkflowExecution `json:"workflowExecution,omitempty"`

--- a/service/frontend/api/handler_test.go
+++ b/service/frontend/api/handler_test.go
@@ -775,7 +775,7 @@ func (s *workflowHandlerSuite) TestDiagnoseWorkflowExecution_Success() {
 		Identity: "",
 	}
 	diagnosticWfDomain := "cadence-system"
-	diagnosticWfID := fmt.Sprintf("%s-%s-%s", testDomain, testWorkflowID, testRunID)
+	diagnosticWfID := fmt.Sprintf("%s-%s", testDomain, testRunID)
 	diagnosticWfRunID := "123"
 	resp := &types.DiagnoseWorkflowExecutionResponse{
 		Domain: diagnosticWfDomain,
@@ -790,35 +790,6 @@ func (s *workflowHandlerSuite) TestDiagnoseWorkflowExecution_Success() {
 	result, err := wh.DiagnoseWorkflowExecution(context.Background(), req)
 	s.NoError(err)
 	s.Equal(resp, result)
-}
-
-func (s *workflowHandlerSuite) TestDiagnoseWorkflowExecution_Failed_InvalidID() {
-	wh := s.getWorkflowHandler(s.newConfig(dc.NewInMemoryClient()))
-
-	req := &types.DiagnoseWorkflowExecutionRequest{
-		Domain: testDomain,
-		WorkflowExecution: &types.WorkflowExecution{
-			WorkflowID: testWorkflowID,
-			RunID:      testRunID,
-		},
-		Identity: "",
-	}
-	diagnosticWfDomain := "cadence-system"
-	diagnosticWfRunID := "123"
-	resp := &types.DiagnoseWorkflowExecutionResponse{
-		Domain: diagnosticWfDomain,
-		DiagnosticWorkflowExecution: &types.WorkflowExecution{
-			RunID: diagnosticWfRunID,
-		},
-	}
-
-	s.mockDomainCache.EXPECT().GetDomainID(diagnosticWfDomain).Return(s.testDomainID, nil).Times(2)
-	wh.config.WorkflowIDMaxLength = dc.GetIntPropertyFilteredByDomain(36)
-	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.StartWorkflowExecutionResponse{RunID: diagnosticWfRunID}, nil)
-	result, err := wh.DiagnoseWorkflowExecution(context.Background(), req)
-	s.NoError(err)
-	s.Equal(resp.GetDiagnosticWorkflowExecution().GetRunID(), result.GetDiagnosticWorkflowExecution().GetRunID())
-	s.Equal(resp.GetDomain(), result.GetDomain())
 }
 
 func (s *workflowHandlerSuite) TestDiagnoseWorkflowExecution_Failed_RequestNotSet() {

--- a/service/frontend/api/handler_test.go
+++ b/service/frontend/api/handler_test.go
@@ -792,6 +792,35 @@ func (s *workflowHandlerSuite) TestDiagnoseWorkflowExecution_Success() {
 	s.Equal(resp, result)
 }
 
+func (s *workflowHandlerSuite) TestDiagnoseWorkflowExecution_Failed_InvalidID() {
+	wh := s.getWorkflowHandler(s.newConfig(dc.NewInMemoryClient()))
+
+	req := &types.DiagnoseWorkflowExecutionRequest{
+		Domain: testDomain,
+		WorkflowExecution: &types.WorkflowExecution{
+			WorkflowID: testWorkflowID,
+			RunID:      testRunID,
+		},
+		Identity: "",
+	}
+	diagnosticWfDomain := "cadence-system"
+	diagnosticWfRunID := "123"
+	resp := &types.DiagnoseWorkflowExecutionResponse{
+		Domain: diagnosticWfDomain,
+		DiagnosticWorkflowExecution: &types.WorkflowExecution{
+			RunID: diagnosticWfRunID,
+		},
+	}
+
+	s.mockDomainCache.EXPECT().GetDomainID(diagnosticWfDomain).Return(s.testDomainID, nil).Times(2)
+	wh.config.WorkflowIDMaxLength = dc.GetIntPropertyFilteredByDomain(36)
+	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.StartWorkflowExecutionResponse{RunID: diagnosticWfRunID}, nil)
+	result, err := wh.DiagnoseWorkflowExecution(context.Background(), req)
+	s.NoError(err)
+	s.Equal(resp.GetDiagnosticWorkflowExecution().GetRunID(), result.GetDiagnosticWorkflowExecution().GetRunID())
+	s.Equal(resp.GetDomain(), result.GetDomain())
+}
+
 func (s *workflowHandlerSuite) TestDiagnoseWorkflowExecution_Failed_RequestNotSet() {
 	wh := s.getWorkflowHandler(s.newConfig(dc.NewInMemoryClient()))
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Diagnostics workflow will be started with domain-runid as workflowID could be too long. The PR also adds a getter for identity in the request that was missed before

<!-- Tell your future self why have you made these changes -->
**Why?**
Input based workflowID could result in too long an ID depending on the workflow being diagnosed. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
