### PR TITLE
Restructure Admin TaskList commands to operate on multiple types

### DIFF
--- a/tools/cli/admin_task_list_commands.go
+++ b/tools/cli/admin_task_list_commands.go
@@ -25,9 +25,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v2"
+	"go.uber.org/multierr"
+	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
@@ -37,19 +40,22 @@ import (
 
 type (
 	TaskListRow struct {
-		Name        string `header:"Task List Name"`
-		Type        string `header:"Type"`
-		PollerCount int    `header:"Poller Count"`
+		Name                string `header:"Task List Name"`
+		ActivityPollerCount int    `header:"Activity Poller Count"`
+		DecisionPollerCount int    `header:"Decision Poller Count"`
 	}
 	TaskListStatusRow struct {
-		ReadLevel int64   `header:"Read Level"`
-		AckLevel  int64   `header:"Ack Level"`
-		Backlog   int64   `header:"Backlog"`
-		RPS       float64 `header:"RPS"`
-		StartID   int64   `header:"Lease Start TaskID"`
-		EndID     int64   `header:"Lease End TaskID"`
+		Type        string  `header:"Type"`
+		PollerCount int     `header:"PollerCount"`
+		ReadLevel   int64   `header:"Read Level"`
+		AckLevel    int64   `header:"Ack Level"`
+		Backlog     int64   `header:"Backlog"`
+		RPS         float64 `header:"RPS"`
+		StartID     int64   `header:"Lease Start TaskID"`
+		EndID       int64   `header:"Lease End TaskID"`
 	}
 	TaskListPartitionConfigRow struct {
+		Type            string                           `header:"Type"`
 		Version         int64                            `header:"Version"`
 		ReadPartitions  map[int]*types.TaskListPartition `header:"Read Partitions"`
 		WritePartitions map[int]*types.TaskListPartition `header:"Write Partitions"`
@@ -70,9 +76,9 @@ func AdminDescribeTaskList(c *cli.Context) error {
 	if err != nil {
 		return commoncli.Problem("Required flag not found: ", err)
 	}
-	taskListType := types.TaskListTypeDecision
-	if strings.ToLower(c.String(FlagTaskListType)) == "activity" {
-		taskListType = types.TaskListTypeActivity
+	taskListTypes, err := getTaskListTypes(c)
+	if err != nil {
+		return err
 	}
 
 	ctx, cancel, err := newContext(c)
@@ -80,37 +86,36 @@ func AdminDescribeTaskList(c *cli.Context) error {
 	if err != nil {
 		return commoncli.Problem("Error in creating context:", err)
 	}
-	request := &types.DescribeTaskListRequest{
-		Domain:                domain,
-		TaskList:              &types.TaskList{Name: taskList},
-		TaskListType:          &taskListType,
-		IncludeTaskListStatus: true,
+	responses := make(map[types.TaskListType]*types.DescribeTaskListResponse)
+	for _, tlType := range taskListTypes {
+		request := &types.DescribeTaskListRequest{
+			Domain:                domain,
+			TaskList:              &types.TaskList{Name: taskList},
+			TaskListType:          tlType.Ptr(),
+			IncludeTaskListStatus: true,
+		}
+
+		response, err := frontendClient.DescribeTaskList(ctx, request)
+		if err != nil {
+			return commoncli.Problem("Operation DescribeTaskList failed for type: "+tlType.String(), err)
+		}
+		responses[tlType] = response
+	}
+	if c.String(FlagFormat) == formatJSON {
+		prettyPrintJSONObject(getDeps(c).Output(), responses)
+		return nil
 	}
 
-	response, err := frontendClient.DescribeTaskList(ctx, request)
-	if err != nil {
-		return commoncli.Problem("Operation DescribeTaskList failed.", err)
-	}
-
-	taskListStatus := response.GetTaskListStatus()
-	if taskListStatus == nil {
-		return commoncli.Problem(colorMagenta("No tasklist status information."), nil)
-	}
-	if err := printTaskListStatus(getDeps(c).Output(), taskListStatus); err != nil {
+	if err := printTaskListStatus(getDeps(c).Output(), responses); err != nil {
 		return fmt.Errorf("failed to print task list status: %w", err)
 	}
 	getDeps(c).Output().Write([]byte("\n"))
-	if response.PartitionConfig != nil {
-		if err := printTaskListPartitionConfig(getDeps(c).Output(), response.PartitionConfig); err != nil {
-			return fmt.Errorf("failed to print task list partition config: %w", err)
-		}
-		getDeps(c).Output().Write([]byte("\n"))
+	if err := printTaskListPartitionConfig(getDeps(c).Output(), responses); err != nil {
+		return fmt.Errorf("failed to print task list partition config: %w", err)
 	}
-	pollers := response.Pollers
-	if len(pollers) == 0 {
-		return commoncli.Problem(colorMagenta("No poller for tasklist: "+taskList), nil)
-	}
-	return printTaskListPollers(getDeps(c).Output(), pollers, taskListType)
+	getDeps(c).Output().Write([]byte("\n"))
+
+	return nil
 }
 
 // AdminListTaskList displays all task lists under a domain.
@@ -137,35 +142,74 @@ func AdminListTaskList(c *cli.Context) error {
 		return commoncli.Problem("Operation GetTaskListByDomain failed.", err)
 	}
 
-	fmt.Println("Task Lists for domain " + domain + ":")
-	table := []TaskListRow{}
+	if c.String(FlagFormat) == formatJSON {
+		prettyPrintJSONObject(getDeps(c).Output(), response)
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(getDeps(c).Output(), "Task Lists for domain ", domain, ":")
+	tlByName := make(map[string]TaskListRow)
 	for name, taskList := range response.GetDecisionTaskListMap() {
-		table = append(table, TaskListRow{name, "Decision", len(taskList.GetPollers())})
+		row := tlByName[name]
+		row.Name = name
+		row.DecisionPollerCount = len(taskList.GetPollers())
+		tlByName[name] = row
 	}
 	for name, taskList := range response.GetActivityTaskListMap() {
-		table = append(table, TaskListRow{name, "Activity", len(taskList.GetPollers())})
+		row := tlByName[name]
+		row.Name = name
+		row.ActivityPollerCount = len(taskList.GetPollers())
+		tlByName[name] = row
 	}
+	table := maps.Values(tlByName)
+	slices.SortFunc(table, func(a, b TaskListRow) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	return RenderTable(os.Stdout, table, RenderOptions{Color: true, Border: true})
 }
 
-func printTaskListStatus(w io.Writer, taskListStatus *types.TaskListStatus) error {
-	table := []TaskListStatusRow{{
-		ReadLevel: taskListStatus.GetReadLevel(),
-		AckLevel:  taskListStatus.GetAckLevel(),
-		Backlog:   taskListStatus.GetBacklogCountHint(),
-		RPS:       taskListStatus.GetRatePerSecond(),
-		StartID:   taskListStatus.GetTaskIDBlock().GetStartID(),
-		EndID:     taskListStatus.GetTaskIDBlock().GetEndID(),
-	}}
+func printTaskListStatus(w io.Writer, responses map[types.TaskListType]*types.DescribeTaskListResponse) error {
+	var table []TaskListStatusRow
+	for tlType, response := range responses {
+		taskListStatus := response.TaskListStatus
+		table = append(table, TaskListStatusRow{
+			Type:        tlType.String(),
+			PollerCount: len(response.Pollers),
+			ReadLevel:   taskListStatus.GetReadLevel(),
+			AckLevel:    taskListStatus.GetAckLevel(),
+			Backlog:     taskListStatus.GetBacklogCountHint(),
+			RPS:         taskListStatus.GetRatePerSecond(),
+			StartID:     taskListStatus.GetTaskIDBlock().GetStartID(),
+			EndID:       taskListStatus.GetTaskIDBlock().GetEndID(),
+		})
+	}
+	slices.SortFunc(table, func(a, b TaskListStatusRow) int {
+		return strings.Compare(a.Type, b.Type)
+	})
 	return RenderTable(w, table, RenderOptions{Color: true})
 }
 
-func printTaskListPartitionConfig(w io.Writer, config *types.TaskListPartitionConfig) error {
-	table := TaskListPartitionConfigRow{
-		Version:         config.Version,
-		ReadPartitions:  config.ReadPartitions,
-		WritePartitions: config.WritePartitions,
+func printTaskListPartitionConfig(w io.Writer, responses map[types.TaskListType]*types.DescribeTaskListResponse) error {
+	var table []TaskListPartitionConfigRow
+	for tlType, response := range responses {
+		config := response.PartitionConfig
+		if config == nil {
+			config = &types.TaskListPartitionConfig{
+				Version:         0,
+				ReadPartitions:  createPartitions(1),
+				WritePartitions: createPartitions(1),
+			}
+		}
+		table = append(table, TaskListPartitionConfigRow{
+			Type:            tlType.String(),
+			Version:         config.Version,
+			ReadPartitions:  config.ReadPartitions,
+			WritePartitions: config.WritePartitions,
+		})
 	}
+	slices.SortFunc(table, func(a, b TaskListPartitionConfigRow) int {
+		return strings.Compare(a.Type, b.Type)
+	})
 	return RenderTable(w, table, RenderOptions{Color: true})
 }
 
@@ -187,13 +231,9 @@ func AdminUpdateTaskListPartitionConfig(c *cli.Context) error {
 		return commoncli.Problem("Required flag not found: ", err)
 	}
 	force := c.Bool(FlagForce)
-	var taskListType *types.TaskListType
-	if strings.ToLower(c.String(FlagTaskListType)) == "activity" {
-		taskListType = types.TaskListTypeActivity.Ptr()
-	} else if strings.ToLower(c.String(FlagTaskListType)) == "decision" {
-		taskListType = types.TaskListTypeDecision.Ptr()
-	} else {
-		return commoncli.Problem("Invalid task list type: valid types are [activity, decision]", nil)
+	taskListTypes, err := getTaskListTypes(c)
+	if err != nil {
+		return err
 	}
 	numReadPartitions, err := getRequiredIntOption(c, FlagNumReadPartitions)
 	if err != nil {
@@ -214,38 +254,52 @@ func AdminUpdateTaskListPartitionConfig(c *cli.Context) error {
 	}
 	tl := &types.TaskList{Name: taskList, Kind: types.TaskListKindNormal.Ptr()}
 	if !force {
-		err = validateChange(ctx, frontendClient, domain, tl, taskListType, cfg)
-		if err != nil {
-			return commoncli.Problem("Potentially unsafe operation. Specify '--force' to proceed anyway: ", err)
+		hasPollers := false
+		var errors []error
+		for _, tlType := range taskListTypes {
+			typeHasPollers, typeErr := validateChange(ctx, frontendClient, domain, tl, tlType.Ptr(), cfg)
+			if typeErr != nil {
+				errors = append(errors, fmt.Errorf("%s:%s failed validation: %w", tl.Name, tlType, typeErr))
+			}
+			hasPollers = typeHasPollers || hasPollers
+		}
+		if len(errors) > 0 {
+			return commoncli.Problem("Potentially unsafe operation. Specify '--force' to proceed anyway", multierr.Combine(errors...))
+		}
+		if !hasPollers {
+			return commoncli.Problem(fmt.Sprintf("Operation is safe but %s has no pollers of the specified types. Is the name correct? Specify '--force' to proceed anyway", tl.Name), nil)
 		}
 	}
-	_, err = adminClient.UpdateTaskListPartitionConfig(ctx, &types.UpdateTaskListPartitionConfigRequest{
-		Domain:          domain,
-		TaskList:        tl,
-		TaskListType:    taskListType,
-		PartitionConfig: cfg,
-	})
-	if err != nil {
-		return commoncli.Problem("Operation UpdateTaskListPartitionConfig failed.", err)
+	for _, tlType := range taskListTypes {
+		_, err = adminClient.UpdateTaskListPartitionConfig(ctx, &types.UpdateTaskListPartitionConfigRequest{
+			Domain:          domain,
+			TaskList:        tl,
+			TaskListType:    tlType.Ptr(),
+			PartitionConfig: cfg,
+		})
+		if err != nil {
+			return commoncli.Problem("Operation UpdateTaskListPartitionConfig failed for type: "+tlType.String(), err)
+		}
+		_, _ = fmt.Fprintln(getDeps(c).Output(), "Successfully updated ", tl.Name, ":", tlType)
 	}
 	return nil
 }
 
-func validateChange(ctx context.Context, client frontend.Client, domain string, tl *types.TaskList, tlt *types.TaskListType, newCfg *types.TaskListPartitionConfig) error {
+func validateChange(ctx context.Context, client frontend.Client, domain string, tl *types.TaskList, tlt *types.TaskListType, newCfg *types.TaskListPartitionConfig) (bool, error) {
 	description, err := client.DescribeTaskList(ctx, &types.DescribeTaskListRequest{
 		Domain:       domain,
 		TaskList:     tl,
 		TaskListType: tlt,
 	})
 	if err != nil {
-		return fmt.Errorf("DescribeTaskList failed: %w", err)
+		return false, fmt.Errorf("DescribeTaskList failed: %w", err)
 	}
 	// Illegal operations are rejected by the server (read < write), but unsafe ones are still allowed
 	if description.PartitionConfig != nil {
 		oldCfg := description.PartitionConfig
 		// Ensure they're not removing active write partitions
 		if len(newCfg.ReadPartitions) < len(oldCfg.WritePartitions) {
-			return fmt.Errorf("remove write partitions, then read partitions. Removing an active write partition risks losing tasks. Proposed read count is less than current write count (%d < %d)", len(newCfg.ReadPartitions), len(oldCfg.WritePartitions))
+			return false, fmt.Errorf("remove write partitions, then read partitions. Removing an active write partition risks losing tasks. Proposed read count is less than current write count (%d < %d)", len(newCfg.ReadPartitions), len(oldCfg.WritePartitions))
 		}
 		// Ensure removed read partitions are drained
 		for i := len(newCfg.ReadPartitions); i < len(oldCfg.ReadPartitions); i++ {
@@ -256,18 +310,15 @@ func validateChange(ctx context.Context, client frontend.Client, domain string, 
 				IncludeTaskListStatus: true,
 			})
 			if err != nil {
-				return fmt.Errorf("DescribeTaskList failed for partition %d: %w", i, err)
+				return false, fmt.Errorf("DescribeTaskList failed for partition %d: %w", i, err)
 			}
 			if partition.TaskListStatus.BacklogCountHint != 0 {
-				return fmt.Errorf("partition %d still has %d tasks remaining", i, partition.TaskListStatus.BacklogCountHint)
+				return false, fmt.Errorf("partition %d still has %d tasks remaining", i, partition.TaskListStatus.BacklogCountHint)
 			}
 		}
 	}
 	// If it's otherwise valid but there are no pollers, they might have mistyped the name
-	if len(description.Pollers) == 0 {
-		return fmt.Errorf("'%s' has no pollers of type '%s'", tl.Name, tlt.String())
-	}
-	return nil
+	return len(description.Pollers) > 0, nil
 }
 
 func createPartitions(num int) map[int]*types.TaskListPartition {
@@ -283,4 +334,18 @@ func getPartitionTaskListName(root string, partition int) string {
 		return root
 	}
 	return fmt.Sprintf("%v%v/%v", common.ReservedTaskListPrefix, root, partition)
+}
+
+func getTaskListTypes(c *cli.Context) ([]types.TaskListType, error) {
+	var taskListTypes []types.TaskListType
+	if strings.ToLower(c.String(FlagTaskListType)) == "activity" {
+		taskListTypes = []types.TaskListType{types.TaskListTypeActivity}
+	} else if strings.ToLower(c.String(FlagTaskListType)) == "decision" {
+		taskListTypes = []types.TaskListType{types.TaskListTypeDecision}
+	} else if c.String(FlagTaskListType) == "" {
+		taskListTypes = []types.TaskListType{types.TaskListTypeActivity, types.TaskListTypeDecision}
+	} else {
+		return nil, commoncli.Problem("Invalid task list type: valid types are 'activity', 'decision', or empty (both)", nil)
+	}
+	return taskListTypes, nil
 }

--- a/tools/cli/admin_task_list_commands_test.go
+++ b/tools/cli/admin_task_list_commands_test.go
@@ -23,10 +23,13 @@
 package cli
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 
@@ -37,9 +40,7 @@ import (
 )
 
 func TestAdminDescribeTaskList(t *testing.T) {
-	td := newCLITestData(t)
-
-	expectedResponse := &types.DescribeTaskListResponse{
+	response := &types.DescribeTaskListResponse{
 		Pollers: []*types.PollerInfo{
 			{
 				Identity: "test-poller",
@@ -49,163 +50,217 @@ func TestAdminDescribeTaskList(t *testing.T) {
 			BacklogCountHint: 10,
 		},
 	}
-	td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(expectedResponse, nil).Times(1)
-
-	cliCtx := newTaskListCLIContext(t, td.app)
-	err := AdminDescribeTaskList(cliCtx)
-	assert.NoError(t, err)
-}
-
-func TestAdminDescribeTaskList_DescribeTaskListFails(t *testing.T) {
-	td := newCLITestData(t)
-
-	td.mockFrontendClient.EXPECT().
-		DescribeTaskList(gomock.Any(), gomock.Any()).
-		Return(nil, fmt.Errorf("DescribeTaskList failed")).
-		Times(1)
-
-	cliCtx := newTaskListCLIContext(t, td.app)
-	err := AdminDescribeTaskList(cliCtx)
-	assert.ErrorContains(t, err, "Operation DescribeTaskList failed.")
-}
-
-func TestAdminDescribeTaskList_NoTaskListStatus(t *testing.T) {
-	td := newCLITestData(t)
-
-	expectedResponse := &types.DescribeTaskListResponse{
-		Pollers:        []*types.PollerInfo{},
-		TaskListStatus: nil,
+	taskList := &types.TaskList{
+		Name: testTaskList,
 	}
 
-	td.mockFrontendClient.EXPECT().
-		DescribeTaskList(gomock.Any(), gomock.Any()).
-		Return(expectedResponse, nil).
-		Times(1)
-
-	cliCtx := newTaskListCLIContext(t, td.app)
-	err := AdminDescribeTaskList(cliCtx)
-	assert.ErrorContains(t, err, "No tasklist status information.")
-}
-
-func TestAdminDescribeTaskList_NoPollers(t *testing.T) {
-	td := newCLITestData(t)
-	expectedResponse := &types.DescribeTaskListResponse{
-		Pollers: []*types.PollerInfo{},
-		TaskListStatus: &types.TaskListStatus{
-			BacklogCountHint: 0,
-		},
-	}
-
-	td.mockFrontendClient.EXPECT().
-		DescribeTaskList(gomock.Any(), gomock.Any()).
-		Return(expectedResponse, nil).
-		Times(1)
-
-	cliCtx := newTaskListCLIContext(t, td.app)
-	err := AdminDescribeTaskList(cliCtx)
-	assert.ErrorContains(t, err, "No poller for tasklist: test-tasklist")
-}
-
-func TestAdminDescribeTaskList_GetRequiredOptionDomainError(t *testing.T) {
-	td := newCLITestData(t)
-
-	cliCtx := clitest.NewCLIContext(
-		t,
-		td.app,
-		/* omit the domain flag */
-		clitest.StringArgument(FlagTaskList, testTaskList),
-		clitest.StringArgument(FlagTaskListType, testTaskListType),
-	)
-
-	err := AdminDescribeTaskList(cliCtx)
-	assert.ErrorContains(t, err, "Required flag not found: ")
-}
-
-func TestAdminDescribeTaskList_GetRequiredOptionTaskListError(t *testing.T) {
-	td := newCLITestData(t)
-
-	cliCtx := clitest.NewCLIContext(
-		t,
-		td.app,
-		clitest.StringArgument(FlagDomain, testDomain),
-		/* omit the task-list flag */
-		clitest.StringArgument(FlagTaskListType, testTaskListType),
-	)
-
-	err := AdminDescribeTaskList(cliCtx)
-	assert.ErrorContains(t, err, "Required flag not found: ")
-}
-
-func TestAdminDescribeTaskList_InvalidTaskListType(t *testing.T) {
-	td := newCLITestData(t)
-
-	expectedResponse := &types.DescribeTaskListResponse{
-		Pollers: []*types.PollerInfo{
-			{
-				Identity: "test-poller",
+	tests := []struct {
+		name        string
+		allowance   func(td *cliTestData)
+		tlType      string
+		format      string
+		baseArgs    []clitest.CliArgument
+		assertions  func(t *testing.T, td *cliTestData)
+		expectedErr string
+	}{
+		{
+			name: "success",
+			allowance: func(td *cliTestData) {
+				td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:                testDomain,
+					TaskList:              taskList,
+					TaskListType:          types.TaskListTypeActivity.Ptr(),
+					IncludeTaskListStatus: true,
+				}).Return(response, nil).Times(1)
+				td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:                testDomain,
+					TaskList:              taskList,
+					TaskListType:          types.TaskListTypeDecision.Ptr(),
+					IncludeTaskListStatus: true,
+				}).Return(response, nil).Times(1)
 			},
 		},
-		TaskListStatus: &types.TaskListStatus{
-			BacklogCountHint: 10,
+		{
+			name:   "success - decision only",
+			tlType: "decision",
+			allowance: func(td *cliTestData) {
+				td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:                testDomain,
+					TaskList:              taskList,
+					TaskListType:          types.TaskListTypeDecision.Ptr(),
+					IncludeTaskListStatus: true,
+				}).Return(response, nil).Times(1)
+			},
+		},
+		{
+			name:   "success - activity only",
+			tlType: "activity",
+			allowance: func(td *cliTestData) {
+				td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:                testDomain,
+					TaskList:              taskList,
+					TaskListType:          types.TaskListTypeActivity.Ptr(),
+					IncludeTaskListStatus: true,
+				}).Return(response, nil).Times(1)
+			},
+		},
+		{
+			name:   "json",
+			tlType: "decision",
+			format: "json",
+			allowance: func(td *cliTestData) {
+				td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:                testDomain,
+					TaskList:              taskList,
+					TaskListType:          types.TaskListTypeDecision.Ptr(),
+					IncludeTaskListStatus: true,
+				}).Return(response, nil).Times(1)
+			},
+			assertions: func(t *testing.T, td *cliTestData) {
+				expected := map[types.TaskListType]*types.DescribeTaskListResponse{
+					types.TaskListTypeDecision: response,
+				}
+				output := td.consoleOutput()
+				var result map[types.TaskListType]*types.DescribeTaskListResponse
+				err := json.Unmarshal([]byte(output), &result)
+				require.NoError(t, err)
+				assert.Equal(t, expected, result)
+			},
+		},
+		{
+			name:        "error - missing domain",
+			expectedErr: "Required flag not found",
+			baseArgs: []clitest.CliArgument{
+				clitest.StringArgument(FlagTaskList, testTaskList),
+			},
+		},
+		{
+			name:        "error - missing tasklist",
+			expectedErr: "Required flag not found",
+			baseArgs: []clitest.CliArgument{
+				clitest.StringArgument(FlagDomain, testDomain),
+			},
+		},
+
+		{
+			name:   "error - from server",
+			tlType: "decision",
+			allowance: func(td *cliTestData) {
+				td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:                testDomain,
+					TaskList:              taskList,
+					TaskListType:          types.TaskListTypeDecision.Ptr(),
+					IncludeTaskListStatus: true,
+				}).Return(nil, errors.New("oh no")).Times(1)
+			},
+			expectedErr: "oh no",
 		},
 	}
-	td.mockFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), gomock.Any()).Return(expectedResponse, nil).Times(1)
 
-	cliCtx := clitest.NewCLIContext(
-		t,
-		td.app,
-		clitest.StringArgument(FlagDomain, testDomain),
-		clitest.StringArgument(FlagTaskList, testTaskList),
-		clitest.StringArgument(FlagTaskListType, "activity"),
-	)
-	err := AdminDescribeTaskList(cliCtx)
-	assert.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			td := newCLITestData(t)
+
+			var args []clitest.CliArgument
+			if tc.baseArgs == nil {
+				args = []clitest.CliArgument{
+					clitest.StringArgument(FlagDomain, testDomain),
+					clitest.StringArgument(FlagTaskList, testTaskList),
+				}
+			} else {
+				args = tc.baseArgs
+			}
+			if tc.tlType != "" {
+				args = append(args, clitest.StringArgument(FlagTaskListType, tc.tlType))
+			}
+			if tc.format != "" {
+				args = append(args, clitest.StringArgument(FlagFormat, tc.format))
+			}
+
+			cliCtx := clitest.NewCLIContext(
+				t,
+				td.app,
+				args...,
+			)
+
+			if tc.allowance != nil {
+				tc.allowance(td)
+			}
+
+			err := AdminDescribeTaskList(cliCtx)
+
+			if tc.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			}
+
+			if tc.assertions != nil {
+				tc.assertions(t, td)
+			}
+		})
+	}
 }
 
 func TestAdminListTaskList(t *testing.T) {
+	expectedResponse := &types.GetTaskListsByDomainResponse{
+		DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
+			"decision-tasklist-1": {
+				Pollers: []*types.PollerInfo{
+					{Identity: "poller1"},
+					{Identity: "poller2"},
+				},
+			},
+			"decision-tasklist-2": {
+				Pollers: []*types.PollerInfo{
+					{Identity: "poller3"},
+				},
+			},
+		},
+		ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{
+			"activity-tasklist-1": {
+				Pollers: []*types.PollerInfo{
+					{Identity: "poller4"},
+				},
+			},
+		},
+	}
 	// Define table of test cases
 	tests := []struct {
 		name          string
 		setupMocks    func(*frontend.MockClient)
+		assertions    func(t *testing.T, td *cliTestData)
 		expectedError string
 		domainFlag    string
-		taskListFlag  string
-		taskListType  string
+		format        string
 	}{
 		{
 			name: "Success",
 			setupMocks: func(client *frontend.MockClient) {
-				expectedResponse := &types.GetTaskListsByDomainResponse{
-					DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
-						"decision-tasklist-1": {
-							Pollers: []*types.PollerInfo{
-								{Identity: "poller1"},
-								{Identity: "poller2"},
-							},
-						},
-						"decision-tasklist-2": {
-							Pollers: []*types.PollerInfo{
-								{Identity: "poller3"},
-							},
-						},
-					},
-					ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{
-						"activity-tasklist-1": {
-							Pollers: []*types.PollerInfo{
-								{Identity: "poller4"},
-							},
-						},
-					},
-				}
 				client.EXPECT().
 					GetTaskListsByDomain(gomock.Any(), gomock.Any()).
 					Return(expectedResponse, nil).
 					Times(1)
 			},
-			expectedError: "",
-			domainFlag:    "test-domain",
-			taskListFlag:  "test-tasklist",
-			taskListType:  "decision",
+			domainFlag: "test-domain",
+		},
+		{
+			name:   "Success - json",
+			format: "json",
+			setupMocks: func(client *frontend.MockClient) {
+				client.EXPECT().
+					GetTaskListsByDomain(gomock.Any(), gomock.Any()).
+					Return(expectedResponse, nil).
+					Times(1)
+			},
+			assertions: func(t *testing.T, td *cliTestData) {
+				output := td.consoleOutput()
+				var result *types.GetTaskListsByDomainResponse
+				err := json.Unmarshal([]byte(output), &result)
+				require.NoError(t, err)
+				assert.Equal(t, expectedResponse, result)
+			},
+			domainFlag: "test-domain",
 		},
 		{
 			name: "GetTaskListsByDomainFails",
@@ -217,16 +272,12 @@ func TestAdminListTaskList(t *testing.T) {
 			},
 			expectedError: "Operation GetTaskListByDomain failed",
 			domainFlag:    "test-domain",
-			taskListFlag:  "test-tasklist",
-			taskListType:  "decision",
 		},
 		{
 			name:          "NoDomainFlag",
 			setupMocks:    func(client *frontend.MockClient) {},
 			expectedError: "Required flag not found",
 			domainFlag:    "", // Omit Domain flag
-			taskListFlag:  "test-tasklist",
-			taskListType:  "decision",
 		},
 	}
 
@@ -243,13 +294,16 @@ func TestAdminListTaskList(t *testing.T) {
 				cliCtx = clitest.NewCLIContext(
 					t,
 					td.app,
-					clitest.StringArgument(FlagTaskList, testTaskList),
 					/* omit the domain flag */
-					clitest.StringArgument(FlagTaskListType, testTaskListType),
+					clitest.StringArgument(FlagFormat, tt.format),
 				)
 			} else {
-				// construct cli context with all the required arguments
-				cliCtx = newTaskListCLIContext(t, td.app)
+				cliCtx = clitest.NewCLIContext(
+					t,
+					td.app,
+					clitest.StringArgument(FlagDomain, testDomain),
+					clitest.StringArgument(FlagFormat, tt.format),
+				)
 			}
 
 			err := AdminListTaskList(cliCtx)
@@ -257,6 +311,10 @@ func TestAdminListTaskList(t *testing.T) {
 				assert.NoError(t, err)
 			} else {
 				assert.ErrorContains(t, err, tt.expectedError)
+			}
+
+			if tt.assertions != nil {
+				tt.assertions(t, td)
 			}
 		})
 	}
@@ -311,6 +369,64 @@ func TestAdminUpdateTaskListPartitionConfig(t *testing.T) {
 			numWritePartitions: 2,
 		},
 		{
+			name: "Success - both types",
+			setupMocks: func(client *admin.MockClient, f *frontend.MockClient) {
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeDecision.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers: []*types.PollerInfo{
+						{
+							Identity: "poller",
+						},
+					},
+					PartitionConfig: nil,
+				}, nil).Times(1)
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeActivity.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers: []*types.PollerInfo{
+						{
+							Identity: "poller",
+						},
+					},
+					PartitionConfig: nil,
+				}, nil).Times(1)
+				client.EXPECT().
+					UpdateTaskListPartitionConfig(gomock.Any(), &types.UpdateTaskListPartitionConfigRequest{
+						Domain:       "test-domain",
+						TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+						TaskListType: types.TaskListTypeDecision.Ptr(),
+						PartitionConfig: &types.TaskListPartitionConfig{
+							ReadPartitions:  createPartitions(2),
+							WritePartitions: createPartitions(2),
+						},
+					}).
+					Return(&types.UpdateTaskListPartitionConfigResponse{}, nil).
+					Times(1)
+				client.EXPECT().
+					UpdateTaskListPartitionConfig(gomock.Any(), &types.UpdateTaskListPartitionConfigRequest{
+						Domain:       "test-domain",
+						TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+						TaskListType: types.TaskListTypeActivity.Ptr(),
+						PartitionConfig: &types.TaskListPartitionConfig{
+							ReadPartitions:  createPartitions(2),
+							WritePartitions: createPartitions(2),
+						},
+					}).
+					Return(&types.UpdateTaskListPartitionConfigResponse{}, nil).
+					Times(1)
+			},
+			expectedError:      "",
+			domainFlag:         "test-domain",
+			taskListFlag:       "test-tasklist",
+			numReadPartitions:  2,
+			numWritePartitions: 2,
+		},
+		{
 			name: "Success - force",
 			setupMocks: func(client *admin.MockClient, f *frontend.MockClient) {
 				client.EXPECT().
@@ -354,7 +470,7 @@ func TestAdminUpdateTaskListPartitionConfig(t *testing.T) {
 					Return(nil, fmt.Errorf("API failed")).
 					Times(1)
 			},
-			expectedError:      "Operation UpdateTaskListPartitionConfig failed.: API failed",
+			expectedError:      "API failed",
 			domainFlag:         "test-domain",
 			taskListFlag:       "test-tasklist",
 			taskListType:       "decision",
@@ -380,9 +496,10 @@ func TestAdminUpdateTaskListPartitionConfig(t *testing.T) {
 		},
 		{
 			name:               "Invalid task list type",
-			expectedError:      "Invalid task list type: valid types are [activity, decision]",
+			expectedError:      "Invalid task list type: valid types are 'activity', 'decision', or empty (both)",
 			domainFlag:         "test-domain",
 			taskListFlag:       "test-tasklist",
+			taskListType:       "ihsdajhi",
 			numReadPartitions:  2,
 			numWritePartitions: 2,
 		},
@@ -469,6 +586,59 @@ func TestAdminUpdateTaskListPartitionConfig(t *testing.T) {
 			numWritePartitions: 1,
 		},
 		{
+			name: "Safe - only one type missing pollers",
+			setupMocks: func(client *admin.MockClient, f *frontend.MockClient) {
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeDecision.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers: []*types.PollerInfo{
+						{
+							Identity: "poller",
+						},
+					},
+					PartitionConfig: nil,
+				}, nil).Times(1)
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeActivity.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers:         nil,
+					PartitionConfig: nil,
+				}, nil).Times(1)
+				client.EXPECT().
+					UpdateTaskListPartitionConfig(gomock.Any(), &types.UpdateTaskListPartitionConfigRequest{
+						Domain:       "test-domain",
+						TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+						TaskListType: types.TaskListTypeDecision.Ptr(),
+						PartitionConfig: &types.TaskListPartitionConfig{
+							ReadPartitions:  createPartitions(2),
+							WritePartitions: createPartitions(2),
+						},
+					}).
+					Return(&types.UpdateTaskListPartitionConfigResponse{}, nil).
+					Times(1)
+				client.EXPECT().
+					UpdateTaskListPartitionConfig(gomock.Any(), &types.UpdateTaskListPartitionConfigRequest{
+						Domain:       "test-domain",
+						TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+						TaskListType: types.TaskListTypeActivity.Ptr(),
+						PartitionConfig: &types.TaskListPartitionConfig{
+							ReadPartitions:  createPartitions(2),
+							WritePartitions: createPartitions(2),
+						},
+					}).
+					Return(&types.UpdateTaskListPartitionConfigResponse{}, nil).
+					Times(1)
+			},
+			domainFlag:         "test-domain",
+			taskListFlag:       "test-tasklist",
+			numReadPartitions:  2,
+			numWritePartitions: 2,
+		},
+		{
 			name: "Unsafe - no pollers",
 			setupMocks: func(client *admin.MockClient, f *frontend.MockClient) {
 				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
@@ -480,10 +650,36 @@ func TestAdminUpdateTaskListPartitionConfig(t *testing.T) {
 					PartitionConfig: nil,
 				}, nil).Times(1)
 			},
