### PR TITLE
Ratelimiter-wrapper improvement: don't release the lock when synchronously rejecting a Wait

### DIFF
--- a/common/clock/event_timer_gate_test.go
+++ b/common/clock/event_timer_gate_test.go
@@ -40,7 +40,7 @@ type (
 	}
 )
 
-func TesteventTimerGeteSuite(t *testing.T) {
+func TestEventTimerGeteSuite(t *testing.T) {
 	s := new(eventTimerGateSuite)
 	suite.Run(t, s)
 }

--- a/common/clock/ratelimiter_bench_test.go
+++ b/common/clock/ratelimiter_bench_test.go
@@ -303,7 +303,7 @@ func BenchmarkLimiter(b *testing.B) {
 						// b.Run seems to target <1s, but very fast or very slow things can extend it,
 						// and up to about 2s seems normal for these.
 						// because of that, 5s occasionally timed out, but 10s seems fine.
-						timeout := 10 * time.Second
+						timeout := 20 * time.Second
 						ctx, cancel := context.WithTimeout(context.Background(), timeout)
 						defer cancel()
 


### PR DESCRIPTION
We're getting some odd `Wait`-using ratelimiting issues in our benchmarking-cluster (significant under-allowing, like <10%), and reading through code carefully found a small issue here which _could_ be a cause.

# The issue:

Because the lock was released and then re-acquired when canceling a reserved token when there is insufficient deadline to wait, it's possible for another goroutine to acquire the lock, advance `now`, and cause the `res.CancelAt` to fail to return a token.
This could lead to over-limit waiting (negative tokens), and e.g. arbitrarily long delays that reject many short-deadline requests, if bad-enough sequences were triggered.

I have unfortunately NOT been able to confirm this though, even fairly extreme local benchmarking with goroutine-yielding in the critical section seems to work fine.  It slows down a bit under very high contention (thousands of contending goroutines), but that's not surprising - the underlying ratelimiter does too.  And it doesn't truly match what the benchmarking-cluster does, concurrency there is rather low, and in low-ish concurrency this wrapper appears to behave perfectly (unlike the underlying limiter).

But, it's a clear possibility.

# The fix

Luckly this gap can be completely eliminated: cancel the token without releasing the lock.
I'm not sure why I didn't do this earlier tbh, it seems obvious now.

That's easy and worth doing, and we can rerun the bigger benchmark that's causing weird behavior to see if the issue goes away.  If it doesn't, it's at least a sign that it isn't the limiter.

The same "unable to cancel" issue does still exist if a wait is canceled _while waiting_, but I believe that is fundamentally unavoidable with the current implementation because cancels are unreliable.  It'd also require racing cancels near _every_ Wait-completion to produce a noticeable dip in throughput, so I don't think anyone will be able to observe this one IRL.

# Perf changes / benchmark result changes

None that I can see.  I'm a bit surprised that it isn't slightly faster, but I see no actual evidence of it.