### PR TITLE
Reprioritize responses of GetReplicationMessagesResponse in frontend

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -823,7 +823,7 @@ func cmpGetReplicationMessagesWithSize(a, b *getReplicationMessagesWithSize) int
 	return 1
 }
 
-// buildGetReplicationMessagesResponse builds a new GetReplicationMessagesResponse from peerResponses - a slice of responses from peers.
+// buildGetReplicationMessagesResponse builds a new GetReplicationMessagesResponse from peer responses
 // The response can be partial if the total size of the response exceeds the max size.
 // In this case, responses with oldest replication tasks will be returned
 func (c *clientImpl) buildGetReplicationMessagesResponse(peerResponses []*getReplicationMessagesWithSize) *types.GetReplicationMessagesResponse {

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -829,9 +829,9 @@ func cmpGetReplicationMessagesWithSize(a, b *getReplicationMessagesWithSize) int
 func (c *clientImpl) buildGetReplicationMessagesResponse(peerResponses []*getReplicationMessagesWithSize) *types.GetReplicationMessagesResponse {
 
 	// Peers with large response can cause the response to exceed the max size.
-	// In this case, we need to skip some response to make sure the response size is within the limit.
-	// To prevent a replication lag in the future, we need to return the response with the oldest replication task.
-	// So we sort the response by the earliest creation time of the replication task.
+	// In this case, we need to skip peer responses to make sure the result response size is within the limit.
+	// To prevent a replication lag in the future, we should return the response with the oldest replication task.
+	// So we sort the peer responses by the earliest creation time of the replication task.
 	// This will sure that shards with the oldest replication tasks will be processed first.
 	slices.SortStableFunc(peerResponses, cmpGetReplicationMessagesWithSize)
 

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -23,9 +23,8 @@ package history
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"slices"
 	"sync"
-	"time"
 
 	"go.uber.org/yarpc"
 	"golang.org/x/sync/errgroup"
@@ -54,6 +53,9 @@ type (
 		response *types.GetReplicationMessagesResponse
 		size     int
 		peer     string
+
+		// earliestCreationTime of replication tasks of response
+		earliestCreationTime *int64
 	}
 )
 
@@ -774,9 +776,10 @@ func (c *clientImpl) GetReplicationMessages(
 			}
 			responseMutex.Lock()
 			peerResponses = append(peerResponses, &getReplicationMessagesWithSize{
-				response: resp,
-				size:     responseInfo.Size,
-				peer:     peer,
+				response:             resp,
+				size:                 responseInfo.Size,
+				peer:                 peer,
+				earliestCreationTime: resp.GetEarliestCreationTime(),
 			})
 			responseMutex.Unlock()
 			return nil
@@ -787,16 +790,50 @@ func (c *clientImpl) GetReplicationMessages(
 		return nil, err
 	}
 
-	// Peers with largest responses can be slowest to return data.
-	// They end up in the end of array and have a possibility of not fitting in the response message.
-	// Skipped peers grow their responses even more and next they will be even slower and end up in the end again.
-	// This can lead to starving peers.
-	// Shuffle the slice of responses to prevent such scenario. All peer will have equal chance to be pick up first.
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := range peerResponses {
-		j := r.Intn(i + 1)
-		peerResponses[i], peerResponses[j] = peerResponses[j], peerResponses[i]
+	return c.buildGetReplicationMessagesResponse(peerResponses), nil
+}
+
+// cmpGetReplicationMessagesWithSize compares two getReplicationMessagesWithSize objects
+// it can be used as a comparison func for slices.SortStableFunc
+// if a, b, or their earliestCreationTime is nil, slices.SortStableFunc will put them to the end of a slice
+// othewise it will compare the earliestCreationTime of the replication tasks
+func cmpGetReplicationMessagesWithSize(a, b *getReplicationMessagesWithSize) int {
+	// a > b
+	if a == nil || a.earliestCreationTime == nil {
+		return 1
 	}
+	// a < b
+	if b == nil || b.earliestCreationTime == nil {
+		return -1
+	}
+
+	// if both are not nil, compare the creation time
+
+	// a < b
+	if *a.earliestCreationTime < *b.earliestCreationTime {
+		return -1
+	}
+
+	// a = b
+	if *a.earliestCreationTime == *b.earliestCreationTime {
+		return 0
+	}
+
+	// a > b
+	return 1
+}
+
+// buildGetReplicationMessagesResponse builds a new GetReplicationMessagesResponse from peerResponses - a slice of responses from peers.
+// The response can be partial if the total size of the response exceeds the max size.
+// In this case, responses with oldest replication tasks will be returned
+func (c *clientImpl) buildGetReplicationMessagesResponse(peerResponses []*getReplicationMessagesWithSize) *types.GetReplicationMessagesResponse {
+
+	// Peers with large response can cause the response to exceed the max size.
+	// In this case, we need to skip some response to make sure the response size is within the limit.
+	// To prevent a replication lag in the future, we need to return the response with the oldest replication task.
+	// So we sort the response by the earliest creation time of the replication task.
+	// This will sure that shards with the oldest replication tasks will be processed first.
+	slices.SortStableFunc(peerResponses, cmpGetReplicationMessagesWithSize)
 
 	response := &types.GetReplicationMessagesResponse{MessagesByShard: make(map[int32]*types.ReplicationMessages)}
 	responseTotalSize := 0
@@ -825,7 +862,8 @@ func (c *clientImpl) GetReplicationMessages(
 			response.MessagesByShard[shardID] = tasks
 		}
 	}
-	return response, nil
+
+	return response
 }
 
 func (c *clientImpl) GetDLQReplicationMessages(

--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -1355,7 +1355,7 @@ func Test_sortGetReplicationMessageWithSize(t *testing.T) {
 		want      []*getReplicationMessagesWithSize
 	}{
 		"empty": {},
-		"nil, nil, 20, 10": {
+		"multiple nil, non nil earliestCreationTime": {
 			responses: []*getReplicationMessagesWithSize{
 				{earliestCreationTime: nil},
 				{earliestCreationTime: nil},
@@ -1369,7 +1369,7 @@ func Test_sortGetReplicationMessageWithSize(t *testing.T) {
 				{earliestCreationTime: nil},
 			},
 		},
-		"nil, nil, 100 - 50, 100 - 30, 20": {
+		"multiple nil, non nil same earliestCreationTime, different size": {
 			responses: []*getReplicationMessagesWithSize{
 				{earliestCreationTime: nil},
 				{earliestCreationTime: nil},

--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -27,10 +27,9 @@ import (
 	"fmt"
 	"testing"
 
-	"go.uber.org/thriftrw/ptr"
-
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/common"

--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -1305,7 +1305,7 @@ func Test_cmpGetReplicationMessagesWithSize(t *testing.T) {
 		want int
 	}{
 		"both nil": {
-			a: nil, b: nil, want: 0,
+			a: nil, b: nil, want: 1,
 		},
 		"a time is nil, b is nil": {
 			a: &getReplicationMessagesWithSize{earliestCreationTime: nil}, b: nil, want: 1,

--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
-	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/common"
@@ -1311,36 +1310,36 @@ func Test_cmpGetReplicationMessagesWithSize(t *testing.T) {
 			a: &getReplicationMessagesWithSize{earliestCreationTime: nil}, b: nil, want: 1,
 		},
 		"a time is not nil, b is nil": {
-			a: &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10)}, b: nil, want: -1,
+			a: &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10)}, b: nil, want: -1,
 		},
 		"a time is not nil, b time is nil": {
-			a:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10)},
+			a:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10)},
 			b:    &getReplicationMessagesWithSize{earliestCreationTime: nil},
 			want: -1,
 		},
 		"a time less b time": {
-			a:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10)},
-			b:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(20)},
+			a:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10)},
+			b:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(20)},
 			want: -1,
 		},
 		"a time greater b time": {
-			a:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(20)},
-			b:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10)},
+			a:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(20)},
+			b:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10)},
 			want: 1,
 		},
 		"a size less b size": {
-			a:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10), size: 10},
-			b:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10), size: 20},
+			a:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10), size: 10},
+			b:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10), size: 20},
 			want: -1,
 		},
 		"a size greater b size": {
-			a:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10), size: 20},
-			b:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10), size: 10},
+			a:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10), size: 20},
+			b:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10), size: 10},
 			want: 1,
 		},
 		"a equal b": {
-			a:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10)},
-			b:    &getReplicationMessagesWithSize{earliestCreationTime: ptr.Int64(10)},
+			a:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10)},
+			b:    &getReplicationMessagesWithSize{earliestCreationTime: common.Int64Ptr(10)},
 			want: 0,
 		},
 	} {
@@ -1360,12 +1359,12 @@ func Test_sortGetReplicationMessageWithSize(t *testing.T) {
 			responses: []*getReplicationMessagesWithSize{
 				{earliestCreationTime: nil},
 				{earliestCreationTime: nil},
-				{earliestCreationTime: ptr.Int64(20)},
-				{earliestCreationTime: ptr.Int64(10)},
+				{earliestCreationTime: common.Int64Ptr(20)},
+				{earliestCreationTime: common.Int64Ptr(10)},
 			},
 			want: []*getReplicationMessagesWithSize{
-				{earliestCreationTime: ptr.Int64(10)},
-				{earliestCreationTime: ptr.Int64(20)},
+				{earliestCreationTime: common.Int64Ptr(10)},
+				{earliestCreationTime: common.Int64Ptr(20)},
 				{earliestCreationTime: nil},
 				{earliestCreationTime: nil},
 			},
@@ -1374,14 +1373,14 @@ func Test_sortGetReplicationMessageWithSize(t *testing.T) {
 			responses: []*getReplicationMessagesWithSize{
 				{earliestCreationTime: nil},
 				{earliestCreationTime: nil},
-				{earliestCreationTime: ptr.Int64(100), size: 50},
-				{earliestCreationTime: ptr.Int64(100), size: 30},
-				{earliestCreationTime: ptr.Int64(20)},
+				{earliestCreationTime: common.Int64Ptr(100), size: 50},
+				{earliestCreationTime: common.Int64Ptr(100), size: 30},
+				{earliestCreationTime: common.Int64Ptr(20)},
 			},
 			want: []*getReplicationMessagesWithSize{
-				{earliestCreationTime: ptr.Int64(20)},
-				{earliestCreationTime: ptr.Int64(100), size: 30},
-				{earliestCreationTime: ptr.Int64(100), size: 50},
+				{earliestCreationTime: common.Int64Ptr(20)},
+				{earliestCreationTime: common.Int64Ptr(100), size: 30},
+				{earliestCreationTime: common.Int64Ptr(100), size: 50},
 				{earliestCreationTime: nil},
 				{earliestCreationTime: nil},
 			},

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -305,6 +305,33 @@ func (v *GetReplicationMessagesResponse) GetMessagesByShard() (o map[int32]*Repl
 	return
 }
 
+// GetEarliestCreationTime returns the earliest creation time of replication tasks if it exists, otherwise return nil
+func (v *GetReplicationMessagesResponse) GetEarliestCreationTime() *int64 {
+	if v == nil {
+		return nil
+	}
+
+	var earliestTime *int64
+	for _, messages := range v.MessagesByShard {
+
+		creationTime := messages.GetEarliestCreationTime()
+		if creationTime == nil {
+			continue
+		}
+
+		if earliestTime == nil || *creationTime < *earliestTime {
+			earliestTime = creationTime
+		}
+	}
+
+	if earliestTime == nil {
+		return nil
+	}
+
+	result := *earliestTime
+	return &result
+}
+
 // HistoryTaskV2Attributes is an internal type (TBD...)
 type HistoryTaskV2Attributes struct {
 	DomainID            string                `json:"domainId,omitempty"`
@@ -590,6 +617,32 @@ func (v *ReplicationMessages) GetSyncShardStatus() (o *SyncShardStatus) {
 		return v.SyncShardStatus
 	}
 	return
+}
+
+// GetEarliestCreationTime returns the earliest message time in the replication tasks if it exists
+// otherwise return nil
+func (v *ReplicationMessages) GetEarliestCreationTime() *int64 {
+	if v == nil {
+		return nil
+	}
+
+	var earliestTime *int64
+	for _, task := range v.GetReplicationTasks() {
+		if task.CreationTime == nil {
+			continue
+		}
+
+		if earliestTime == nil || *task.CreationTime < *earliestTime {
+			earliestTime = task.CreationTime
+		}
+	}
+
+	if earliestTime == nil {
+		return nil
+	}
+
+	result := *earliestTime
+	return &result
 }
 
 // ReplicationTask is an internal type (TBD...)

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -328,6 +328,8 @@ func (v *GetReplicationMessagesResponse) GetEarliestCreationTime() *int64 {
 		return nil
 	}
 
+	// avoid returning a pointer to the internal value
+	// for immutability
 	result := *earliestTime
 	return &result
 }
@@ -641,6 +643,8 @@ func (v *ReplicationMessages) GetEarliestCreationTime() *int64 {
 		return nil
 	}
 
+	// avoid returning a pointer to the internal value
+	// for immutability
 	result := *earliestTime
 	return &result
 }

--- a/common/types/replicator_test.go
+++ b/common/types/replicator_test.go
@@ -25,9 +25,8 @@ package types
 import (
 	"testing"
 
-	"github.com/uber/cadence/common"
-
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/thriftrw/ptr"
 )
 
 func TestDLQType_Ptr(t *testing.T) {
@@ -404,10 +403,10 @@ func TestGetReplicationMessagesResponse_GetEarliestCreationTime(t *testing.T) {
 			response: &GetReplicationMessagesResponse{
 				MessagesByShard: map[int32]*ReplicationMessages{
 					1: {ReplicationTasks: []*ReplicationTask{
-						{}, {CreationTime: common.Int64Ptr(20)}, {CreationTime: common.Int64Ptr(1000)}},
+						{}, {CreationTime: ptr.Int64(20)}, {CreationTime: ptr.Int64(1000)}},
 					},
 					2: {ReplicationTasks: []*ReplicationTask{
-						{CreationTime: common.Int64Ptr(10)}, {}, {CreationTime: common.Int64Ptr(12000)}}},
+						{CreationTime: ptr.Int64(10)}, {}, {CreationTime: ptr.Int64(12000)}}},
 				},
 			},
 			want: ptrInt64(10),
