### PR TITLE
Don't log error when an ES request fails due to a version conflict

### DIFF
--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -135,7 +135,7 @@ func (p *ESProcessorImpl) bulkAfterAction(id int64, requests []bulk.GenericBulka
 				// This happens after configured retry, which means something bad happens on cluster or index
 				// When cluster back to live, bulkProcessor will re-commit those failure requests
 				// retryable errors will be retried by the bulk processor
-				p.logger.Error("Error commit bulk request. ES request failed and not retryable", tag.Error(err.Details), tag.ESRequest(request.String()))
+				p.logger.Error("Error commit bulk request. ES request failed and is retryable", tag.Error(err.Details), tag.ESRequest(request.String()))
 			} else {
 				key := p.retrieveKafkaKey(request)
 				if key == "" {

--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -129,15 +129,13 @@ func (p *ESProcessorImpl) bulkBeforeAction(executionID int64, requests []bulk.Ge
 // bulkAfterAction is triggered after bulk bulkProcessor commit
 func (p *ESProcessorImpl) bulkAfterAction(id int64, requests []bulk.GenericBulkableRequest, response *bulk.GenericBulkResponse, err *bulk.GenericError) {
 	if err != nil {
-		// This happens after configured retry, which means something bad happens on cluster or index
-		// When cluster back to live, bulkProcessor will re-commit those failure requests
-		p.logger.Error("Error commit bulk request.", tag.Error(err.Details))
-
 		isRetryable := isResponseRetriable(err.Status)
 		for _, request := range requests {
 			if isRetryable {
+				// This happens after configured retry, which means something bad happens on cluster or index
+				// When cluster back to live, bulkProcessor will re-commit those failure requests
 				// retryable errors will be retried by the bulk processor
-				p.logger.Error("ES request failed", tag.ESRequest(request.String()))
+				p.logger.Error("Error commit bulk request. ES request failed and not retryable", tag.Error(err.Details), tag.ESRequest(request.String()))
 			} else {
 				key := p.retrieveKafkaKey(request)
 				if key == "" {
@@ -172,7 +170,7 @@ func (p *ESProcessorImpl) bulkAfterAction(id int64, requests []bulk.GenericBulka
 						p.scope.IncCounter(metrics.ESProcessorCorruptedData)
 					}
 				}
-				p.logger.Error("ES request failed and is not retryable",
+				p.logger.Error("Error commit bulk request. ES request failed and is not retryable",
 					tag.ESResponseStatus(err.Status),
 					tag.ESRequest(request.String()),
 					tag.WorkflowID(wid),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
These messages are not actually failed to commit, they have newer updates already committed because of kafka messages are out of order sometimes. However we are adding error logs which are unnecessary

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve log messages

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
