### PR TITLE
Adjust task isolation metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2629,6 +2629,7 @@ const (
 	RemoteToLocalMatchPerTaskListCounter
 	RemoteToRemoteMatchPerTaskListCounter
 	IsolationTaskMatchPerTaskListCounter
+	IsolationSuccessPerTaskListCounter
 	PollerPerTaskListCounter
 	PollerInvalidIsolationGroupCounter
 	TaskListPartitionUpdateFailedCounter
@@ -3341,6 +3342,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		RemoteToLocalMatchPerTaskListCounter:                    {metricName: "remote_to_local_matches_per_tl", metricRollupName: "remote_to_local_matches"},
 		RemoteToRemoteMatchPerTaskListCounter:                   {metricName: "remote_to_remote_matches_per_tl", metricRollupName: "remote_to_remote_matches"},
 		IsolationTaskMatchPerTaskListCounter:                    {metricName: "isolation_task_matches_per_tl", metricType: Counter},
+		IsolationSuccessPerTaskListCounter:                      {metricName: "isolation_success_per_tl", metricRollupName: "isolation_success"},
 		PollerPerTaskListCounter:                                {metricName: "poller_count_per_tl", metricRollupName: "poller_count"},
 		PollerInvalidIsolationGroupCounter:                      {metricName: "poller_invalid_isolation_group_per_tl", metricType: Counter},
 		TaskListPartitionUpdateFailedCounter:                    {metricName: "tasklist_partition_update_failed_per_tl", metricType: Counter},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -65,7 +65,6 @@ const (
 	workflowCloseStatus       = "workflow_close_status"
 	isolationEnabled          = "isolation_enabled"
 	isolationGroup            = "isolation_group"
-	originalIsolationGroup    = "original_isolation_group"
 	leakCause                 = "leak_cause"
 	topic                     = "topic"
 	mode                      = "mode"
@@ -312,10 +311,6 @@ func WorkflowTerminationReasonTag(value string) Tag {
 func WorkflowCloseStatusTag(value string) Tag {
 	value = safeAlphaNumericStringRE.ReplaceAllString(value, "_")
 	return simpleMetric{key: workflowCloseStatus, value: value}
-}
-
-func OriginalIsolationGroupTag(group string) Tag {
-	return simpleMetric{key: originalIsolationGroup, value: sanitizer.Value(group)}
 }
 
 func IsolationGroupTag(group string) Tag {

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -1342,7 +1342,10 @@ func (e *matchingEngineImpl) emitTaskIsolationMetrics(
 		if !ok {
 			originalGroup = currentGroup
 		}
-		scope.Tagged(metrics.OriginalIsolationGroupTag(originalGroup), metrics.IsolationGroupTag(currentGroup), metrics.PollerIsolationGroupTag(pollerIsolationGroup)).IncCounter(metrics.IsolationTaskMatchPerTaskListCounter)
+		scope.Tagged(metrics.IsolationGroupTag(originalGroup), metrics.PollerIsolationGroupTag(pollerIsolationGroup)).IncCounter(metrics.IsolationTaskMatchPerTaskListCounter)
+		if originalGroup == pollerIsolationGroup {
+			scope.Tagged(metrics.IsolationGroupTag(originalGroup)).IncCounter(metrics.IsolationSuccessPerTaskListCounter)
+		}
 	}
 }
 


### PR DESCRIPTION
When we're dispatching a task we have three groups:
- The original isolation group. This comes from the workflow.
- The isolation group that we're dispatching the task as. This is either the original or `""`.
- The isolation group of the poller.

Remove the isolation group that we're currently dispatching the task as. It isn't useful. We only care whether the original matches the poller. I originally added it in #6544 to try and evaluate whether we're "incidentally" getting successes, but it really doesn't matter. We have subsequently added another metric to report when we abandon isolation and why.

Add an explicit metric to count when the original group matches the poller. This is a lot easier to monitor and query compared to finding where the tags match.

<!-- Describe what has changed in this PR -->
**What changed?**
- Remove the group that we're currently dispatching the task as from `isolation_task_matches_per_tl`
- Create a new metric `isolation_success_per_tl` any time the group the task is from matches the poller.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Simplify monitoring isolation success rate

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
