### PR TITLE
[history] Ad extra context to replication size breach

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -860,6 +860,11 @@ func ResponseMaxSize(size int) Tag {
 	return newInt("response-max-size", size)
 }
 
+// ResponseNumberOfTasks returns tag for ResponseNumberOfTasks
+func ResponseNumberOfTasks(num int) Tag {
+	return newInt("response-number-of-tasks", num)
+}
+
 // /////////////////  Archival tags defined here: archival- ///////////////////
 // archival request tags
 

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -1589,6 +1589,7 @@ func (h *handlerImpl) GetReplicationMessages(
 
 	responseSize := 0
 	maxResponseSize := h.config.MaxResponseSize
+	numberOfTasksInBatch := 0
 
 	messagesByShard := make(map[int32]*types.ReplicationMessages)
 	result.Range(func(key, value interface{}) bool {
@@ -1605,11 +1606,14 @@ func (h *handlerImpl) GetReplicationMessages(
 				tag.ResponseSize(size),
 				tag.ResponseTotalSize(responseSize),
 				tag.ResponseMaxSize(maxResponseSize),
+				tag.ResponseNumberOfTasks(numberOfTasksInBatch),
 			)
-		} else {
-			responseSize += size
-			messagesByShard[shardID] = tasks
+			return true
 		}
+
+		responseSize += size
+		messagesByShard[shardID] = tasks
+		numberOfTasksInBatch += len(tasks.ReplicationTasks)
 
 		return true
 	})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding extra log context for issues with replication breaching max size.

<!-- Tell your future self why have you made these changes -->
**Why?**
If we observe to big of a change it is nice to know how many tasks are in this chunk so we can adjust the threshold to resolve it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
