### PR TITLE
Refactor Size() method to ByteSize() avoiding naming collision

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -153,5 +153,5 @@ type DomainMetricsScopeCache interface {
 // Sizeable is a interface that implements Size() function
 type Sizeable interface {
 	// Size returns an approximate size of the object in bytes
-	Size() uint64
+	ByteSize() uint64
 }

--- a/common/cache/interface_mock.go
+++ b/common/cache/interface_mock.go
@@ -388,16 +388,16 @@ func (m *MockSizeable) EXPECT() *MockSizeableMockRecorder {
 	return m.recorder
 }
 
-// Size mocks base method.
-func (m *MockSizeable) Size() uint64 {
+// ByteSize mocks base method.
+func (m *MockSizeable) ByteSize() uint64 {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Size")
+	ret := m.ctrl.Call(m, "ByteSize")
 	ret0, _ := ret[0].(uint64)
 	return ret0
 }
 
-// Size indicates an expected call of Size.
-func (mr *MockSizeableMockRecorder) Size() *gomock.Call {
+// ByteSize indicates an expected call of ByteSize.
+func (mr *MockSizeableMockRecorder) ByteSize() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockSizeable)(nil).Size))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByteSize", reflect.TypeOf((*MockSizeable)(nil).ByteSize))
 }

--- a/common/definition/workflowIdentifier.go
+++ b/common/definition/workflowIdentifier.go
@@ -34,7 +34,7 @@ type (
 )
 
 // Size calculates the size in bytes of the WorkflowIdentifier struct.
-func (wi *WorkflowIdentifier) Size() uint64 {
+func (wi *WorkflowIdentifier) ByteSize() uint64 {
 	// Calculate the size of strings in bytes, we assume that all those fields are using ASCII which is 1 byte per char
 	size := len(wi.DomainID) + len(wi.WorkflowID) + len(wi.RunID)
 	// Each string internally holds a reference pointer and a length, which are 8 bytes each

--- a/common/definition/workflowidentifier_test.go
+++ b/common/definition/workflowidentifier_test.go
@@ -54,7 +54,7 @@ func TestWorkflowIdentifierSize(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			size := test.wi.Size()
+			size := test.wi.ByteSize()
 			assert.Equal(t, test.expected, size)
 		})
 	}

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1407,7 +1407,7 @@ func (c *contextImpl) ReapplyEvents(
 	)
 }
 
-func (c *contextImpl) Size() uint64 {
+func (c *contextImpl) ByteSize() uint64 {
 
 	var size int
 	// Estimate size of strings

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -67,6 +67,20 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 	return m.recorder
 }
 
+// ByteSize mocks base method.
+func (m *MockContext) ByteSize() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ByteSize")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ByteSize indicates an expected call of ByteSize.
+func (mr *MockContextMockRecorder) ByteSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByteSize", reflect.TypeOf((*MockContext)(nil).ByteSize))
+}
+
 // Clear mocks base method.
 func (m *MockContext) Clear() {
 	m.ctrl.T.Helper()
@@ -302,20 +316,6 @@ func (m *MockContext) SetWorkflowExecution(mutableState MutableState) {
 func (mr *MockContextMockRecorder) SetWorkflowExecution(mutableState any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkflowExecution", reflect.TypeOf((*MockContext)(nil).SetWorkflowExecution), mutableState)
-}
-
-// Size mocks base method.
-func (m *MockContext) Size() uint64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Size")
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-// Size indicates an expected call of Size.
-func (mr *MockContextMockRecorder) Size() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockContext)(nil).Size))
 }
 
 // Unlock mocks base method.

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1596,7 +1596,7 @@ func (e *mutableStateBuilder) SetHistorySize(size int64) {
 	e.executionStats.HistorySize = size
 }
 
-func (e *mutableStateBuilder) Size() uint64 {
+func (e *mutableStateBuilder) ByteSize() uint64 {
 	// TODO: To be implemented
 	return 0
 }

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -813,6 +813,20 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionTerminatedEvent(firs
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionTerminatedEvent), firstEventID, reason, details, identity)
 }
 
+// ByteSize mocks base method.
+func (m *MockMutableState) ByteSize() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ByteSize")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ByteSize indicates an expected call of ByteSize.
+func (mr *MockMutableStateMockRecorder) ByteSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByteSize", reflect.TypeOf((*MockMutableState)(nil).ByteSize))
+}
+
 // CheckResettable mocks base method.
 func (m *MockMutableState) CheckResettable() error {
 	m.ctrl.T.Helper()
@@ -2476,20 +2490,6 @@ func (m *MockMutableState) SetVersionHistories(arg0 *persistence.VersionHistorie
 func (mr *MockMutableStateMockRecorder) SetVersionHistories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersionHistories", reflect.TypeOf((*MockMutableState)(nil).SetVersionHistories), arg0)
-}
-
-// Size mocks base method.
-func (m *MockMutableState) Size() uint64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Size")
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-// Size indicates an expected call of Size.
-func (mr *MockMutableStateMockRecorder) Size() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockMutableState)(nil).Size))
 }
 
 // StartTransaction mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor Size() method to ByteSize() avoiding naming collision

<!-- Tell your future self why have you made these changes -->
**Why?**
Using Size() method could cause naming collision with some struct with a Size field [example](https://github.com/cadence-workflow/cadence/blob/6d4ff3b9586899afadea49387fa6cfe75b0d00aa/common/persistence/data_manager_interfaces.go#L995)
Therefore, we refactor the method to ByteSize avoiding the naming collision

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