@@ -688,13 +687,13 @@ func TestReplicationMessages_GetEarliestCreationTime(t *testing.T) {
 		"a few tasks with creation time": {
 			msgs: &ReplicationMessages{
 				ReplicationTasks: []*ReplicationTask{
-					{CreationTime: common.Int64Ptr(50)},
-					{CreationTime: common.Int64Ptr(20)},
+					{CreationTime: ptr.Int64(50)},
+					{CreationTime: ptr.Int64(20)},
 					{}, {}, {},
-					{CreationTime: common.Int64Ptr(100)},
+					{CreationTime: ptr.Int64(100)},
 				},
 			},
-			want: common.Int64Ptr(20),
+			want: ptr.Int64(20),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/common/types/replicator_test.go
+++ b/common/types/replicator_test.go
@@ -25,6 +25,8 @@ package types
 import (
 	"testing"
 
+	"go.uber.org/thriftrw/ptr"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -383,6 +385,40 @@ func TestGetReplicationMessagesResponse_GetMessagesByShard(t *testing.T) {
 	assert.Nil(t, res)
 }
 
+func TestGetReplicationMessagesResponse_GetEarliestCreationTime(t *testing.T) {
+	for name, c := range map[string]struct {
+		response *GetReplicationMessagesResponse
+		want     *int64
+	}{
+		"nil":           {response: nil, want: nil},
+		"zero messages": {response: &GetReplicationMessagesResponse{}, want: nil},
+		"no messages with creation time": {
+			response: &GetReplicationMessagesResponse{
+				MessagesByShard: map[int32]*ReplicationMessages{
+					1: {ReplicationTasks: []*ReplicationTask{{}, {}, {}}},
+					2: {ReplicationTasks: []*ReplicationTask{{}, {}, {}}},
+				},
+			},
+		},
+		"a few messages with creation time": {
+			response: &GetReplicationMessagesResponse{
+				MessagesByShard: map[int32]*ReplicationMessages{
+					1: {ReplicationTasks: []*ReplicationTask{
+						{}, {CreationTime: ptr.Int64(20)}, {CreationTime: ptr.Int64(1000)}},
+					},
+					2: {ReplicationTasks: []*ReplicationTask{
+						{CreationTime: ptr.Int64(10)}, {}, {CreationTime: ptr.Int64(12000)}}},
+				},
+			},
+			want: ptrInt64(10),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.want, c.response.GetEarliestCreationTime())
+		})
+	}
+}
+
 func TestCountDLQMessagesResponse(t *testing.T) {
 	history := map[HistoryDLQCountKey]int64{
 		{ShardID: 1, SourceCluster: "cluster-1"}: 100,
@@ -632,6 +668,39 @@ func TestReplicationMessages_GetSyncShardStatus(t *testing.T) {
 	var nilStruct *ReplicationMessages
 	res = nilStruct.GetSyncShardStatus()
 	assert.Nil(t, res)
+}
+
+func TestReplicationMessages_GetEarliestCreationTime(t *testing.T) {
+	for name, c := range map[string]struct {
+		msgs *ReplicationMessages
+		want *int64
+	}{
+		"nil":        {msgs: nil, want: nil},
+		"zero tasks": {msgs: &ReplicationMessages{}, want: nil},
+		"no tasks with creation time": {
+			msgs: &ReplicationMessages{
+				ReplicationTasks: []*ReplicationTask{
+					{}, {}, {},
+				},
+			},
+			want: nil,
+		},
+		"a few tasks with creation time": {
+			msgs: &ReplicationMessages{
+				ReplicationTasks: []*ReplicationTask{
+					{CreationTime: ptr.Int64(50)},
+					{CreationTime: ptr.Int64(20)},
+					{}, {}, {},
+					{CreationTime: ptr.Int64(100)},
+				},
+			},
+			want: ptr.Int64(20),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.want, c.msgs.GetEarliestCreationTime())
+		})
+	}
 }
 
 func TestReplicationTask_GetTaskType(t *testing.T) {

--- a/common/types/replicator_test.go
+++ b/common/types/replicator_test.go
@@ -25,9 +25,8 @@ package types
 import (
 	"testing"
 
-	"go.uber.org/thriftrw/ptr"
-
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/thriftrw/ptr"
 )
 
 func TestDLQType_Ptr(t *testing.T) {

--- a/common/types/replicator_test.go
+++ b/common/types/replicator_test.go
@@ -25,8 +25,9 @@ package types
 import (
 	"testing"
 
+	"github.com/uber/cadence/common"
+
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/thriftrw/ptr"
 )
 
 func TestDLQType_Ptr(t *testing.T) {
@@ -403,10 +404,10 @@ func TestGetReplicationMessagesResponse_GetEarliestCreationTime(t *testing.T) {
 			response: &GetReplicationMessagesResponse{
 				MessagesByShard: map[int32]*ReplicationMessages{
 					1: {ReplicationTasks: []*ReplicationTask{
-						{}, {CreationTime: ptr.Int64(20)}, {CreationTime: ptr.Int64(1000)}},
+						{}, {CreationTime: common.Int64Ptr(20)}, {CreationTime: common.Int64Ptr(1000)}},
 					},
 					2: {ReplicationTasks: []*ReplicationTask{
-						{CreationTime: ptr.Int64(10)}, {}, {CreationTime: ptr.Int64(12000)}}},
+						{CreationTime: common.Int64Ptr(10)}, {}, {CreationTime: common.Int64Ptr(12000)}}},
 				},
 			},
 			want: ptrInt64(10),
@@ -687,13 +688,13 @@ func TestReplicationMessages_GetEarliestCreationTime(t *testing.T) {
 		"a few tasks with creation time": {
 			msgs: &ReplicationMessages{
 				ReplicationTasks: []*ReplicationTask{
-					{CreationTime: ptr.Int64(50)},
-					{CreationTime: ptr.Int64(20)},
+					{CreationTime: common.Int64Ptr(50)},
+					{CreationTime: common.Int64Ptr(20)},
 					{}, {}, {},
-					{CreationTime: ptr.Int64(100)},
+					{CreationTime: common.Int64Ptr(100)},
 				},
 			},
-			want: ptr.Int64(20),
+			want: common.Int64Ptr(20),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
In case of a shrunk response to the `GetReplicationMessages` call, the frontend service will give priority to responses from peers with the older creation time of replication tasks in responses from history services.

<!-- Tell your future self why have you made these changes -->
**Why?**

A replication request comes from a passive side to an active side. A request aggregates requests over multiple shardIDs. Frontend service on the active side calls GetReplicationMessages per each peer (a peer contains multiple shards) to history services. The result is aggregated into one response and sent back to the passive side. 

In some cases the result response may exceed max payload size (4MB by default). In this case, frontend service is used to choose randomly some responses. A replication lag could be caused if some child responses took the whole response, but could not be selected for response due to randomized sorting of peer response. 

The PR changes the sorting logic and use sorting by CreationTime of replications tasks. Instead of randomized order, frontend will put responses with the older creation time of replication tasks first to the final response, and put with newer time later. It should prevent replication lag for shards which replication tasks are quite big. 

The PR will allow to avoidance of manual actions from an on-call engineer to re-run the replication for stuck shards. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Unit tests
* Manual tests on staging envs


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Potentially other shards without big replication tasks may experience some bigger delays due to giving prioritization to older shards. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
