### PR TITLE
Eagerly leak tasks that don't match the partition config

### DIFF
--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -73,7 +74,10 @@ var (
 	IsolationLeakCauseError           = metrics.IsolationLeakCause("error")
 	IsolationLeakCauseGroupDrained    = metrics.IsolationLeakCause("group_drained")
 	IsolationLeakCauseNoRecentPollers = metrics.IsolationLeakCause("no_recent_pollers")
+	IsolationLeakCausePartitionChange = metrics.IsolationLeakCause("partition_change")
 	IsolationLeakCauseExpired         = metrics.IsolationLeakCause("expired")
+
+	defaultPartition = &types.TaskListPartition{}
 )
 
 type (
@@ -349,6 +353,26 @@ func (c *taskListManagerImpl) TaskListPartitionConfig() *types.TaskListPartition
 	return &config
 }
 
+func (c *taskListManagerImpl) PartitionReadConfig() (*types.TaskListPartition, bool) {
+	tlConfig := c.TaskListPartitionConfig()
+	// no config indicates 1 partition
+	if tlConfig == nil {
+		return defaultPartition, true
+	}
+	partition, ok := tlConfig.ReadPartitions[c.taskListID.Partition()]
+	return partition, ok
+}
+
+func (c *taskListManagerImpl) PartitionWriteConfig() (*types.TaskListPartition, bool) {
+	tlConfig := c.TaskListPartitionConfig()
+	// no config indicates 1 partition
+	if tlConfig == nil {
+		return defaultPartition, true
+	}
+	partition, ok := tlConfig.WritePartitions[c.taskListID.Partition()]
+	return partition, ok
+}
+
 func (c *taskListManagerImpl) LoadBalancerHints() *types.LoadBalancerHints {
 	c.startWG.Wait()
 	if c.timeSource.Now().Sub(c.createTime) < time.Second*10 {
@@ -493,12 +517,9 @@ func (c *taskListManagerImpl) AddTask(ctx context.Context, params AddTaskParams)
 		return false, errShutdown
 	}
 	if c.config.EnableGetNumberOfPartitionsFromCache() {
-		partitionConfig := c.TaskListPartitionConfig()
-		if partitionConfig != nil {
-			_, ok := partitionConfig.WritePartitions[c.taskListID.Partition()]
-			if !ok {
-				return false, &types.InternalServiceError{Message: "Current partition is drained."}
-			}
+		_, ok := c.PartitionWriteConfig()
+		if !ok {
+			return false, &types.InternalServiceError{Message: "Current partition is drained."}
 		}
 	}
 	if params.ForwardedFrom == "" {
@@ -865,6 +886,11 @@ func (c *taskListManagerImpl) getIsolationGroupForTask(ctx context.Context, task
 	}
 	if !c.pollers.HasPollerFromIsolationGroupAfter(group, c.timeSource.Now().Add(-1*c.config.TaskIsolationPollerWindow())) {
 		c.scope.Tagged(metrics.IsolationGroupTag(group), IsolationLeakCauseNoRecentPollers).IncCounter(metrics.TaskIsolationLeakPerTaskList)
+		return defaultTaskBufferIsolationGroup, noIsolationTimeout
+	}
+	partition, ok := c.PartitionReadConfig()
+	if !ok || (len(partition.IsolationGroups) != 0 && !slices.Contains(partition.IsolationGroups, group)) {
+		c.scope.Tagged(metrics.IsolationGroupTag(group), IsolationLeakCausePartitionChange).IncCounter(metrics.TaskIsolationLeakPerTaskList)
 		return defaultTaskBufferIsolationGroup, noIsolationTimeout
 	}
 


### PR DESCRIPTION
If the partition config has changed and the partition is no longer assigned a specific isolation group, eagerly leak the tasks for it. Otherwise tasks from that isolation group that end up in that partition (such as an existing backlog) will require the isolation duration to expire or the recent poller duration to expire before they can be dispatched. This could add additional latency to each task.

<!-- Describe what has changed in this PR -->
**What changed?**
- Eagerly leak tasks from isolation groups that a partition doesn't believe it is assigned

<!-- Tell your future self why have you made these changes -->
**Why?**
- Reduce task latency caused by the eventually consistent nature of task routing

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
