### PR TITLE
Hide the actual values for context headers in visibility store 

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2827,6 +2827,13 @@ const (
 	// Allowed filters: N/A
 	PinotOptimizedQueryColumns
 
+	// SearchAttributesHiddenValueKeys is the list of search attributes that values should be hidden
+	// KeyName: frontend.searchAttributesHiddenValueKeys
+	// Value type: Map
+	// Default value: empty map
+	// Allowed filters: N/A
+	SearchAttributesHiddenValueKeys
+
 	// LastMapKey must be the last one in this const group
 	LastMapKey
 )
@@ -5102,6 +5109,11 @@ var MapKeys = map[MapKey]DynamicMap{
 	PinotOptimizedQueryColumns: {
 		KeyName:      "frontend.pinotOptimizedQueryColumns",
 		Description:  "PinotOptimizedQueryColumns is the list of search attributes that can be used in pinot optimized query",
+		DefaultValue: map[string]interface{}{},
+	},
+	SearchAttributesHiddenValueKeys: {
+		KeyName:      "frontend.searchAttributesHiddenValueKeys",
+		Description:  "SearchAttributesHiddenValueKeys is the list of search attributes that values should be hidden",
 		DefaultValue: map[string]interface{}{},
 	},
 }

--- a/common/service/config.go
+++ b/common/service/config.go
@@ -47,9 +47,10 @@ type (
 		DBVisibilityListMaxQPS                      dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 
 		// configs for es visibility
-		ESIndexMaxResultWindow     dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
-		ValidSearchAttributes      dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
-		PinotOptimizedQueryColumns dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
+		ESIndexMaxResultWindow          dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
+		ValidSearchAttributes           dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
+		PinotOptimizedQueryColumns      dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
+		SearchAttributesHiddenValueKeys dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
 		// deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS
 		ESVisibilityListMaxQPS dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -220,6 +220,7 @@ type Config struct {
 	SearchAttributesNumberOfKeysLimit dynamicconfig.IntPropertyFnWithDomainFilter
 	SearchAttributesSizeOfValueLimit  dynamicconfig.IntPropertyFnWithDomainFilter
 	SearchAttributesTotalSizeLimit    dynamicconfig.IntPropertyFnWithDomainFilter
+	SearchAttributesHiddenValueKeys   dynamicconfig.MapPropertyFn
 
 	// Decision settings
 	// StickyTTL is to expire a sticky tasklist if no update more than this duration
@@ -481,6 +482,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		SearchAttributesNumberOfKeysLimit:        dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesNumberOfKeysLimit),
 		SearchAttributesSizeOfValueLimit:         dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesSizeOfValueLimit),
 		SearchAttributesTotalSizeLimit:           dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesTotalSizeLimit),
+		SearchAttributesHiddenValueKeys:          dc.GetMapProperty(dynamicconfig.SearchAttributesHiddenValueKeys),
 		StickyTTL:                                dc.GetDurationPropertyFilteredByDomain(dynamicconfig.StickyTTL),
 		DecisionHeartbeatTimeout:                 dc.GetDurationPropertyFilteredByDomain(dynamicconfig.DecisionHeartbeatTimeout),
 		DecisionRetryCriticalAttempts:            dc.GetIntProperty(dynamicconfig.DecisionRetryCriticalAttempts),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -255,6 +255,7 @@ func TestNewConfig(t *testing.T) {
 		"TaskSchedulerEnableRateLimiterShadowMode":             {dynamicconfig.TaskSchedulerEnableRateLimiterShadowMode, false},
 		"TaskSchedulerEnableRateLimiter":                       {dynamicconfig.TaskSchedulerEnableRateLimiter, true},
 		"HostName":                                             {nil, hostname},
+		"SearchAttributesHiddenValueKeys":                      {dynamicconfig.SearchAttributesHiddenValueKeys, map[string]interface{}{"CustomStringField": true}},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/history/task/transfer_task_executor_base_test.go
+++ b/service/history/task/transfer_task_executor_base_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2017-2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package task
+
+import (
+	"testing"
+)
+
+func TestShouldRedactContextHeader(t *testing.T) {
+	cases := []struct {
+		key             string
+		hiddenValueKeys map[string]interface{}
+		expected        bool
+	}{
+		{
+			key: "key1",
+			hiddenValueKeys: map[string]interface{}{
+				"key1": true,
+			},
+			expected: true,
+		},
+		{
+			key: "key2",
+			hiddenValueKeys: map[string]interface{}{
+				"key1": true,
+			},
+			expected: false,
+		},
+		{
+			key:             "key3",
+			hiddenValueKeys: map[string]interface{}{},
+			expected:        false,
+		},
+		{
+			key:             "key4",
+			hiddenValueKeys: nil,
+			expected:        false,
+		},
+		{
+			key: "key5",
+			hiddenValueKeys: map[string]interface{}{
+				"key5": "true",
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		result := shouldRedactContextHeader(c.key, c.hiddenValueKeys)
+		if result != c.expected {
+			t.Errorf("shouldRedactContextHeader(%s, %v) = %t; expected %t", c.key, c.hiddenValueKeys, result, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added SearchAttributesHiddenValueKeys and the actual value in visibility store when the key is in the list

<!-- Tell your future self why have you made these changes -->
**Why?**
The context header may contain sensitive info which we don't want to store in the visibility store

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
