### PR TITLE
Add log/metric for workflow context lock held duration

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1118,3 +1118,7 @@ func ActivityTaskState(state int32) Tag {
 func Namespace(name string) Tag {
 	return newStringTag("namespace", name)
 }
+
+func WorkflowContextLockLatency(duration time.Duration) Tag {
+	return newDurationTag("workflow-context-lock-latency", duration)
+}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2471,6 +2471,7 @@ const (
 	CacheFullCounter
 	AcquireLockFailedCounter
 	WorkflowContextCleared
+	WorkflowContextLockLatency
 	MutableStateSize
 	ExecutionInfoSize
 	ActivityInfoSize
@@ -3182,6 +3183,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		CacheFullCounter:                                             {metricName: "cache_full", metricType: Counter},
 		AcquireLockFailedCounter:                                     {metricName: "acquire_lock_failed", metricType: Counter},
 		WorkflowContextCleared:                                       {metricName: "workflow_context_cleared", metricType: Counter},
+		WorkflowContextLockLatency:                                   {metricName: "workflow_context_lock_latency", metricType: Timer},
 		MutableStateSize:                                             {metricName: "mutable_state_size", metricType: Timer},
 		ExecutionInfoSize:                                            {metricName: "execution_info_size", metricType: Timer},
 		ActivityInfoSize:                                             {metricName: "activity_info_size", metricType: Timer},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We have metrics showing the latency of workflow context creation via cache which captures time taken to 
- create cache entry
- evict old items from cache if needed
- add it to cache
- acquire the workflow context lock

We are missing a metric which shows the duration of workflow context lock held. Adding this metric as well as an optional log statement which is only logged when a max duration is observed. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Help troubleshoot potential lock contentions.
