### PR TITLE
Add SQLite schema

### DIFF
--- a/common/persistence/sql/sqlplugin/sqlite/admin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/admin.go
@@ -1,0 +1,37 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package sqlite
+
+import "errors"
+
+// CreateDatabase is not supported by sqlite
+// each sqlite file is a database
+func (mdb *DB) CreateDatabase(name string) error {
+	return errors.New("sqlite doesn't support creating database")
+}
+
+// DropDatabase is not supported by sqlite
+// each sqlite file is a database
+func (mdb *DB) DropDatabase(name string) error {
+	return errors.New("sqlite doesn't support dropping database")
+}

--- a/common/persistence/sql/sqlplugin/sqlite/plugin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/plugin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/persistence/sql/sqldriver"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
@@ -41,6 +42,10 @@ const (
 type plugin struct{}
 
 var _ sqlplugin.Plugin = (*plugin)(nil)
+
+func init() {
+	sql.RegisterPlugin(PluginName, &plugin{})
+}
 
 // CreateDB wraps createDB to return an instance of sqlplugin.DB
 func (p *plugin) CreateDB(cfg *config.SQL) (sqlplugin.DB, error) {

--- a/schema/sqlite/cadence/schema.sql
+++ b/schema/sqlite/cadence/schema.sql
@@ -1,0 +1,302 @@
+CREATE TABLE domains
+(
+    shard_id      INT                 NOT NULL DEFAULT 54321,
+    id            BINARY(16)          NOT NULL,
+    name          VARCHAR(255) UNIQUE NOT NULL,
+    --
+    data          MEDIUMBLOB          NOT NULL,
+    data_encoding VARCHAR(16)         NOT NULL,
+    is_global     TINYINT(1)          NOT NULL,
+    PRIMARY KEY (shard_id, id)
+);
+
+CREATE TABLE domain_metadata
+(
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    notification_version BIGINT                            NOT NULL
+);
+
+INSERT INTO domain_metadata (notification_version)
+VALUES (1);
+
+CREATE TABLE shards
+(
+    shard_id      INT         NOT NULL,
+    --
+    range_id      BIGINT      NOT NULL,
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id)
+);
+
+CREATE TABLE transfer_tasks
+(
+    shard_id      INT         NOT NULL,
+    task_id       BIGINT      NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE cross_cluster_tasks
+(
+    target_cluster VARCHAR(255) NOT NULL,
+    shard_id       INT          NOT NULL,
+    task_id        BIGINT       NOT NULL,
+    --
+    data           MEDIUMBLOB   NOT NULL,
+    data_encoding  VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (target_cluster, shard_id, task_id)
+);
+
+CREATE TABLE executions
+(
+    shard_id           INT          NOT NULL,
+    domain_id          BINARY(16)   NOT NULL,
+    workflow_id        VARCHAR(255) NOT NULL,
+    run_id             BINARY(16)   NOT NULL,
+    --
+    next_event_id      BIGINT       NOT NULL,
+    last_write_version BIGINT       NOT NULL,
+    data               MEDIUMBLOB   NOT NULL,
+    data_encoding      VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);
+
+CREATE TABLE current_executions
+(
+    shard_id           INT          NOT NULL,
+    domain_id          BINARY(16)   NOT NULL,
+    workflow_id        VARCHAR(255) NOT NULL,
+    --
+    run_id             BINARY(16)   NOT NULL,
+    create_request_id  VARCHAR(64)  NOT NULL,
+    state              INT          NOT NULL,
+    close_status       INT          NOT NULL,
+    start_version      BIGINT       NOT NULL,
+    last_write_version BIGINT       NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id)
+);
+
+CREATE TABLE buffered_events
+(
+    id            BIGINT AUTO_INCREMENT NOT NULL,
+    shard_id      INT                   NOT NULL,
+    domain_id     BINARY(16)            NOT NULL,
+    workflow_id   VARCHAR(255)          NOT NULL,
+    run_id        BINARY(16)            NOT NULL,
+    --
+    data          MEDIUMBLOB            NOT NULL,
+    data_encoding VARCHAR(16)           NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX buffered_events_by_events_ids ON buffered_events (shard_id, domain_id, workflow_id, run_id);
+
+CREATE TABLE tasks
+(
+    domain_id      BINARY(16)   NOT NULL,
+    task_list_name VARCHAR(255) NOT NULL,
+    task_type      TINYINT      NOT NULL, -- {Activity, Decision}
+    task_id        BIGINT       NOT NULL,
+    --
+    data           MEDIUMBLOB   NOT NULL,
+    data_encoding  VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (domain_id, task_list_name, task_type, task_id)
+);
+
+CREATE TABLE task_lists
+(
+    shard_id      INT          NOT NULL,
+    domain_id     BINARY(16)   NOT NULL,
+    name          VARCHAR(255) NOT NULL,
+    task_type     TINYINT      NOT NULL, -- {Activity, Decision}
+    --
+    range_id      BIGINT       NOT NULL,
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, name, task_type)
+);
+
+CREATE TABLE replication_tasks
+(
+    shard_id      INT         NOT NULL,
+    task_id       BIGINT      NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE replication_tasks_dlq
+(
+    source_cluster_name VARCHAR(255) NOT NULL,
+    shard_id            INT          NOT NULL,
+    task_id             BIGINT       NOT NULL,
+    --
+    data                MEDIUMBLOB   NOT NULL,
+    data_encoding       VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (source_cluster_name, shard_id, task_id)
+);
+
+CREATE TABLE timer_tasks
+(
+    shard_id             INT         NOT NULL,
+    visibility_timestamp DATETIME(6) NOT NULL,
+    task_id              BIGINT      NOT NULL,
+    --
+    data                 MEDIUMBLOB  NOT NULL,
+    data_encoding        VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, visibility_timestamp, task_id)
+);
+
+CREATE TABLE activity_info_maps
+(
+-- each row corresponds to one key of one map<string, ActivityInfo>
+    shard_id                    INT          NOT NULL,
+    domain_id                   BINARY(16)   NOT NULL,
+    workflow_id                 VARCHAR(255) NOT NULL,
+    run_id                      BINARY(16)   NOT NULL,
+    schedule_id                 BIGINT       NOT NULL,
+--
+    data                        MEDIUMBLOB   NOT NULL,
+    data_encoding               VARCHAR(16),
+    last_heartbeat_details      BLOB,
+    last_heartbeat_updated_time DATETIME(6)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, schedule_id)
+);
+
+CREATE TABLE timer_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id     BINARY(16)   NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id        BINARY(16)   NOT NULL,
+    timer_id      VARCHAR(255) NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, timer_id)
+);
+
+CREATE TABLE child_execution_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id     BINARY(16)   NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id        BINARY(16)   NOT NULL,
+    initiated_id  BIGINT       NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE request_cancel_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id     BINARY(16)   NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id        BINARY(16)   NOT NULL,
+    initiated_id  BIGINT       NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signal_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id     BINARY(16)   NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id        BINARY(16)   NOT NULL,
+    initiated_id  BIGINT       NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE buffered_replication_task_maps
+(
+    shard_id                    INT          NOT NULL,
+    domain_id                   BINARY(16)   NOT NULL,
+    workflow_id                 VARCHAR(255) NOT NULL,
+    run_id                      BINARY(16)   NOT NULL,
+    first_event_id              BIGINT       NOT NULL,
+--
+    version                     BIGINT       NOT NULL,
+    next_event_id               BIGINT       NOT NULL,
+    history                     MEDIUMBLOB,
+    history_encoding            VARCHAR(16)  NOT NULL,
+    new_run_history             MEDIUMBLOB,
+    new_run_history_encoding    VARCHAR(16)  NOT NULL DEFAULT 'json',
+    event_store_version         INT          NOT NULL, -- indicates which version of event store to query
+    new_run_event_store_version INT          NOT NULL, -- indicates which version of event store to query for new run(continueAsNew)
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, first_event_id)
+);
+
+CREATE TABLE signals_requested_sets
+(
+    shard_id    INT          NOT NULL,
+    domain_id   BINARY(16)   NOT NULL,
+    workflow_id VARCHAR(255) NOT NULL,
+    run_id      BINARY(16)   NOT NULL,
+    signal_id   VARCHAR(64)  NOT NULL,
+    --
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, signal_id)
+);
+
+-- history eventsV2: history_node stores history event data
+CREATE TABLE history_node
+(
+    shard_id      INT         NOT NULL,
+    tree_id       BINARY(16)  NOT NULL,
+    branch_id     BINARY(16)  NOT NULL,
+    node_id       BIGINT      NOT NULL,
+    txn_id        BIGINT      NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, tree_id, branch_id, node_id, txn_id)
+);
+
+-- history eventsV2: history_tree stores branch metadata
+CREATE TABLE history_tree
+(
+    shard_id      INT         NOT NULL,
+    tree_id       BINARY(16)  NOT NULL,
+    branch_id     BINARY(16)  NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, tree_id, branch_id)
+);
+
+CREATE TABLE queue
+(
+    queue_type      INT        NOT NULL,
+    message_id      BIGINT     NOT NULL,
+    message_payload MEDIUMBLOB NOT NULL,
+    PRIMARY KEY (queue_type, message_id)
+);
+
+CREATE TABLE queue_metadata
+(
+    queue_type INT        NOT NULL,
+    data       MEDIUMBLOB NOT NULL,
+    PRIMARY KEY (queue_type)
+);
+
+CREATE TABLE cluster_config
+(
+    row_type      INT         NOT NULL,
+    version       BIGINT      NOT NULL,
+    --
+    timestamp     DATETIME(6) NOT NULL,
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (row_type, version)
+);

