### PR TITLE
Append unauthorized errors in CLI with message to check domain and cluster input

### DIFF
--- a/tools/common/commoncli/cli.go
+++ b/tools/common/commoncli/cli.go
@@ -182,6 +182,9 @@ func printErr(err error, to io.Writer) (writeErr error) {
 //	  ErrorDetails:
 //	    more nested errors
 func Problem(msg string, err error) error {
+	if err != nil && strings.Contains(err.Error(), "Request unauthorized") {
+		msg = fmt.Sprintf("%s. Ensure the domain and cluster are correct.", msg)
+	}
 	return &printableErr{msg, err}
 }
 

--- a/tools/common/commoncli/cli_test.go
+++ b/tools/common/commoncli/cli_test.go
@@ -25,11 +25,12 @@ package commoncli
 import (
 	"errors"
 	"fmt"
-	"github.com/uber/cadence/common/types"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/types"
 )
 
 func TestPrintErr(t *testing.T) {

--- a/tools/common/commoncli/cli_test.go
+++ b/tools/common/commoncli/cli_test.go
@@ -25,6 +25,7 @@ package commoncli
 import (
 	"errors"
 	"fmt"
+	"github.com/uber/cadence/common/types"
 	"strings"
 	"testing"
 
@@ -59,6 +60,19 @@ Error: a problem
 Error details:
   wrapper
   cause
+`, str)
+	})
+	t.Run("printable top with access denied", func(t *testing.T) {
+		str := run(t,
+			Problem("a problem",
+				fmt.Errorf("wrapper: %w",
+					&types.AccessDeniedError{Message: "Request unauthorized."})))
+		// causes are nested flat, chains are cleaned up
+		assert.Equal(t, `
+Error: a problem. Ensure the domain and cluster are correct.
+Error details:
+  wrapper
+  Request unauthorized.
 `, str)
 	})
 	t.Run("printable top fancy middle", func(t *testing.T) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Error message when user sees request unauthorised error

<!-- Tell your future self why have you made these changes -->
**Why?**
when a user request is unauthorised it could occur when the domain doesnt exist but request gets access denied before the domain check

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
