### PR TITLE
Fix admin config get CLI command

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -1313,9 +1313,9 @@ func newAdminConfigStoreCommands() []*cli.Command {
 					Usage:    "Name of Dynamic Config parameter to get value of",
 					Required: true,
 				},
-				&cli.StringSliceFlag{
+				&cli.StringFlag{
 					Name:  FlagDynamicConfigFilter,
-					Usage: fmt.Sprintf(`Optional. Can be specified multiple times for multiple filters. ex: --%s '{"Name":"domainName","Value":"global-samples-domain"}'`, FlagDynamicConfigFilter),
+					Usage: fmt.Sprintf(`Optional. ex: --%s '{"domainName":"global-samples-domain", "shardID":1, "isEnabled": true}'`, FlagDynamicConfigFilter),
 				},
 			},
 			Action: AdminGetDynamicConfig,
@@ -1348,9 +1348,9 @@ func newAdminConfigStoreCommands() []*cli.Command {
 					Usage:    "Name of Dynamic Config parameter to restore",
 					Required: true,
 				},
-				&cli.StringSliceFlag{
+				&cli.StringFlag{
 					Name:  FlagDynamicConfigFilter,
-					Usage: fmt.Sprintf(`Optional. Can be specified multiple times for multiple filters. ex: --%s '{"Name":"domainName","Value":"global-samples-domain"}'`, FlagDynamicConfigFilter),
+					Usage: fmt.Sprintf(`Optional. ex: --%s '{"domainName":"global-samples-domain", "shardID":1, "isEnabled": true}'`, FlagDynamicConfigFilter),
 				},
 			},
 			Action: AdminRestoreDynamicConfig,

--- a/tools/cli/admin_config_store_commands_test.go
+++ b/tools/cli/admin_config_store_commands_test.go
@@ -84,7 +84,7 @@ func TestAdminGetDynamicConfig(t *testing.T) {
 						return &types.GetDynamicConfigResponse{
 							Value: &types.DataBlob{
 								EncodingType: types.EncodingTypeThriftRW.Ptr(),
-								Data:         []byte("config-value"),
+								Data:         []byte(`"config-value"`),
 							},
 						}, nil
 					})

--- a/tools/cli/admin_config_store_commands_test.go
+++ b/tools/cli/admin_config_store_commands_test.go
@@ -105,7 +105,7 @@ func TestAdminGetDynamicConfig(t *testing.T) {
 				td.mockAdminClient.EXPECT().GetDynamicConfig(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, request *types.GetDynamicConfigRequest, _ ...yarpc.CallOption) (*types.GetDynamicConfigResponse, error) {
 						assert.Equal(t, request.ConfigName, testDynamicConfigName)
-						assert.Equal(t, request.Filters, []*types.DynamicConfigFilter{
+						assert.ElementsMatch(t, request.Filters, []*types.DynamicConfigFilter{
 							{
 								Name: "domainName",
 								Value: &types.DataBlob{

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -247,6 +247,9 @@ func NewCliApp(cf ClientFactory, opts ...CLIAppOptions) *cli.App {
 		printMessage(output, "command not found: "+command)
 	}
 
+	// DisableSliceFlagSeparator is set to true to allow having comma in JSON values for slice flags
+	app.DisableSliceFlagSeparator = true
+
 	for _, opt := range opts {
 		opt(app)
 	}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -247,9 +247,6 @@ func NewCliApp(cf ClientFactory, opts ...CLIAppOptions) *cli.App {
 		printMessage(output, "command not found: "+command)
 	}
 
-	// DisableSliceFlagSeparator is set to true to allow having comma in JSON values for slice flags
-	app.DisableSliceFlagSeparator = true
-
 	for _, opt := range opts {
 		opt(app)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

`AdminGetDynamicConfig` or `admin config get` has been changed. In the previous version, if no filter are specified, CLI called `ListValue` method that was supposed to list all values. No internal dynamic config supports it.`GetValue` already supports filtering, so we don't really need to do filtering on CLI side, because it is already supported on server-side. 

Flag type of `--filter` of `admin config restore` and `admin config get` commands have been changed from StringSlice to String and support json map instead of json value. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The commands didn't work properly. `filter` parameter was not tested and used, because `StringSlice` separated the input value by a comma. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests have been added


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
`AdminGetDynamicConfig` and `AdminRestoreDynamicConfig` have changed their semantics in filters, however there was no usage of the flags due to the bug, so no risks are expected.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
