### PR TITLE
Fix get name when use db visibility

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -168,6 +168,7 @@ const (
 const (
 	ESPersistenceName    = "elasticsearch"
 	PinotPersistenceName = "pinot"
+	DBPersistenceName    = "db"
 )
 
 const (

--- a/common/constants.go
+++ b/common/constants.go
@@ -151,7 +151,7 @@ const (
 	ArchivalPaused = "paused"
 )
 
-// enum for dynamic config AdvancedVisibility write/read mode
+// dynamic config AdvancedVisibility write/read mode
 const (
 	// AdvancedVisibilityModeOff means do not use advanced visibility store
 	AdvancedVisibilityModeOff = "off"
@@ -163,6 +163,11 @@ const (
 	VisibilityModeOS = "os"
 	// AdvancedVisibilityModeDB means db visibility mode
 	VisibilityModeDB = "db"
+)
+
+const (
+	ESPersistenceName    = "elasticsearch"
+	PinotPersistenceName = "pinot"
 )
 
 const (

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -310,6 +310,7 @@ func (f *factoryImpl) NewVisibilityManager(
 			resourceConfig.ReadVisibilityStoreName,
 			resourceConfig.WriteVisibilityStoreName,
 			resourceConfig.EnableLogCustomerQueryParameter,
+			common.PinotPersistenceName,
 			f.logger,
 		), nil
 	case common.OSVisibilityStoreName:
@@ -335,6 +336,7 @@ func (f *factoryImpl) NewVisibilityManager(
 			resourceConfig.ReadVisibilityStoreName,
 			resourceConfig.WriteVisibilityStoreName,
 			resourceConfig.EnableLogCustomerQueryParameter,
+			common.ESPersistenceName,
 			f.logger,
 		), nil
 	case common.ESVisibilityStoreName:
@@ -351,6 +353,7 @@ func (f *factoryImpl) NewVisibilityManager(
 			resourceConfig.ReadVisibilityStoreName,
 			resourceConfig.WriteVisibilityStoreName,
 			resourceConfig.EnableLogCustomerQueryParameter,
+			common.ESPersistenceName,
 			f.logger,
 		), nil
 	default:
@@ -362,6 +365,7 @@ func (f *factoryImpl) NewVisibilityManager(
 			resourceConfig.ReadVisibilityStoreName,
 			resourceConfig.WriteVisibilityStoreName,
 			resourceConfig.EnableLogCustomerQueryParameter,
+			visibilityFromDB.GetName(), // db has multiple different stores
 			f.logger,
 		), nil
 	}

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -360,14 +360,17 @@ func (f *factoryImpl) NewVisibilityManager(
 		visibilityMgrs := map[string]p.VisibilityManager{
 			common.VisibilityModeDB: visibilityFromDB,
 		}
-		return p.NewVisibilityHybridManager(
-			visibilityMgrs,
-			resourceConfig.ReadVisibilityStoreName,
-			resourceConfig.WriteVisibilityStoreName,
-			resourceConfig.EnableLogCustomerQueryParameter,
-			common.DBPersistenceName, // db has multiple different stores
-			f.logger,
-		), nil
+		if visibilityFromDB != nil {
+			return p.NewVisibilityHybridManager(
+				visibilityMgrs,
+				resourceConfig.ReadVisibilityStoreName,
+				resourceConfig.WriteVisibilityStoreName,
+				resourceConfig.EnableLogCustomerQueryParameter,
+				visibilityFromDB.GetName(), // db has multiple different stores
+				f.logger,
+			), nil
+		}
+		return nil, nil // no visibility manager available for write
 	}
 }
 

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -365,7 +365,7 @@ func (f *factoryImpl) NewVisibilityManager(
 			resourceConfig.ReadVisibilityStoreName,
 			resourceConfig.WriteVisibilityStoreName,
 			resourceConfig.EnableLogCustomerQueryParameter,
-			visibilityFromDB.GetName(), // db has multiple different stores
+			common.DBPersistenceName, // db has multiple different stores
 			f.logger,
 		), nil
 	}

--- a/common/persistence/client/factory_test.go
+++ b/common/persistence/client/factory_test.go
@@ -107,34 +107,6 @@ func TestFactoryMethods(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, em)
 	})
