### PR TITLE
[Wf-Diagnostics] use current clustername for emission of usage logs

### DIFF
--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -24,7 +24,6 @@ package diagnostics
 
 import (
 	"context"
-	"github.com/uber/cadence/common/cluster"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
@@ -35,6 +34,7 @@ import (
 
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/common/cluster"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
@@ -54,6 +55,7 @@ type dw struct {
 	tallyScope      tally.Scope
 	worker          worker.Worker
 	invariants      []invariant.Invariant
+	clusterMetadata cluster.Metadata
 }
 
 type Params struct {
@@ -64,6 +66,7 @@ type Params struct {
 	Logger          log.Logger
 	TallyScope      tally.Scope
 	Invariants      []invariant.Invariant
+	ClusterMetadata cluster.Metadata
 }
 
 // New creates a new diagnostics workflow.
@@ -76,6 +79,7 @@ func New(params Params) DiagnosticsWorkflow {
 		clientBean:      params.ClientBean,
 		logger:          params.Logger,
 		invariants:      params.Invariants,
+		clusterMetadata: params.ClusterMetadata,
 	}
 }
 

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -99,6 +99,7 @@ func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params Diagnostics
 		RunID:                 params.RunID,
 		Identity:              params.Identity,
 		IssueType:             getIssueType(diagWfResult),
+		Environment:           w.clusterMetadata.GetCurrentClusterName(),
 		DiagnosticsWorkflowID: childWfExec.ID,
 		DiagnosticsRunID:      childWfExec.RunID,
 		DiagnosticsStartTime:  childWfStart,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -350,6 +350,7 @@ func (s *Service) startDiagnostics() {
 		ClientBean:      s.GetClientBean(),
 		Logger:          s.GetLogger(),
 		Invariants:      s.params.DiagnosticsInvariants,
+		ClusterMetadata: s.GetClusterMetadata(),
 	}
 	if err := diagnostics.New(params).Start(); err != nil {
 		s.Stop()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
current clustername used in data for emission of usage logs

<!-- Tell your future self why have you made these changes -->
**Why?**
to provide insights into where diagnostics is used

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
