### PR TITLE
add reset checker on the failover version

### DIFF
--- a/service/history/engine/engineimpl/reset_workflow_execution.go
+++ b/service/history/engine/engineimpl/reset_workflow_execution.go
@@ -206,7 +206,7 @@ func (e *historyEngineImpl) isWorkflowResettable(baseMutableState execution.Muta
 	}
 
 	if currentCluster := e.clusterMetadata.GetCurrentClusterName(); currentCluster != startClusterName {
-		return fmt.Errorf("workflow was not started in the current cluster, this could happen if domain was active in another cluster before")
+		return fmt.Errorf("workflow was not started in the current cluster: failover to workflow start cluster %s before reset", startClusterName)
 	}
 
 	return nil

--- a/service/history/engine/engineimpl/reset_workflow_execution.go
+++ b/service/history/engine/engineimpl/reset_workflow_execution.go
@@ -23,6 +23,7 @@ package engineimpl
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pborman/uuid"
 
@@ -83,6 +84,13 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// validate if workflow is resettable
+	if err := e.isWorkflowResettable(baseMutableState, domainID); err != nil {
+		return nil, &types.BadRequestError{
+			Message: fmt.Sprintf("workflow is not resettable. Error: %v", err),
+		}
 	}
 
 	currentRunID := resp.RunID
@@ -181,4 +189,25 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 	return &types.ResetWorkflowExecutionResponse{
 		RunID: resetRunID,
 	}, nil
+}
+
+/*
+If a workflow was started in a different cluster, it is not resettable because replication stack is not able to handle workflow start event.
+*/
+func (e *historyEngineImpl) isWorkflowResettable(baseMutableState execution.MutableState, domainID string) error {
+	startVersion, err := baseMutableState.GetStartVersion()
+	if err != nil {
+		return fmt.Errorf("fail to get failover version of workflow start event: %w", err)
+	}
+
+	startClusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(startVersion)
+	if err != nil {
+		return fmt.Errorf("fail to get cluster name for failover version: %w", err)
+	}
+
+	if currentCluster := e.clusterMetadata.GetCurrentClusterName(); currentCluster != startClusterName {
+		return fmt.Errorf("workflow was not started in the current cluster, this could happen if domain was active in another cluster before")
+	}
+
+	return nil
 }

