### PR TITLE
fix version conflict after renaming Size() to ByteSize()

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -156,8 +156,8 @@ type DomainMetricsScopeCache interface {
 	common.Daemon
 }
 
-// Sizeable is a interface that implements Size() function
+// Sizeable is a interface that implements ByteSize() function
 type Sizeable interface {
-	// Size returns an approximate size of the object in bytes
+	// ByteSize returns an approximate size of the object in bytes
 	ByteSize() uint64
 }

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -313,7 +313,7 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 		if !ok {
 			return nil, fmt.Errorf("value %T does not implement sizable. Key: %+v", value, key)
 		}
-		valueSize = sizeableValue.Size()
+		valueSize = sizeableValue.ByteSize()
 	}
 	c.mut.Lock()
 	defer c.mut.Unlock()

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -289,7 +289,7 @@ type sizeableValue struct {
 	size uint64
 }
 
-func (s sizeableValue) Size() uint64 {
+func (s sizeableValue) ByteSize() uint64 {
 	return s.size
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR fix a merge issue from [a previous commit](https://github.com/timl3136/cadence/commit/6f0aab8e7a08b8d9fcda2230f7e0e4588a97a1bc) where base cache cannot build properly

<!-- Tell your future self why have you made these changes -->
**Why?**
This change is required to resolve build failure caused by previous commit

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