--- a/schema/sqlite/cadence/versioned/v0.1/base.sql
+++ b/schema/sqlite/cadence/versioned/v0.1/base.sql
@@ -1,0 +1,302 @@
+CREATE TABLE domains
+(
+    shard_id      INT                 NOT NULL DEFAULT 54321,
+    id BINARY (16) NOT NULL,
+    name          VARCHAR(255) UNIQUE NOT NULL,
+    --
+    data          MEDIUMBLOB          NOT NULL,
+    data_encoding VARCHAR(16)         NOT NULL,
+    is_global     TINYINT(1)          NOT NULL,
+    PRIMARY KEY (shard_id, id)
+);
+
+CREATE TABLE domain_metadata
+(
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    notification_version BIGINT NOT NULL
+);
+
+INSERT INTO domain_metadata (notification_version)
+VALUES (1);
+
+CREATE TABLE shards
+(
+    shard_id      INT         NOT NULL,
+    --
+    range_id      BIGINT      NOT NULL,
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id)
+);
+
+CREATE TABLE transfer_tasks
+(
+    shard_id      INT         NOT NULL,
+    task_id       BIGINT      NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE cross_cluster_tasks
+(
+    target_cluster VARCHAR(255) NOT NULL,
+    shard_id       INT          NOT NULL,
+    task_id        BIGINT       NOT NULL,
+    --
+    data           MEDIUMBLOB   NOT NULL,
+    data_encoding  VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (target_cluster, shard_id, task_id)
+);
+
+CREATE TABLE executions
+(
+    shard_id           INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id        VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    --
+    next_event_id      BIGINT       NOT NULL,
+    last_write_version BIGINT       NOT NULL,
+    data               MEDIUMBLOB   NOT NULL,
+    data_encoding      VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);
+
+CREATE TABLE current_executions
+(
+    shard_id           INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id        VARCHAR(255) NOT NULL,
+    --
+    run_id BINARY (16) NOT NULL,
+    create_request_id  VARCHAR(64)  NOT NULL,
+    state              INT          NOT NULL,
+    close_status       INT          NOT NULL,
+    start_version      BIGINT       NOT NULL,
+    last_write_version BIGINT       NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id)
+);
+
+CREATE TABLE buffered_events
+(
+    id            BIGINT AUTO_INCREMENT NOT NULL,
+    shard_id      INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    --
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX buffered_events_by_events_ids ON buffered_events (shard_id, domain_id, workflow_id, run_id);
+
+CREATE TABLE tasks
+(
+    domain_id BINARY (16) NOT NULL,
+    task_list_name VARCHAR(255) NOT NULL,
+    task_type      TINYINT      NOT NULL, -- {Activity, Decision}
+    task_id        BIGINT       NOT NULL,
+    --
+    data           MEDIUMBLOB   NOT NULL,
+    data_encoding  VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (domain_id, task_list_name, task_type, task_id)
+);
+
+CREATE TABLE task_lists
+(
+    shard_id      INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    name          VARCHAR(255) NOT NULL,
+    task_type     TINYINT      NOT NULL, -- {Activity, Decision}
+    --
+    range_id      BIGINT       NOT NULL,
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, name, task_type)
+);
+
+CREATE TABLE replication_tasks
+(
+    shard_id      INT         NOT NULL,
+    task_id       BIGINT      NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE replication_tasks_dlq
+(
+    source_cluster_name VARCHAR(255) NOT NULL,
+    shard_id            INT          NOT NULL,
+    task_id             BIGINT       NOT NULL,
+    --
+    data                MEDIUMBLOB   NOT NULL,
+    data_encoding       VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (source_cluster_name, shard_id, task_id)
+);
+
+CREATE TABLE timer_tasks
+(
+    shard_id             INT         NOT NULL,
+    visibility_timestamp DATETIME(6) NOT NULL,
+    task_id              BIGINT      NOT NULL,
+    --
+    data                 MEDIUMBLOB  NOT NULL,
+    data_encoding        VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, visibility_timestamp, task_id)
+);
+
+CREATE TABLE activity_info_maps
+(
+-- each row corresponds to one key of one map<string, ActivityInfo>
+    shard_id                    INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id                 VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    schedule_id                 BIGINT       NOT NULL,
+--
+    data                        MEDIUMBLOB   NOT NULL,
+    data_encoding               VARCHAR(16),
+    last_heartbeat_details      BLOB,
+    last_heartbeat_updated_time DATETIME(6)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, schedule_id)
+);
+
+CREATE TABLE timer_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    timer_id      VARCHAR(255) NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, timer_id)
+);
+
+CREATE TABLE child_execution_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    initiated_id  BIGINT       NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE request_cancel_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    initiated_id  BIGINT       NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signal_info_maps
+(
+    shard_id      INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    initiated_id  BIGINT       NOT NULL,
+--
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16),
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE buffered_replication_task_maps
+(
+    shard_id                    INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id                 VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    first_event_id              BIGINT       NOT NULL,
+--
+    version                     BIGINT       NOT NULL,
+    next_event_id               BIGINT       NOT NULL,
+    history                     MEDIUMBLOB,
+    history_encoding            VARCHAR(16)  NOT NULL,
+    new_run_history             MEDIUMBLOB,
+    new_run_history_encoding    VARCHAR(16)  NOT NULL DEFAULT 'json',
+    event_store_version         INT          NOT NULL, -- indicates which version of event store to query
+    new_run_event_store_version INT          NOT NULL, -- indicates which version of event store to query for new run(continueAsNew)
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, first_event_id)
+);
+
+CREATE TABLE signals_requested_sets
+(
+    shard_id    INT          NOT NULL,
+    domain_id BINARY (16) NOT NULL,
+    workflow_id VARCHAR(255) NOT NULL,
+    run_id BINARY (16) NOT NULL,
+    signal_id   VARCHAR(64)  NOT NULL,
+    --
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, signal_id)
+);
+
+-- history eventsV2: history_node stores history event data
+CREATE TABLE history_node
+(
+    shard_id      INT         NOT NULL,
+    tree_id BINARY (16) NOT NULL,
+    branch_id BINARY (16) NOT NULL,
+    node_id       BIGINT      NOT NULL,
+    txn_id        BIGINT      NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, tree_id, branch_id, node_id, txn_id)
+);
+
+-- history eventsV2: history_tree stores branch metadata
+CREATE TABLE history_tree
+(
+    shard_id      INT         NOT NULL,
+    tree_id BINARY (16) NOT NULL,
+    branch_id BINARY (16) NOT NULL,
+    --
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (shard_id, tree_id, branch_id)
+);
+
+CREATE TABLE queue
+(
+    queue_type      INT        NOT NULL,
+    message_id      BIGINT     NOT NULL,
+    message_payload MEDIUMBLOB NOT NULL,
+    PRIMARY KEY (queue_type, message_id)
+);
+
+CREATE TABLE queue_metadata
+(
+    queue_type INT        NOT NULL,
+    data       MEDIUMBLOB NOT NULL,
+    PRIMARY KEY (queue_type)
+);
+
+CREATE TABLE cluster_config
+(
+    row_type      INT         NOT NULL,
+    version       BIGINT      NOT NULL,
+    --
+    timestamp     DATETIME(6) NOT NULL,
+    data          MEDIUMBLOB  NOT NULL,
+    data_encoding VARCHAR(16) NOT NULL,
+    PRIMARY KEY (row_type, version)
+);

