### PR TITLE
Refactor weighted round robin scheduler

### DIFF
--- a/common/task/weighted_channel_pool.go
+++ b/common/task/weighted_channel_pool.go
@@ -1,0 +1,238 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package task
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+)
+
+const defaultIdleChannelTTLInSeconds = 3600
+
+type (
+	weightedChannels[V any] []*weightedChannel[V]
+
+	weightedChannel[V any] struct {
+		weight        int
+		c             chan V
+		refCount      atomic.Int32
+		lastWriteTime atomic.Int64
+	}
+
+	WeightedRoundRobinChannelPoolOptions struct {
+		BufferSize              int
+		IdleChannelTTLInSeconds int64
+	}
+
+	WeightedRoundRobinChannelPool[K comparable, V any] struct {
+		sync.RWMutex
+		status                  int32
+		shutdownCh              chan struct{}
+		shutdownWG              sync.WaitGroup
+		bufferSize              int
+		idleChannelTTLInSeconds int64
+		logger                  log.Logger
+		timeSource              clock.TimeSource
+		channelMap              map[K]*weightedChannel[V]
+		// precalculated / flattened task chan schedule according to weight
+		// e.g. if
+		// ChannelKeyToWeight has the following mapping
+		//  0 -> 5
+		//  1 -> 3
+		//  2 -> 2
+		//  3 -> 1
+		// then iwrrChannels will contain chan [0, 0, 0, 1, 0, 1, 2, 0, 1, 2, 3] (ID-ed by channel key)
+		// This implementation uses interleaved weighted round robin schedule instead of classic weighted round robin schedule
+		// ref: https://en.wikipedia.org/wiki/Weighted_round_robin#Interleaved_WRR
+		iwrrSchedule atomic.Value // []*weightedChannel[V]
+	}
+)
+
+func NewWeightedRoundRobinChannelPool[K comparable, V any](
+	logger log.Logger,
+	timeSource clock.TimeSource,
+	options WeightedRoundRobinChannelPoolOptions,
+) *WeightedRoundRobinChannelPool[K, V] {
+	return &WeightedRoundRobinChannelPool[K, V]{
+		bufferSize:              options.BufferSize,
+		idleChannelTTLInSeconds: options.IdleChannelTTLInSeconds,
+		logger:                  logger,
+		timeSource:              timeSource,
+		channelMap:              make(map[K]*weightedChannel[V]),
+		shutdownCh:              make(chan struct{}),
+	}
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) Start() {
+	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+
+	p.shutdownWG.Add(1)
+	go p.cleanupLoop()
+
+	p.logger.Info("Weighted round robin channel pool started.")
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) Stop() {
+	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+
+	close(p.shutdownCh)
+	p.shutdownWG.Wait()
+
+	p.logger.Info("Weighted round robin channel pool stopped.")
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) cleanupLoop() {
+	defer p.shutdownWG.Done()
+	ticker := p.timeSource.NewTicker(time.Duration((p.idleChannelTTLInSeconds / 2)) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.Chan():
+			p.doCleanup()
+		case <-p.shutdownCh:
+			return
+		}
+	}
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) doCleanup() {
+	p.Lock()
+	defer p.Unlock()
+	var channelsToCleanup []K
+	now := p.timeSource.Now().Unix()
+	for k, v := range p.channelMap {
+		if now-v.lastWriteTime.Load() > p.idleChannelTTLInSeconds && len(v.c) == 0 && v.refCount.Load() == 0 {
+			channelsToCleanup = append(channelsToCleanup, k)
+		}
+	}
+
+	for _, k := range channelsToCleanup {
+		delete(p.channelMap, k)
+	}
+
+	if len(channelsToCleanup) > 0 {
+		p.logger.Info("clean up idle channels", tag.Dynamic("channels", channelsToCleanup))
+		p.updateScheduleLocked()
+	}
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) GetOrCreateChannel(key K, weight int) (chan V, func()) {
+	p.RLock()
+	if v := p.channelMap[key]; v != nil && v.weight == weight {
+		v.refCount.Add(1)
+		v.lastWriteTime.Store(p.timeSource.Now().Unix())
+		p.RUnlock()
+		return v.c, func() {
+			v.refCount.Add(-1)
+		}
+	}
+	p.RUnlock()
+
+	p.Lock()
+	defer p.Unlock()
+	if v := p.channelMap[key]; v != nil {
+		v.refCount.Add(1)
+		v.lastWriteTime.Store(p.timeSource.Now().Unix())
+		if v.weight != weight {
+			v.weight = weight
+			p.updateScheduleLocked()
+		}
+		return v.c, func() {
+			v.refCount.Add(-1)
+		}
+	}
+
+	v := &weightedChannel[V]{
+		weight: weight,
+		c:      make(chan V, p.bufferSize),
+	}
+	p.channelMap[key] = v
+	v.refCount.Add(1)
+	v.lastWriteTime.Store(p.timeSource.Now().Unix())
+	p.updateScheduleLocked()
+	return v.c, func() {
+		v.refCount.Add(-1)
+	}
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) GetAllChannels() []chan V {
+	p.RLock()
+	defer p.RUnlock()
+	allChannels := make([]chan V, 0, len(p.channelMap))
+	for _, v := range p.channelMap {
+		allChannels = append(allChannels, v.c)
+	}
+	return allChannels
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) GetSchedule() []chan V {
+	return p.iwrrSchedule.Load().([]chan V)
+}
+
+func (p *WeightedRoundRobinChannelPool[K, V]) updateScheduleLocked() {
+	totalWeight := 0
+	orderedChannels := make(weightedChannels[V], 0, len(p.channelMap))
+	for _, v := range p.channelMap {
+		totalWeight += v.weight
+		orderedChannels = append(orderedChannels, v)
+	}
+	sort.Sort(orderedChannels)
+
+	iwrrSchedule := make([]chan V, 0, totalWeight)
+	if totalWeight == 0 {
+		p.iwrrSchedule.Store(iwrrSchedule)
+		return
+	}
+
+	maxWeight := orderedChannels[len(orderedChannels)-1].weight
+	for round := maxWeight - 1; round >= 0; round-- {
+		for i := len(orderedChannels) - 1; i >= 0 && orderedChannels[i].weight > round; i-- {
+			iwrrSchedule = append(iwrrSchedule, orderedChannels[i].c)
+		}
+	}
+	p.iwrrSchedule.Store(iwrrSchedule)
+}
+
+func (w weightedChannels[V]) Len() int {
+	return len(w)
+}
+
+func (w weightedChannels[V]) Less(i, j int) bool {
+	return w[i].weight < w[j].weight
+}
+
+func (w weightedChannels[V]) Swap(i, j int) {
+	w[i], w[j] = w[j], w[i]
+}

