### PR TITLE
Optimize poller counting

### DIFF
--- a/service/matching/poller/history.go
+++ b/service/matching/poller/history.go
@@ -46,6 +46,7 @@ type (
 	History interface {
 		UpdatePollerInfo(id Identity, info Info)
 		HasPollerAfter(earliestAccessTime time.Time) bool
+		GetPollerCount() int
 		GetPollerInfo(earliestAccessTime time.Time) []*types.PollerInfo
 		GetPollerIsolationGroups(earliestAccessTime time.Time) map[string]int
 	}
@@ -104,6 +105,10 @@ func (pollers *history) HasPollerAfter(earliestAccessTime time.Time) bool {
 	}
 
 	return false
+}
+
+func (pollers *history) GetPollerCount() int {
+	return pollers.historyCache.Size()
 }
 
 func (pollers *history) GetPollerInfo(earliestAccessTime time.Time) []*types.PollerInfo {

--- a/service/matching/poller/history_test.go
+++ b/service/matching/poller/history_test.go
@@ -120,6 +120,16 @@ func TestHistory_HasPollerAfter(t *testing.T) {
 	})
 }
 
+func TestGetPollerCount(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockCache := cache.NewMockCache(mockCtrl)
+	mockCache.EXPECT().Size().Return(10)
+	p := &history{
+		historyCache: mockCache,
+	}
+	assert.Equal(t, 10, p.GetPollerCount())
+}
+
 func TestGetPollerInfo(t *testing.T) {
 	t.Run("with_time_filter", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
Instead of iterating through the entire history cache, use the count where the values aren't needed.

Additionally remove the tasklist isolation specific logic from emitMisconfiguredPartitionMetrics. This could add additional CPU usage when enabling tasklist isolation and is inaccurate when tasklist <-> isolation group assignment is implemented.

Generally we need to revisit this metric as the source of truth for partition count is moving from the dynamic config to persistence, but this metric still relies only on dynamic config. If partition autoscaling is enabled then it seems strange to alert in this scenario.

<!-- Describe what has changed in this PR -->
**What changed?**
- Replace `len(tlMgr.pollerHistory.GetPollerInfo(time.Time{})))` with getting the size of the cache.
- Remove tasklist isolation specific calculations from `emitMisconfiguredPartitionMetrics`.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Reduce CPU usage when the number of pollers is high.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