--- a/schema/sqlite/cadence/versioned/v0.1/manifest.json
+++ b/schema/sqlite/cadence/versioned/v0.1/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.1",
+  "MinCompatibleVersion": "0.1",
+  "Description": "base version of schema",
+  "SchemaUpdateCqlFiles": [
+    "base.sql"
+  ]
+}

--- a/schema/sqlite/embed.go
+++ b/schema/sqlite/embed.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sqlite
+
+import "embed"
+
+//go:embed cadence/* visibility/*
+var SchemaFS embed.FS

--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sqlite
+
+// NOTE: whenever there is a new data base schema update, plz update the following versions
+
+// Version is the SQLite database release version
+const Version = "0.1"
+
+// VisibilityVersion is the SQLite visibility database release version
+const VisibilityVersion = "0.1"

--- a/schema/sqlite/visibility/schema.sql
+++ b/schema/sqlite/visibility/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE executions_visibility
+(
+    domain_id          CHAR(64)                   NOT NULL,
+    run_id             CHAR(64)                   NOT NULL,
+    start_time         DATETIME(6)                NOT NULL,
+    execution_time     DATETIME(6)                NOT NULL,
+    workflow_id        VARCHAR(255)               NOT NULL,
+    workflow_type_name VARCHAR(255)               NOT NULL,
+    close_status       INT, -- enum WorkflowExecutionCloseStatus {COMPLETED, FAILED, CANCELED, TERMINATED, CONTINUED_AS_NEW, TIMED_OUT}
+    close_time         DATETIME(6)                NULL,
+    history_length     BIGINT,
+    memo               BLOB,
+    encoding           VARCHAR(64)                NOT NULL,
+    task_list          VARCHAR(255) DEFAULT ''    NOT NULL,
+    is_cron            BOOLEAN      DEFAULT false NOT NULL,
+    num_clusters       INT                        NULL,
+    update_time        DATETIME(6)                NULL,
+    shard_id           INT                        NULL,
+
+    PRIMARY KEY (domain_id, run_id)
+);
+
+CREATE INDEX by_type_start_time ON executions_visibility (domain_id, workflow_type_name, close_status, start_time DESC, run_id);
+CREATE INDEX by_workflow_id_start_time ON executions_visibility (domain_id, workflow_id, close_status, start_time DESC, run_id);
+CREATE INDEX by_status_by_close_time ON executions_visibility (domain_id, close_status, start_time DESC, run_id);
+CREATE INDEX by_close_time_by_status ON executions_visibility (domain_id, close_time DESC, run_id, close_status);

