### PR TITLE
Revert 'Use matching architecture for GitHub Actions when pushing multi-arch images'

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -46,11 +46,7 @@ jobs:
   push_server_image:
     name: Push server image to Docker Hub
     needs: meta
-    strategy:
-      matrix:
-        os: [linux]
-        arch: [x64, arm64]
-    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }} # ubuntu-24.04 or ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }} # linux/amd64 or linux/arm64
+          platforms: linux/amd64, linux/arm64
           build-args: TARGET=server
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}
@@ -79,11 +75,7 @@ jobs:
   push_server_auto_setup_image:
     name: Push auto-setup image to Docker Hub
     needs: meta
-    strategy:
-      matrix:
-        os: [linux]
-        arch: [x64, arm64]
-    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }} # ubuntu-24.04 or ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,7 +93,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }} # linux/amd64 or linux/arm64
+          platforms: linux/amd64, linux/arm64
           build-args: TARGET=auto-setup
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/server:${{ needs.meta.outputs.image_tag }}-auto-setup
@@ -113,11 +105,7 @@ jobs:
   push_cli_image:
     name: Push CLI image to Docker Hub
     needs: meta
-    strategy:
-      matrix:
-        os: [linux]
-        arch: [x64, arm64]
-    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }} # ubuntu-24.04 or ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -135,7 +123,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }} # linux/amd64 or linux/arm64
+          platforms: linux/amd64, linux/arm64
           build-args: TARGET=cli
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
           tags: ubercadence/cli:${{ needs.meta.outputs.image_tag }}
@@ -165,7 +153,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           build-args: TARGET=bench
           tags: ubercadence/bench:master
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}
@@ -192,7 +180,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           build-args: TARGET=canary
           tags: ubercadence/canary:master
           push: ${{ needs.meta.outputs.push_enabled == 'true' }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Reverting #6649 because it didn't work as intended. Splitted jobs push images that override each other. What we need is prepare & merge jobs that can handle merging final manifest.

