### PR TITLE
Use lower case when parse read/write visibility store names

### DIFF
--- a/common/persistence/visibility_hybrid_manager.go
+++ b/common/persistence/visibility_hybrid_manager.go
@@ -230,9 +230,16 @@ func (v *visibilityHybridManager) chooseVisibilityManagerForWrite(ctx context.Co
 		}
 	}
 	modes := strings.Split(writeMode, ",")
+	var filteredModes []string
+	for _, mode := range modes {
+		mode = strings.TrimSpace(strings.ToLower(mode))
+		if mode != "" {
+			filteredModes = append(filteredModes, mode)
+		}
+	}
 
 	var errors []string
-	for _, mode := range modes {
+	for _, mode := range filteredModes {
 		if mode == advancedWriteModeOff {
 			mode = dbVisStoreName
 		}
@@ -546,6 +553,9 @@ func (v *visibilityHybridManager) chooseVisibilityManagerForRead(ctx context.Con
 	}
 	var visibilityMgr, shadowMgr VisibilityManager
 	stores := strings.Split(v.readVisibilityStoreName(domain), ",")
+	for i := range stores {
+		stores[i] = strings.ToLower(strings.TrimSpace(stores[i]))
+	}
 	readStore := stores[0] // if read stores have more than 1, the others will go shadow read
 	if v.visibilityMgrs[readStore] != nil {
 		visibilityMgr = v.visibilityMgrs[readStore]

--- a/common/persistence/visibility_hybrid_manager.go
+++ b/common/persistence/visibility_hybrid_manager.go
@@ -230,16 +230,12 @@ func (v *visibilityHybridManager) chooseVisibilityManagerForWrite(ctx context.Co
 		}
 	}
 	modes := strings.Split(writeMode, ",")
-	var filteredModes []string
-	for _, mode := range modes {
-		mode = strings.TrimSpace(strings.ToLower(mode))
-		if mode != "" {
-			filteredModes = append(filteredModes, mode)
-		}
+	for i := range modes {
+		modes[i] = strings.ToLower(strings.TrimSpace(modes[i]))
 	}
 
 	var errors []string
-	for _, mode := range filteredModes {
+	for _, mode := range modes {
 		if mode == advancedWriteModeOff {
 			mode = dbVisStoreName
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Visibility managers are using a map in the hybrid manager and the keys are the store names. User might put ES, es or Es for the write/read visibility store name, all these should be valid, so we convert them to lower case when parse the config

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
