### PR TITLE
Validate TaskList partition updates via CLI are safe

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -736,6 +736,11 @@ func newAdminTaskListCommands() []*cli.Command {
 					Aliases: []string{"nwp"},
 					Usage:   "Number of write partitions",
 				},
+				&cli.BoolFlag{
+					Name:    FlagForce,
+					Aliases: []string{"f"},
+					Usage:   "Force an update operation that may be unsafe",
+				},
 			},
 			Action: AdminUpdateTaskListPartitionConfig,
 		},


### PR DESCRIPTION
Add additional validation to confirm that the proposed update is safe. Provide a "force" flag to skip this additional validation.

This covers three main potential errors:
- Prevent updating the wrong TaskList by checking whether it has pollers
- Prevent removing currently active write partitions as they could have tasks. These have to be removed in a two-step process where they're removed from writing and then from reading.
- Prevent removing read partitions that still have tasks. These need to stay as read partitions until pollers have taken all the tasks (or the tasks have timed out).

<!-- Describe what has changed in this PR -->
**What changed?**
- Add additional validation to the recently added `admin tasklist up` command before applying the update.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Ensure operators don't accidentally update the wrong tasklist or perform an unsafe action.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Immediately after a matching host is assigned a TaskList it might have no pollers and would flag updates as being unsafe. These false positives seem like a reasonable compromise.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
