### PR TITLE
Upgrade postgres version in docker compose files from 12.4 to 17.4

### DIFF
--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -31,7 +31,7 @@ services:
           - mysql
 
   postgres:
-    image: postgres:12.4
+    image: postgres:17.4
     environment:
       POSTGRES_PASSWORD: cadence
       POSTGRES_USER: cadence

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -24,7 +24,7 @@ services:
           - mysql
 
   postgres:
-    image: postgres:12.4
+    image: postgres:17.4
     environment:
       POSTGRES_PASSWORD: cadence
     ports:

--- a/docker/dev/postgres.yml
+++ b/docker/dev/postgres.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:12.4
+    image: postgres:17.4
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: cadence

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:12.4
+    image: postgres:17.4
     environment:
       POSTGRES_USER: cadence
       POSTGRES_PASSWORD: cadence


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Upgraded existing version of Postgres from 12.4 to Postgres 17.4

<!-- Tell your future self why have you made these changes -->
**Why?**
- To ensure we're compatible with the latest version of Postgres. Addressing https://github.com/cadence-workflow/cadence/issues/6594 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Ran test and test_e2e
- created a local dev setup `docker/dev/postgres.yml` using postgres 17.4, started the server and ran helloworld workflow successfully
- created environment using `docker/docker-compose-postgres.yml`, started the server and ran helloworld workflow successfully

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Given our current usage of PostgreSQL for basic CRUD operations, the risks associated with upgrading to PostgreSQL 17.4 are minimal. At most user will not be able to start the server using Postgres 17.4 and can rollback to older 12.4 version

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
- Postgres version has been upgraded to 17.4
