### PR TITLE
Migrate history task scheduler to domain based WRR scheduler

### DIFF
--- a/common/dynamicconfig/config_test.go
+++ b/common/dynamicconfig/config_test.go
@@ -273,6 +273,20 @@ func (s *configSuite) TestGetMapProperty() {
 	s.Equal("321", value()["testKey"])
 }
 
+func (s *configSuite) TestGetMapPropertyFilteredByDomain() {
+	key := TestGetMapPropertyKey
+	domain := "testDomain"
+	val := map[string]interface{}{
+		"testKey": 123,
+	}
+	value := s.cln.GetMapPropertyFilteredByDomain(key)
+	s.Equal(key.DefaultMap(), value(domain))
+	val["testKey"] = "321"
+	s.client.SetValue(key, val)
+	s.Equal(val, value(domain))
+	s.Equal("321", value(domain)["testKey"])
+}
+
 func (s *configSuite) TestGetListProperty() {
 	key := TestGetListPropertyKey
 	arr := []interface{}{}

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1185,6 +1185,7 @@ const (
 	// Default value: 0
 	// Allowed filters: DomainName
 	MutableStateChecksumVerifyProbability
+	TaskSchedulerMigrationRatio
 	// MaxActivityCountDispatchByDomain max # of activity tasks to dispatch to matching before creating transfer tasks. This is an performance optimization to skip activity scheduling efforts.
 	// KeyName: history.activityDispatchForSyncMatchCountByDomain
 	// Value type: Int
@@ -1697,6 +1698,7 @@ const (
 	TransferProcessorEnableValidator
 	TaskSchedulerEnableRateLimiter
 	TaskSchedulerEnableRateLimiterShadowMode
+	TaskSchedulerEnableMigration
 	// EnableAdminProtection is whether to enable admin checking
 	// KeyName: history.enableAdminProtection
 	// Value type: Bool
@@ -2807,6 +2809,7 @@ const (
 	// Default value: please see common.ConvertIntMapToDynamicConfigMapProperty(DefaultTaskPriorityWeight) in code base
 	// Allowed filters: N/A
 	TaskSchedulerRoundRobinWeights
+	TaskSchedulerDomainRoundRobinWeights
 	// QueueProcessorPendingTaskSplitThreshold is the threshold for the number of pending tasks per domain
 	// KeyName: history.queueProcessorPendingTaskSplitThreshold
 	// Value type: Map
@@ -3615,6 +3618,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "MutableStateChecksumVerifyProbability is the probability [0-100] that checksum will be verified for mutable state",
 		DefaultValue: 0,
 	},
+	TaskSchedulerMigrationRatio: {
+		KeyName:      "history.taskSchedulerMigrationRatio",
+		Description:  "TaskSchedulerMigrationRatio is the ratio of task that is migrated to new scheduler",
+		DefaultValue: 0,
+	},
 	MaxActivityCountDispatchByDomain: {
 		KeyName:      "history.maxActivityCountDispatchByDomain",
 		Description:  "MaxActivityCountDispatchByDomain max # of activity tasks to dispatch to matching before creating transfer tasks. This is an performance optimization to skip activity scheduling efforts.",
@@ -4082,6 +4090,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "history.taskSchedulerEnableRateLimiterShadowMode",
 		Description:  "TaskSchedulerEnableRateLimiterShadowMode indicates whether the task scheduler rate limiter is in shadow mode",
 		DefaultValue: true,
+	},
+	TaskSchedulerEnableMigration: {
+		KeyName:      "history.taskSchedulerEnableMigration",
+		Description:  "TaskSchedulerEnableMigration indicates whether the task scheduler migration is enabled",
+		DefaultValue: false,
 	},
 	EnableAdminProtection: {
 		KeyName:      "history.enableAdminProtection",
@@ -5087,6 +5100,12 @@ var MapKeys = map[MapKey]DynamicMap{
 	TaskSchedulerRoundRobinWeights: {
 		KeyName:      "history.taskSchedulerRoundRobinWeight",
 		Description:  "TaskSchedulerRoundRobinWeights is the priority weight for weighted round robin task scheduler",
+		DefaultValue: common.ConvertIntMapToDynamicConfigMapProperty(DefaultTaskSchedulerRoundRobinWeights),
+	},
+	TaskSchedulerDomainRoundRobinWeights: {
+		KeyName:      "history.taskSchedulerDomainRoundRobinWeight",
+		Description:  "TaskSchedulerDomainRoundRobinWeights is the priority round robin weights for domains",
+		Filters:      []Filter{DomainName},
 		DefaultValue: common.ConvertIntMapToDynamicConfigMapProperty(DefaultTaskSchedulerRoundRobinWeights),
 	},
 	QueueProcessorPendingTaskSplitThreshold: {

--- a/common/task/fifo_task_scheduler_test.go
+++ b/common/task/fifo_task_scheduler_test.go
@@ -124,5 +124,5 @@ func (s *fifoTaskSchedulerSuite) TestTrySubmit() {
 }
 
 func (s *fifoTaskSchedulerSuite) TestSchedulerContract() {
-	testSchedulerContract(s.Assertions, s.controller, s.scheduler)
+	testSchedulerContract(s.Assertions, s.controller, s.scheduler, nil)
 }

--- a/common/task/scheduler_options.go
+++ b/common/task/scheduler_options.go
@@ -55,9 +55,7 @@ func NewSchedulerOptions[K comparable](
 	case SchedulerTypeWRR:
 		options.WRRSchedulerOptions = &WeightedRoundRobinTaskSchedulerOptions[K]{
 			QueueSize:            queueSize,
-			WorkerCount:          workerCount,
 			DispatcherCount:      dispatcherCount,
-			RetryPolicy:          common.CreateTaskProcessingRetryPolicy(),
 			TaskToChannelKeyFn:   taskToChannelKeyFn,
 			ChannelKeyToWeightFn: channelKeyToWeightFn,
 		}

--- a/common/task/scheduler_options_test.go
+++ b/common/task/scheduler_options_test.go
@@ -50,7 +50,7 @@ func TestSchedulerOptionsString(t *testing.T) {
 			queueSize:       3,
 			workerCount:     dynamicconfig.GetIntPropertyFn(4),
 			dispatcherCount: 5,
-			want:            "{schedulerType:2, fifoSchedulerOptions:<nil>, wrrSchedulerOptions:{QueueSize: 3, WorkerCount: 4, DispatcherCount: 5}}",
+			want:            "{schedulerType:2, fifoSchedulerOptions:<nil>, wrrSchedulerOptions:{QueueSize: 3, DispatcherCount: 5}}",
 		},
 		{
 			desc:          "InvalidSchedulerType",

--- a/common/task/weighted_round_robin_task_scheduler_options.go
+++ b/common/task/weighted_round_robin_task_scheduler_options.go
@@ -22,21 +22,16 @@ package task
 
 import (
 	"fmt"
-
-	"github.com/uber/cadence/common/backoff"
-	"github.com/uber/cadence/common/dynamicconfig"
 )
 
 // WeightedRoundRobinTaskSchedulerOptions configs WRR task scheduler
 type WeightedRoundRobinTaskSchedulerOptions[K comparable] struct {
 	QueueSize            int
-	WorkerCount          dynamicconfig.IntPropertyFn
 	DispatcherCount      int
-	RetryPolicy          backoff.RetryPolicy
 	TaskToChannelKeyFn   func(PriorityTask) K
 	ChannelKeyToWeightFn func(K) int
 }
 
 func (o *WeightedRoundRobinTaskSchedulerOptions[K]) String() string {
-	return fmt.Sprintf("{QueueSize: %v, WorkerCount: %v, DispatcherCount: %v}", o.QueueSize, o.WorkerCount(), o.DispatcherCount)
+	return fmt.Sprintf("{QueueSize: %v, DispatcherCount: %v}", o.QueueSize, o.DispatcherCount)
 }

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -94,9 +94,12 @@ type Config struct {
 	TaskSchedulerQueueSize                   dynamicconfig.IntPropertyFn
 	TaskSchedulerDispatcherCount             dynamicconfig.IntPropertyFn
 	TaskSchedulerRoundRobinWeights           dynamicconfig.MapPropertyFn
+	TaskSchedulerDomainRoundRobinWeights     dynamicconfig.MapPropertyFnWithDomainFilter
 	TaskSchedulerGlobalDomainRPS             dynamicconfig.IntPropertyFnWithDomainFilter
 	TaskSchedulerEnableRateLimiter           dynamicconfig.BoolPropertyFn
 	TaskSchedulerEnableRateLimiterShadowMode dynamicconfig.BoolPropertyFnWithDomainFilter
+	TaskSchedulerEnableMigration             dynamicconfig.BoolPropertyFn
+	TaskSchedulerMigrationRatio              dynamicconfig.IntPropertyFn
 	TaskCriticalRetryCount                   dynamicconfig.IntPropertyFn
 	ActiveTaskRedispatchInterval             dynamicconfig.DurationPropertyFn
 	StandbyTaskRedispatchInterval            dynamicconfig.DurationPropertyFn
@@ -372,9 +375,12 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		TaskSchedulerQueueSize:                   dc.GetIntProperty(dynamicconfig.TaskSchedulerQueueSize),
 		TaskSchedulerDispatcherCount:             dc.GetIntProperty(dynamicconfig.TaskSchedulerDispatcherCount),
 		TaskSchedulerRoundRobinWeights:           dc.GetMapProperty(dynamicconfig.TaskSchedulerRoundRobinWeights),
+		TaskSchedulerDomainRoundRobinWeights:     dc.GetMapPropertyFilteredByDomain(dynamicconfig.TaskSchedulerDomainRoundRobinWeights),
 		TaskSchedulerGlobalDomainRPS:             dc.GetIntPropertyFilteredByDomain(dynamicconfig.TaskSchedulerGlobalDomainRPS),
 		TaskSchedulerEnableRateLimiter:           dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableRateLimiter),
 		TaskSchedulerEnableRateLimiterShadowMode: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.TaskSchedulerEnableRateLimiterShadowMode),
+		TaskSchedulerEnableMigration:             dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableMigration),
+		TaskSchedulerMigrationRatio:              dc.GetIntProperty(dynamicconfig.TaskSchedulerMigrationRatio),
 		TaskCriticalRetryCount:                   dc.GetIntProperty(dynamicconfig.TaskCriticalRetryCount),
 		ActiveTaskRedispatchInterval:             dc.GetDurationProperty(dynamicconfig.ActiveTaskRedispatchInterval),
 		StandbyTaskRedispatchInterval:            dc.GetDurationProperty(dynamicconfig.StandbyTaskRedispatchInterval),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -97,6 +97,9 @@ func TestNewConfig(t *testing.T) {
 		"TaskSchedulerQueueSize":                               {dynamicconfig.TaskSchedulerQueueSize, 34},
 		"TaskSchedulerDispatcherCount":                         {dynamicconfig.TaskSchedulerDispatcherCount, 35},
 		"TaskSchedulerRoundRobinWeights":                       {dynamicconfig.TaskSchedulerRoundRobinWeights, map[string]interface{}{"key": 1}},
+		"TaskSchedulerDomainRoundRobinWeights":                 {dynamicconfig.TaskSchedulerDomainRoundRobinWeights, map[string]interface{}{"key": 2}},
+		"TaskSchedulerEnableMigration":                         {dynamicconfig.TaskSchedulerEnableMigration, true},
+		"TaskSchedulerMigrationRatio":                          {dynamicconfig.TaskSchedulerMigrationRatio, 36},
 		"TaskCriticalRetryCount":                               {dynamicconfig.TaskCriticalRetryCount, 37},
 		"ActiveTaskRedispatchInterval":                         {dynamicconfig.ActiveTaskRedispatchInterval, time.Second},
 		"StandbyTaskRedispatchInterval":                        {dynamicconfig.StandbyTaskRedispatchInterval, time.Second},
@@ -340,6 +343,8 @@ func getValue(f *reflect.Value) interface{} {
 			return fn(0)
 		case dynamicconfig.BoolPropertyFnWithDomainIDAndWorkflowIDFilter:
 			return fn("domain", "workflowID")
+		case dynamicconfig.MapPropertyFnWithDomainFilter:
+			return fn("domain")
 		case func() []string:
 			return fn()
 		default:

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -142,6 +142,7 @@ func (h *handlerImpl) Start() {
 		h.GetLogger(),
 		h.GetMetricsClient(),
 		h.GetTimeSource(),
+		h.GetDomainCache(),
 	)
 	if err != nil {
 		h.GetLogger().Fatal("Creating priority task processor failed", tag.Error(err))

--- a/service/history/task/processor_test.go
+++ b/service/history/task/processor_test.go
@@ -29,15 +29,14 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
-	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/task"
 	"github.com/uber/cadence/service/history/config"
-	"github.com/uber/cadence/service/history/shard"
 )
 
 type (
@@ -46,7 +45,7 @@ type (
 		*require.Assertions
 
 		controller           *gomock.Controller
-		mockShard            *shard.TestContext
+		mockDomainCache      *cache.MockDomainCache
 		mockPriorityAssigner *MockPriorityAssigner
 
 		timeSource    clock.TimeSource
@@ -66,15 +65,7 @@ func (s *queueTaskProcessorSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
 	s.controller = gomock.NewController(s.T())
-	s.mockShard = shard.NewTestContext(
-		s.T(),
-		s.controller,
-		&persistence.ShardInfo{
-			ShardID: 10,
-			RangeID: 1,
-		},
-		config.NewForTest(),
-	)
+	s.mockDomainCache = cache.NewMockDomainCache(s.controller)
 	s.mockPriorityAssigner = NewMockPriorityAssigner(s.controller)
 
 	s.timeSource = clock.NewRealTimeSource()
@@ -84,26 +75,24 @@ func (s *queueTaskProcessorSuite) SetupTest() {
 	s.processor = s.newTestQueueTaskProcessor()
 }
 
-func (s *queueTaskProcessorSuite) TearDownTest() {
-	s.controller.Finish()
-	s.mockShard.Finish(s.T())
-}
-
-func (s *queueTaskProcessorSuite) TestIsRunning() {
-	s.False(s.processor.isRunning())
-
-	s.processor.Start()
-	s.True(s.processor.isRunning())
-
-	s.processor.Stop()
-	s.False(s.processor.isRunning())
-}
+func (s *queueTaskProcessorSuite) TearDownTest() {}
 
 func (s *queueTaskProcessorSuite) TestStartStop() {
 	mockScheduler := task.NewMockScheduler(s.controller)
 	mockScheduler.EXPECT().Start().Times(1)
 	mockScheduler.EXPECT().Stop().Times(1)
-	s.processor.hostScheduler = mockScheduler
+	s.processor.scheduler = mockScheduler
+
+	s.processor.Start()
+	s.processor.Stop()
+}
+
+func (s *queueTaskProcessorSuite) TestStartStopWithNewScheduler() {
+	mockScheduler := task.NewMockScheduler(s.controller)
+	mockScheduler.EXPECT().Start().Times(2)
+	mockScheduler.EXPECT().Stop().Times(2)
+	s.processor.scheduler = mockScheduler
+	s.processor.newScheduler = mockScheduler
 
 	s.processor.Start()
 	s.processor.Stop()
@@ -116,7 +105,21 @@ func (s *queueTaskProcessorSuite) TestSubmit() {
 	mockScheduler := task.NewMockScheduler(s.controller)
 	mockScheduler.EXPECT().Submit(NewMockTaskMatcher(mockTask)).Return(nil).Times(1)
 
-	s.processor.hostScheduler = mockScheduler
+	s.processor.scheduler = mockScheduler
+
+	err := s.processor.Submit(mockTask)
+	s.NoError(err)
+}
+
+func (s *queueTaskProcessorSuite) TestSubmitNewScheduler() {
+	mockTask := NewMockTask(s.controller)
+	s.mockPriorityAssigner.EXPECT().Assign(NewMockTaskMatcher(mockTask)).Return(nil).Times(1)
+
+	mockScheduler := task.NewMockScheduler(s.controller)
+	mockScheduler.EXPECT().Submit(NewMockTaskMatcher(mockTask)).Return(nil).Times(1)
+
+	s.processor.newScheduler = mockScheduler
+	s.processor.newSchedulerProbabilityFn = func(...dynamicconfig.FilterOption) int { return 100 }
 
 	err := s.processor.Submit(mockTask)
 	s.NoError(err)
@@ -141,13 +144,28 @@ func (s *queueTaskProcessorSuite) TestTrySubmit_Fail() {
 	mockScheduler := task.NewMockScheduler(s.controller)
 	mockScheduler.EXPECT().TrySubmit(NewMockTaskMatcher(mockTask)).Return(false, errTrySubmit).Times(1)
 
-	s.processor.hostScheduler = mockScheduler
+	s.processor.scheduler = mockScheduler
 
 	submitted, err := s.processor.TrySubmit(mockTask)
 	s.Equal(errTrySubmit, err)
 	s.False(submitted)
 }
 
+func (s *queueTaskProcessorSuite) TestTrySubmit_Fail_NewScheduler() {
+	mockTask := NewMockTask(s.controller)
+	s.mockPriorityAssigner.EXPECT().Assign(NewMockTaskMatcher(mockTask)).Return(nil).Times(1)
+
+	errTrySubmit := errors.New("some randome error")
+	mockScheduler := task.NewMockScheduler(s.controller)
+	mockScheduler.EXPECT().TrySubmit(NewMockTaskMatcher(mockTask)).Return(false, errTrySubmit).Times(1)
+
+	s.processor.newScheduler = mockScheduler
+	s.processor.newSchedulerProbabilityFn = func(...dynamicconfig.FilterOption) int { return 100 }
+
+	submitted, err := s.processor.TrySubmit(mockTask)
+	s.Equal(errTrySubmit, err)
+	s.False(submitted)
+}
 func (s *queueTaskProcessorSuite) TestNewSchedulerOptions_UnknownSchedulerType() {
 	options, err := task.NewSchedulerOptions[int](0, 100, dynamicconfig.GetIntPropertyFn(10), 1, func(task.PriorityTask) int { return 1 }, func(int) int { return 1 })
 	s.Error(err)
@@ -162,7 +180,72 @@ func (s *queueTaskProcessorSuite) newTestQueueTaskProcessor() *processorImpl {
 		s.logger,
 		s.metricsClient,
 		s.timeSource,
+		s.mockDomainCache,
 	)
 	s.NoError(err)
 	return processor.(*processorImpl)
+}
+
+func TestGetDomainPriorityWeight(t *testing.T) {
+	testCases := []struct {
+		name      string
+		mockSetup func(*cache.MockDomainCache, dynamicconfig.Client)
+		expected  int
+	}{
+		{
+			name: "success",
+			mockSetup: func(mockDomainCache *cache.MockDomainCache, client dynamicconfig.Client) {
+				mockDomainCache.EXPECT().GetDomainName("test-domain-id").Return("test-domain-name", nil).Times(1)
+				client.UpdateValue(dynamicconfig.TaskSchedulerDomainRoundRobinWeights, map[string]interface{}{"1": 10})
+			},
+			expected: 10,
+		},
+		{
+			name: "domain cache error, use default",
+			mockSetup: func(mockDomainCache *cache.MockDomainCache, client dynamicconfig.Client) {
+				mockDomainCache.EXPECT().GetDomainName("test-domain-id").Return("", errors.New("test-error")).Times(1)
+				client.UpdateValue(dynamicconfig.TaskSchedulerDomainRoundRobinWeights, map[string]interface{}{"1": 10})
+			},
+			expected: 500,
+		},
+		{
+			name: "invalid map value, use default",
+			mockSetup: func(mockDomainCache *cache.MockDomainCache, client dynamicconfig.Client) {
+				mockDomainCache.EXPECT().GetDomainName("test-domain-id").Return("test-domain-name", nil).Times(1)
+				client.UpdateValue(dynamicconfig.TaskSchedulerDomainRoundRobinWeights, map[string]interface{}{"1": "invalid"})
+			},
+			expected: 500,
+		},
+		{
+			name: "unspecified priority",
+			mockSetup: func(mockDomainCache *cache.MockDomainCache, client dynamicconfig.Client) {
+				mockDomainCache.EXPECT().GetDomainName("test-domain-id").Return("test-domain-name", nil).Times(1)
+				client.UpdateValue(dynamicconfig.TaskSchedulerDomainRoundRobinWeights, map[string]interface{}{"2": 10})
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+
+			mockDomainCache := cache.NewMockDomainCache(mockCtrl)
+			client := dynamicconfig.NewInMemoryClient()
+			config := config.New(
+				dynamicconfig.NewCollection(
+					client,
+					testlogger.New(t),
+				),
+				1024,
+				1024,
+				false,
+				"hostname",
+			)
+			tc.mockSetup(mockDomainCache, client)
+
+			weight := getDomainPriorityWeight(testlogger.New(t), config, mockDomainCache, DomainPriorityKey{DomainID: "test-domain-id", Priority: 1})
+			require.Equal(t, tc.expected, weight)
+		})
+	}
 }

--- a/service/history/task/processor_test.go
+++ b/service/history/task/processor_test.go
@@ -222,7 +222,7 @@ func TestGetDomainPriorityWeight(t *testing.T) {
 				mockDomainCache.EXPECT().GetDomainName("test-domain-id").Return("test-domain-name", nil).Times(1)
 				client.UpdateValue(dynamicconfig.TaskSchedulerDomainRoundRobinWeights, map[string]interface{}{"2": 10})
 			},
-			expected: 0,
+			expected: 1,
 		},
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Implement a migration framework inside history task processor to migrate history task scheduler from priority based WRR scheduler to domain-priority based WRR scheduler

<!-- Tell your future self why have you made these changes -->
**Why?**
To eliminate the noisy neighbor issue for history task processing

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, also tested in dev2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The change is behind 2 feature flags, no risk.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
