### PR TITLE
Add dynamic config for pinot optimized query columns

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2822,6 +2822,13 @@ const (
 	// Allowed filters: N/A
 	QueueProcessorStuckTaskSplitThreshold
 
+	// PinotOptimizedQueryColumns is the list of search attributes that can be used in pinot optimized query
+	// KeyName: frontend.pinotOptimizedQueryColumns
+	// Value type: Map
+	// Default value: empty map
+	// Allowed filters: N/A
+	PinotOptimizedQueryColumns
+
 	// LastMapKey must be the last one in this const group
 	LastMapKey
 )
@@ -5068,6 +5075,11 @@ var MapKeys = map[MapKey]DynamicMap{
 		KeyName:      "history.queueProcessorStuckTaskSplitThreshold",
 		Description:  "QueueProcessorStuckTaskSplitThreshold is the threshold for the number of attempts of a task",
 		DefaultValue: common.ConvertIntMapToDynamicConfigMapProperty(map[int]int{0: 100, 1: 10000}),
+	},
+	PinotOptimizedQueryColumns: {
+		KeyName:      "frontend.pinotOptimizedQueryColumns",
+		Description:  "PinotOptimizedQueryColumns is the list of search attributes that can be used in pinot optimized query",
+		DefaultValue: map[string]interface{}{},
 	},
 }
 

