### PR TITLE
Fix nil mutablestatebuilder panic issue in historyBuilder entities

### DIFF
--- a/service/history/execution/history_builder.go
+++ b/service/history/execution/history_builder.go
@@ -47,9 +47,10 @@ func NewHistoryBuilder(msBuilder MutableState) *HistoryBuilder {
 }
 
 // NewHistoryBuilderFromEvents creates a new history builder based on the given workflow history events
-func NewHistoryBuilderFromEvents(history []*types.HistoryEvent) *HistoryBuilder {
+func NewHistoryBuilderFromEvents(history []*types.HistoryEvent, msBuilder MutableState) *HistoryBuilder {
 	return &HistoryBuilder{
 		history: history,
+		msBuilder: msBuilder,
 	}
 }
 

--- a/service/history/execution/history_builder.go
+++ b/service/history/execution/history_builder.go
@@ -49,7 +49,7 @@ func NewHistoryBuilder(msBuilder MutableState) *HistoryBuilder {
 // NewHistoryBuilderFromEvents creates a new history builder based on the given workflow history events
 func NewHistoryBuilderFromEvents(history []*types.HistoryEvent, msBuilder MutableState) *HistoryBuilder {
 	return &HistoryBuilder{
-		history: history,
+		history:   history,
 		msBuilder: msBuilder,
 	}
 }

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -513,7 +513,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 	b.mutableState.GetExecutionInfo().SetLastFirstEventID(firstEvent.ID)
 	b.mutableState.GetExecutionInfo().SetNextEventID(lastEvent.ID + 1)
 
-	b.mutableState.SetHistoryBuilder(NewHistoryBuilderFromEvents(history))
+	b.mutableState.SetHistoryBuilder(NewHistoryBuilderFromEvents(history, b.mutableState))
 
 	return newRunMutableStateBuilder, nil
 }

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -114,7 +114,7 @@ func (s *stateBuilderSuite) mockUpdateVersion(events ...*types.HistoryEvent) {
 	for _, event := range events {
 		s.mockMutableState.EXPECT().UpdateCurrentVersion(event.Version, true).Times(1)
 	}
-	s.mockMutableState.EXPECT().SetHistoryBuilder(NewHistoryBuilderFromEvents(events)).Times(1)
+	s.mockMutableState.EXPECT().SetHistoryBuilder(NewHistoryBuilderFromEvents(events, s.mockMutableState)).Times(1)
 }
 
 func (s *stateBuilderSuite) toHistory(events ...*types.HistoryEvent) []*types.HistoryEvent {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Always populate mutablestatebuilder field in HistoryBuilder entities

<!-- Tell your future self why have you made these changes -->
**Why?**

Every HistoryBuilder needs to have MutableStateBuilder to ensure adding events are applicable. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

deployed in a testing environment and passed all tests and no alerts

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
