### PR TITLE
Adds some metrics / logs for an edge case in workflow cleanup

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3114,7 +3114,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		StaleMutableStateCounter:                                     {metricName: "stale_mutable_state", metricType: Counter},
 		DataInconsistentCounter:                                      {metricName: "data_inconsistent", metricType: Counter},
 		TimerResurrectionCounter:                                     {metricName: "timer_resurrection", metricType: Counter},
-		TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading:  {metricName: "timer_processing_skipping_deletion_due_to_missing_mutable_State", metricType: Counter},
+		TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading:  {metricName: "timer_processing_skipping_deletion_due_to_missing_mutable_state", metricType: Counter},
 		TimerProcessingDeletionTimerNoopDueToWFRunning:               {metricName: "timer_processing_skipping_deletion_due_to_running", metricType: Counter},
 		ActivityResurrectionCounter:                                  {metricName: "activity_resurrection", metricType: Counter},
 		AutoResetPointsLimitExceededCounter:                          {metricName: "auto_reset_points_exceed_limit", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2400,6 +2400,8 @@ const (
 	StaleMutableStateCounter
 	DataInconsistentCounter
 	TimerResurrectionCounter
+	TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading
+	TimerProcessingDeletionTimerNoopDueToWFRunning
 	ActivityResurrectionCounter
 	AutoResetPointsLimitExceededCounter
 	AutoResetPointCorruptionCounter
@@ -3112,6 +3114,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		StaleMutableStateCounter:                                     {metricName: "stale_mutable_state", metricType: Counter},
 		DataInconsistentCounter:                                      {metricName: "data_inconsistent", metricType: Counter},
 		TimerResurrectionCounter:                                     {metricName: "timer_resurrection", metricType: Counter},
+		TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading:  {metricName: "timer_processing_skipping_deletion_due_to_missing_mutable_State", metricType: Counter},
+		TimerProcessingDeletionTimerNoopDueToWFRunning:               {metricName: "timer_processing_skipping_deletion_due_to_running", metricType: Counter},
 		ActivityResurrectionCounter:                                  {metricName: "activity_resurrection", metricType: Counter},
 		AutoResetPointsLimitExceededCounter:                          {metricName: "auto_reset_points_exceed_limit", metricType: Counter},
 		AutoResetPointCorruptionCounter:                              {metricName: "auto_reset_point_corruption", metricType: Counter},

--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -23,12 +23,11 @@ package task
 import (
 	"context"
 
-	"github.com/uber/cadence/common/log/tag"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"

--- a/service/history/task/timer_task_executor_base_test.go
+++ b/service/history/task/timer_task_executor_base_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/execution"
+	executioncache "github.com/uber/cadence/service/history/execution"
 	"github.com/uber/cadence/service/history/shard"
 	"github.com/uber/cadence/service/worker/archiver"
 )
@@ -216,4 +217,171 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_SendSignalErr() {
 		s.mockMutableState, domainCacheEntry,
 	)
 	s.Error(err)
+}
+
+func TestExecuteDeleteHistoryEventTask(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(*gomock.Controller) (*timerTaskExecutorBase, *persistence.TimerTaskInfo)
+		expectedError error
+	}{
+		{
+			name: "mutable was not able to be loaded",
+			setupMocks: func(controller *gomock.Controller) (*timerTaskExecutorBase, *persistence.TimerTaskInfo) {
+
+				mockShard := shard.NewTestContext(
+					t,
+					controller,
+					&persistence.ShardInfo{
+						ShardID:          0,
+						RangeID:          1,
+						TransferAckLevel: 0,
+					},
+					config.NewForTest(),
+				)
+
+				mockShard.Resource.DomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.NewDomainCacheEntryForTest(
+					&persistence.DomainInfo{},
+					&persistence.DomainConfig{},
+					false,
+					nil,
+					0,
+					nil,
+					0,
+					0,
+					0,
+				), nil)
+
+				timerTask := &persistence.TimerTaskInfo{
+					DomainID:            "test-domain-id",
+					WorkflowID:          "test-workflow-id",
+					RunID:               "test-run-id",
+					TaskType:            persistence.TaskTypeDeleteHistoryEvent,
+					VisibilityTimestamp: time.Now(),
+				}
+
+				wfContext := execution.NewContext(
+					timerTask.DomainID,
+					types.WorkflowExecution{
+						WorkflowID: timerTask.WorkflowID,
+						RunID:      timerTask.RunID,
+					},
+					mockShard,
+					mockShard.Resource.ExecutionMgr,
+					mockShard.GetLogger(),
+				)
+
+				executionCache := executioncache.NewMockCache(controller)
+				executionCache.EXPECT().GetOrCreateWorkflowExecutionWithTimeout(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wfContext, func(error) {}, nil)
+
+				mockExecutionMgr := mockShard.Resource.ExecutionMgr
+				mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(nil, &types.EntityNotExistsError{}).Once()
+
+				return newTimerTaskExecutorBase(
+					mockShard,
+					&archiver.ClientMock{},
+					executionCache,
+					mockShard.GetLogger(),
+					mockShard.GetMetricsClient(),
+					mockShard.GetConfig(),
+				), timerTask
+			},
+			expectedError: nil,
+		},
+		{
+			name: "mutable showed that the workflow was still running ",
+			setupMocks: func(controller *gomock.Controller) (*timerTaskExecutorBase, *persistence.TimerTaskInfo) {
+
+				mockShard := shard.NewTestContext(
+					t,
+					controller,
+					&persistence.ShardInfo{
+						ShardID:          0,
+						RangeID:          1,
+						TransferAckLevel: 0,
+					},
+					config.NewForTest(),
+				)
+
+				mockShard.Resource.DomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.NewDomainCacheEntryForTest(
+					&persistence.DomainInfo{},
+					&persistence.DomainConfig{},
+					false,
+					nil,
+					0,
+					nil,
+					0,
+					0,
+					0,
+				), nil).AnyTimes()
+
+				timerTask := &persistence.TimerTaskInfo{
+					DomainID:            "test-domain-id",
+					WorkflowID:          "test-workflow-id",
+					RunID:               "test-run-id",
+					TaskType:            persistence.TaskTypeDeleteHistoryEvent,
+					VisibilityTimestamp: time.Now(),
+				}
+
+				wfContext := execution.NewContext(
+					timerTask.DomainID,
+					types.WorkflowExecution{
+						WorkflowID: timerTask.WorkflowID,
+						RunID:      timerTask.RunID,
+					},
+					mockShard,
+					mockShard.Resource.ExecutionMgr,
+					mockShard.GetLogger(),
+				)
+
+				executionCache := executioncache.NewMockCache(controller)
+				executionCache.EXPECT().GetOrCreateWorkflowExecutionWithTimeout(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wfContext, func(error) {}, nil)
+
+				mockExecutionMgr := mockShard.Resource.ExecutionMgr
+				mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{
+					State: &persistence.WorkflowMutableState{
+						ExecutionStats: &persistence.ExecutionStats{},
+						ExecutionInfo: &persistence.WorkflowExecutionInfo{
+							CloseStatus: 0,
+							State:       persistence.WorkflowStateRunning,
+						},
+					},
+				}, nil)
+
+				return newTimerTaskExecutorBase(
+					mockShard,
+					&archiver.ClientMock{},
+					executionCache,
+					mockShard.GetLogger(),
+					mockShard.GetMetricsClient(),
+					mockShard.GetConfig(),
+				), timerTask
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			executor, timerTask := tt.setupMocks(controller)
+			err := executor.executeDeleteHistoryEventTask(context.Background(), timerTask)
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adds some metrics and logs around two conditions which - I don't think are the problem - but which could cause garbage data that I'm looking to track down.

- I would be somewhat surprised if there was a lot of the logs where the execution record is flat-out missing. I'm not currently aware of any conditions which might cause this, but just guarding with a metric /log nonetheless
- I would be quite surprised if the timer tries to delete a running workflow, same behaviour

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

unit tests only


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