--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -93,7 +93,7 @@ func NewPinotVisibilityStore(
 		producer:            producer,
 		logger:              logger.WithTags(tag.ComponentPinotVisibilityManager),
 		config:              config,
-		pinotQueryValidator: pnt.NewPinotQueryValidator(config.ValidSearchAttributes),
+		pinotQueryValidator: pnt.NewPinotQueryValidator(config.ValidSearchAttributes, config.PinotOptimizedQueryColumns),
 	}
 }
 

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -131,8 +131,9 @@ func TestRecordWorkflowExecutionStarted(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -195,8 +196,9 @@ func TestRecordWorkflowExecutionClosed(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -240,8 +242,9 @@ func TestRecordWorkflowExecutionUninitialized(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -300,8 +303,9 @@ func TestUpsertWorkflowExecution(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -345,8 +349,9 @@ func TestDeleteWorkflowExecution(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -391,8 +396,9 @@ func TestDeleteUninitializedWorkflowExecution(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -448,8 +454,9 @@ func TestListOpenWorkflowExecutions(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -507,8 +514,9 @@ func TestListClosedWorkflowExecutions(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -567,8 +575,9 @@ func TestListOpenWorkflowExecutionsByType(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -626,8 +635,9 @@ func TestListClosedWorkflowExecutionsByType(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -684,8 +694,9 @@ func TestListOpenWorkflowExecutionsByWorkflowID(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -742,8 +753,9 @@ func TestListClosedWorkflowExecutionsByWorkflowID(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -800,8 +812,9 @@ func TestListClosedWorkflowExecutionsByStatus(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -866,8 +879,9 @@ func TestGetClosedWorkflowExecution(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -920,8 +934,9 @@ func TestListWorkflowExecutions(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -975,8 +990,9 @@ func TestScanWorkflowExecutions(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -1061,8 +1077,9 @@ func TestGetName(t *testing.T) {
 	mockPinotClient := pnt.NewMockGenericClient(ctrl)
 	mockProducer := &mocks.KafkaProducer{}
 	mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-		ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-		ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+		ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+		ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+		PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 	}, mockProducer, log.NewNoop())
 	visibilityStore := mgr.(*pinotVisibilityStore)
 	assert.NotEmpty(t, visibilityStore.GetName())
@@ -1133,8 +1150,9 @@ AND WorkflowID = 'wfid'
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -1393,8 +1411,9 @@ LIMIT 0, 0
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
@@ -1941,8 +1960,9 @@ func TestClose(t *testing.T) {
 	mockPinotClient := pnt.NewMockGenericClient(ctrl)
 	mockProducer := &mocks.KafkaProducer{}
 	mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-		ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-		ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+		ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+		ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+		PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 	}, mockProducer, log.NewNoop())
 	visibilityStore := mgr.(*pinotVisibilityStore)
 

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1037,8 +1037,9 @@ func TestCountWorkflowExecutions(t *testing.T) {
 			mockPinotClient := pnt.NewMockGenericClient(ctrl)
 			mockProducer := &mocks.KafkaProducer{}
 			mgr := NewPinotVisibilityStore(mockPinotClient, &service.Config{
-				ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-				ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
+				ValidSearchAttributes:      dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
+				ESIndexMaxResultWindow:     dynamicconfig.GetIntPropertyFn(3),
+				PinotOptimizedQueryColumns: dynamicconfig.GetMapPropertyFn(map[string]interface{}{}),
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -236,9 +236,13 @@ func (qv *VisibilityQueryValidator) IsValidSearchAttributes(key string) bool {
 
 // IsOptimizedQueryColumn return true if colNameStr is in the optimized query columns
 func (qv *VisibilityQueryValidator) IsOptimizedQueryColumn(colNameStr string) bool {
-	optimizedQueryColumns := qv.pinotOptimizedQueryColumns()
-	_, isOptimizedQueryColumn := optimizedQueryColumns[colNameStr]
-	return isOptimizedQueryColumn
+	if qv.pinotOptimizedQueryColumns() == nil {
+		return false
+	} else {
+		optimizedQueryColumns := qv.pinotOptimizedQueryColumns()
+		_, isOptimizedQueryColumn := optimizedQueryColumns[colNameStr]
+		return isOptimizedQueryColumn
+	}
 }
 
 func (qv *VisibilityQueryValidator) processSystemBoolKey(colNameStr string, comparisonExpr sqlparser.ComparisonExpr) (string, error) {

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -457,6 +457,7 @@ func processEqual(colNameStr string, colValStr string) string {
 
 func processCustomKeyword(operator string, colNameStr string, colValStr string, useOptimizedQuery bool) string {
 	if useOptimizedQuery {
+		// replace "-" with "" for optimized query so Pinot can tokenize the whole UUID
 		filteredColValStr := strings.ReplaceAll(colValStr, "-", "")
 		return fmt.Sprintf("%s %s '%s'", colNameStr, operator, filteredColValStr)
 	}
@@ -477,6 +478,7 @@ func processCustomKeyword(operator string, colNameStr string, colValStr string, 
 
 func processCustomString(operator string, colNameStr string, colValStr string, useOptimizedQuery bool) string {
 	if useOptimizedQuery {
+		// replace "-" with "" for optimized query so Pinot can tokenize the whole UUID
 		filteredColValStr := strings.ReplaceAll(colValStr, "-", "")
 		return fmt.Sprintf("%s %s '%s'", colNameStr, operator, filteredColValStr)
 	}

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -40,7 +40,8 @@ import (
 
 // VisibilityQueryValidator for sql query validation
 type VisibilityQueryValidator struct {
-	validSearchAttributes dynamicconfig.MapPropertyFn
+	validSearchAttributes      dynamicconfig.MapPropertyFn
+	pinotOptimizedQueryColumns dynamicconfig.MapPropertyFn
 }
 
 var timeSystemKeys = map[string]bool{
@@ -51,9 +52,10 @@ var timeSystemKeys = map[string]bool{
 }
 
 // NewPinotQueryValidator create VisibilityQueryValidator
-func NewPinotQueryValidator(validSearchAttributes dynamicconfig.MapPropertyFn) *VisibilityQueryValidator {
+func NewPinotQueryValidator(validSearchAttributes dynamicconfig.MapPropertyFn, pinotOptimizedQueryColumns dynamicconfig.MapPropertyFn) *VisibilityQueryValidator {
 	return &VisibilityQueryValidator{
-		validSearchAttributes: validSearchAttributes,
+		validSearchAttributes:      validSearchAttributes,
+		pinotOptimizedQueryColumns: pinotOptimizedQueryColumns,
 	}
 }
 
@@ -232,6 +234,13 @@ func (qv *VisibilityQueryValidator) IsValidSearchAttributes(key string) bool {
 	return isValidKey
 }
 
+// IsOptimizedQueryColumn return true if colNameStr is in the optimized query columns
+func (qv *VisibilityQueryValidator) IsOptimizedQueryColumn(colNameStr string) bool {
+	optimizedQueryColumns := qv.pinotOptimizedQueryColumns()
+	_, isOptimizedQueryColumn := optimizedQueryColumns[colNameStr]
+	return isOptimizedQueryColumn
+}
+
 func (qv *VisibilityQueryValidator) processSystemBoolKey(colNameStr string, comparisonExpr sqlparser.ComparisonExpr) (string, error) {
 	// case1: isCron = false
 	colVal, ok := comparisonExpr.Right.(sqlparser.BoolVal)
@@ -391,6 +400,7 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 	if !ok {
 		return "", fmt.Errorf("invalid search attribute")
 	}
+	useOptimizedQuery := qv.IsOptimizedQueryColumn(colNameStr)
 
 	// process IN clause in json indexed col: Attr
 	operator := strings.ToLower(comparisonExpr.Operator)
@@ -410,9 +420,9 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 
 	switch indexValType {
 	case types.IndexedValueTypeString:
-		return processCustomString(operator, colNameStr, colValStr), nil
+		return processCustomString(operator, colNameStr, colValStr, useOptimizedQuery), nil
 	case types.IndexedValueTypeKeyword:
-		return processCustomKeyword(operator, colNameStr, colValStr), nil
+		return processCustomKeyword(operator, colNameStr, colValStr, useOptimizedQuery), nil
 	case types.IndexedValueTypeDatetime:
 		var err error
 		colVal, err = trimTimeFieldValueFromNanoToMilliSeconds(colVal)
@@ -442,34 +452,36 @@ func processEqual(colNameStr string, colValStr string) string {
 	return fmt.Sprintf("JSON_MATCH(Attr, '\"$.%s\"=''%s''')", colNameStr, colValStr)
 }
 
-func processCustomKeyword(operator string, colNameStr string, colValStr string) string {
-	// edge case
-	if operator == "!=" {
-		return createKeywordQuery(operator, colNameStr, colValStr, "and", "NOT ")
+func processCustomKeyword(operator string, colNameStr string, colValStr string, useOptimizedQuery bool) string {
+	if useOptimizedQuery {
+		filteredColValStr := strings.ReplaceAll(colValStr, "-", "")
+		return fmt.Sprintf("%s %s '%s'", colNameStr, operator, filteredColValStr)
 	}
 
-	return createKeywordQuery(operator, colNameStr, colValStr, "or", "")
-}
-
-func createKeywordQuery(operator string, colNameStr string, colValStr string, connector string, notEqual string) string {
 	if colValStr == "" {
 		// partial match for an empty string (still it will only match empty string)
 		// so it equals to exact match for an empty string
-		return createCustomStringQuery(colNameStr, colValStr, notEqual)
+		return processCustomString(operator, colNameStr, colValStr, useOptimizedQuery)
+	}
+
+	connector := "or"
+	if operator == "!=" {
+		connector = "and"
 	}
 	return fmt.Sprintf("(JSON_MATCH(Attr, '\"$.%s\"%s''%s''') %s JSON_MATCH(Attr, '\"$.%s[*]\"%s''%s'''))",
 		colNameStr, operator, colValStr, connector, colNameStr, operator, colValStr)
 }
 
-func processCustomString(operator string, colNameStr string, colValStr string) string {
-	if operator == "!=" {
-		return createCustomStringQuery(colNameStr, colValStr, "NOT ")
+func processCustomString(operator string, colNameStr string, colValStr string, useOptimizedQuery bool) string {
+	if useOptimizedQuery {
+		filteredColValStr := strings.ReplaceAll(colValStr, "-", "")
+		return fmt.Sprintf("%s %s '%s'", colNameStr, operator, filteredColValStr)
 	}
 
-	return createCustomStringQuery(colNameStr, colValStr, "")
-}
-
-func createCustomStringQuery(colNameStr string, colValStr string, notEqual string) string {
+	notEqual := ""
+	if operator == "!=" {
+		notEqual = "NOT "
+	}
 	// handle edge case
 	if colValStr == "" {
 		return fmt.Sprintf("JSON_MATCH(Attr, '\"$.%s\" is not null') "+

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -236,13 +236,12 @@ func (qv *VisibilityQueryValidator) IsValidSearchAttributes(key string) bool {
 
 // IsOptimizedQueryColumn return true if colNameStr is in the optimized query columns
 func (qv *VisibilityQueryValidator) IsOptimizedQueryColumn(colNameStr string) bool {
-	if qv.pinotOptimizedQueryColumns() == nil {
-		return false
-	} else {
+	if qv.pinotOptimizedQueryColumns() != nil {
 		optimizedQueryColumns := qv.pinotOptimizedQueryColumns()
 		_, isOptimizedQueryColumn := optimizedQueryColumns[colNameStr]
 		return isOptimizedQueryColumn
 	}
+	return false
 }
 
 func (qv *VisibilityQueryValidator) processSystemBoolKey(colNameStr string, comparisonExpr sqlparser.ComparisonExpr) (string, error) {

--- a/common/service/config.go
+++ b/common/service/config.go
@@ -47,8 +47,9 @@ type (
 		DBVisibilityListMaxQPS                      dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 
 		// configs for es visibility
-		ESIndexMaxResultWindow dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
-		ValidSearchAttributes  dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
+		ESIndexMaxResultWindow     dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
+		ValidSearchAttributes      dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
+		PinotOptimizedQueryColumns dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
 		// deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS
 		ESVisibilityListMaxQPS dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -100,7 +100,7 @@ type Config struct {
 	SearchAttributesNumberOfKeysLimit dynamicconfig.IntPropertyFnWithDomainFilter
 	SearchAttributesSizeOfValueLimit  dynamicconfig.IntPropertyFnWithDomainFilter
 	SearchAttributesTotalSizeLimit    dynamicconfig.IntPropertyFnWithDomainFilter
-
+	PinotOptimizedQueryColumns        dynamicconfig.MapPropertyFn
 	// VisibilityArchival system protection
 	VisibilityArchivalQueryMaxPageSize dynamicconfig.IntPropertyFn
 
@@ -173,6 +173,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		SearchAttributesNumberOfKeysLimit:           dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesNumberOfKeysLimit),
 		SearchAttributesSizeOfValueLimit:            dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesSizeOfValueLimit),
 		SearchAttributesTotalSizeLimit:              dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesTotalSizeLimit),
+		PinotOptimizedQueryColumns:                  dc.GetMapProperty(dynamicconfig.PinotOptimizedQueryColumns),
 		VisibilityArchivalQueryMaxPageSize:          dc.GetIntProperty(dynamicconfig.VisibilityArchivalQueryMaxPageSize),
 		DisallowQuery:                               dc.GetBoolPropertyFilteredByDomain(dynamicconfig.DisallowQuery),
 		SendRawWorkflowHistory:                      dc.GetBoolPropertyFilteredByDomain(dynamicconfig.SendRawWorkflowHistory),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -104,6 +104,7 @@ func TestNewConfig(t *testing.T) {
 		"EnableTasklistIsolation":                     {dynamicconfig.EnableTasklistIsolation, true},
 		"GlobalRatelimiterKeyMode":                    {dynamicconfig.FrontendGlobalRatelimiterMode, "disabled"},
 		"GlobalRatelimiterUpdateInterval":             {dynamicconfig.GlobalRatelimiterUpdateInterval, 3 * time.Second},
+		"PinotOptimizedQueryColumns":                  {dynamicconfig.PinotOptimizedQueryColumns, map[string]interface{}{"foo": "bar"}},
 	}
 	domainFields := map[string]configTestCase{
 		"MaxBadBinaryCount":      {dynamicconfig.FrontendMaxBadBinaries, 40},

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -98,10 +98,11 @@ func NewService(
 			WriteDBVisibilityOpenMaxQPS:                 nil, // frontend service never write
 			WriteDBVisibilityClosedMaxQPS:               nil, // frontend service never write
 
-			ESVisibilityListMaxQPS:   serviceConfig.ESVisibilityListMaxQPS,
-			ESIndexMaxResultWindow:   serviceConfig.ESIndexMaxResultWindow,
-			ValidSearchAttributes:    serviceConfig.ValidSearchAttributes,
-			IsErrorRetryableFunction: common.FrontendRetry,
+			ESVisibilityListMaxQPS:     serviceConfig.ESVisibilityListMaxQPS,
+			ESIndexMaxResultWindow:     serviceConfig.ESIndexMaxResultWindow,
+			ValidSearchAttributes:      serviceConfig.ValidSearchAttributes,
+			IsErrorRetryableFunction:   common.FrontendRetry,
+			PinotOptimizedQueryColumns: serviceConfig.PinotOptimizedQueryColumns,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add dynamic config for pinot optimized query columns
Used improved query for the columns in the list

<!-- Tell your future self why have you made these changes -->
**Why?**
Pinot query performance issue in gs-prod. Currently the query will timeout in cluster. The bottleneck here is we store the customized search attribute in a json column, it has to use json index and Pinot cannot apply text index to it. Text index has better performance for text search.
We discussed with Pinot team, the only option here is populate the fields into separate columns, pinot team added transformation logic on their side when ingest from Kafka topic. Then they can apply text index to the populated columns.
Besides that, they have added another logic to remove the - in the UUID which can help tokenize the whole UUID instead of tokenizing each piece of it, which makes sense for UUID. This can also help improve the latency.
These changes will only apply to the selected columns in certain clusters.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
