### PR TITLE
Remove obsolete docker-compose version

### DIFF
--- a/docker/docker-compose-async-wf-kafka.yml
+++ b/docker/docker-compose-async-wf-kafka.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-bench.yml
+++ b/docker/docker-compose-bench.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cadence-bench:
     image: ubercadence/cadence-bench:master

--- a/docker/docker-compose-canary.yml
+++ b/docker/docker-compose-canary.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cadence-canary:
     image: ubercadence/cadence-canary:master

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-http-api.yml
+++ b/docker/docker-compose-http-api.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-multiclusters.yml
+++ b/docker/docker-compose-multiclusters.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mysql:
     platform: linux/amd64

--- a/docker/docker-compose-oauth.yml
+++ b/docker/docker-compose-oauth.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres:
     image: postgres:12.4

--- a/docker/docker-compose-scylla.yml
+++ b/docker/docker-compose-scylla.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   scylla:
     image: scylladb/scylla:4.3.1

--- a/docker/docker-compose-statsd.yml
+++ b/docker/docker-compose-statsd.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cassandra:
     image: cassandra:4.1.1


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
removed docker-compose version label


<!-- Tell your future self why have you made these changes -->
**Why?**
version is obsolete since long time ago
docker-compose suggests removing it at start.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
docker-compose doesn't complain anymore


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