-			expectedError:      "'test-tasklist' has no pollers of type 'Decision'",
+			expectedError:      "no pollers",
 			domainFlag:         "test-domain",
 			taskListFlag:       "test-tasklist",
 			taskListType:       "decision",
+			numReadPartitions:  2,
+			numWritePartitions: 2,
+		},
+		{
+			name: "Unsafe - both types no pollers",
+			setupMocks: func(client *admin.MockClient, f *frontend.MockClient) {
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeDecision.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers:         nil,
+					PartitionConfig: nil,
+				}, nil).Times(1)
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeActivity.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers:         nil,
+					PartitionConfig: nil,
+				}, nil).Times(1)
+			},
+			expectedError:      "no pollers",
+			domainFlag:         "test-domain",
+			taskListFlag:       "test-tasklist",
 			numReadPartitions:  2,
 			numWritePartitions: 2,
 		},
@@ -553,6 +749,48 @@ func TestAdminUpdateTaskListPartitionConfig(t *testing.T) {
 			numReadPartitions:  2,
 			numWritePartitions: 2,
 		},
+		{
+			name: "Unsafe - one type fails validation",
+			setupMocks: func(client *admin.MockClient, f *frontend.MockClient) {
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeDecision.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers: []*types.PollerInfo{
+						{
+							Identity: "poller",
+						},
+					},
+					PartitionConfig: &types.TaskListPartitionConfig{
+						Version:         1,
+						ReadPartitions:  createPartitions(3),
+						WritePartitions: createPartitions(3),
+					},
+				}, nil).Times(1)
+				f.EXPECT().DescribeTaskList(gomock.Any(), &types.DescribeTaskListRequest{
+					Domain:       "test-domain",
+					TaskList:     &types.TaskList{Name: "test-tasklist", Kind: types.TaskListKindNormal.Ptr()},
+					TaskListType: types.TaskListTypeActivity.Ptr(),
+				}).Return(&types.DescribeTaskListResponse{
+					Pollers: []*types.PollerInfo{
+						{
+							Identity: "poller",
+						},
+					},
+					PartitionConfig: &types.TaskListPartitionConfig{
+						Version:         1,
+						ReadPartitions:  createPartitions(2),
+						WritePartitions: createPartitions(2),
+					},
+				}, nil).Times(1)
+			},
+			expectedError:      "test-tasklist:Decision failed validation:",
+			domainFlag:         "test-domain",
+			taskListFlag:       "test-tasklist",
+			numReadPartitions:  2,
+			numWritePartitions: 2,
+		},
 	}
 
 	// Loop through test cases