--- a/common/task/weighted_channel_pool_test.go
+++ b/common/task/weighted_channel_pool_test.go
@@ -1,0 +1,178 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package task
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log/testlogger"
+)
+
+func TestGetOrCreateChannel(t *testing.T) {
+	timeSource := clock.NewMockedTimeSource()
+	pool := NewWeightedRoundRobinChannelPool[string, int](
+		testlogger.New(t),
+		timeSource,
+		WeightedRoundRobinChannelPoolOptions{
+			BufferSize:              1000,
+			IdleChannelTTLInSeconds: 10,
+		},
+	)
+
+	// First, verify that the method returns the same channel if the key and weight are the same
+	c1, releaseFn1 := pool.GetOrCreateChannel("k1", 1)
+	defer releaseFn1()
+	c2, releaseFn2 := pool.GetOrCreateChannel("k1", 1)
+	defer releaseFn2()
+	assert.Equal(t, c1, c2)
+
+	// Next, verify that the methods returns the same channel if the key is the same but weight is different
+	c3, releaseFn3 := pool.GetOrCreateChannel("k1", 2)
+	defer releaseFn3()
+	assert.Equal(t, c1, c3)
+}
+
+func TestGetOrCreateChannelConcurrent(t *testing.T) {
+	timeSource := clock.NewMockedTimeSource()
+	pool := NewWeightedRoundRobinChannelPool[string, int](
+		testlogger.New(t),
+		timeSource,
+		WeightedRoundRobinChannelPoolOptions{
+			BufferSize:              1000,
+			IdleChannelTTLInSeconds: 10,
+		},
+	)
+
+	var wg sync.WaitGroup
+	var chMap sync.Map
+	wg.Add(15)
+
+	for i := 0; i < 5; i++ {
+		go func(i int) {
+			defer wg.Done()
+			c, releaseFn := pool.GetOrCreateChannel("k1", i+1)
+			defer releaseFn()
+			chMap.Store("k1", c)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			c, releaseFn := pool.GetOrCreateChannel("k2", i+1)
+			defer releaseFn()
+			chMap.Store("k2", c)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			c, releaseFn := pool.GetOrCreateChannel("k3", i+1)
+			defer releaseFn()
+			chMap.Store("k3", c)
+		}(i)
+	}
+	wg.Wait()
+
+	chs := pool.GetAllChannels()
+	assert.Len(t, chs, 3)
+	ch1, _ := chMap.Load("k1")
+	ch2, _ := chMap.Load("k2")
+	ch3, _ := chMap.Load("k3")
+	expectedChs := []chan int{ch1.(chan int), ch2.(chan int), ch3.(chan int)}
+	assert.ElementsMatch(t, expectedChs, chs)
+}
+
+func TestGetSchedule(t *testing.T) {
+	timeSource := clock.NewMockedTimeSource()
+	pool := NewWeightedRoundRobinChannelPool[string, int](
+		testlogger.New(t),
+		timeSource,
+		WeightedRoundRobinChannelPoolOptions{
+			BufferSize:              1000,
+			IdleChannelTTLInSeconds: 10,
+		},
+	)
+
+	c1, releaseFn1 := pool.GetOrCreateChannel("k1", 1)
+	defer releaseFn1()
+	c2, releaseFn2 := pool.GetOrCreateChannel("k2", 2)
+	defer releaseFn2()
+	c3, releaseFn3 := pool.GetOrCreateChannel("k3", 3)
+	defer releaseFn3()
+
+	schedule := pool.GetSchedule()
+	assert.Len(t, schedule, 6)
+
+	assert.Equal(t, c3, schedule[0])
+	assert.Equal(t, c3, schedule[1])
+	assert.Equal(t, c2, schedule[2])
+	assert.Equal(t, c3, schedule[3])
+	assert.Equal(t, c2, schedule[4])
+	assert.Equal(t, c1, schedule[5])
+
+	c4, releaseFn4 := pool.GetOrCreateChannel("k2", 4)
+	defer releaseFn4()
+	assert.Equal(t, c2, c4)
+	schedule = pool.GetSchedule()
+	assert.Len(t, schedule, 8)
+
+	assert.Equal(t, c2, schedule[0])
+	assert.Equal(t, c2, schedule[1])
+	assert.Equal(t, c3, schedule[2])
+	assert.Equal(t, c2, schedule[3])
+	assert.Equal(t, c3, schedule[4])
+	assert.Equal(t, c2, schedule[5])
+	assert.Equal(t, c3, schedule[6])
+	assert.Equal(t, c1, schedule[7])
+}
+
+func TestCleanup(t *testing.T) {
+	timeSource := clock.NewRealTimeSource()
+	pool := NewWeightedRoundRobinChannelPool[string, int](
+		testlogger.New(t),
+		timeSource,
+		WeightedRoundRobinChannelPoolOptions{
+			BufferSize:              1000,
+			IdleChannelTTLInSeconds: 2,
+		},
+	)
+	pool.Start()
+	defer pool.Stop()
+
+	// First, verify that the method returns the same channel if the key and weight are the same
+	_, releaseFn1 := pool.GetOrCreateChannel("k1", 1)
+	ch2, releaseFn2 := pool.GetOrCreateChannel("k2", 1)
+	ch3, releaseFn3 := pool.GetOrCreateChannel("k3", 1)
+	ch3 <- 1
+
+	assert.Len(t, pool.GetAllChannels(), 3)
+	releaseFn1()
+	releaseFn3()
+	time.Sleep(time.Second * 4)
+	// only c1 is deleted
+	chs := pool.GetAllChannels()
+	assert.ElementsMatch(t, chs, []chan int{ch2, ch3})
+
+	releaseFn2()
+}

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -133,6 +133,7 @@ func (h *handlerImpl) Start() {
 		h.config,
 		h.GetLogger(),
 		h.GetMetricsClient(),
+		h.GetTimeSource(),
 	)
 	if err != nil {
 		h.GetLogger().Fatal("Creating priority task processor failed", tag.Error(err))

--- a/service/history/task/processor_test.go
+++ b/service/history/task/processor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -48,6 +49,7 @@ type (
 		mockShard            *shard.TestContext
 		mockPriorityAssigner *MockPriorityAssigner
 
+		timeSource    clock.TimeSource
 		metricsClient metrics.Client
 		logger        log.Logger
 
@@ -75,6 +77,7 @@ func (s *queueTaskProcessorSuite) SetupTest() {
 	)
 	s.mockPriorityAssigner = NewMockPriorityAssigner(s.controller)
 
+	s.timeSource = clock.NewRealTimeSource()
 	s.metricsClient = metrics.NewClient(tally.NoopScope, metrics.History)
 	s.logger = testlogger.New(s.Suite.T())
 
@@ -223,6 +226,7 @@ func (s *queueTaskProcessorSuite) newTestQueueTaskProcessor() *processorImpl {
 		config,
 		s.logger,
 		s.metricsClient,
+		s.timeSource,
 	)
 	s.NoError(err)
 	return processor.(*processorImpl)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Introduce weighted channel pool component to manage task channels for weighted round robin scheduler
- Refactor weighted round robin scheduler
- Change classic weighted round robin to interleaved weighted round robin

<!-- Tell your future self why have you made these changes -->
**Why?**
- Improve code quality
- Interleaved weighed round robin is fairer than classic weighted round robin.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests + dev environment

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
task scheduler might be broken and history task processing might be stuck

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
