### PR TITLE
Use equality comparison for CloseStatus in pinot query instead of range

### DIFF
--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -967,7 +967,7 @@ func getListWorkflowExecutionsQuery(tableName string, request *p.InternalListWor
 		query.filters.addGte(CloseStatus, 0)
 	} else {
 		query.filters.addTimeRange(StartTime, earliest, latest) // convert Unix Time to miliseconds
-		query.filters.addLt(CloseStatus, 0)
+		query.filters.addEqual(CloseStatus, -1)
 		query.filters.addEqual(CloseTime, -1)
 	}
 
@@ -994,7 +994,7 @@ func getListWorkflowExecutionsByTypeQuery(tableName string, request *p.InternalL
 		query.filters.addGte(CloseStatus, 0)
 	} else {
 		query.filters.addTimeRange(StartTime, earliest, latest) // convert Unix Time to miliseconds
-		query.filters.addLt(CloseStatus, 0)
+		query.filters.addEqual(CloseStatus, -1)
 		query.filters.addEqual(CloseTime, -1)
 	}
 
@@ -1029,7 +1029,7 @@ func getListWorkflowExecutionsByWorkflowIDQuery(tableName string, request *p.Int
 		query.filters.addGte(CloseStatus, 0)
 	} else {
 		query.filters.addTimeRange(StartTime, earliest, latest) // convert Unix Time to miliseconds
-		query.filters.addLt(CloseStatus, 0)
+		query.filters.addEqual(CloseStatus, -1)
 		query.filters.addEqual(CloseTime, -1)
 	}
 

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1314,12 +1314,12 @@ LIMIT 0, 10
 				Domain:        testDomain,
 				PageSize:      testPageSize,
 				NextPageToken: serializedToken,
-				Query:         "CloseStatus < 0 and CustomKeywordField = 'keywordCustomized' AND CustomIntField<=10 and CustomStringField = 'String field is for text' Order by DomainID Desc",
+				Query:         "CloseStatus = -1 and CustomKeywordField = 'keywordCustomized' AND CustomIntField<=10 and CustomStringField = 'String field is for text' Order by DomainID Desc",
 			},
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND CloseStatus < 0 and (JSON_MATCH(Attr, '"$.CustomKeywordField"=''keywordCustomized''') or JSON_MATCH(Attr, '"$.CustomKeywordField[*]"=''keywordCustomized''')) and (JSON_MATCH(Attr, '"$.CustomIntField" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) <= 10) and JSON_MATCH(Attr, '"$.CustomStringField" is not null') AND JSON_MATCH(Attr, 'REGEXP_LIKE("$.CustomStringField", ''.*String field is for text.*'')')
+AND CloseStatus = -1 and (JSON_MATCH(Attr, '"$.CustomKeywordField"=''keywordCustomized''') or JSON_MATCH(Attr, '"$.CustomKeywordField[*]"=''keywordCustomized''')) and (JSON_MATCH(Attr, '"$.CustomIntField" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) <= 10) and JSON_MATCH(Attr, '"$.CustomStringField" is not null') AND JSON_MATCH(Attr, 'REGEXP_LIKE("$.CustomStringField", ''.*String field is for text.*'')')
 Order by DomainID Desc
 LIMIT 11, 10
 `, testTableName),
@@ -1453,7 +1453,7 @@ LIMIT 0, 10
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
-AND CloseStatus < 0
+AND CloseStatus = -1
 AND CloseTime = -1
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1498,7 +1498,7 @@ FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND WorkflowType = 'test-wf-type'
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
-AND CloseStatus < 0
+AND CloseStatus = -1
 AND CloseTime = -1
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1543,7 +1543,7 @@ FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND WorkflowID = 'test-wid'
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
-AND CloseStatus < 0
+AND CloseStatus = -1
 AND CloseTime = -1
 Order BY StartTime DESC
 LIMIT 0, 10


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Currently we are using CloseStatus < 0 in Pinot to filter the open workflows which is a range query and can not apply inverted index, Pinot will have to do full scan of the table and the query performance is bad. We are switching to use CloseStatus = -1 which is supposed to have better performance

<!-- Tell your future self why have you made these changes -->
**Why?**
Query performance

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