--- a/service/history/engine/engineimpl/reset_workflow_execution_test.go
+++ b/service/history/engine/engineimpl/reset_workflow_execution_test.go
@@ -269,7 +269,7 @@ func TestResetWorkflowExecution(t *testing.T) {
 				},
 			},
 			expectedErr: &types.BadRequestError{
-				Message: "workflow is not resettable. Error: workflow was not started in the current cluster, this could happen if domain was active in another cluster before",
+				Message: "workflow is not resettable. Error: workflow was not started in the current cluster: failover to workflow start cluster standby before reset",
 			},
 		},
 		{

--- a/service/history/engine/engineimpl/reset_workflow_execution_test.go
+++ b/service/history/engine/engineimpl/reset_workflow_execution_test.go
@@ -159,7 +159,7 @@ func TestResetWorkflowExecution(t *testing.T) {
 			// Can't assert on the result because the runID is random
 		},
 		{
-			name: "Success using version histories",
+			name: "Success using version histories started in current cluster",
 			// This corresponds to VersionHistories.Histories.Items.EventID
 			request: resetExecutionRequest(latestExecution, 50),
 			init: []InitFn{
@@ -183,15 +183,15 @@ func TestResetWorkflowExecution(t *testing.T) {
 								Items: []*persistence.VersionHistoryItem{
 									{
 										EventID: 1,
-										Version: 1001,
+										Version: 1000, // current cluster
 									},
 									{
 										EventID: 50,
-										Version: 1002,
+										Version: 1001,
 									},
 									{
 										EventID: 51,
-										Version: 1003,
+										Version: 1002,
 									},
 								},
 							},
@@ -211,7 +211,7 @@ func TestResetWorkflowExecution(t *testing.T) {
 						gomock.Eq(latestExecution.RunID),
 						gomock.Eq([]byte("yes")), //VersionHistories.Histories.BranchToken
 						gomock.Eq(int64(49)),     // Request.DecisionFinishEventID - 1
-						gomock.Eq(int64(1002)),   // VersionHistories.Histories.Items.Version
+						gomock.Eq(int64(1001)),   // VersionHistories.Histories.Items.Version
 						gomock.Eq(int64(100)),    // NextEventID
 						gomock.Any(),             // random uuid
 						gomock.Eq(testRequestID),
@@ -223,6 +223,130 @@ func TestResetWorkflowExecution(t *testing.T) {
 				},
 			},
 			// Can't assert on the result because the runID is random
+		},
+		{
+			name: "Failure using version histories not started in current cluster",
+			// This corresponds to VersionHistories.Histories.Items.EventID
+			request: resetExecutionRequest(latestExecution, 50),
+			init: []InitFn{
+				withCurrentExecution(latestExecution),
+				withState(latestExecution, &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:    constants.TestDomainID,
+						WorkflowID:  constants.TestWorkflowID,
+						RunID:       latestRunID,
+						NextEventID: 100,
+						BranchToken: []byte("branch token"),
+					},
+					VersionHistories: &persistence.VersionHistories{
+						CurrentVersionHistoryIndex: 0,
+						Histories: []*persistence.VersionHistory{
+							{
+								BranchToken: []byte("yes"),
+								Items: []*persistence.VersionHistoryItem{
+									{
+										EventID: 1,
+										Version: 1001, // not current cluster
+									},
+									{
+										EventID: 50,
+										Version: 1002,
+									},
+									{
+										EventID: 51,
+										Version: 1003,
+									},
+								},
+							},
+						},
+					},
+					ExecutionStats: &persistence.ExecutionStats{HistorySize: 1},
+				}),
+				func(t *testing.T, engine *testdata.EngineForTest) {
+					ctrl := gomock.NewController(t)
+					mockResetter := reset.NewMockWorkflowResetter(ctrl)
+					engine.Engine.(*historyEngineImpl).workflowResetter = mockResetter
+				},
+			},
+			expectedErr: &types.BadRequestError{
+				Message: "workflow is not resettable. Error: workflow was not started in the current cluster, this could happen if domain was active in another cluster before",
+			},
+		},
+		{
+			name: "Failure using empty version histories",
+			// This corresponds to VersionHistories.Histories.Items.EventID
+			request: resetExecutionRequest(latestExecution, 50),
+			init: []InitFn{
+				withCurrentExecution(latestExecution),
+				withState(latestExecution, &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:    constants.TestDomainID,
+						WorkflowID:  constants.TestWorkflowID,
+						RunID:       latestRunID,
+						NextEventID: 100,
+						BranchToken: []byte("branch token"),
+					},
+					VersionHistories: &persistence.VersionHistories{
+						CurrentVersionHistoryIndex: 0,
+						Histories: []*persistence.VersionHistory{
+							{},
+						},
+					},
+					ExecutionStats: &persistence.ExecutionStats{HistorySize: 1},
+				}),
+				func(t *testing.T, engine *testdata.EngineForTest) {
+					ctrl := gomock.NewController(t)
+					mockResetter := reset.NewMockWorkflowResetter(ctrl)
+					engine.Engine.(*historyEngineImpl).workflowResetter = mockResetter
+				},
+			},
+			expectedErr: &types.BadRequestError{
+				Message: "workflow is not resettable. Error: fail to get failover version of workflow start event: version history is empty.",
+			},
+		},
+		{
+			name: "Failure using errorneous version histories",
+			// This corresponds to VersionHistories.Histories.Items.EventID
+			request: resetExecutionRequest(latestExecution, 50),
+			init: []InitFn{
+				withCurrentExecution(latestExecution),
+				withState(latestExecution, &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:    constants.TestDomainID,
+						WorkflowID:  constants.TestWorkflowID,
+						RunID:       latestRunID,
+						NextEventID: 100,
+						BranchToken: []byte("branch token"),
+					},
+					VersionHistories: &persistence.VersionHistories{
+						CurrentVersionHistoryIndex: 0,
+						Histories: []*persistence.VersionHistory{
+							{
+								BranchToken: []byte("yes"),
+								Items: []*persistence.VersionHistoryItem{
+									{
+										EventID: 1,
+										Version: 1004, // unknown version
+									},
+									{
+										EventID: 50,
+										Version: 1005, // unknown version
+									},
+								},
+							},
+						},
+					},
+					ExecutionStats: &persistence.ExecutionStats{HistorySize: 1},
+				}),
+				func(t *testing.T, engine *testdata.EngineForTest) {
+					ctrl := gomock.NewController(t)
+					mockResetter := reset.NewMockWorkflowResetter(ctrl)
+					engine.Engine.(*historyEngineImpl).workflowResetter = mockResetter
+				},
+			},
+			expectedErr: &types.BadRequestError{
+				Message: "workflow is not resettable. Error: fail to get cluster name for failover version: failed to resolve failover version: could not resolve failover version: 1004",
+			},
 		},
 		{
 			name:    "Success using previous version",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* history engine will now check resettability by verifying the failover version of start event

<!-- Tell your future self why have you made these changes -->
**Why?**

Replication stack cannot handle reset workflows that were started in another cluster due to createAsZombie logic. https://github.com/cadence-workflow/cadence/blob/3248455a875a12549204bf2498a675aa698e8d28/service/history/execution/workflow.go#L191-L193 

This conditional check in replication was created to avoid data racing and thus should not be changed. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

Tested in a dev environment

After failover, workflows that were started before cannot be reset
```
shengs@shengs-DQG34F2RHF cassandra % cadence --proxy_region phx --env dev2 --do cadence-canary domain update --active_cluster dev2_phx
Will set active cluster name to: dev2_phx, other flag will be omitted.
Domain cadence-canary successfully updated.
shengs@shengs-DQG34F2RHF cassandra % cadence --proxy_region dca --env dev2 --do cadence-canary wf reset --wid cadence.canary.cron-workflow.sanity-2025-02-27T19:15:35Z/workflow.echo --rid 8162871a-4f72-437f-85df-579eb89c2eb7 --reason "test for reset checker" --event_id 2
2025/02/27 11:26:58 reset failed: workflow is not resettable. Error: workflow was not started in the current cluster: failover to workflow start cluster dev2_dca before reset
```

After failing back the domain, workflows are again resettable
```
shengs@shengs-DQG34F2RHF cassandra % cadence --proxy_region dca --env dev2 --do cadence-canary domain update --active_cluster dev2_dca --ft force
Will set active cluster name to: dev2_dca, other flag will be omitted.
Domain cadence-canary successfully updated.
shengs@shengs-DQG34F2RHF cassandra % cadence --proxy_region dca --env dev2 --do cadence-canary wf reset --wid cadence.canary.cron-workflow.sanity-2025-02-27T19:15:35Z/workflow.echo --rid 8162871a-4f72-437f-85df-579eb89c2eb7 --reason "test for reset checker" --event_id 2
{
  "runId": "946c7a26-6a84-44ee-ade9-bbb185533404"
}
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

HistoryEngine reset handler is only used by frontend api. So the risk is maybe some valid reset cases will now get failures to avoid replication dlq. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
