### PR TITLE
removed docker-compose version label for buildkite

### DIFF
--- a/docker/buildkite/docker-compose-cassandra-lwt.yml
+++ b/docker/buildkite/docker-compose-cassandra-lwt.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cass1:
     container_name: cass1

--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-local-async-wf.yml
+++ b/docker/buildkite/docker-compose-local-async-wf.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-local-matching-simulation.yml
+++ b/docker/buildkite/docker-compose-local-matching-simulation.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-local-pinot.yml
+++ b/docker/buildkite/docker-compose-local-pinot.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-local-replication-simulation.yml
+++ b/docker/buildkite/docker-compose-local-replication-simulation.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-opensearch2.yml
+++ b/docker/buildkite/docker-compose-opensearch2.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose-pinot.yml
+++ b/docker/buildkite/docker-compose-pinot.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   cassandra:
     image: cassandra:4.1.1


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
removed docker-compose version label from buildkite files

<!-- Tell your future self why have you made these changes -->
**Why?**
Continuation of #6736
version is obsolete since long time ago
docker-compose suggests removing it at start.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Let's see how buildkite compiles that


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
