### PR TITLE
Fix compilation of matching_simulation_test.go

### DIFF
--- a/simulation/matching/matching_simulation_test.go
+++ b/simulation/matching/matching_simulation_test.go
@@ -213,8 +213,8 @@ func (s *MatchingSimulationSuite) TestMatchingSimulation() {
 			TaskList:     &types.TaskList{Name: tasklist, Kind: types.TaskListKindNormal.Ptr()},
 			TaskListType: types.TaskListTypeDecision.Ptr(),
 			PartitionConfig: &types.TaskListPartitionConfig{
-				NumReadPartitions:  int32(getPartitions(s.TestClusterConfig.MatchingConfig.SimulationConfig.TaskListReadPartitions)),
-				NumWritePartitions: int32(getPartitions(s.TestClusterConfig.MatchingConfig.SimulationConfig.TaskListWritePartitions)),
+				ReadPartitions:  getPartitions(s.TestClusterConfig.MatchingConfig.SimulationConfig.TaskListReadPartitions),
+				WritePartitions: getPartitions(s.TestClusterConfig.MatchingConfig.SimulationConfig.TaskListWritePartitions),
 			},
 		})
 		s.NoError(err)
@@ -600,11 +600,17 @@ func getTaskIsolationGroups(c host.SimulationTaskConfiguration) []string {
 	return c.IsolationGroups
 }
 
-func getPartitions(i int) int {
+func getPartitions(i int) map[int]*types.TaskListPartition {
 	if i == 0 {
-		return 1
+		return map[int]*types.TaskListPartition{
+			0: {},
+		}
 	}
-	return i
+	result := make(map[int]*types.TaskListPartition)
+	for j := 0; j < i; j++ {
+		result[j] = &types.TaskListPartition{}
+	}
+	return result
 }
 
 func getForwarderMaxOutstandingPolls(i int) int {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix an issue introduced in https://github.com/cadence-workflow/cadence/commit/2b99f2ade29bace66665bbe3104f880379a5a616 that resulted in the matching simulator not compiling. 

<!-- Tell your future self why have you made these changes -->
**Why?**
- So the matching simulator can be used

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Ran the matching simulator

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- None, this is non-production code

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
