### PR TITLE
Add shrinking ReplicationMessages by size

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -860,6 +860,33 @@ func ResponseMaxSize(size int) Tag {
 	return newInt("response-max-size", size)
 }
 
+// ReplicationMessagesTotalSize returns tag for ReplicationMessagesTotalSize
+// Should be used to indicate the final size of types.ReplicationMessages
+func ReplicationMessagesTotalSize(size int) Tag {
+	return newInt("replication-messages-total-size", size)
+}
+
+// ReplicationMessagesMaxSize returns tag for ReplicationMessagesMaxSize
+// Should be used to indicate maximum allowed size of types.ReplicationMessages
+func ReplicationMessagesMaxSize(size int) Tag {
+	return newInt("replication-messages-max-size", size)
+}
+
+// ReplicationTaskID returns tag for ReplicationTaskID
+// Should be used to indicate id of a types.ReplicationTask
+func ReplicationTaskID(id int64) Tag {
+	return newInt64("replication-task-id", id)
+}
+
+// ReplicationTaskCreationTime returns tag for ReplicationTaskCreationTime
+// Should be used to indicate CreationTime of a types.ReplicationTask
+func ReplicationTaskCreationTime(creationTime *int64) Tag {
+	if creationTime == nil {
+		return newStringTag("replication-task-creation-time", "nil")
+	}
+	return newInt64("replication-task-creation-time", *creationTime)
+}
+
 // /////////////////  Archival tags defined here: archival- ///////////////////
 // archival request tags
 

--- a/common/types/mapper/proto/shared.go
+++ b/common/types/mapper/proto/shared.go
@@ -639,6 +639,14 @@ func ToReplicationMessages(t *adminv1.ReplicationMessages) *types.ReplicationMes
 	}
 }
 
