### PR TITLE
(docs): Update Cross Region README commands to new version syntax

### DIFF
--- a/service/worker/README.md
+++ b/service/worker/README.md
@@ -32,7 +32,7 @@ make install-schema-xdc
 
 3. Create a global Cadence domain that replicates data across clusters
 ```
-cadence --do sample domain register --ac cluster0 --cl cluster0 cluster1 cluster2
+cadence --do samples-domain domain register --ac cluster0 --cl cluster0,cluster1,cluster2
 ```
 Then run a helloworld from [Go Client Sample](https://github.com/cadence-workflow/cadence-samples/) or [Java Client Sample](https://github.com/cadence-workflow/cadence-java-samples)
 
@@ -48,7 +48,7 @@ or failover to cluster2:
    ```
 Failback to cluster0:
 ```
-cadence --do sample samples-domain update --ac cluster0
+cadence --do samples-domain domain update --ac cluster0
 ```
 
 ## Multiple region setup


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Updates the worker README with syntax for creating a local cross-region cadence cluster. 

<!-- Tell your future self why have you made these changes -->

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Tested by running through the README locally with the latest master build. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->


<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->

