### PR TITLE
Add a new Sizeable interface in cadence common cache

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -149,3 +149,9 @@ type DomainMetricsScopeCache interface {
 
 	common.Daemon
 }
+
+// Sizeable is a interface that implements Size() function
+type Sizeable interface {
+	// Size returns an approximate size of the object in bytes, or error if the size could not be calculated
+	Size() (uint64, error)
+}

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -152,6 +152,6 @@ type DomainMetricsScopeCache interface {
 
 // Sizeable is a interface that implements Size() function
 type Sizeable interface {
-	// Size returns an approximate size of the object in bytes, or error if the size could not be calculated
-	Size() (uint64, error)
+	// Size returns an approximate size of the object in bytes
+	Size() uint64
 }

--- a/common/cache/interface_mock.go
+++ b/common/cache/interface_mock.go
@@ -363,3 +363,42 @@ func (mr *MockDomainMetricsScopeCacheMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockDomainMetricsScopeCache)(nil).Stop))
 }
+
+// MockSizeable is a mock of Sizeable interface.
+type MockSizeable struct {
+	ctrl     *gomock.Controller
+	recorder *MockSizeableMockRecorder
+	isgomock struct{}
+}
+
+// MockSizeableMockRecorder is the mock recorder for MockSizeable.
+type MockSizeableMockRecorder struct {
+	mock *MockSizeable
+}
+
+// NewMockSizeable creates a new mock instance.
+func NewMockSizeable(ctrl *gomock.Controller) *MockSizeable {
+	mock := &MockSizeable{ctrl: ctrl}
+	mock.recorder = &MockSizeableMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSizeable) EXPECT() *MockSizeableMockRecorder {
+	return m.recorder
+}
+
+// Size mocks base method.
+func (m *MockSizeable) Size() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockSizeableMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockSizeable)(nil).Size))
+}

--- a/common/cache/interface_mock.go
+++ b/common/cache/interface_mock.go
@@ -389,12 +389,11 @@ func (m *MockSizeable) EXPECT() *MockSizeableMockRecorder {
 }
 
 // Size mocks base method.
-func (m *MockSizeable) Size() (uint64, error) {
+func (m *MockSizeable) Size() uint64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Size")
 	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // Size indicates an expected call of Size.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a new Sizeable interface that implements Size() function which returns the size of that interface in bytes

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to modernize existing cadence common cache implement to a bytes-based system. That means we need to have a method to measure each entry (which is currently accepting any generic interface). We found the "Reflect" package provides a measuring function but runtime is too slow to be used in cache operations. Therefore, we will require all usages to implement the Size() function in their cache logic if they want to migrate to the new bytes-based system.

In order to seamless transition from the current cache system with an entry-based model, the implementation and rollout will be done in following phases:

1. Define the Sizeable interface **<-- This PR**
2. Implement Sizeable for cadence-history service
a. Implement Size() for ExecutionCache
b. Implement Size() for EventCache
4. Implement bytes-based cache system
5. Enable new cache system for usage in cadence-history service
6. Implement and enable new cache system for the remaining usages

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This is only an addition of a new interface that is not used.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk since it's only an addition of a new interface that is not used.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
