### PR TITLE
Implement bytes-based LRU cache using Sizeable interface

### DIFF
--- a/client/matching/partition_config_provider.go
+++ b/client/matching/partition_config_provider.go
@@ -98,7 +98,7 @@ func NewPartitionConfigProvider(
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-		}),
+		}, logger),
 	}
 }
 

--- a/client/matching/rr_loadbalancer.go
+++ b/client/matching/rr_loadbalancer.go
@@ -56,14 +56,14 @@ func NewRoundRobinLoadBalancer(
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-		}),
+		}, nil),
 		writeCache: cache.New(&cache.Options{
 			TTL:             0,
 			InitialCapacity: 100,
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-		}),
+		}, nil),
 		pickPartitionFn: pickPartition,
 	}
 }

--- a/client/matching/weighted_loadbalancer.go
+++ b/client/matching/weighted_loadbalancer.go
@@ -125,7 +125,7 @@ func NewWeightedLoadBalancer(
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-		}),
+		}, logger),
 		logger: logger,
 	}
 }

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/metrics"
 )
 
@@ -77,10 +78,10 @@ type Options struct {
 	// It is required option if MaxSize is not provided
 	MaxCount int
 
-	// MaxSize is an optional and must be set along with GetCacheItemSizeFunc
+	// MaxSize is an optional flag, but it has to be used along with a value that implements Sizeable() interface
 	// to control the max size in bytes of the cache
 	// It is required option if MaxCount is not provided
-	MaxSize uint64
+	MaxSize dynamicconfig.IntPropertyFn
 
 	// ActivelyEvict will evict items that has expired TTL at every operation in the cache
 	// This can be expensive if a lot of items expire at the same time

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -77,11 +77,6 @@ type Options struct {
 	// It is required option if MaxSize is not provided
 	MaxCount int
 
-	// GetCacheItemSizeFunc is a function called upon adding the item to update the cache size.
-	// It returns 0 by default, assuming the cache is just count based
-	// It is required option if MaxCount is not provided
-	GetCacheItemSizeFunc GetCacheItemSizeFunc
-
 	// MaxSize is an optional and must be set along with GetCacheItemSizeFunc
 	// to control the max size in bytes of the cache
 	// It is required option if MaxCount is not provided
@@ -98,6 +93,16 @@ type Options struct {
 	// TimeSource is used to get the current time
 	// It is optional and defaults to clock.NewRealTimeSource()
 	TimeSource clock.TimeSource
+
+	// IsSizeBased is an optional flag to indicate if the cache is size based
+	// If set to true, the cache will evict items based on item size instead of count
+	// But the item HAS to be able to cast as a Sizeable interface otherwise the cache will fail
+	IsSizeBased bool
+
+	// Deprecated: GetCacheItemSizeFunc is a function called upon adding the item to update the cache size.
+	// It returns 0 by default, assuming the cache is just count based
+	// It is required option if MaxCount is not provided
+	GetCacheItemSizeFunc GetCacheItemSizeFunc
 }
 
 // SimpleOptions provides options that can be used to configure SimpleCache

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -23,6 +23,7 @@ package cache
 import (
 	"container/list"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -310,7 +311,7 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 	if c.isSizeBased {
 		sizeableValue, ok := value.(Sizeable)
 		if !ok {
-			return nil, errors.New("value does not implement Sizeable interface")
+			return nil, fmt.Errorf("value %T does not implement sizable. Key: %+v", value, key)
 		}
 		valueSize = sizeableValue.Size()
 	}

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -157,9 +157,8 @@ func New(opts *Options) Cache {
 		rmFunc:        opts.RemovedFunc,
 		activelyEvict: opts.ActivelyEvict,
 		timeSource:    timeSource,
+		isSizeBased:   opts.IsSizeBased,
 	}
-
-	cache.isSizeBased = opts.GetCacheItemSizeFunc != nil && opts.MaxSize > 0
 
 	if cache.isSizeBased {
 		cache.sizeFunc = opts.GetCacheItemSizeFunc
@@ -308,8 +307,7 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 						oldest := c.byAccess.Back().Value.(*entryImpl)
 						if oldest.refCount > 0 {
 							// Cache is full with pinned elements
-							// revert the update and return
-							entry.value = existing
+							// we don't update
 							return existing, ErrCacheFull
 						}
 						c.deleteInternal(c.byAccess.Back())

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 )
@@ -39,6 +40,9 @@ var (
 // upper limit to prevent infinite growing
 const cacheCountLimit = 1 << 25
 
+// default size limit for size based cache if not defined (1 GB)
+const cacheDefaultSizeLimit = 1 << 30
+
 // lru is a concurrent fixed size cache that evicts elements in lru order
 type (
 	lru struct {
@@ -50,7 +54,7 @@ type (
 		pin           bool
 		rmFunc        RemovedFunc
 		sizeFunc      GetCacheItemSizeFunc
-		maxSize       uint64
+		maxSize       dynamicconfig.IntPropertyFn
 		currSize      uint64
 		sizeByKey     map[interface{}]uint64
 		isSizeBased   bool
@@ -143,7 +147,7 @@ func (entry *entryImpl) CreateTime() time.Time {
 
 // New creates a new cache with the given options
 func New(opts *Options, logger log.Logger) Cache {
-	if opts == nil || (opts.MaxCount <= 0 && (opts.MaxSize <= 0 || opts.GetCacheItemSizeFunc == nil)) {
+	if opts == nil || (opts.MaxCount <= 0 && (opts.MaxSize() <= 0 || opts.GetCacheItemSizeFunc == nil)) {
 		panic("Either MaxCount (count based) or " +
 			"MaxSize and GetCacheItemSizeFunc (size based) options must be provided for the LRU cache")
 	}
@@ -171,10 +175,15 @@ func New(opts *Options, logger log.Logger) Cache {
 	if cache.isSizeBased {
 		cache.sizeFunc = opts.GetCacheItemSizeFunc
 		cache.maxSize = opts.MaxSize
+		if cache.maxSize == nil {
+			// If maxSize is not defined for size-based cache, set default to cacheCountLimit
+			cache.maxSize = dynamicconfig.GetIntPropertyFn(cacheDefaultSizeLimit)
+		}
 		cache.sizeByKey = make(map[interface{}]uint64, opts.InitialCapacity)
 	} else {
 		// cache is count based if max size and sizeFunc are not provided
 		cache.maxCount = opts.MaxCount
+		cache.maxSize = dynamicconfig.GetIntPropertyFn(0)
 		cache.sizeFunc = func(interface{}) uint64 {
 			return 0
 		}
@@ -182,10 +191,9 @@ func New(opts *Options, logger log.Logger) Cache {
 
 	cache.logger.Info("LRU cache initialized",
 		tag.Value(map[string]interface{}{
-			"isSizeBased":     cache.isSizeBased,
-			"initialCapacity": opts.InitialCapacity,
-			"maxCount":        opts.MaxCount,
-			"maxSize":         opts.MaxSize,
+			"isSizeBased": cache.isSizeBased,
+			"maxCount":    cache.maxCount,
+			"maxSize":     cache.maxSize(),
 		}),
 	)
 
@@ -392,8 +400,8 @@ func (c *lru) isEntryExpired(entry *entryImpl, currentTime time.Time) bool {
 
 func (c *lru) isCacheFull() bool {
 	count := len(c.byKey)
-	// if the value size is greater than maxSize(should never happen) then the item wont be cached
-	return (!c.isSizeBased && count == c.maxCount) || c.currSize > c.maxSize || count > cacheCountLimit
+	// if the value size is greater than maxSize(should never happen) then the item won't be cached
+	return (!c.isSizeBased && count == c.maxCount) || c.currSize > uint64(c.maxSize()) || count > cacheCountLimit
 }
 
 func (c *lru) updateSizeOnAdd(key interface{}, valueSize uint64) {

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -37,7 +37,7 @@ type keyType struct {
 }
 
 func TestLRU(t *testing.T) {
-	cache := New(&Options{MaxCount: 5})
+	cache := New(&Options{MaxCount: 5}, nil)
 
 	cache.Put("A", "Foo")
 	assert.Equal(t, "Foo", cache.Get("A"))
@@ -78,7 +78,7 @@ func TestGenerics(t *testing.T) {
 	}
 	value := "some random value"
 
-	cache := New(&Options{MaxCount: 5})
+	cache := New(&Options{MaxCount: 5}, nil)
 	cache.Put(key, value)
 
 	assert.Equal(t, value, cache.Get(key))
@@ -98,7 +98,7 @@ func TestLRUWithTTL(t *testing.T) {
 		MaxCount:   5,
 		TTL:        time.Millisecond * 100,
 		TimeSource: mockTimeSource,
-	}).(*lru)
+	}, nil).(*lru)
 
 	cache.Put("A", "foo")
 	assert.Equal(t, "foo", cache.Get("A"))
@@ -110,7 +110,7 @@ func TestLRUWithTTL(t *testing.T) {
 }
 
 func TestLRUCacheConcurrentAccess(t *testing.T) {
-	cache := New(&Options{MaxCount: 5})
+	cache := New(&Options{MaxCount: 5}, nil)
 	values := map[string]string{
 		"A": "foo",
 		"B": "bar",
@@ -171,7 +171,7 @@ func TestRemoveFunc(t *testing.T) {
 			assert.True(t, ok)
 			ch <- true
 		},
-	})
+	}, nil)
 
 	cache.Put("testing", t)
 	cache.Delete("testing")
@@ -198,7 +198,7 @@ func TestRemovedFuncWithTTL(t *testing.T) {
 			ch <- true
 		},
 		TimeSource: mockTimeSource,
-	}).(*lru)
+	}, nil).(*lru)
 
 	cache.Put("A", t)
 	assert.Equal(t, t, cache.Get("A"))
@@ -228,7 +228,7 @@ func TestRemovedFuncWithTTL_Pin(t *testing.T) {
 			ch <- true
 		},
 		TimeSource: mockTimeSource,
-	}).(*lru)
+	}, nil).(*lru)
 
 	_, err := cache.PutIfNotExist("A", t)
 	assert.NoError(t, err)
@@ -257,7 +257,7 @@ func TestIterator(t *testing.T) {
 		"D": "Delta",
 	}
 
-	cache := New(&Options{MaxCount: 5})
+	cache := New(&Options{MaxCount: 5}, nil)
 
 	for k, v := range expected {
 		cache.Put(k, v)
@@ -297,7 +297,7 @@ func TestLRU_SizeBased_SizeExceeded(t *testing.T) {
 		MaxCount:    5,
 		IsSizeBased: true,
 		MaxSize:     15,
-	})
+	}, nil)
 
 	fooValue := sizeableValue{val: "Foo", size: 5}
 	cache.Put("A", fooValue)
@@ -345,7 +345,7 @@ func TestLRU_SizeBased_CountExceeded(t *testing.T) {
 		MaxCount:    5,
 		IsSizeBased: true,
 		MaxSize:     10000,
-	})
+	}, nil)
 
 	fooValue := sizeableValue{val: "Foo", size: 5}
 	cache.Put("A", fooValue)