@@ -597,15 +835,4 @@ func TestAdminUpdateTaskListPartitionConfig(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper function to set up the CLI context
-func newTaskListCLIContext(t *testing.T, app *cli.App) *cli.Context {
-	return clitest.NewCLIContext(
-		t,
-		app,
-		clitest.StringArgument(FlagDomain, testDomain),
-		clitest.StringArgument(FlagTaskList, testTaskList),
-		clitest.StringArgument(FlagTaskListType, testTaskListType),
-	)
 }


### PR DESCRIPTION
While Activity/Decision TaskLists with a given name are independent, they typically represent a common purpose and we have never operated on just a single type. Handling them entirely separately within the admin commands doubles the amount of commands needed to run to operate on the TaskList and makes it harder to understand whether a given TaskList name is used for decision and/or activity tasks. Particularly as we move TaskList partition data from dynamic config to the DB it's important that we provide good operator ergonomics to avoid errors.

<!-- Describe what has changed in this PR -->
**What changed?**
Update the Admin TaskList commands with the following:
- The absence of the `tasklisttype` flag now indicates both Activity and Decision. It previously was inconsistent between defaulting to Decision or being required.
- The describe command will output one row per type specified rather than a single row.
- The describe command will output that a TaskList has 1 read/write partition rather than no output if there is no config.
- The describe command will no longer output the list of pollers and instead print out the number of pollers. This functionality is still available via the non-admin version of the command, which does nothing other than printing the pollers.
- The describe command now supports json as an output format.
- The list command will consolidate Activity and Decision TaskLists with a given name to a single row, including separate columns for the number of decision and activity pollers.
- The list command now sorts its output by TaskList name.
- The list command now supports json as an output format.
- The update-partition command now operates on multiple TaskListTypes at once rather than Decision or Activity. It performs a safety check on both before performing any updates.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Simplify operating on TaskLists

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests
- Manual testing against a local Cadence instance

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- This is a breaking change to CLI users of the admin tasklist commands. Their usage is likely rather low, with the commands to update partition data being newly added.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