-	t.Run("NewVisibilityManager", func(t *testing.T) {
-		fact := makeFactory(t)
-		ds := mockDatastore(t, fact, storeTypeVisibility)
-
-		// true/false does not matter, but it should be passed through.
-		// true has been chosen because it's not a zero value, so it's a bit more likely to be
-		// the intended source of `true`.
-		readFromClosed := true
-		ds.EXPECT().NewVisibilityStore(readFromClosed).Return(nil, nil).MinTimes(1)
-		vm, err := fact.NewVisibilityManager(&Params{
-			PersistenceConfig: config.Persistence{
-				// a configured VisibilityStore uses the db store, which is mockable,
-				// unlike basically every other store.
-				VisibilityStore: "fake",
-			},
-		}, &service.Config{
-			// must be non-nil to create a "manager", else nil return from NewVisibilityManager is expected
-			ReadVisibilityStoreName: func(domain string) string {
-				return "es" // any value is fine as there are no read calls
-			},
-			// non-nil avoids a warning log
-			EnableReadDBVisibilityFromClosedExecutionV2: func(opts ...dynamicconfig.FilterOption) bool {
-				return readFromClosed // any value is fine as there are no read calls
-			},
-		})
-		assert.NoError(t, err)
-		assert.NotNil(t, vm)
-	})
 	t.Run("NewVisibilityManager can be nil", func(t *testing.T) {
 		fact := makeFactory(t)
 		// no datastores are mocked as there are no calls at all expected

--- a/common/persistence/elasticsearch/es_visibility_store.go
+++ b/common/persistence/elasticsearch/es_visibility_store.go
@@ -49,10 +49,6 @@ import (
 	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
-const (
-	esPersistenceName = "elasticsearch"
-)
-
 type (
 	esVisibilityStore struct {
 		esClient es.GenericClient
@@ -85,7 +81,7 @@ func NewElasticSearchVisibilityStore(
 func (v *esVisibilityStore) Close() {}
 
 func (v *esVisibilityStore) GetName() string {
-	return esPersistenceName
+	return common.ESPersistenceName
 }
 
 func (v *esVisibilityStore) RecordWorkflowExecutionStarted(

--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -41,27 +41,26 @@ import (
 )
 
 const (
-	pinotPersistenceName = "pinot"
-	DescendingOrder      = "DESC"
-	AscendingOrder       = "ASC"
-	DomainID             = "DomainID"
-	WorkflowID           = "WorkflowID"
-	RunID                = "RunID"
-	WorkflowType         = "WorkflowType"
-	CloseStatus          = "CloseStatus"
-	HistoryLength        = "HistoryLength"
-	TaskList             = "TaskList"
-	IsCron               = "IsCron"
-	NumClusters          = "NumClusters"
-	ShardID              = "ShardID"
-	Attr                 = "Attr"
-	StartTime            = "StartTime"
-	CloseTime            = "CloseTime"
-	UpdateTime           = "UpdateTime"
-	ExecutionTime        = "ExecutionTime"
-	IsDeleted            = "IsDeleted"   // used for Pinot deletion/rolling upsert only, not visible to user
-	EventTimeMs          = "EventTimeMs" // used for Pinot deletion/rolling upsert only, not visible to user
-	Memo                 = "Memo"
+	DescendingOrder = "DESC"
+	AscendingOrder  = "ASC"
+	DomainID        = "DomainID"
+	WorkflowID      = "WorkflowID"
+	RunID           = "RunID"
+	WorkflowType    = "WorkflowType"
+	CloseStatus     = "CloseStatus"
+	HistoryLength   = "HistoryLength"
+	TaskList        = "TaskList"
+	IsCron          = "IsCron"
+	NumClusters     = "NumClusters"
+	ShardID         = "ShardID"
+	Attr            = "Attr"
+	StartTime       = "StartTime"
+	CloseTime       = "CloseTime"
+	UpdateTime      = "UpdateTime"
+	ExecutionTime   = "ExecutionTime"
+	IsDeleted       = "IsDeleted"   // used for Pinot deletion/rolling upsert only, not visible to user
+	EventTimeMs     = "EventTimeMs" // used for Pinot deletion/rolling upsert only, not visible to user
+	Memo            = "Memo"
 
 	// used to be micro second
 	oneMicroSecondInNano = int64(time.Microsecond / time.Nanosecond)
@@ -103,7 +102,7 @@ func (v *pinotVisibilityStore) Close() {
 }
 
 func (v *pinotVisibilityStore) GetName() string {
-	return pinotPersistenceName
+	return common.PinotPersistenceName
 }
 
 func (v *pinotVisibilityStore) RecordWorkflowExecutionStarted(

--- a/common/persistence/visibility_hybrid_manager.go
+++ b/common/persistence/visibility_hybrid_manager.go
@@ -101,11 +101,13 @@ func (v *visibilityHybridManager) Close() {
 }
 
 func (v *visibilityHybridManager) GetName() string {
-	storeNames := strings.Split(v.writeVisibilityStoreName(), ",")
-	if mgr, ok := v.visibilityMgrs[storeNames[0]]; ok && mgr != nil {
-		return mgr.GetName()
+	if v.writeVisibilityStoreName != nil {
+		storeNames := strings.Split(v.writeVisibilityStoreName(), ",")
+		if mgr, ok := v.visibilityMgrs[storeNames[0]]; ok && mgr != nil {
+			return mgr.GetName()
+		}
 	}
-	return storeNames[0] // return the primary store name
+	return v.visibilityMgrs[dbVisStoreName].GetName() // db will always be available
 }
 
 func (v *visibilityHybridManager) RecordWorkflowExecutionStarted(

--- a/common/persistence/visibility_hybrid_manager.go
+++ b/common/persistence/visibility_hybrid_manager.go
@@ -40,6 +40,7 @@ type (
 		readVisibilityStoreName   dynamicconfig.StringPropertyFnWithDomainFilter
 		writeVisibilityStoreName  dynamicconfig.StringPropertyFn
 		logCustomerQueryParameter dynamicconfig.BoolPropertyFnWithDomainFilter
+		name                      string
 	}
 )
 
@@ -72,6 +73,7 @@ func NewVisibilityHybridManager(
 	readVisibilityStoreName dynamicconfig.StringPropertyFnWithDomainFilter,
 	writeVisibilityStoreName dynamicconfig.StringPropertyFn,
 	logCustomerQueryParameter dynamicconfig.BoolPropertyFnWithDomainFilter,
+	name string,
 	logger log.Logger,
 ) VisibilityManager {
 	if len(visibilityMgrs) == 0 {
@@ -89,6 +91,7 @@ func NewVisibilityHybridManager(
 		writeVisibilityStoreName:  writeVisibilityStoreName,
 		logger:                    logger,
 		logCustomerQueryParameter: logCustomerQueryParameter,
+		name:                      name,
 	}
 }
 
@@ -101,18 +104,7 @@ func (v *visibilityHybridManager) Close() {
 }
 
 func (v *visibilityHybridManager) GetName() string {
-	if v.writeVisibilityStoreName != nil {
-		storeNames := strings.Split(v.writeVisibilityStoreName(), ",")
-		if mgr, ok := v.visibilityMgrs[storeNames[0]]; ok && mgr != nil {
-			return mgr.GetName()
-		}
-	} else if v.readVisibilityStoreName != nil {
-		storeNames := strings.Split(v.readVisibilityStoreName(""), ",") // use empty domain name to get the default value for cluster
-		if mgr, ok := v.visibilityMgrs[storeNames[0]]; ok && mgr != nil {
-			return mgr.GetName()
-		}
-	}
-	return v.visibilityMgrs[dbVisStoreName].GetName() // db will always be available
+	return v.name
 }
 
 func (v *visibilityHybridManager) RecordWorkflowExecutionStarted(

--- a/common/persistence/visibility_hybrid_manager.go
+++ b/common/persistence/visibility_hybrid_manager.go
@@ -106,6 +106,11 @@ func (v *visibilityHybridManager) GetName() string {
 		if mgr, ok := v.visibilityMgrs[storeNames[0]]; ok && mgr != nil {
 			return mgr.GetName()
 		}
+	} else if v.readVisibilityStoreName != nil {
+		storeNames := strings.Split(v.readVisibilityStoreName(""), ",") // use empty domain name to get the default value for cluster
+		if mgr, ok := v.visibilityMgrs[storeNames[0]]; ok && mgr != nil {
+			return mgr.GetName()
+		}
 	}
 	return v.visibilityMgrs[dbVisStoreName].GetName() // db will always be available
 }

--- a/common/persistence/visibility_hybrid_manager_test.go
+++ b/common/persistence/visibility_hybrid_manager_test.go
@@ -46,6 +46,7 @@ const (
 	pinotStoreName          = "pinot"
 	VisibilityOverrideES    = "es"
 	VisibilityOverridePinot = "pinot"
+	testStoreName           = "test"
 )
 
 func TestNewVisibilityHybridManager(t *testing.T) {
@@ -77,7 +78,7 @@ func TestNewVisibilityHybridManager(t *testing.T) {
 					esStoreName:    test.mockESVisibilityManager,
 					pinotStoreName: test.mockPinotVisibilityManager,
 				}
-				NewVisibilityHybridManager(visibilityMgrs, nil, dynamicconfig.GetStringPropertyFn(esStoreName), nil, log.NewNoop())
+				NewVisibilityHybridManager(visibilityMgrs, nil, dynamicconfig.GetStringPropertyFn(esStoreName), nil, testStoreName, log.NewNoop())
 			})
 		})
 	}
@@ -87,7 +88,7 @@ func TestNewVisibilityHybridManager_EmptyVisibilityMgr(t *testing.T) {
 	// put this outside because need to use it as an input of the table tests
 	assert.NotPanics(t, func() {
 		visibilityMgrs := map[string]VisibilityManager{}
-		NewVisibilityHybridManager(visibilityMgrs, nil, nil, nil, log.NewNoop())
+		NewVisibilityHybridManager(visibilityMgrs, nil, nil, nil, testStoreName, log.NewNoop())
 	})
 }
 
@@ -139,7 +140,7 @@ func TestVisibilityHybridManagerClose(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, dynamicconfig.GetStringPropertyFn(esStoreName), nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, dynamicconfig.GetStringPropertyFn(esStoreName), nil, testStoreName, log.NewNoop())
 			assert.NotPanics(t, func() {
 				visibilityManager.Close()
 			})
@@ -198,7 +199,7 @@ func TestVisibilityHybridManagerGetName(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, testStoreName, log.NewNoop())
 			assert.NotPanics(t, func() {
 				visibilityManager.GetName()
 			})
@@ -275,7 +276,7 @@ func TestVisibilityHybridRecordWorkflowExecutionStarted(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, testStoreName, log.NewNoop())
 
 			err := visibilityManager.RecordWorkflowExecutionStarted(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -540,7 +541,7 @@ func TestVisibilityHybridRecordWorkflowExecutionClosed(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, testStoreName, log.NewNoop())
 
 			err := visibilityManager.RecordWorkflowExecutionClosed(test.context, test.request)
 			if test.expectedError != nil {
@@ -563,7 +564,7 @@ func TestVisibilityHybridChooseVisibilityModeForAdmin(t *testing.T) {
 		esStoreName:    esManager,
 		pinotStoreName: pntManager,
 	}
-	mgr := NewVisibilityHybridManager(visibilityMgrs, nil, nil, nil, log.NewNoop())
+	mgr := NewVisibilityHybridManager(visibilityMgrs, nil, nil, nil, testStoreName, log.NewNoop())
 	tripleManager := mgr.(*visibilityHybridManager)
 	tripleManager.visibilityMgrs[dbVisStoreName] = nil
 	tripleManager.visibilityMgrs[esStoreName] = nil
@@ -641,7 +642,7 @@ func TestVisibilityHybridRecordWorkflowExecutionUninitialized(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, testStoreName, log.NewNoop())
 
 			err := visibilityManager.RecordWorkflowExecutionUninitialized(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -715,7 +716,7 @@ func TestVisibilityHybridUpsertWorkflowExecution(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, testStoreName, log.NewNoop())
 
 			err := visibilityManager.UpsertWorkflowExecution(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -789,7 +790,7 @@ func TestVisibilityHybridDeleteWorkflowExecution(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, testStoreName, log.NewNoop())
 
 			err := visibilityManager.DeleteWorkflowExecution(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -876,7 +877,7 @@ func TestVisibilityHybridDeleteUninitializedWorkflowExecution(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, nil, test.writeVisibilityStoreName, nil, testStoreName, log.NewNoop())
 
 			err := visibilityManager.DeleteUninitializedWorkflowExecution(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -1066,7 +1067,7 @@ func TestVisibilityHybridListOpenWorkflowExecutions(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListOpenWorkflowExecutions(context.Background(), test.request)
 
@@ -1236,7 +1237,7 @@ func TestVisibilityHybridListClosedWorkflowExecutions(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListClosedWorkflowExecutions(test.context, test.request)
 			if test.expectedError != nil {
@@ -1350,7 +1351,7 @@ func TestVisibilityHybridListOpenWorkflowExecutionsByType(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListOpenWorkflowExecutionsByType(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -1464,7 +1465,7 @@ func TestVisibilityHybridListClosedWorkflowExecutionsByType(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListClosedWorkflowExecutionsByType(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -1579,7 +1580,7 @@ func TestVisibilityHybridListOpenWorkflowExecutionsByWorkflowID(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListOpenWorkflowExecutionsByWorkflowID(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -1693,7 +1694,7 @@ func TestVisibilityHybridListClosedWorkflowExecutionsByWorkflowID(t *testing.T) 
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListClosedWorkflowExecutionsByWorkflowID(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -1808,7 +1809,7 @@ func TestVisibilityHybridListClosedWorkflowExecutionsByStatus(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListClosedWorkflowExecutionsByStatus(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -1920,7 +1921,7 @@ func TestVisibilityHybridGetClosedWorkflowExecution(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.GetClosedWorkflowExecution(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -2032,7 +2033,7 @@ func TestVisibilityHybridListWorkflowExecutions(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ListWorkflowExecutions(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -2145,7 +2146,7 @@ func TestVisibilityHybridScanWorkflowExecutions(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.ScanWorkflowExecutions(context.Background(), test.request)
 			if test.expectedError != nil {
@@ -2256,7 +2257,7 @@ func TestVisibilityHybridCountWorkflowExecutions(t *testing.T) {
 				esStoreName:    test.mockESVisibilityManager,
 				pinotStoreName: test.mockPinotVisibilityManager,
 			}
-			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), log.NewNoop())
+			visibilityManager := NewVisibilityHybridManager(visibilityMgrs, test.readVisibilityStoreName, nil, dynamicconfig.GetBoolPropertyFnFilteredByDomain(true), testStoreName, log.NewNoop())
 
 			_, err := visibilityManager.CountWorkflowExecutions(context.Background(), test.request)
 			if test.expectedError != nil {

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -61,3 +61,7 @@ frontend.validSearchAttributes:
     user: 1
     IsDeleted: 4
   constraints: {}
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Frontend doesn't have writeVisibiltiyStoreName passed in since it should not write to advanced visibility store.
So we pass in the name in the constructor, so we can determine the name in the upper level

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
