### PR TITLE
[domain-deletion]Allow to list workflows for deprecated domains

### DIFF
--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -194,7 +194,8 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainIDRedirect
 	if err != nil {
 		return err
 	}
-	if domainEntry.IsDeprecatedOrDeleted() {
+	// Skip domain deprecation check for ListWorkflowExecutions API
+	if apiName != "ListWorkflowExecutions" && domainEntry.IsDeprecatedOrDeleted() {
 		return &types.DomainNotActiveError{
 			Message:        "domain is deprecated.",
 			DomainName:     domainEntry.GetInfo().Name,
@@ -211,7 +212,8 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainNameRedire
 	if err != nil {
 		return err
 	}
-	if domainEntry.IsDeprecatedOrDeleted() {
+	// Skip domain deprecation check for ListWorkflowExecutions API
+	if apiName != "ListWorkflowExecutions" && domainEntry.IsDeprecatedOrDeleted() {
 		return &types.DomainNotActiveError{
 			Message:        "domain is deprecated or deleted",
 			DomainName:     domainName,

--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -132,6 +132,14 @@ var selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2 = map[string]struct{}{
 	"RespondActivityTaskFailedByID":    {},
 }
 
+// allowedAPIsForDeprecatedDomains contains a list of APIs that are allowed to be called on deprecated domains
+var allowedAPIsForDeprecatedDomains = map[string]struct{}{
+	"ListWorkflowExecutions":     {},
+	"CountWorkflowExecutions":    {},
+	"ScanWorkflowExecutions":     {},
+	"TerminateWorkflowExecution": {},
+}
+
 // RedirectionPolicyGenerator generate corresponding redirection policy
 func RedirectionPolicyGenerator(clusterMetadata cluster.Metadata, config *frontendcfg.Config,
 	domainCache cache.DomainCache, policy config.ClusterRedirectionPolicy) ClusterRedirectionPolicy {
@@ -194,13 +202,15 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainIDRedirect
 	if err != nil {
 		return err
 	}
-	// Skip domain deprecation check for ListWorkflowExecutions API
-	if apiName != "ListWorkflowExecutions" && domainEntry.IsDeprecatedOrDeleted() {
-		return &types.DomainNotActiveError{
-			Message:        "domain is deprecated.",
-			DomainName:     domainEntry.GetInfo().Name,
-			CurrentCluster: policy.currentClusterName,
-			ActiveCluster:  policy.currentClusterName,
+
+	if domainEntry.IsDeprecatedOrDeleted() {
+		if _, ok := allowedAPIsForDeprecatedDomains[apiName]; !ok {
+			return &types.DomainNotActiveError{
+				Message:        "domain is deprecated.",
+				DomainName:     domainEntry.GetInfo().Name,
+				CurrentCluster: policy.currentClusterName,
+				ActiveCluster:  policy.currentClusterName,
+			}
 		}
 	}
 	return policy.withRedirect(ctx, domainEntry, apiName, call)
@@ -212,13 +222,15 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainNameRedire
 	if err != nil {
 		return err
 	}
-	// Skip domain deprecation check for ListWorkflowExecutions API
-	if apiName != "ListWorkflowExecutions" && domainEntry.IsDeprecatedOrDeleted() {
-		return &types.DomainNotActiveError{
-			Message:        "domain is deprecated or deleted",
-			DomainName:     domainName,
-			CurrentCluster: policy.currentClusterName,
-			ActiveCluster:  policy.currentClusterName,
+
+	if domainEntry.IsDeprecatedOrDeleted() {
+		if _, ok := allowedAPIsForDeprecatedDomains[apiName]; !ok {
+			return &types.DomainNotActiveError{
+				Message:        "domain is deprecated or deleted",
+				DomainName:     domainName,
+				CurrentCluster: policy.currentClusterName,
+				ActiveCluster:  policy.currentClusterName,
+			}
 		}
 	}
 	return policy.withRedirect(ctx, domainEntry, apiName, call)

--- a/service/frontend/wrappers/clusterredirection/policy_test.go
+++ b/service/frontend/wrappers/clusterredirection/policy_test.go
@@ -100,6 +100,26 @@ func (s *noopDCRedirectionPolicySuite) TestWithDomainRedirect() {
 	s.Equal(2, callCount)
 }
 
+func (s *noopDCRedirectionPolicySuite) TestWithDomainRedirectForListWorkflows() {
+	domainName := "some random domain name"
+	domainID := "some random domain ID"
+	apiName := "ListWorkflowExecutions"
+	callCount := 0
+	callFn := func(targetCluster string) error {
+		callCount++
+		s.Equal(s.currentClusterName, targetCluster)
+		return nil
+	}
+
+	err := s.policy.WithDomainIDRedirect(context.Background(), domainID, apiName, callFn)
+	s.Nil(err)
+
+	err = s.policy.WithDomainNameRedirect(context.Background(), domainName, apiName, callFn)
+	s.Nil(err)
+
+	s.Equal(2, callCount)
+}
+
 func TestSelectedAPIsForwardingRedirectionPolicySuite(t *testing.T) {
 	s := new(selectedAPIsForwardingRedirectionPolicySuite)
 	suite.Run(t, s)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
In order to remove workflow execution history of a deprecated domain, we need to be able to list all the workflow executions. 
Currently these policy redirects WithDomainIDRedirect() & WithDomainNameRedirect() prevents us to start/terminate/signal workflows, which serves as a guardrail.
This PR adds the exceptions for - ListWorkflowExecutions, CountWorkflowExecutions, ScanWorkflowExecutions, TerminateWorkflowExecution APIs

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
