### PR TITLE
Use matching architecture for GitHub Actions when pushing multi-arch images

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -46,12 +46,11 @@ jobs:
   push_server_image:
     name: Push server image to Docker Hub
     needs: meta
-    # runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [linux]
         arch: [x64, arm64]
-    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
+    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }} # ubuntu-24.04 or ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,8 +68,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          # platforms: linux/amd64, linux/arm64
-          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }} # linux/amd64 or linux/arm64
           build-args: TARGET=server
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -46,7 +46,12 @@ jobs:
   push_server_image:
     name: Push server image to Docker Hub
     needs: meta
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [x64, arm64]
+    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,7 +69,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          # platforms: linux/amd64, linux/arm64
+          platforms: linux/{{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
           build-args: TARGET=server
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -79,7 +79,11 @@ jobs:
   push_server_auto_setup_image:
     name: Push auto-setup image to Docker Hub
     needs: meta
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [x64, arm64]
+    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }} # ubuntu-24.04 or ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,7 +101,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }} # linux/amd64 or linux/arm64
           build-args: TARGET=auto-setup
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}-auto-setup
@@ -109,7 +113,11 @@ jobs:
   push_cli_image:
     name: Push CLI image to Docker Hub
     needs: meta
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [x64, arm64]
+    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }} # ubuntu-24.04 or ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -127,7 +135,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }} # linux/amd64 or linux/arm64
           build-args: TARGET=cli
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/cli:${{ needs.meta.outputs.image_tag }}
@@ -157,7 +165,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           build-args: TARGET=bench
           tags: ubercadence/bench:master
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
@@ -184,7 +192,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           build-args: TARGET=canary
           tags: ubercadence/canary:master
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           context: .
           # platforms: linux/amd64, linux/arm64
-          platforms: linux/{{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
           build-args: TARGET=server
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I noticed the `docker/build-push-action` has been flaky for arm64 architecture ([list of recent runs](https://github.com/cadence-workflow/cadence/actions/workflows/docker_publish.yml?query=branch%3Amaster)). It fails due to cross arch compilation issues that rely on qemu:
```
#45 867.4 github.com/jcmturner/dnsutils/v2: /usr/local/go/pkg/tool/linux_arm64/compile: signal: segmentation fault (core dumped)
#45 1027.9 make: *** [Makefile:513: cadence-server] Error 1
#45 ERROR: process "/bin/sh -c CGO_ENABLED=0 make cadence-cassandra-tool cadence-sql-tool cadence cadence-server cadence-bench cadence-canary" did not complete successfully: exit code: 2
```

We use always ubuntu x64 architecture runner to build images for both amd64 and arm64 architectures. It seems to be not stable with qemu emulator. I have seen others hitting [similar issues](https://github.com/containers/podman/issues/19255).

Adding multiple architecture strategy to the jobs to mitigate this cross arch compilation stability issue. 
```
strategy:
      matrix:
        os: [linux]
        arch: [x64, arm64]
```

The above will run the job twice. One time for arch=x64 and another one for arch=arm64. 

The underlying runner's ubuntu image and docker's platform flag will be populated according to `matrix.arch`.

