### PR TITLE
Remove duplicate registration of FlagDomain

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -431,10 +431,6 @@ func newAdminDomainCommands() []*cli.Command {
 			Usage:   "Get domainID or domainName",
 			Flags: append(getDBFlags(),
 				&cli.StringFlag{
-					Name:  FlagDomain,
-					Usage: "DomainName",
-				},
-				&cli.StringFlag{
 					Name:  FlagDomainID,
 					Usage: "Domain ID(uuid)",
 				}),
@@ -702,14 +698,7 @@ func newAdminTaskListCommands() []*cli.Command {
 			Name:    "list",
 			Aliases: []string{"l"},
 			Usage:   "List active tasklist under a domain",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:    FlagDomain,
-					Aliases: []string{"do"},
-					Usage:   "Required Domain name",
-				},
-			},
-			Action: AdminListTaskList,
+			Action:  AdminListTaskList,
 		},
 		{
 			Name:    "update-partition",
@@ -906,26 +895,14 @@ func newAdminQueueCommands() []*cli.Command {
 func newAdminAsyncQueueCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:  "get",
-			Usage: "get async workflow queue configuration of a domain",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:     FlagDomain,
-					Usage:    `domain name`,
-					Required: true,
-				},
-			},
+			Name:   "get",
+			Usage:  "get async workflow queue configuration of a domain",
 			Action: AdminGetAsyncWFConfig,
 		},
 		{
 			Name:  "update",
 			Usage: "upsert async workflow queue configuration of a domain",
 			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:     FlagDomain,
-					Usage:    `domain name`,
-					Required: true,
-				},
 				&cli.StringFlag{
 					Name:     FlagJSON,
 					Usage:    `AsyncWorkflowConfiguration in json format. Schema can be found in https://github.com/uber/cadence/blob/master/common/types/admin.go`,
@@ -1416,11 +1393,7 @@ func newAdminIsolationGroupCommands() []*cli.Command {
 			Name:  "get-domain",
 			Usage: "gets the domain isolation groups",
 			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:     FlagDomain,
-					Usage:    `The domain to operate on`,
-					Required: true,
-				},
+
 				&cli.StringFlag{
 					Name:  FlagFormat,
 					Usage: `output format`,
@@ -1432,11 +1405,6 @@ func newAdminIsolationGroupCommands() []*cli.Command {
 			Name:  "update-domain",
 			Usage: "sets the domain isolation groups",
 			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:     FlagDomain,
-					Usage:    `The domain to operate on`,
-					Required: true,
-				},
 				&cli.StringFlag{
 					Name:     FlagJSON,
 					Usage:    `the configurations to upsert: eg: [{"Name": "zone-1": "State": 2}]. To remove groups, specify an empty configuration`,


### PR DESCRIPTION
This is a root argument, available for any command. It's unnecessary to register it twice, and when it's registered twice it introduces issues:
- It requires the flag to be specified after the command. For example, `cadence --domain test admin tasklist list` fails while `cadence admin tasklist list --domain test` works.
- It prevents the environmental variable CADENCE_CLI_DOMAIN from being used in place of the `--domain` flag.
- It introduces inconsistency any time the same aliases aren't specified.

<!-- Describe what has changed in this PR -->
**What changed?**
- Admin commands now require `--domain` to be specified before the sub-command, like all other commands.
- CADENCE_CLI_DOMAIN now works across all commands.
- `--do` as an alias for `--domain` now works across all commands.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Consistency across all commands.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests
- Manually tested against local cadence

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- This is a breaking change for impacted commands, as they now require domain to be specified earlier in the command.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