@@ -391,7 +391,7 @@ func TestPanicMaxCountAndSizeNotProvided(t *testing.T) {
 		GetCacheItemSizeFunc: func(interface{}) uint64 {
 			return 5
 		},
-	})
+	}, nil)
 }
 
 func TestPanicMaxCountAndSizeFuncNotProvided(t *testing.T) {
@@ -404,7 +404,7 @@ func TestPanicMaxCountAndSizeFuncNotProvided(t *testing.T) {
 	New(&Options{
 		TTL:     time.Millisecond * 100,
 		MaxSize: 25,
-	})
+	}, nil)
 }
 
 func TestPanicOptionsIsNil(t *testing.T) {
@@ -414,7 +414,7 @@ func TestPanicOptionsIsNil(t *testing.T) {
 		}
 	}()
 
-	New(nil)
+	New(nil, nil)
 }
 
 func TestEvictItemsPastTimeToLive_ActivelyEvict(t *testing.T) {
@@ -425,7 +425,7 @@ func TestEvictItemsPastTimeToLive_ActivelyEvict(t *testing.T) {
 		TTL:           time.Second * 75,
 		ActivelyEvict: true,
 		TimeSource:    mockTimeSource,
-	}).(*lru)
+	}, nil).(*lru)
 	require.True(t, ok)
 
 	_, err := cache.PutIfNotExist("A", 1)

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -294,11 +294,9 @@ func (s sizeableValue) Size() uint64 {
 
 func TestLRU_SizeBased_SizeExceeded(t *testing.T) {
 	cache := New(&Options{
-		MaxCount: 5,
-		GetCacheItemSizeFunc: func(value interface{}) uint64 {
-			return value.(sizeableValue).Size()
-		},
-		MaxSize: 15,
+		MaxCount:    5,
+		IsSizeBased: true,
+		MaxSize:     15,
 	})
 
 	fooValue := sizeableValue{val: "Foo", size: 5}
@@ -344,11 +342,9 @@ func TestLRU_SizeBased_SizeExceeded(t *testing.T) {
 
 func TestLRU_SizeBased_CountExceeded(t *testing.T) {
 	cache := New(&Options{
-		MaxCount: 5,
-		GetCacheItemSizeFunc: func(interface{}) uint64 {
-			return 5
-		},
-		MaxSize: 0,
+		MaxCount:    5,
+		IsSizeBased: true,
+		MaxSize:     10000,
 	})
 
 	fooValue := sizeableValue{val: "Foo", size: 5}
@@ -377,10 +373,10 @@ func TestLRU_SizeBased_CountExceeded(t *testing.T) {
 
 	epsiValue := sizeableValue{val: "Epsi", size: 5}
 	cache.Put("E", epsiValue)
-	assert.Nil(t, cache.Get("B"))
+	assert.Equal(t, barValue, cache.Get("B"))
 	assert.Equal(t, epsiValue, cache.Get("E"))
 	assert.Equal(t, foo2Value, cache.Get("A"))
-	assert.Equal(t, 4, cache.Size())
+	assert.Equal(t, 5, cache.Size())
 }
 
 func TestPanicMaxCountAndSizeNotProvided(t *testing.T) {

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig"
 )
 
 type keyType struct {
@@ -296,7 +297,7 @@ func TestLRU_SizeBased_SizeExceeded(t *testing.T) {
 	cache := New(&Options{
 		MaxCount:    5,
 		IsSizeBased: true,
-		MaxSize:     15,
+		MaxSize:     dynamicconfig.GetIntPropertyFn(15),
 	}, nil)
 
 	fooValue := sizeableValue{val: "Foo", size: 5}
@@ -344,7 +345,7 @@ func TestLRU_SizeBased_CountExceeded(t *testing.T) {
 	cache := New(&Options{
 		MaxCount:    5,
 		IsSizeBased: true,
-		MaxSize:     10000,
+		MaxSize:     dynamicconfig.GetIntPropertyFn(10000),
 	}, nil)
 
 	fooValue := sizeableValue{val: "Foo", size: 5}
@@ -403,7 +404,7 @@ func TestPanicMaxCountAndSizeFuncNotProvided(t *testing.T) {
 
 	New(&Options{
 		TTL:     time.Millisecond * 100,
-		MaxSize: 25,
+		MaxSize: dynamicconfig.GetIntPropertyFn(25),
 	}, nil)
 }
 

--- a/service/frontend/api/producer_manager.go
+++ b/service/frontend/api/producer_manager.go
@@ -69,7 +69,7 @@ func NewProducerManager(
 			InitialCapacity: 5,
 			MaxCount:        100,
 			Pin:             true,
-		}),
+		}, logger),
 	}
 }
 

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -154,7 +154,7 @@ func newCacheWithOption(
 		}
 	}
 	return &cacheImpl{
-		Cache:          cache.New(opts),
+		Cache:          cache.New(opts, logger.WithTags(tag.ComponentEventsCache)),
 		domainCache:    domainCache,
 		historyManager: historyManager,
 		disabled:       disabled,

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -90,7 +91,7 @@ func NewGlobalCache(
 	historyManager persistence.HistoryManager,
 	logger log.Logger,
 	metricsClient metrics.Client,
-	maxSize uint64,
+	maxSize dynamicconfig.IntPropertyFn,
 	domainCache cache.DomainCache,
 ) Cache {
 	return newCacheWithOption(
@@ -125,7 +126,7 @@ func NewCache(
 		false,
 		logger,
 		metricsClient,
-		0,
+		config.EventsCacheMaxSize,
 		domainCache,
 	)
 }
@@ -139,7 +140,7 @@ func newCacheWithOption(
 	disabled bool,
 	logger log.Logger,
 	metrics metrics.Client,
-	maxSize uint64,
+	maxSize dynamicconfig.IntPropertyFn,
 	domainCache cache.DomainCache,
 ) *cacheImpl {
 	opts := &cache.Options{}
@@ -147,7 +148,7 @@ func newCacheWithOption(
 	opts.TTL = ttl
 	opts.MaxCount = maxCount
 
-	if maxSize > 0 {
+	if maxSize() > 0 {
 		opts.MaxSize = maxSize
 		opts.GetCacheItemSizeFunc = func(event interface{}) uint64 {
 			return common.GetSizeOfHistoryEvent(event.(*types.HistoryEvent))

--- a/service/history/events/cache_test.go
+++ b/service/history/events/cache_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
@@ -88,7 +89,7 @@ func (s *eventsCacheSuite) TearDownTest() {
 
 func (s *eventsCacheSuite) newTestEventsCache() *cacheImpl {
 	return newCacheWithOption(common.IntPtr(10), 16, 32, time.Minute, s.mockHistoryManager, false, s.logger,
-		metrics.NewClient(tally.NoopScope, metrics.History), 0, s.domainCache)
+		metrics.NewClient(tally.NoopScope, metrics.History), dynamicconfig.GetIntPropertyFn(0), s.domainCache)
 }
 
 func (s *eventsCacheSuite) TestEventsCacheHitSuccess() {

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -118,7 +118,7 @@ func NewCache(shard shard.Context) Cache {
 	opts.MaxCount = config.HistoryCacheMaxSize()
 
 	return &cacheImpl{
-		Cache:            cache.New(opts),
+		Cache:            cache.New(opts, shard.GetLogger().WithTags(tag.ComponentHistoryCache)),
 		shard:            shard,
 		executionManager: shard.GetExecutionManager(),
 		logger:           shard.GetLogger().WithTags(tag.ComponentHistoryCache),

--- a/service/history/execution/cache_test.go
+++ b/service/history/execution/cache_test.go
@@ -273,7 +273,7 @@ func (s *historyCacheSuite) TestGetOrCreateCurrentWorkflowExecution() {
 					TTL:             s.mockShard.GetConfig().HistoryCacheTTL(),
 					Pin:             true,
 					MaxCount:        s.mockShard.GetConfig().HistoryCacheMaxSize(),
-				}),
+				}, s.mockShard.GetLogger().WithTags(tag.ComponentHistoryCache)),
 				shard:            s.mockShard,
 				executionManager: s.mockShard.GetExecutionManager(),
 				logger:           s.mockShard.GetLogger().WithTags(tag.ComponentHistoryCache),

--- a/service/history/ndc/history_replicator_test.go
+++ b/service/history/ndc/history_replicator_test.go
@@ -68,7 +68,7 @@ func createTestHistoryReplicator(t *testing.T) historyReplicatorImpl {
 	// before going into NewHistoryReplicator
 	mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
 	mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).Times(1)
-	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
+	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(nil).Times(3)
 
 	testExecutionCache := execution.NewCache(mockShard)
@@ -117,7 +117,7 @@ func TestNewHistoryReplicator_newBranchManager(t *testing.T) {
 	// before going into NewHistoryReplicator
 	mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
 	mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).Times(1)
-	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
+	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(nil).Times(3)
 
 	testExecutionCache := execution.NewCache(mockShard)
@@ -166,7 +166,7 @@ func TestNewHistoryReplicator_newConflictResolver(t *testing.T) {
 	// before going into NewHistoryReplicator
 	mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
 	mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).Times(1)
-	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
+	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(nil).Times(3)
 
 	testExecutionCache := execution.NewCache(mockShard)
@@ -278,7 +278,7 @@ func TestNewHistoryReplicator_newStateBuilder(t *testing.T) {
 	// before going into NewHistoryReplicator
 	mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
 	mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).Times(1)
-	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
+	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(nil).Times(3)
 
 	testExecutionCache := execution.NewCache(mockShard)

--- a/service/history/ndc/history_replicator_test.go
+++ b/service/history/ndc/history_replicator_test.go
@@ -219,7 +219,7 @@ func TestNewHistoryReplicator_newWorkflowResetter(t *testing.T) {
 	// before going into NewHistoryReplicator
 	mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
 	mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).Times(1)
-	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
+	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(nil).Times(3)
 
 	testExecutionCache := execution.NewCache(mockShard)
@@ -326,7 +326,7 @@ func TestNewHistoryReplicator_newMutableState(t *testing.T) {
 	// before going into NewHistoryReplicator
 	mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
 	mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).Times(1)
-	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
+	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(nil).Times(4)
 
 	testExecutionCache := execution.NewCache(mockShard)

--- a/service/history/resource/resource.go
+++ b/service/history/resource/resource.go
@@ -129,7 +129,7 @@ func New(
 		serviceResource.GetHistoryManager(),
 		params.Logger,
 		params.MetricsClient,
-		uint64(config.EventsCacheMaxSize()),
+		config.EventsCacheMaxSize,
 		serviceResource.GetDomainCache(),
 	)
 	ratelimitAlgorithm, err := algorithm.New(

--- a/service/history/workflowcache/cache.go
+++ b/service/history/workflowcache/cache.go
@@ -90,7 +90,7 @@ func New(params Params) WFCache {
 			Pin:           false,
 			MaxCount:      params.MaxCount,
 			ActivelyEvict: true,
-		}),
+		}, params.Logger),
 		externalLimiterFactory: params.ExternalLimiterFactory,
 		internalLimiterFactory: params.InternalLimiterFactory,
 		domainCache:            params.DomainCache,

--- a/service/history/workflowcache/cache_test.go
+++ b/service/history/workflowcache/cache_test.go
@@ -150,6 +150,16 @@ func TestWfCache_AllowError(t *testing.T) {
 			tag.WorkflowIDCacheSize(0),
 		},
 	).Times(2)
+	logger.On("Info",
+		"LRU cache initialized",
+		[]tag.Tag{
+			tag.Value(map[string]interface{}{
+				"isSizeBased":     false,
+				"initialCapacity": 0,
+				"maxCount":        1000,
+				"maxSize":         0,
+			}),
+		}).Times(1)
 
 	// Setup the cache, we do not need the factories, as we will mock the getCacheItemFn
 	wfCache := New(Params{

--- a/service/history/workflowcache/cache_test.go
+++ b/service/history/workflowcache/cache_test.go
@@ -154,10 +154,9 @@ func TestWfCache_AllowError(t *testing.T) {
 		"LRU cache initialized",
 		[]tag.Tag{
 			tag.Value(map[string]interface{}{
-				"isSizeBased":     false,
-				"initialCapacity": 0,
-				"maxCount":        1000,
-				"maxSize":         0,
+				"isSizeBased": false,
+				"maxCount":    1000,
+				"maxSize":     0,
 			}),
 		}).Times(1)
 
@@ -205,6 +204,15 @@ func TestWfCache_AllowDomainCacheError(t *testing.T) {
 			tag.WorkflowIDCacheSize(0),
 		},
 	).Times(2)
+	logger.On("Info",
+		"LRU cache initialized",
+		[]tag.Tag{
+			tag.Value(map[string]interface{}{
+				"isSizeBased": false,
+				"maxCount":    1000,
+				"maxSize":     0,
+			}),
+		}).Times(1)
 
 	// Setup the cache, we do not need the factories, as we will mock the getCacheItemFn
 	wfCache := New(Params{
@@ -247,6 +255,16 @@ func TestWfCache_RejectLog(t *testing.T) {
 
 	// Setup the mock logger
 	logger := new(log.MockLogger)
+
+	logger.On("Info",
+		"LRU cache initialized",
+		[]tag.Tag{
+			tag.Value(map[string]interface{}{
+				"isSizeBased": false,
+				"maxCount":    1000,
+				"maxSize":     0,
+			}),
+		}).Times(1)
 
 	expectRatelimitLog(logger, "external")
 	expectRatelimitLog(logger, "internal")

--- a/service/matching/poller/history.go
+++ b/service/matching/poller/history.go
@@ -74,7 +74,7 @@ func NewPollerHistory(historyUpdatedFunc HistoryUpdatedFunc, timeSource clock.Ti
 	}
 
 	return &history{
-		historyCache:         cache.New(opts),
+		historyCache:         cache.New(opts, nil),
 		onHistoryUpdatedFunc: historyUpdatedFunc,
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Implement Sizeable interface usage to base LRU cache, the new logic is only activate when the IsSizeBased flag is true.

<!-- Tell your future self why have you made these changes -->
**Why?**

We want to modernize existing cadence common cache implement to a bytes-based system. That means we need to have a method to measure each entry (which is currently accepting any generic interface). We found the "Reflect" package provides a measuring function but runtime is too slow to be used in cache operations. Therefore, we will require all usages to implement the Size() function in their cache logic if they want to migrate to the new bytes-based system.

In order to seamless transition from the current cache system with an entry-based model, the implementation and rollout will be done in following phases:

1. Define the Sizeable interface 
2. Implement Sizeable for cadence-history service
a. Implement Size() for ExecutionCache 
b. Implement Size() for EventCache
4. Implement bytes-based cache system **<-- This PR**
5. Enable new cache system for usage in cadence-history service
6. Implement and enable new cache system for the remaining usages

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests, also tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there are currently cache system that is size based using legacy implementation, and there is no Sizeable() implementation, it could result in cache not being able to fetch any result causing the cache to fail.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
