### PR TITLE
Replace min/max helpers with built-in min/max

### DIFF
--- a/bench/lib/metrics.go
+++ b/bench/lib/metrics.go
@@ -27,8 +27,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
-
-	"github.com/uber/cadence/common"
 )
 
 // counters go here
@@ -86,7 +84,7 @@ func RecordActivityStart(
 	scheduledTimeNanos int64,
 ) (tally.Scope, tally.Stopwatch) {
 	scope = scope.Tagged(map[string]string{"operation": name})
-	elapsed := common.MaxInt64(0, time.Now().UnixNano()-scheduledTimeNanos)
+	elapsed := max(0, time.Now().UnixNano()-scheduledTimeNanos)
 	scope.Timer(startLatency).Record(time.Duration(elapsed))
 	scope.Counter(startedCount).Inc(1)
 	sw := scope.Timer(latency).Start()
@@ -125,7 +123,7 @@ func recordWorkflowStart(
 ) *WorkflowMetricsProfile {
 	now := workflow.Now(ctx).UnixNano()
 	scope := workflowMetricScope(ctx, wfType)
-	elapsed := common.MaxInt64(0, now-scheduledTimeNanos)
+	elapsed := max(0, now-scheduledTimeNanos)
 	scope.Timer(startLatency).Record(time.Duration(elapsed))
 	scope.Counter(startedCount).Inc(1)
 	return &WorkflowMetricsProfile{

--- a/canary/common.go
+++ b/canary/common.go
@@ -29,13 +29,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func maxInt64(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func absDurationDiff(d1, d2 time.Duration) time.Duration {
 	if d1 > d2 {
 		return d1 - d2

--- a/canary/metrics.go
+++ b/canary/metrics.go
@@ -81,7 +81,7 @@ func workflowMetricScope(ctx workflow.Context, wfType string) tally.Scope {
 func recordWorkflowStart(ctx workflow.Context, wfType string, scheduledTimeNanos int64) *workflowMetricsProfile {
 	now := workflow.Now(ctx).UnixNano()
 	scope := workflowMetricScope(ctx, wfType)
-	elapsed := maxInt64(0, now-scheduledTimeNanos)
+	elapsed := max(0, now-scheduledTimeNanos)
 	scope.Timer(startLatency).Record(time.Duration(elapsed))
 	scope.Counter(startedCount).Inc(1)
 	return &workflowMetricsProfile{
@@ -117,7 +117,7 @@ func (profile *workflowMetricsProfile) end(err error) error {
 func recordActivityStart(
 	scope tally.Scope, activityType string, scheduledTimeNanos int64) (tally.Scope, tally.Stopwatch) {
 	scope = scope.Tagged(map[string]string{"operation": activityType})
-	elapsed := maxInt64(0, time.Now().UnixNano()-scheduledTimeNanos)
+	elapsed := max(0, time.Now().UnixNano()-scheduledTimeNanos)
 	scope.Timer(startLatency).Record(time.Duration(elapsed))
 	scope.Counter(startedCount).Inc(1)
 	sw := scope.Timer(latency).Start()

--- a/common/archiver/filestore/queryParser.go
+++ b/common/archiver/filestore/queryParser.go
@@ -212,13 +212,13 @@ func (p *queryParser) convertCloseTime(timestamp int64, op string, parsedQuery *
 			return err
 		}
 	case "<":
-		parsedQuery.latestCloseTime = common.MinInt64(parsedQuery.latestCloseTime, timestamp-1)
+		parsedQuery.latestCloseTime = min(parsedQuery.latestCloseTime, timestamp-1)
 	case "<=":
-		parsedQuery.latestCloseTime = common.MinInt64(parsedQuery.latestCloseTime, timestamp)
+		parsedQuery.latestCloseTime = min(parsedQuery.latestCloseTime, timestamp)
 	case ">":
-		parsedQuery.earliestCloseTime = common.MaxInt64(parsedQuery.earliestCloseTime, timestamp+1)
+		parsedQuery.earliestCloseTime = max(parsedQuery.earliestCloseTime, timestamp+1)
 	case ">=":
-		parsedQuery.earliestCloseTime = common.MaxInt64(parsedQuery.earliestCloseTime, timestamp)
+		parsedQuery.earliestCloseTime = max(parsedQuery.earliestCloseTime, timestamp)
 	default:
 		return fmt.Errorf("operator %s is not supported for close time", op)
 	}

--- a/common/collection/concurrent_tx_map.go
+++ b/common/collection/concurrent_tx_map.go
@@ -77,7 +77,7 @@ type (
 func NewShardedConcurrentTxMap(initialCap int, hashfn HashFunc) ConcurrentTxMap {
 	cmap := new(ShardedConcurrentTxMap)
 	cmap.hashfn = hashfn
-	cmap.initialCap = MaxInt(nShards, initialCap/nShards)
+	cmap.initialCap = max(nShards, initialCap/nShards)
 	return cmap
 }
 

--- a/common/collection/util.go
+++ b/common/collection/util.go
@@ -43,35 +43,3 @@ func UUIDHashCode(input interface{}) uint32 {
 	}
 	return binary.BigEndian.Uint32(b)
 }
-
-// MinInt returns the min of given two integers
-func MinInt(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
-// MaxInt returns the max of given two integers
-func MaxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// MinInt64 returns the min of given two integers
-func MinInt64(a, b int64) int64 {
-	if a > b {
-		return b
-	}
-	return a
-}
-
-// MaxInt64 returns the max of given two integers
-func MaxInt64(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -1310,7 +1310,7 @@ func updateFailoverHistory(
 	failoverHistory = append([]FailoverEvent{newFailoverEvent}, failoverHistory...)
 
 	// Truncate the history to the max size
-	failoverHistoryJSON, err := json.Marshal(failoverHistory[:common.MinInt(config.FailoverHistoryMaxSize(info.Name), len(failoverHistory))])
+	failoverHistoryJSON, err := json.Marshal(failoverHistory[:min(config.FailoverHistoryMaxSize(info.Name), len(failoverHistory))])
 	if err != nil {
 		return err
 	}

--- a/common/persistence/data_store_interfaces_test.go
+++ b/common/persistence/data_store_interfaces_test.go
@@ -188,10 +188,3 @@ func TestDataBlob(t *testing.T) {
 		})
 	})
 }
-
-func max[T ~int32](a, b T) T {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -33,7 +33,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/collection"
 	"github.com/uber/cadence/common/log"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/serialization"
@@ -1053,7 +1052,7 @@ func getReadLevels(request *p.GetReplicationTasksRequest) (readLevel int64, maxR
 		}
 	}
 
-	maxReadLevelInclusive = collection.MaxInt64(readLevel+int64(request.BatchSize), request.MaxReadLevel)
+	maxReadLevelInclusive = max(readLevel+int64(request.BatchSize), request.MaxReadLevel)
 	return readLevel, maxReadLevelInclusive, nil
 }
 

--- a/common/quotas/global/collection/internal/fallback.go
+++ b/common/quotas/global/collection/internal/fallback.go
@@ -242,11 +242,3 @@ func (b *FallbackLimiter) both() quotas.Limiter {
 	}
 	return NewShadowedLimiter(b.primary, b.fallback)
 }
-
-// intentionally shadows builtin max, so it can simply be deleted when 1.21 is adopted
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/common/util.go
+++ b/common/util.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -466,70 +465,6 @@ func CreateMatchingPollForDecisionTaskResponse(historyResponse *types.RecordDeci
 		matchingResp.PreviousStartedEventID = historyResponse.PreviousStartedEventID
 	}
 	return matchingResp
-}
-
-// MinInt64 returns the smaller of two given int64
-func MinInt64(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// MaxInt64 returns the greater of two given int64
-func MaxInt64(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// MinInt32 return smaller one of two inputs int32
-func MinInt32(a, b int32) int32 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// MinInt returns the smaller of two given integers
-func MinInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// MaxInt returns the greater one of two given integers
-func MaxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// MinDuration returns the smaller of two given time duration
-func MinDuration(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// MaxDuration returns the greater of two given time durations
-func MaxDuration(a, b time.Duration) time.Duration {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// SortInt64Slice sorts the given int64 slice.
-// Sort is not guaranteed to be stable.
-func SortInt64Slice(slice []int64) {
-	sort.Slice(slice, func(i int, j int) bool {
-		return slice[i] < slice[j]
-	})
 }
 
 // ValidateRetryPolicy validates a retry policy
@@ -1027,7 +962,7 @@ func SecondsToDuration(d int64) time.Duration {
 // SleepWithMinDuration sleeps for the minimum of desired and available duration
 // returns the remaining available time duration
 func SleepWithMinDuration(desired time.Duration, available time.Duration) time.Duration {
-	d := MinDuration(desired, available)
+	d := min(desired, available)
 	if d > 0 {
 		time.Sleep(d)
 	}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -291,8 +291,8 @@ func (s *Service) Stop() {
 	// 4. Wait for a second
 	// 5. Stop everything forcefully and return
 
-	requestDrainTime := common.MinDuration(time.Second, s.config.ShutdownDrainDuration())
-	failureDetectionTime := common.MaxDuration(0, s.config.ShutdownDrainDuration()-requestDrainTime)
+	requestDrainTime := min(time.Second, s.config.ShutdownDrainDuration())
+	failureDetectionTime := max(0, s.config.ShutdownDrainDuration()-requestDrainTime)
 
 	s.GetLogger().Info("ShutdownHandler: Updating rpc health status to ShuttingDown")
 	s.handler.UpdateHealthStatus(api.HealthStatusShuttingDown)

--- a/service/history/decision/checker.go
+++ b/service/history/decision/checker.go
@@ -345,7 +345,7 @@ func (v *attrValidator) validateActivityScheduleAttributes(
 
 			domainName, _ := v.domainCache.GetDomainName(domainID) // if this call returns an error, we will just used the default value for max timeout
 			maximumScheduleToStartTimeoutForRetryInSeconds := int32(v.config.ActivityMaxScheduleToStartTimeoutForRetry(domainName).Seconds())
-			scheduleToStartExpiration := common.MinInt32(expiration, maximumScheduleToStartTimeoutForRetryInSeconds)
+			scheduleToStartExpiration := min(expiration, maximumScheduleToStartTimeoutForRetryInSeconds)
 			if attributes.GetScheduleToStartTimeoutSeconds() < scheduleToStartExpiration {
 				attributes.ScheduleToStartTimeoutSeconds = common.Int32Ptr(scheduleToStartExpiration)
 			}

--- a/service/history/engine/engineimpl/poll_mutable_state.go
+++ b/service/history/engine/engineimpl/poll_mutable_state.go
@@ -276,7 +276,7 @@ func (e *historyEngineImpl) longPollForEventID(
 			return nil, context.DeadlineExceeded
 		}
 		// longPollCompletionBuffer is here to leave some room to finish current request without its timeout.
-		expirationInterval = common.MinDuration(
+		expirationInterval = min(
 			expirationInterval,
 			remainingTime-longPollCompletionBuffer,
 		)

--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -580,8 +580,8 @@ func (e *historyEngineImpl) overrideStartWorkflowExecutionRequest(
 	maxDecisionStartToCloseTimeoutSeconds := int32(e.config.MaxDecisionStartToCloseSeconds(domainName))
 
 	taskStartToCloseTimeoutSecs := request.GetTaskStartToCloseTimeoutSeconds()
-	taskStartToCloseTimeoutSecs = common.MinInt32(taskStartToCloseTimeoutSecs, maxDecisionStartToCloseTimeoutSeconds)
-	taskStartToCloseTimeoutSecs = common.MinInt32(taskStartToCloseTimeoutSecs, request.GetExecutionStartToCloseTimeoutSeconds())
+	taskStartToCloseTimeoutSecs = min(taskStartToCloseTimeoutSecs, maxDecisionStartToCloseTimeoutSeconds)
+	taskStartToCloseTimeoutSecs = min(taskStartToCloseTimeoutSecs, request.GetExecutionStartToCloseTimeoutSeconds())
 
 	if taskStartToCloseTimeoutSecs != request.GetTaskStartToCloseTimeoutSeconds() {
 		request.TaskStartToCloseTimeoutSeconds = &taskStartToCloseTimeoutSecs

--- a/service/history/execution/checksum.go
+++ b/service/history/execution/checksum.go
@@ -22,6 +22,7 @@ package execution
 
 import (
 	"fmt"
+	"slices"
 
 	checksumgen "github.com/uber/cadence/.gen/go/checksum"
 	"github.com/uber/cadence/common"
@@ -80,35 +81,35 @@ func newMutableStateChecksumPayload(ms MutableState) *checksumgen.MutableStateCh
 	for _, ti := range ms.GetPendingTimerInfos() {
 		pendingTimerIDs = append(pendingTimerIDs, ti.StartedID)
 	}
-	common.SortInt64Slice(pendingTimerIDs)
+	slices.Sort(pendingTimerIDs)
 	payload.PendingTimerStartedIDs = pendingTimerIDs
 
 	pendingActivityIDs := make([]int64, 0, len(ms.GetPendingActivityInfos()))
 	for id := range ms.GetPendingActivityInfos() {
 		pendingActivityIDs = append(pendingActivityIDs, id)
 	}
-	common.SortInt64Slice(pendingActivityIDs)
+	slices.Sort(pendingActivityIDs)
 	payload.PendingActivityScheduledIDs = pendingActivityIDs
 
 	pendingChildIDs := make([]int64, 0, len(ms.GetPendingChildExecutionInfos()))
 	for id := range ms.GetPendingChildExecutionInfos() {
 		pendingChildIDs = append(pendingChildIDs, id)
 	}
-	common.SortInt64Slice(pendingChildIDs)
+	slices.Sort(pendingChildIDs)
 	payload.PendingChildInitiatedIDs = pendingChildIDs
 
 	signalIDs := make([]int64, 0, len(ms.GetPendingSignalExternalInfos()))
 	for id := range ms.GetPendingSignalExternalInfos() {
 		signalIDs = append(signalIDs, id)
 	}
-	common.SortInt64Slice(signalIDs)
+	slices.Sort(signalIDs)
 	payload.PendingSignalInitiatedIDs = signalIDs
 
 	requestCancelIDs := make([]int64, 0, len(ms.GetPendingRequestCancelExternalInfos()))
 	for id := range ms.GetPendingRequestCancelExternalInfos() {
 		requestCancelIDs = append(requestCancelIDs, id)
 	}
-	common.SortInt64Slice(requestCancelIDs)
+	slices.Sort(requestCancelIDs)
 	payload.PendingReqCancelInitiatedIDs = requestCancelIDs
 	return payload
 }

--- a/service/history/execution/context_util.go
+++ b/service/history/execution/context_util.go
@@ -23,7 +23,6 @@ package execution
 import (
 	"time"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -35,7 +34,7 @@ func (c *contextImpl) emitLargeWorkflowShardIDStats(blobSize int64, oldHistoryCo
 	if c.shard.GetConfig().EnableShardIDMetrics() {
 		shardID := c.shard.GetShardID()
 
-		blobSizeWarn := common.MinInt64(int64(c.shard.GetConfig().LargeShardHistoryBlobMetricThreshold()), int64(c.shard.GetConfig().BlobSizeLimitWarn(c.GetDomainName())))
+		blobSizeWarn := min(int64(c.shard.GetConfig().LargeShardHistoryBlobMetricThreshold()), int64(c.shard.GetConfig().BlobSizeLimitWarn(c.GetDomainName())))
 		// check if blob size is larger than threshold in Dynamic config if so alert on it every time
 		if blobSize > blobSizeWarn {
 			c.logger.SampleInfo("Workflow writing a large blob", c.shard.GetConfig().SampleLoggingRate(), tag.WorkflowDomainName(c.GetDomainName()),
@@ -43,7 +42,7 @@ func (c *contextImpl) emitLargeWorkflowShardIDStats(blobSize int64, oldHistoryCo
 			c.metricsClient.Scope(metrics.LargeExecutionBlobShardScope, metrics.ShardIDTag(shardID), metrics.DomainTag(c.GetDomainName())).IncCounter(metrics.LargeHistoryBlobCount)
 		}
 
-		historyCountWarn := common.MinInt64(int64(c.shard.GetConfig().LargeShardHistoryEventMetricThreshold()), int64(c.shard.GetConfig().HistoryCountLimitWarn(c.GetDomainName())))
+		historyCountWarn := min(int64(c.shard.GetConfig().LargeShardHistoryEventMetricThreshold()), int64(c.shard.GetConfig().HistoryCountLimitWarn(c.GetDomainName())))
 		// check if the new history count is greater than our threshold and only count/log it once when it passes it
 		// this seems to double count and I can't figure out why but should be ok to get a rough idea and identify bad actors
 		if oldHistoryCount < historyCountWarn && newHistoryCount >= historyCountWarn {
@@ -52,7 +51,7 @@ func (c *contextImpl) emitLargeWorkflowShardIDStats(blobSize int64, oldHistoryCo
 			c.metricsClient.Scope(metrics.LargeExecutionCountShardScope, metrics.ShardIDTag(shardID), metrics.DomainTag(c.GetDomainName())).IncCounter(metrics.LargeHistoryEventCount)
 		}
 
-		historySizeWarn := common.MinInt64(int64(c.shard.GetConfig().LargeShardHistorySizeMetricThreshold()), int64(c.shard.GetConfig().HistorySizeLimitWarn(c.GetDomainName())))
+		historySizeWarn := min(int64(c.shard.GetConfig().LargeShardHistorySizeMetricThreshold()), int64(c.shard.GetConfig().HistorySizeLimitWarn(c.GetDomainName())))
 		// check if the new history size is greater than our threshold and only count/log it once when it passes it
 		if oldHistorySize < historySizeWarn && c.stats.HistorySize >= historySizeWarn {
 			c.logger.Warn("Workflow history event size is reaching dangerous levels", tag.WorkflowDomainName(c.GetDomainName()),

--- a/service/history/queue/queue_processor_util.go
+++ b/service/history/queue/queue_processor_util.go
@@ -111,7 +111,7 @@ func validateProcessingQueueStates(pStates []*types.ProcessingQueueState, ackLev
 
 	minAckLevel := pStates[0].GetAckLevel()
 	for _, pState := range pStates {
-		minAckLevel = common.MinInt64(minAckLevel, pState.GetAckLevel())
+		minAckLevel = min(minAckLevel, pState.GetAckLevel())
 	}
 
 	switch ackLevel := ackLevel.(type) {

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -501,7 +501,7 @@ func (t *transferQueueProcessorBase) splitQueue() {
 		func(key task.Key, domainID string) task.Key {
 			totalLookAhead := t.estimatedTasksPerMinute * int64(t.options.SplitLookAheadDurationByDomainID(domainID).Minutes())
 			// ensure the above calculation doesn't overflow and cap the maximun look ahead interval
-			totalLookAhead = common.MaxInt64(common.MinInt64(totalLookAhead, 2<<t.shard.GetConfig().RangeSizeBits), 0)
+			totalLookAhead = max(min(totalLookAhead, 2<<t.shard.GetConfig().RangeSizeBits), 0)
 			return newTransferTaskKey(key.(transferTaskKey).taskID + totalLookAhead)
 		},
 	)

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -329,7 +329,7 @@ func (s *contextImpl) UpdateTransferProcessingQueueStates(cluster string, states
 	// for backward compatibility
 	ackLevel := states[0].GetAckLevel()
 	for _, state := range states {
-		ackLevel = common.MinInt64(ackLevel, state.GetAckLevel())
+		ackLevel = min(ackLevel, state.GetAckLevel())
 	}
 	s.shardInfo.ClusterTransferAckLevel[cluster] = ackLevel
 
@@ -445,7 +445,7 @@ func (s *contextImpl) UpdateTimerProcessingQueueStates(cluster string, states []
 	// for backward compatibility
 	ackLevel := states[0].GetAckLevel()
 	for _, state := range states {
-		ackLevel = common.MinInt64(ackLevel, state.GetAckLevel())
+		ackLevel = min(ackLevel, state.GetAckLevel())
 	}
 	s.shardInfo.ClusterTimerAckLevel[cluster] = time.Unix(0, ackLevel)
 

--- a/service/history/shard/controller.go
+++ b/service/history/shard/controller.go
@@ -392,7 +392,7 @@ func (c *controller) acquireShards() {
 	}
 	close(shardActionCh)
 
-	concurrency := common.MaxInt(c.config.AcquireShardConcurrency(), 1)
+	concurrency := max(c.config.AcquireShardConcurrency(), 1)
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
 	// Spawn workers that would do lookup and add/remove shards concurrently.

--- a/service/history/task/event_logger_test.go
+++ b/service/history/task/event_logger_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 )
@@ -84,7 +83,7 @@ func (s *eventLoggerSuite) TestFlushEvents() {
 			s.eventLogger.AddEvent("some random event")
 		}
 
-		expectedEventsFlushed := common.MinInt(numEvents, defaultTaskEventLoggerSize)
+		expectedEventsFlushed := min(numEvents, defaultTaskEventLoggerSize)
 		s.mockLogger.On("Info", mock.Anything, mock.Anything, mock.Anything).Times(1)
 
 		s.Equal(expectedEventsFlushed, s.eventLogger.FlushEvents("some random message"))

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -196,7 +196,7 @@ func (t *transferActiveTaskExecutor) processActivityTask(
 		return err
 	}
 
-	timeout := common.MinInt32(ai.ScheduleToStartTimeout, common.MaxTaskTimeout)
+	timeout := min(ai.ScheduleToStartTimeout, common.MaxTaskTimeout)
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
@@ -253,7 +253,7 @@ func (t *transferActiveTaskExecutor) processDecisionTask(
 	domainName := mutableState.GetDomainEntry().GetInfo().Name
 	executionInfo := mutableState.GetExecutionInfo()
 	workflowTimeout := executionInfo.WorkflowTimeout
-	decisionTimeout := common.MinInt32(workflowTimeout, common.MaxTaskTimeout)
+	decisionTimeout := min(workflowTimeout, common.MaxTaskTimeout)
 
 	// NOTE: previously this section check whether mutable state has enabled
 	// sticky decision, if so convert the decision to a sticky decision.
@@ -1761,7 +1761,7 @@ func (t *transferActiveTaskExecutor) processParentClosePolicy(
 		len(childInfos) >= t.shard.GetConfig().ParentClosePolicyThreshold(domainName) {
 
 		batchSize := t.shard.GetConfig().ParentClosePolicyBatchSize(domainName)
-		executions := make([]parentclosepolicy.RequestDetail, 0, common.MinInt(len(childInfos), batchSize))
+		executions := make([]parentclosepolicy.RequestDetail, 0, min(len(childInfos), batchSize))
 		count := 0
 		for _, childInfo := range childInfos {
 			count++
@@ -1785,7 +1785,7 @@ func (t *transferActiveTaskExecutor) processParentClosePolicy(
 				if err != nil {
 					return err
 				}
-				executions = make([]parentclosepolicy.RequestDetail, 0, common.MinInt(len(childInfos)-count, batchSize))
+				executions = make([]parentclosepolicy.RequestDetail, 0, min(len(childInfos)-count, batchSize))
 			}
 		}
 

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -180,7 +180,7 @@ func (t *transferStandbyTaskExecutor) processDecisionTask(
 
 		executionInfo := mutableState.GetExecutionInfo()
 		workflowTimeout := executionInfo.WorkflowTimeout
-		decisionTimeout := common.MinInt32(workflowTimeout, common.MaxTaskTimeout)
+		decisionTimeout := min(workflowTimeout, common.MaxTaskTimeout)
 		if executionInfo.TaskList != transferTask.TaskList {
 			// Experimental: try to push sticky task as regular task with sticky timeout as TTL.
 			// workflow might be sticky before namespace become standby
@@ -598,7 +598,7 @@ func (t *transferStandbyTaskExecutor) pushActivity(
 	}
 
 	pushActivityInfo := postActionInfo.(*pushActivityToMatchingInfo)
-	timeout := common.MinInt32(pushActivityInfo.activityScheduleToStartTimeout, common.MaxTaskTimeout)
+	timeout := min(pushActivityInfo.activityScheduleToStartTimeout, common.MaxTaskTimeout)
 	return t.transferTaskExecutorBase.pushActivity(
 		ctx,
 		task.(*persistence.TransferTaskInfo),
@@ -619,7 +619,7 @@ func (t *transferStandbyTaskExecutor) pushDecision(
 	}
 
 	pushDecisionInfo := postActionInfo.(*pushDecisionToMatchingInfo)
-	timeout := common.MinInt32(pushDecisionInfo.decisionScheduleToStartTimeout, common.MaxTaskTimeout)
+	timeout := min(pushDecisionInfo.decisionScheduleToStartTimeout, common.MaxTaskTimeout)
 	return t.transferTaskExecutorBase.pushDecision(
 		ctx,
 		task.(*persistence.TransferTaskInfo),

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -873,7 +873,7 @@ func (c *taskListManagerImpl) newChildContext(
 	}
 	remaining := time.Until(deadline) - tailroom
 	if remaining < timeout {
-		timeout = time.Duration(common.MaxInt64(0, int64(remaining)))
+		timeout = time.Duration(max(0, int64(remaining)))
 	}
 	return context.WithTimeout(parent, timeout)
 }
@@ -1067,10 +1067,10 @@ func newTaskListConfig(id *Identifier, cfg *config.Config, domainName string) *c
 			return cfg.MaxTaskBatchSize(domainName, taskListName, taskType)
 		},
 		NumWritePartitions: func() int {
-			return common.MaxInt(1, cfg.NumTasklistWritePartitions(domainName, taskListName, taskType))
+			return max(1, cfg.NumTasklistWritePartitions(domainName, taskListName, taskType))
 		},
 		NumReadPartitions: func() int {
-			return common.MaxInt(1, cfg.NumTasklistReadPartitions(domainName, taskListName, taskType))
+			return max(1, cfg.NumTasklistReadPartitions(domainName, taskListName, taskType))
 		},
 		EnableGetNumberOfPartitionsFromCache: func() bool {
 			return cfg.EnableGetNumberOfPartitionsFromCache(domainName, id.GetRoot(), taskType)
@@ -1122,7 +1122,7 @@ func newTaskListConfig(id *Identifier, cfg *config.Config, domainName string) *c
 				return cfg.ForwarderMaxRatePerSecond(domainName, taskListName, taskType)
 			},
 			ForwarderMaxChildrenPerNode: func() int {
-				return common.MaxInt(1, cfg.ForwarderMaxChildrenPerNode(domainName, taskListName, taskType))
+				return max(1, cfg.ForwarderMaxChildrenPerNode(domainName, taskListName, taskType))
 			},
 		},
 		HostName:                  cfg.HostName,

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -875,7 +875,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 
 	// wait until all tasks are read by the task pump and enqeued into the in-memory buffer
 	// at the end of this step, ackManager readLevel will also be equal to the buffer size
-	expectedBufSize := common.MinInt(cap(tlm.taskReader.taskBuffers[defaultTaskBufferIsolationGroup]), taskCount)
+	expectedBufSize := min(cap(tlm.taskReader.taskBuffers[defaultTaskBufferIsolationGroup]), taskCount)
 	assert.True(t, awaitCondition(func() bool {
 		return len(tlm.taskReader.taskBuffers[defaultTaskBufferIsolationGroup]) == expectedBufSize
 	}, 10*time.Second))

--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -259,7 +259,7 @@ func failoverDomainsByBatch(
 		pauseSignalHandler()
 
 		failoverActivityParams := &FailoverActivityParams{
-			Domains:                          domains[i*batchSize : common.MinInt((i+1)*batchSize, totalNumOfDomains)],
+			Domains:                          domains[i*batchSize : min((i+1)*batchSize, totalNumOfDomains)],
 			TargetCluster:                    targetCluster,
 			GracefulFailoverTimeoutInSeconds: params.GracefulFailoverTimeoutInSeconds,
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This PR replaces min/max helpers (`MinInt`, `MaxInt`, `MinInt64`, etc.) with built-in `min` and `max` functions.


<!-- Tell your future self why have you made these changes -->
**Why?**

We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

```
go test ./...
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