--- a/schema/sqlite/visibility/versioned/v0.1/base.sql
+++ b/schema/sqlite/visibility/versioned/v0.1/base.sql
@@ -1,0 +1,26 @@
+CREATE TABLE executions_visibility
+(
+    domain_id          CHAR(64)                   NOT NULL,
+    run_id             CHAR(64)                   NOT NULL,
+    start_time         DATETIME(6)                NOT NULL,
+    execution_time     DATETIME(6)                NOT NULL,
+    workflow_id        VARCHAR(255)               NOT NULL,
+    workflow_type_name VARCHAR(255)               NOT NULL,
+    close_status       INT, -- enum WorkflowExecutionCloseStatus {COMPLETED, FAILED, CANCELED, TERMINATED, CONTINUED_AS_NEW, TIMED_OUT}
+    close_time         DATETIME(6)                NULL,
+    history_length     BIGINT,
+    memo               BLOB,
+    encoding           VARCHAR(64)                NOT NULL,
+    task_list          VARCHAR(255) DEFAULT ''    NOT NULL,
+    is_cron            BOOLEAN      DEFAULT false NOT NULL,
+    num_clusters       INT                        NULL,
+    update_time        DATETIME(6)                NULL,
+    shard_id           INT                        NULL,
+
+    PRIMARY KEY (domain_id, run_id)
+);
+
+CREATE INDEX by_type_start_time ON executions_visibility (domain_id, workflow_type_name, close_status, start_time DESC, run_id);
+CREATE INDEX by_workflow_id_start_time ON executions_visibility (domain_id, workflow_id, close_status, start_time DESC, run_id);
+CREATE INDEX by_status_by_close_time ON executions_visibility (domain_id, close_status, start_time DESC, run_id);
+CREATE INDEX by_close_time_by_status ON executions_visibility (domain_id, close_time DESC, run_id, close_status);