+// ReplicationMessagesSize returns the size (in bytes) of the types.ReplicationMessages
+func ReplicationMessagesSize(t *types.ReplicationMessages) int {
+	if t == nil {
+		return 0
+	}
+	return FromReplicationMessages(t).Size()
+}
+
 func FromReplicationTaskInfo(t *types.ReplicationTaskInfo) *adminv1.ReplicationTaskInfo {
 	if t == nil {
 		return nil

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -649,6 +649,9 @@ func (v *ReplicationMessages) GetEarliestCreationTime() *int64 {
 	return &result
 }
 
+// ReplicationMessagesSizeFn is a function type to calculate size of ReplicationMessages
+type ReplicationMessagesSizeFn func(v *ReplicationMessages) int
+
 // ReplicationTask is an internal type (TBD...)
 type ReplicationTask struct {
 	TaskType                      *ReplicationTaskType           `json:"taskType,omitempty"`

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -26,8 +26,6 @@ import (
 	"errors"
 	"time"
 
-	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
-
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/client/wrappers/retryable"
 	"github.com/uber/cadence/common"
@@ -46,6 +44,7 @@ import (
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/proto"
 	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/decision"
@@ -62,6 +61,7 @@ import (
 	"github.com/uber/cadence/service/history/workflow"
 	"github.com/uber/cadence/service/history/workflowcache"
 	warchiver "github.com/uber/cadence/service/worker/archiver"
+	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 )
 
 const (
@@ -224,6 +224,8 @@ func NewEngineWithShardContext(
 			replicationReader,
 			replicationTaskStore,
 			shard.GetTimeSource(),
+			config,
+			proto.ReplicationMessagesSize,
 		),
 		replicationTaskStore: replicationTaskStore,
 		replicationMetricsEmitter: replication.NewMetricsEmitter(

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -26,6 +26,8 @@ import (
 	"errors"
 	"time"
 
+	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/client/wrappers/retryable"
 	"github.com/uber/cadence/common"
@@ -61,7 +63,6 @@ import (
 	"github.com/uber/cadence/service/history/workflow"
 	"github.com/uber/cadence/service/history/workflowcache"
 	warchiver "github.com/uber/cadence/service/worker/archiver"
-	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 )
 
 const (

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -1578,7 +1578,6 @@ func (h *handlerImpl) GetReplicationMessages(
 
 // getReplicationShardMessages gets replication messages from all the shards of the request
 // it queries the replication tasks from each shard in parallel
-// and returns the replication tasks in the order of the request tokens
 func (h *handlerImpl) getReplicationShardMessages(
 	ctx context.Context,
 	request *types.GetReplicationMessagesRequest,
@@ -1629,7 +1628,7 @@ func (h *handlerImpl) getReplicationShardMessages(
 // The response can be partial if the total size of the response exceeds the max size.
 // In this case, responses with oldest replication tasks will be returned
 func (h *handlerImpl) buildGetReplicationMessagesResponse(metricsScope metrics.Scope, msgs []replicationShardMessages) *types.GetReplicationMessagesResponse {
-	// Shards with large maessages can cause the response to exceed the max size.
+	// Shards with large messages can cause the response to exceed the max size.
 	// In this case, we need to skip some shard messages to make sure the result response size is within the limit.
 	// To prevent a replication lag in the future, we should return the messages with the oldest replication task.
 	// So we sort the shard messages by the earliest creation time of the replication task.

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -25,8 +25,11 @@ package replication
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/uber/cadence/service/history/config"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
@@ -47,6 +50,13 @@ type (
 
 		reader taskReader
 		store  *TaskStore
+
+		// replicationMessagesSizeFn is the function to calculate the size of types.ReplicationMessages
+		replicationMessagesSizeFn types.ReplicationMessagesSizeFn
+
+		// maxReplicationMessagesSize is the max size of types.ReplicationMessages
+		// that can be sent in a single RPC call
+		maxReplicationMessagesSize int
 
 		timeSource clock.TimeSource
 	}
@@ -71,6 +81,8 @@ func NewTaskAckManager(
 	reader taskReader,
 	store *TaskStore,
 	timeSource clock.TimeSource,
+	config *config.Config,
+	replicationMessagesSizeFn types.ReplicationMessagesSizeFn,
 ) TaskAckManager {
 
 	return TaskAckManager{
@@ -83,6 +95,9 @@ func NewTaskAckManager(
 		reader:     reader,
 		store:      store,
 		timeSource: timeSource,
+
+		maxReplicationMessagesSize: config.MaxResponseSize,
+		replicationMessagesSizeFn:  replicationMessagesSizeFn,
 	}
 }
 
@@ -97,14 +112,17 @@ func (t *TaskAckManager) GetTasks(ctx context.Context, pollingCluster string, la
 	if err != nil {
 		return nil, err
 	}
-
-	// Happy path assumption - we will push all tasks to replication tasks.
-	replicationTasks := make([]*types.ReplicationTask, 0, len(tasks))
+	t.scope.RecordTimer(metrics.ReplicationTasksFetched, time.Duration(len(tasks)))
 
 	var (
-		readLevel                      = lastReadTaskID
 		oldestUnprocessedTaskTimestamp = t.timeSource.Now().UnixNano()
 		oldestUnprocessedTaskID        = t.ackLevels.GetTransferMaxReadLevel()
+		msgs                           = &types.ReplicationMessages{
+			// Happy path assumption - we will push all tasks to replication tasks.
+			ReplicationTasks:       make([]*types.ReplicationTask, 0, len(tasks)),
+			HasMore:                hasMore,
+			LastRetrievedMessageID: lastReadTaskID,
+		}
 	)
 
 	if len(tasks) > 0 {
@@ -123,26 +141,33 @@ func (t *TaskAckManager) GetTasks(ctx context.Context, pollingCluster string, la
 				t.logger.Warn("Failed to get replication task.", tag.Error(err))
 			} else {
 				t.logger.Error("Failed to get replication task. Return what we have so far.", tag.Error(err))
-				hasMore = true
+				msgs.HasMore = true
 				break
 			}
 		}
 
 		// We update readLevel only if we have found matching replication tasks on the passive side.
-		readLevel = task.TaskID
+		msgs.LastRetrievedMessageID = task.TaskID
 		if replicationTask != nil {
-			replicationTasks = append(replicationTasks, replicationTask)
+			msgs.ReplicationTasks = append(msgs.ReplicationTasks, replicationTask)
 		}
 	}
+
 	taskGeneratedTimer.Stop()
 
 	t.scope.RecordTimer(metrics.ReplicationTasksLagRaw, time.Duration(t.ackLevels.GetTransferMaxReadLevel()-oldestUnprocessedTaskID))
 	t.scope.RecordTimer(metrics.ReplicationTasksDelay, time.Duration(oldestUnprocessedTaskTimestamp-t.timeSource.Now().UnixNano()))
 
-	t.scope.RecordTimer(metrics.ReplicationTasksLag, time.Duration(t.ackLevels.GetTransferMaxReadLevel()-readLevel))
-	t.scope.RecordTimer(metrics.ReplicationTasksFetched, time.Duration(len(tasks)))
-	t.scope.RecordTimer(metrics.ReplicationTasksReturned, time.Duration(len(replicationTasks)))
-	t.scope.RecordTimer(metrics.ReplicationTasksReturnedDiff, time.Duration(len(tasks)-len(replicationTasks)))
+	// Sometimes the total size of replication tasks can be larger than the max response size
+	// It caused the replication lag until history.replicatorTaskBatchSize is not adjusted to a smaller value
+	// To prevent the lag and manual actions, we stop adding more tasks to the batch if the total size exceeds the limit
+	if err := t.shrinkMessagesBySize(msgs); err != nil {
+		return nil, err
+	}
+
+	t.scope.RecordTimer(metrics.ReplicationTasksLag, time.Duration(t.ackLevels.GetTransferMaxReadLevel()-msgs.LastRetrievedMessageID))
+	t.scope.RecordTimer(metrics.ReplicationTasksReturned, time.Duration(len(msgs.ReplicationTasks)))
+	t.scope.RecordTimer(metrics.ReplicationTasksReturnedDiff, time.Duration(len(tasks)-len(msgs.ReplicationTasks)))
 
 	if err := t.ackLevels.UpdateClusterReplicationLevel(pollingCluster, lastReadTaskID); err != nil {
 		t.logger.Error("error updating replication level for shard", tag.Error(err), tag.OperationFailed)
@@ -152,10 +177,54 @@ func (t *TaskAckManager) GetTasks(ctx context.Context, pollingCluster string, la
 		t.logger.Error("error updating replication level for hydrated task store", tag.Error(err), tag.OperationFailed)
 	}
 
-	t.logger.Debug("Get replication tasks", tag.SourceCluster(pollingCluster), tag.ShardReplicationAck(lastReadTaskID), tag.ReadLevel(readLevel))
-	return &types.ReplicationMessages{
-		ReplicationTasks:       replicationTasks,
-		HasMore:                hasMore,
-		LastRetrievedMessageID: readLevel,
-	}, nil
+	t.logger.Debug(
+		"Get replication tasks",
+		tag.SourceCluster(pollingCluster),
+		tag.ShardReplicationAck(lastReadTaskID),
+		tag.ReadLevel(msgs.LastRetrievedMessageID),
+	)
+	return msgs, nil
+}
+
+// shrinkMessagesBySize shrinks the replication messages by removing the last replication task until the total size is allowed
+func (t *TaskAckManager) shrinkMessagesBySize(msgs *types.ReplicationMessages) error {
+	// if there are no replication tasks, do nothing
+	if len(msgs.ReplicationTasks) == 0 {
+		return nil
+	}
+
+	maxSize := t.maxReplicationMessagesSize
+
+	for {
+		totalSize := t.replicationMessagesSizeFn(msgs)
+
+		// if the total size is allowed, return the replication messages
+		if totalSize < maxSize {
+			return nil
+		}
+
+		lastTask := msgs.ReplicationTasks[len(msgs.ReplicationTasks)-1]
+		t.logger.Warn("Replication messages size is too large. Shrinking the messages by removing the last replication task",
+			tag.ReplicationMessagesTotalSize(totalSize),
+			tag.ReplicationMessagesMaxSize(maxSize),
+			tag.ReplicationTaskID(lastTask.SourceTaskID),
+			tag.ReplicationTaskCreationTime(lastTask.CreationTime),
+		)
+
+		// change HasMore to true to indicate that there are more tasks to be fetched
+		msgs.HasMore = true
+
+		// remove the last replication task
+		msgs.ReplicationTasks = msgs.ReplicationTasks[:len(msgs.ReplicationTasks)-1]
+
+		// should never happen, but just in case
+		// if there are no more replication tasks, return an error
+		if len(msgs.ReplicationTasks) == 0 {
+			return fmt.Errorf("replication messages size is too large and cannot be shrunk anymore, shard will be stuck until the message size is reduced or max size is increased")
+
+		}
+
+		// update the last retrieved message ID to the new last task ID
+		msgs.LastRetrievedMessageID = msgs.ReplicationTasks[len(msgs.ReplicationTasks)-1].SourceTaskID
+	}
 }

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -29,8 +29,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/uber/cadence/service/history/config"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
@@ -38,6 +36,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/config"
 )
 
 type (

--- a/service/history/replication/task_ack_manager_test.go
+++ b/service/history/replication/task_ack_manager_test.go
@@ -27,10 +27,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/uber/cadence/common/types/mapper/proto"
-
-	"github.com/uber/cadence/service/history/config"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,6 +36,8 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/proto"
+	"github.com/uber/cadence/service/history/config"
 )
 
 var (

--- a/service/history/replication/task_ack_manager_test.go
+++ b/service/history/replication/task_ack_manager_test.go
@@ -27,6 +27,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/uber/cadence/common/types/mapper/proto"
+
+	"github.com/uber/cadence/service/history/config"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -46,6 +50,7 @@ var (
 
 	testHydratedTask11 = types.ReplicationTask{SourceTaskID: 11, HistoryTaskV2Attributes: &types.HistoryTaskV2Attributes{DomainID: testDomainID}}
 	testHydratedTask12 = types.ReplicationTask{SourceTaskID: 12, SyncActivityTaskAttributes: &types.SyncActivityTaskAttributes{DomainID: testDomainID}}
+	testHydratedTask13 = types.ReplicationTask{SourceTaskID: 13, HistoryTaskV2Attributes: &types.HistoryTaskV2Attributes{DomainID: testDomainID}}
 	testHydratedTask14 = types.ReplicationTask{SourceTaskID: 14, FailoverMarkerAttributes: &types.FailoverMarkerAttributes{DomainID: testDomainID}}
 
 	testHydratedTaskErrorRecoverable    = types.ReplicationTask{SourceTaskID: -100}
@@ -72,6 +77,10 @@ var (
 	)
 )
 
+const (
+	testMaxResponseSize = 4 * 1024 * 1024 // 4MB
+)
+
 func TestTaskAckManager_GetTasks(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -84,7 +93,27 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 		expectResult   *types.ReplicationMessages
 		expectErr      string
 		expectAckLevel int64
+		config         *config.Config
 	}{
+		{
+			name: "main flow - no replication tasks",
+			ackLevels: &fakeAckLevelStore{
+				readLevel: 200,
+				remote:    map[string]int64{testClusterA: 2},
+			},
+			domains:        fakeDomainCache{testDomainID: testDomain},
+			reader:         fakeTaskReader{},
+			hydrator:       fakeTaskHydrator{},
+			pollingCluster: testClusterA,
+			lastReadLevel:  5,
+			expectResult: &types.ReplicationMessages{
+				ReplicationTasks:       []*types.ReplicationTask{},
+				LastRetrievedMessageID: 5,
+				HasMore:                false,
+			},
+			expectAckLevel: 5,
+			config:         &config.Config{MaxResponseSize: testMaxResponseSize},
+		},
 		{
 			name: "main flow - continues on recoverable error",
 			ackLevels: &fakeAckLevelStore{
@@ -107,6 +136,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 				HasMore:                false,
 			},
 			expectAckLevel: 5,
+			config:         &config.Config{MaxResponseSize: testMaxResponseSize},
 		},
 		{
 			name: "main flow - stops at non recoverable error",
@@ -130,6 +160,60 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 				HasMore:                true,
 			},
 			expectAckLevel: 5,
+			config:         &config.Config{MaxResponseSize: testMaxResponseSize},
+		},
+		{
+			name: "main flow - stops at a message exceeded max response size",
+			ackLevels: &fakeAckLevelStore{
+				readLevel: 200,
+				remote:    map[string]int64{testClusterA: 2},
+			},
+			domains: fakeDomainCache{testDomainID: testDomain},
+			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
+			hydrator: fakeTaskHydrator{
+				testTask11.TaskID: testHydratedTask11,
+				testTask12.TaskID: testHydratedTask12,
+				testTask13.TaskID: testHydratedTask13,
+				testTask14.TaskID: testHydratedTask14, // Will stop adding tasks beyond this point
+			},
+			pollingCluster: testClusterA,
+			lastReadLevel:  5,
+			expectResult: &types.ReplicationMessages{
+				ReplicationTasks:       []*types.ReplicationTask{&testHydratedTask11, &testHydratedTask12, &testHydratedTask13},
+				LastRetrievedMessageID: 13,
+				HasMore:                true,
+			},
+			expectAckLevel: 5,
+			config: &config.Config{
+				MaxResponseSize: proto.FromReplicationMessages(&types.ReplicationMessages{
+					ReplicationTasks:       []*types.ReplicationTask{&testHydratedTask11, &testHydratedTask12, &testHydratedTask13},
+					LastRetrievedMessageID: 13,
+					HasMore:                true,
+				}).Size() + 1,
+			},
+		},
+		{
+			name: "main flow - fail at a message exceeded max response size",
+			ackLevels: &fakeAckLevelStore{
+				readLevel: 200,
+				remote:    map[string]int64{testClusterA: 2},
+			},
+			domains: fakeDomainCache{testDomainID: testDomain},
+			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
+			hydrator: fakeTaskHydrator{
+				testTask11.TaskID: testHydratedTask11,
+				testTask12.TaskID: testHydratedTask12,
+				testTask13.TaskID: testHydratedTask13,
+				testTask14.TaskID: testHydratedTask14, // Will stop adding tasks beyond this point
+			},
+			pollingCluster: testClusterA,
+			lastReadLevel:  5,
+			expectResult:   nil,
+			expectErr:      "replication messages size is too large and cannot be shrunk anymore, shard will be stuck until the message size is reduced or max size is increased",
+			expectAckLevel: 2,
+			config: &config.Config{
+				MaxResponseSize: 0,
+			},
 		},
 		{
 			name: "skips tasks for domains non belonging to polling cluster",
@@ -148,6 +232,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 				HasMore:                false,
 			},
 			expectAckLevel: 5,
+			config:         &config.Config{MaxResponseSize: testMaxResponseSize},
 		},
 		{
 			name: "uses remote ack level for first fetch (empty task ID)",
@@ -166,6 +251,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 				HasMore:                false,
 			},
 			expectAckLevel: 12,
+			config:         &config.Config{MaxResponseSize: testMaxResponseSize},
 		},
 		{
 			name: "failed to read replication tasks - return error",
@@ -177,6 +263,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			pollingCluster: testClusterA,
 			lastReadLevel:  5,
 			expectErr:      "error reading replication tasks",
+			config:         &config.Config{MaxResponseSize: testMaxResponseSize},
 		},
 		{
 			name: "failed to get domain - stops",
@@ -194,6 +281,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 				LastRetrievedMessageID: 5,
 				HasMore:                true,
 			},
+			config: &config.Config{MaxResponseSize: testMaxResponseSize},
 		},
 		{
 			name: "failed to update ack level - no error, return response anyway",
@@ -212,13 +300,24 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 				LastRetrievedMessageID: 11,
 				HasMore:                false,
 			},
+			config: &config.Config{MaxResponseSize: testMaxResponseSize},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			taskStore := createTestTaskStore(t, tt.domains, tt.hydrator)
-			ackManager := NewTaskAckManager(testShardID, tt.ackLevels, metrics.NewNoopMetricsClient(), log.NewNoop(), tt.reader, taskStore, clock.NewMockedTimeSource())
+			ackManager := NewTaskAckManager(
+				testShardID,
+				tt.ackLevels,
+				metrics.NewNoopMetricsClient(),
+				log.NewNoop(),
+				tt.reader,
+				taskStore,
+				clock.NewMockedTimeSource(),
+				tt.config,
+				proto.ReplicationMessagesSize,
+			)
 			result, err := ackManager.GetTasks(context.Background(), tt.pollingCluster, tt.lastReadLevel)
 
 			if tt.expectErr != "" {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
A new function `shrinkMessagesBySize` has been added to `TaskAckManager.GetTasks`. If a total size of output `types.ReplicationMessages` is greater than `maxResponseSize` (4 MB), the new function will remove the last task from the output array of `types.ReplicationTasks` and updates `HasMore` to true and `LastRetrievedMessageID` to the new last task's id. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The log message `Replication messages did not fit in the response (history host)` indicates that the size of a shard message exceeds the max allowed size. It causes the task processing of this shard to be stuck. To prevent it, `history.replicatorTaskBatchSize` can be changed to a low number to allow `historyEngine` to retrieve a smaller number of messages. It requires some manual actions and they will be prevented by this PR. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Unit test
* Manual testing on staging envs


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Replication can stuck if there are some non-covered bugs. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
