### PR TITLE
Separate ReadRangeSize from RangeSize in matching

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -812,6 +812,12 @@ const (
 	// Default value: 20
 	// Allowed filters: DomainName,TasklistName,TasklistType
 	MatchingForwarderMaxChildrenPerNode
+	// MatchingReadRangeSize is the read range size for the task reader
+	// KeyName: matching.readRangeSize
+	// Value type: Int
+	// Default value: 50000
+	// Allowed filters: N/A
+	MatchingReadRangeSize
 
 	MatchingPartitionUpscaleRPS
 

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3278,6 +3278,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "MatchingForwarderMaxChildrenPerNode is the max number of children per node in the task list partition tree",
 		DefaultValue: 20,
 	},
+	MatchingReadRangeSize: {
+		KeyName:      "matching.readRangeSize",
+		Description:  "MatchingReadRangeSize is the read range size for the task reader",
+		DefaultValue: 50000,
+	},
 	MatchingPartitionUpscaleRPS: {
 		KeyName:      "matching.partitionUpscaleRPS",
 		Filters:      []Filter{DomainName, TaskListName, TaskType},

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -111,7 +111,7 @@ type (
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval          func() time.Duration
 		RangeSize                           int64
-		ReadRangeSize                       int
+		ReadRangeSize                       dynamicconfig.IntPropertyFn
 		ActivityTaskSyncMatchWaitTime       dynamicconfig.DurationPropertyFnWithDomainFilter
 		GetTasksBatchSize                   func() int
 		UpdateAckInterval                   func() time.Duration

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -40,6 +40,7 @@ type (
 
 		// taskListManager configuration
 		RangeSize                            int64
+		ReadRangeSize                        dynamicconfig.IntPropertyFn
 		GetTasksBatchSize                    dynamicconfig.IntPropertyFnWithTaskListInfoFilters
 		UpdateAckInterval                    dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 		IdleTasklistCheckInterval            dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
@@ -110,6 +111,7 @@ type (
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval          func() time.Duration
 		RangeSize                           int64
+		ReadRangeSize                       int
 		ActivityTaskSyncMatchWaitTime       dynamicconfig.DurationPropertyFnWithDomainFilter
 		GetTasksBatchSize                   func() int
 		UpdateAckInterval                   func() time.Duration
@@ -163,6 +165,7 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, getIsolationGroups
 		DomainUserRPS:                        dc.GetIntPropertyFilteredByDomain(dynamicconfig.MatchingDomainUserRPS),
 		DomainWorkerRPS:                      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MatchingDomainWorkerRPS),
 		RangeSize:                            100000,
+		ReadRangeSize:                        dc.GetIntProperty(dynamicconfig.MatchingReadRangeSize),
 		GetTasksBatchSize:                    dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingGetTasksBatchSize),
 		UpdateAckInterval:                    dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingUpdateAckInterval),
 		IdleTasklistCheckInterval:            dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingIdleTasklistCheckInterval),

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -50,6 +50,7 @@ func TestNewConfig(t *testing.T) {
 		"DomainUserRPS":                        {dynamicconfig.MatchingDomainUserRPS, 5},
 		"DomainWorkerRPS":                      {dynamicconfig.MatchingDomainWorkerRPS, 6},
 		"RangeSize":                            {nil, int64(100000)},
+		"ReadRangeSize":                        {dynamicconfig.MatchingReadRangeSize, 50000},
 		"GetTasksBatchSize":                    {dynamicconfig.MatchingGetTasksBatchSize, 7},
 		"UpdateAckInterval":                    {dynamicconfig.MatchingUpdateAckInterval, time.Duration(8)},
 		"IdleTasklistCheckInterval":            {dynamicconfig.MatchingIdleTasklistCheckInterval, time.Duration(9)},

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -264,6 +264,7 @@ func (s *matchingEngineSuite) PollForDecisionTasksResultTest() {
 	stickyTaskList.Kind = &stickyTlKind
 
 	s.matchingEngine.config.RangeSize = 2 // to test that range is not updated without tasks
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(2)
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 
 	runID := "run1"
@@ -344,6 +345,7 @@ func (s *matchingEngineSuite) PollForDecisionTasksResultTest() {
 
 func (s *matchingEngineSuite) PollForTasksEmptyResultTest(callContext context.Context, taskType int) {
 	s.matchingEngine.config.RangeSize = 2 // to test that range is not updated without tasks
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(2)
 	if _, ok := callContext.Deadline(); !ok {
 		s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 	}
@@ -415,6 +417,7 @@ func (s *matchingEngineSuite) TestQueryWorkflow() {
 	stickyTaskList.Kind = &stickyTlKind
 
 	s.matchingEngine.config.RangeSize = 2 // to test that range is not updated without tasks
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(2)
 
 	runID := "run1"
 	workflowID := "workflow1"
@@ -510,6 +513,7 @@ func (s *matchingEngineSuite) TestAddDecisionTasksForwarded() {
 
 func (s *matchingEngineSuite) AddTasksTest(taskType int, isForwarded bool) {
 	s.matchingEngine.config.RangeSize = 300 // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(300)
 
 	domainID := "domainId"
 	tl := "makeToast"
@@ -584,6 +588,7 @@ func (s *matchingEngineSuite) AddAndPollTasks(taskType int, enableIsolation bool
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 
 	s.setupGetDrainStatus()
 
@@ -661,6 +666,7 @@ func (s *matchingEngineSuite) SyncMatchTasks(taskType int, enableIsolation bool)
 	// Set a short long poll expiration so we don't have to wait too long for 0 throttling cases
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(200 * time.Millisecond)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 	s.matchingEngine.config.TaskDispatchRPSTTL = time.Nanosecond
 	s.matchingEngine.config.MinTaskThrottlingBurstSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(_minBurst)
 	// So we can get snapshots
@@ -831,6 +837,7 @@ func (s *matchingEngineSuite) ConcurrentAddAndPollTasks(taskType int, workerCoun
 	testParam := newTestParam(s.T(), taskType)
 	tlKind := types.TaskListKindNormal
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 	s.matchingEngine.config.TaskDispatchRPSTTL = time.Nanosecond
 	s.matchingEngine.config.MinTaskThrottlingBurstSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(_minBurst)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
@@ -980,9 +987,11 @@ func (s *matchingEngineSuite) MultipleEnginesTasksRangeStealing(taskType int) {
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 
 	engine1 := s.newMatchingEngine(defaultTestConfig(), s.taskManager)
 	engine1.config.RangeSize = rangeSize
+	engine1.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 	engine1.Start()
 	defer engine1.Stop()
 
@@ -1005,6 +1014,7 @@ func (s *matchingEngineSuite) MultipleEnginesTasksRangeStealing(taskType int) {
 
 	engine2 := s.newMatchingEngine(defaultTestConfig(), s.taskManager)
 	engine2.config.RangeSize = rangeSize
+	engine2.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 	engine2.Start()
 	defer engine2.Stop()
 
@@ -1115,6 +1125,7 @@ func (s *matchingEngineSuite) UnloadTasklistOnIsolationConfigChange(taskType int
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 
 	addRequest := &addTaskRequest{
 		TaskType:                      taskType,
@@ -1181,6 +1192,7 @@ func (s *matchingEngineSuite) DrainBacklogNoPollersIsolationGroup(taskType int) 
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 	_, err := s.matchingEngine.getTaskListManager(testParam.TaskListID, testParam.TaskList.Kind)
 	s.NoError(err)
 	// advance the time a bit more than warmup time of new tasklist after the creation of tasklist manager, which is 1 minute
@@ -1249,6 +1261,7 @@ func (s *matchingEngineSuite) TestAddStickyDecisionNoPollerIsolation() {
 	testParam.TaskList.Kind = &stickyKind
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 
 	s.setupGetDrainStatus()
 

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -264,7 +264,7 @@ func (s *matchingEngineSuite) PollForDecisionTasksResultTest() {
 	stickyTaskList.Kind = &stickyTlKind
 
 	s.matchingEngine.config.RangeSize = 2 // to test that range is not updated without tasks
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(2)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(1)
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 
 	runID := "run1"
@@ -345,7 +345,7 @@ func (s *matchingEngineSuite) PollForDecisionTasksResultTest() {
 
 func (s *matchingEngineSuite) PollForTasksEmptyResultTest(callContext context.Context, taskType int) {
 	s.matchingEngine.config.RangeSize = 2 // to test that range is not updated without tasks
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(2)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(1)
 	if _, ok := callContext.Deadline(); !ok {
 		s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 	}
@@ -417,7 +417,7 @@ func (s *matchingEngineSuite) TestQueryWorkflow() {
 	stickyTaskList.Kind = &stickyTlKind
 
 	s.matchingEngine.config.RangeSize = 2 // to test that range is not updated without tasks
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(2)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(1)
 
 	runID := "run1"
 	workflowID := "workflow1"
@@ -513,7 +513,7 @@ func (s *matchingEngineSuite) TestAddDecisionTasksForwarded() {
 
 func (s *matchingEngineSuite) AddTasksTest(taskType int, isForwarded bool) {
 	s.matchingEngine.config.RangeSize = 300 // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(300)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(150)
 
 	domainID := "domainId"
 	tl := "makeToast"
@@ -588,7 +588,7 @@ func (s *matchingEngineSuite) AddAndPollTasks(taskType int, enableIsolation bool
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 
 	s.setupGetDrainStatus()
 
@@ -666,7 +666,7 @@ func (s *matchingEngineSuite) SyncMatchTasks(taskType int, enableIsolation bool)
 	// Set a short long poll expiration so we don't have to wait too long for 0 throttling cases
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(200 * time.Millisecond)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 	s.matchingEngine.config.TaskDispatchRPSTTL = time.Nanosecond
 	s.matchingEngine.config.MinTaskThrottlingBurstSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(_minBurst)
 	// So we can get snapshots
@@ -837,7 +837,7 @@ func (s *matchingEngineSuite) ConcurrentAddAndPollTasks(taskType int, workerCoun
 	testParam := newTestParam(s.T(), taskType)
 	tlKind := types.TaskListKindNormal
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 	s.matchingEngine.config.TaskDispatchRPSTTL = time.Nanosecond
 	s.matchingEngine.config.MinTaskThrottlingBurstSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(_minBurst)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
@@ -987,11 +987,11 @@ func (s *matchingEngineSuite) MultipleEnginesTasksRangeStealing(taskType int) {
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 
 	engine1 := s.newMatchingEngine(defaultTestConfig(), s.taskManager)
 	engine1.config.RangeSize = rangeSize
-	engine1.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	engine1.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 	engine1.Start()
 	defer engine1.Stop()
 
@@ -1014,7 +1014,7 @@ func (s *matchingEngineSuite) MultipleEnginesTasksRangeStealing(taskType int) {
 
 	engine2 := s.newMatchingEngine(defaultTestConfig(), s.taskManager)
 	engine2.config.RangeSize = rangeSize
-	engine2.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	engine2.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 	engine2.Start()
 	defer engine2.Stop()
 
@@ -1125,7 +1125,7 @@ func (s *matchingEngineSuite) UnloadTasklistOnIsolationConfigChange(taskType int
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 
 	addRequest := &addTaskRequest{
 		TaskType:                      taskType,
@@ -1192,7 +1192,7 @@ func (s *matchingEngineSuite) DrainBacklogNoPollersIsolationGroup(taskType int) 
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 	_, err := s.matchingEngine.getTaskListManager(testParam.TaskListID, testParam.TaskList.Kind)
 	s.NoError(err)
 	// advance the time a bit more than warmup time of new tasklist after the creation of tasklist manager, which is 1 minute
@@ -1261,7 +1261,7 @@ func (s *matchingEngineSuite) TestAddStickyDecisionNoPollerIsolation() {
 	testParam.TaskList.Kind = &stickyKind
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	s.matchingEngine.config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 
 	s.setupGetDrainStatus()
 

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -1456,6 +1456,7 @@ func defaultTestConfig() *config.Config {
 	config := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", getIsolationGroupsHelper)
 	config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(100 * time.Millisecond)
 	config.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(1)
+	config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(50000)
 	config.GetTasksBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(10)
 	config.AsyncTaskDispatchTimeout = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 	config.MaxTimeBetweenTaskDeletes = time.Duration(0)

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -1030,6 +1030,7 @@ func newTaskListConfig(id *Identifier, cfg *config.Config, domainName string) *c
 	taskType := id.GetType()
 	return &config.TaskListConfig{
 		RangeSize:          cfg.RangeSize,
+		ReadRangeSize:      cfg.ReadRangeSize,
 		AllIsolationGroups: cfg.AllIsolationGroups,
 		EnableTasklistIsolation: func() bool {
 			return cfg.EnableTasklistIsolation(domainName)

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -834,6 +834,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 	taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 	cfg := defaultTestConfig()
 	cfg.RangeSize = rangeSize
+	cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 	tlMgr, err := NewManager(
 		mockDomainCache,
 		logger,
@@ -962,6 +963,7 @@ func TestTaskListReaderPumpAdvancesAckLevelAfterEmptyReads(t *testing.T) {
 	taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 	cfg := defaultTestConfig()
 	cfg.RangeSize = rangeSize
+	cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 
 	tlMgr, err := NewManager(
 		mockDomainCache,
@@ -1036,6 +1038,7 @@ func TestTaskListManagerGetTaskBatch_ReadBatchDone(t *testing.T) {
 	const maxReadLevel = int64(120)
 	config := defaultTestConfig()
 	config.RangeSize = rangeSize
+	config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 	controller := gomock.NewController(t)
 	logger := testlogger.New(t)
 	tlm := createTestTaskListManagerWithConfig(t, logger, controller, config, clock.NewMockedTimeSource())
@@ -1095,6 +1098,7 @@ func TestTaskExpiryAndCompletion(t *testing.T) {
 			taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 			cfg := defaultTestConfig()
 			cfg.RangeSize = rangeSize
+			cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
 			cfg.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(tc.batchSize)
 			cfg.MaxTimeBetweenTaskDeletes = tc.maxTimeBtwnDeletes
 			// set idle timer check to a really small value to assert that we don't accidentally drop tasks while blocking

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -896,8 +896,8 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 	tlm.taskAckManager.SetReadLevel(0)
 	tasks, readLevel, isReadBatchDone, err = tlm.taskReader.getTaskBatch(tlm.taskAckManager.GetReadLevel(), tlm.taskWriter.GetMaxReadLevel())
 	assert.NoError(t, err)
-	assert.Equal(t, rangeSize, len(tasks))
-	assert.Equal(t, rangeSize, int(readLevel))
+	assert.Equal(t, rangeSize/2, len(tasks))
+	assert.Equal(t, rangeSize/2, int(readLevel))
 	assert.True(t, isReadBatchDone)
 
 	// reset the ackManager readLevel to the buffer size and consume
@@ -1047,7 +1047,15 @@ func TestTaskListManagerGetTaskBatch_ReadBatchDone(t *testing.T) {
 	atomic.StoreInt64(&tlm.taskWriter.maxReadLevel, maxReadLevel)
 	tasks, readLevel, isReadBatchDone, err := tlm.taskReader.getTaskBatch(tlm.taskAckManager.GetReadLevel(), tlm.taskWriter.GetMaxReadLevel())
 	assert.Empty(t, tasks)
-	assert.Equal(t, int64(rangeSize*10), readLevel)
+	assert.Equal(t, int64(rangeSize/2*10), readLevel)
+	assert.False(t, isReadBatchDone)
+	assert.NoError(t, err)
+
+	tlm.taskAckManager.SetReadLevel(readLevel)
+	atomic.StoreInt64(&tlm.taskWriter.maxReadLevel, maxReadLevel)
+	tasks, readLevel, isReadBatchDone, err = tlm.taskReader.getTaskBatch(tlm.taskAckManager.GetReadLevel(), tlm.taskWriter.GetMaxReadLevel())
+	assert.Empty(t, tasks)
+	assert.Equal(t, 2*int64(rangeSize/2*10), readLevel)
 	assert.False(t, isReadBatchDone)
 	assert.NoError(t, err)
 

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -834,7 +834,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 	taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 	cfg := defaultTestConfig()
 	cfg.RangeSize = rangeSize
-	cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 	tlMgr, err := NewManager(
 		mockDomainCache,
 		logger,
@@ -963,7 +963,7 @@ func TestTaskListReaderPumpAdvancesAckLevelAfterEmptyReads(t *testing.T) {
 	taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 	cfg := defaultTestConfig()
 	cfg.RangeSize = rangeSize
-	cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 
 	tlMgr, err := NewManager(
 		mockDomainCache,
@@ -1038,7 +1038,7 @@ func TestTaskListManagerGetTaskBatch_ReadBatchDone(t *testing.T) {
 	const maxReadLevel = int64(120)
 	config := defaultTestConfig()
 	config.RangeSize = rangeSize
-	config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+	config.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 	controller := gomock.NewController(t)
 	logger := testlogger.New(t)
 	tlm := createTestTaskListManagerWithConfig(t, logger, controller, config, clock.NewMockedTimeSource())
@@ -1098,7 +1098,7 @@ func TestTaskExpiryAndCompletion(t *testing.T) {
 			taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 			cfg := defaultTestConfig()
 			cfg.RangeSize = rangeSize
-			cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize)
+			cfg.ReadRangeSize = dynamicconfig.GetIntPropertyFn(rangeSize / 2)
 			cfg.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(tc.batchSize)
 			cfg.MaxTimeBetweenTaskDeletes = tc.maxTimeBtwnDeletes
 			// set idle timer check to a really small value to assert that we don't accidentally drop tasks while blocking

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -281,7 +281,7 @@ func (tr *taskReader) getTaskBatch(readLevel, maxReadLevel int64) ([]*persistenc
 
 	// counter i is used to break and let caller check whether tasklist is still alive and need resume read.
 	for i := 0; i < 10 && readLevel < maxReadLevel; i++ {
-		upper := readLevel + tr.config.RangeSize
+		upper := readLevel + int64(tr.config.ReadRangeSize)
 		if upper > maxReadLevel {
 			upper = maxReadLevel
 		}

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -281,7 +281,7 @@ func (tr *taskReader) getTaskBatch(readLevel, maxReadLevel int64) ([]*persistenc
 
 	// counter i is used to break and let caller check whether tasklist is still alive and need resume read.
 	for i := 0; i < 10 && readLevel < maxReadLevel; i++ {
-		upper := readLevel + int64(tr.config.ReadRangeSize)
+		upper := readLevel + int64(tr.config.ReadRangeSize())
 		if upper > maxReadLevel {
 			upper = maxReadLevel
 		}


### PR DESCRIPTION
**What changed?**
Added ReadRangeSize and use it in task_reader instead of using RangeSize. Also made it dynamic, allowing the tuning of it based on db latency.

**Why?**
Range size is set to 100000. It's used as part of the lease and write mechanism. The reason for the change here is to avoid cassandra errors in the task reader due to too many tombstones that's usually set at 100000. By decoupling the ReadRangeSize, we can control the range for the reads and avoid the errors. The scan range should not change but it may be done in more calls.

**How did you test it?**
Integration and unit tests.


**Potential risks**
It will produce more calls to the db but the range will be smaller and will avoid the cassandra tombstone problem

**Release notes**

**Documentation Changes**
