### PR TITLE
Emit metrics on how many rows are returned per persistence operation

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2108,6 +2108,7 @@ const (
 	PersistenceErrDBUnavailableCounter
 	PersistenceSampledCounter
 	PersistenceEmptyResponseCounter
+	PersistenceResponseRowSize
 
 	PersistenceRequestsPerDomain
 	PersistenceRequestsPerShard
@@ -2808,6 +2809,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PersistenceErrDBUnavailableCounter:                           {metricName: "persistence_errors_db_unavailable", metricType: Counter},
 		PersistenceSampledCounter:                                    {metricName: "persistence_sampled", metricType: Counter},
 		PersistenceEmptyResponseCounter:                              {metricName: "persistence_empty_response", metricType: Counter},
+		PersistenceResponseRowSize:                                   {metricName: "persistence_response_row_size", metricType: Histogram, buckets: ResponseRowSizeBuckets},
 		PersistenceRequestsPerDomain:                                 {metricName: "persistence_requests_per_domain", metricRollupName: "persistence_requests", metricType: Counter},
 		PersistenceRequestsPerShard:                                  {metricName: "persistence_requests_per_shard", metricType: Counter},
 		PersistenceFailuresPerDomain:                                 {metricName: "persistence_errors_per_domain", metricRollupName: "persistence_errors", metricType: Counter},
@@ -3516,6 +3518,12 @@ var PersistenceLatencyBuckets = tally.DurationBuckets([]time.Duration{
 // this is intended for coarse scale checking, not alerting, so the buckets
 // should be considered unstable and can be changed whenever desired.
 var GlobalRatelimiterUsageHistogram = append(
+	tally.ValueBuckets{0},                              // need an explicit 0 or zero is reported as 1
+	tally.MustMakeExponentialValueBuckets(1, 2, 17)..., // 1..65536
+)
+
+// ResponseRowSizeBuckets contains buckets for tracking how many rows are returned per persistence operation
+var ResponseRowSizeBuckets = append(
 	tally.ValueBuckets{0},                              // need an explicit 0 or zero is reported as 1
 	tally.MustMakeExponentialValueBuckets(1, 2, 17)..., // 1..65536
 )

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -193,11 +193,17 @@ func (p *base) emptyMetric(methodName string, req any, res any, err error) {
 		return
 	}
 
-	if err != nil || resLen.Len() > 0 {
+	if err != nil {
 		return
 	}
+
 	metricScope := p.metricClient.Scope(scope.scope, getCustomMetricTags(req)...)
-	metricScope.IncCounter(metrics.PersistenceEmptyResponseCounter)
+
+	if resLen.Len() == 0 {
+		metricScope.IncCounter(metrics.PersistenceEmptyResponseCounter)
+	} else {
+		metricScope.RecordHistogramValue(metrics.PersistenceResponseRowSize, float64(resLen.Len()))
+	}
 }
 
 var emptyCountedMethods = map[string]struct {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Currently we only have visibility on how many persistence requests returned an empty response, this PR adds a metric for the row size of the responses

<!-- Tell your future self why have you made these changes -->
**Why?**

If we see large responses from Cassandra there's not enough information for us to track down which operation is causing this.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Dev env

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