--- a/schema/sqlite/visibility/versioned/v0.1/manifest.json
+++ b/schema/sqlite/visibility/versioned/v0.1/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.1",
+  "MinCompatibleVersion": "0.1",
+  "Description": "base version of visibility schema",
+  "SchemaUpdateCqlFiles": [
+    "base.sql"
+  ]
+}

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/uber/cadence/schema/cassandra"
 	"github.com/uber/cadence/schema/mysql"
 	"github.com/uber/cadence/schema/postgres"
+	"github.com/uber/cadence/schema/sqlite"
 )
 
 type UpdateTaskTestSuite struct {
@@ -110,6 +111,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
 }
 
 func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
+	// Cassandra
 	fsys, err := fs.Sub(cassandra.SchemaFS, "cadence/versioned")
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
@@ -122,6 +124,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	s.Equal([]string{"v0.7", "v0.8", "v0.9"}, ans)
 
+	// MySQL
 	fsys, err = fs.Sub(mysql.SchemaFS, "v8/cadence/versioned")
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.3", "")
@@ -134,6 +137,20 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	s.Equal([]string{"v0.6", "v0.7"}, ans)
 
+	// SQLite
+	fsys, err = fs.Sub(sqlite.SchemaFS, "cadence/versioned")
+	s.NoError(err)
+	ans, err = readSchemaDir(fsys, "0.1", "")
+	s.NoError(err)
+	s.Nil(ans, "no version dirs found after 0.1")
+
+	fsys, err = fs.Sub(sqlite.SchemaFS, "visibility/versioned")
+	s.NoError(err)
+	ans, err = readSchemaDir(fsys, "0.1", "")
+	s.NoError(err)
+	s.Nil(ans, "no version dirs found after 0.1")
+
+	// Postgres
 	fsys, err = fs.Sub(postgres.SchemaFS, "cadence/versioned")
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.3", "")

--- a/tools/sql/sqlite/sqlite_test.go
+++ b/tools/sql/sqlite/sqlite_test.go
@@ -1,0 +1,82 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package sqlite
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/config"
+	sqliteplugin "github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
+	"github.com/uber/cadence/schema/sqlite"
+	"github.com/uber/cadence/tools/common/schema"
+	"github.com/uber/cadence/tools/sql"
+)
+
+// Test_SetupSchema test that setup schema works for all database sqlite schemas
+// in-memory sqlite database is used for testing
+func Test_SetupSchema(t *testing.T) {
+	for _, dbName := range listDatabaseNames(t) {
+		t.Run(dbName, func(t *testing.T) {
+			conn := newInMemoryDB(t)
+
+			err := schema.SetupFromConfig(&schema.SetupConfig{
+				SchemaFilePath:    fmt.Sprintf("../../../schema/sqlite/%s/schema.sql", dbName),
+				InitialVersion:    "0.1",
+				Overwrite:         false,
+				DisableVersioning: false,
+			}, conn)
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// newInMemoryDB returns a new in-memory sqlite connection
+func newInMemoryDB(t *testing.T) *sql.Connection {
+	t.Helper()
+
+	conn, err := sql.NewConnection(&config.SQL{
+		PluginName: sqliteplugin.PluginName,
+	})
+	require.NoError(t, err)
+	return conn
+}
+
+// listDatabaseSchemaFilePaths returns a list of database schema file paths
+func listDatabaseNames(t *testing.T) []string {
+	t.Helper()
+
+	dirs, err := sqlite.SchemaFS.ReadDir(".")
+	require.NoError(t, err)
+
+	var databaseNames = make([]string, len(dirs))
+	for i, dir := range dirs {
+		databaseNames[i] = dir.Name()
+	}
+
+	return databaseNames
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`sqlite` schema has been added. 99.9% is a [`mysql` schema](https://github.com/cadence-workflow/cadence/tree/15f7fea8a8e3daed2a1c3a47421f6de9dfa1d75e/schema/mysql). There is a few differences:
* All versioned schemas were removed due to not having sqlite plugin before. Only `0.1` schemas are left, but they were replaced by schemas described in `cadence/schema.sql` and `visibility/schema.sql`, so they're identical. 
* `domain_metadata` table's `id` type has been changed to INTEGER. SQLite [doesn't support AUTOINCREMENT for BIGINT](https://sqlite.org/forum/info/2dfa968a702e1506e885cb06d92157d492108b22bf39459506ab9f7125bca7fd). 

`sqlite` plugin has been registered, so should be appeared in all services. However, the methods have not been tested yet, it will be done in the future. Without adding, schema setup wouldn't have been able to be tested.

<!-- Tell your future self why have you made these changes -->
**Why?**
SQLite storage will be used in the future as an in-memory replacement for persistence storage. The diff is a part of the project In-Memory Storage.

Previous PRs:
- [x] https://github.com/cadence-workflow/cadence/pull/6637
- [x] https://github.com/cadence-workflow/cadence/pull/6643
- [x] https://github.com/cadence-workflow/cadence/pull/6689


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests are passed. 

There is a new `sqlite` package in `tools/sql`. The package contains only one test `SetupSchema` that calls `SetupFromConfig` func to setup schema to in-memory running sqlite db. It tests that all databases schemas (cadence and visibility) can be setup. 

Unfortunately, I couldn't reuse tests from `clitest` package that were supposed to be used for this case. These tests are subject to be refactored as they were created only for `mysql`. 

At the same time, I couldn't reuse `tools/common/schema/test/` package, as it also calls `sql-tool` that requires to having `config.SQL` filled as it's done for Postgres or MySQL. If we need to support SQLite, we will need to refactor the package. Also, the tests don't support other SQL plugins than MySQL, so it also needs to be added. 

I decided to not focus on this problem, as most of these test cases covering schema updating that it is not critical for SQLite, as it will be used as in-memory storage (or with temporary database files).

We should focus on this problem later, when we will work on the Local Cadence project.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

**Detailed Description**
No need, as only there are no break changes. 

**Impact Analysis**
- **Backward Compatibility**: [Analysis of backward compatibility]
- **Forward Compatibility**: [Analysis of forward compatibility]

**Testing Plan**
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
