### PR TITLE
[server] Start the server as a Fx application

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -21,108 +21,24 @@
 package cadence
 
 import (
+	"context"
 	"fmt"
-	"log"
+	stdLog "log"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/urfave/cli/v2"
+	"go.uber.org/fx"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"github.com/uber/cadence/common/log/logfx"
 	"github.com/uber/cadence/common/service"
-	"github.com/uber/cadence/tools/cassandra"
-	"github.com/uber/cadence/tools/sql"
 )
 
 // validServices is the list of all valid cadence services
 var validServices = service.ShortNames(service.List)
-
-// startHandler is the handler for the cli start command
-func startHandler(c *cli.Context) error {
-	env := getEnvironment(c)
-	zone := getZone(c)
-	configDir := getConfigDir(c)
-	rootDir := getRootDir(c)
-
-	log.Printf("Loading config; env=%v,zone=%v,configDir=%v\n", env, zone, configDir)
-
-	var cfg config.Config
-	err := config.Load(env, configDir, zone, &cfg)
-	if err != nil {
-		return fmt.Errorf("Config file corrupted: %w", err)
-	}
-	if cfg.Log.Level == "debug" {
-		log.Printf("config=%v", cfg.String())
-	}
-	if cfg.DynamicConfig.Client == "" {
-		cfg.DynamicConfigClient.Filepath = constructPathIfNeed(rootDir, cfg.DynamicConfigClient.Filepath)
-	} else {
-		cfg.DynamicConfig.FileBased.Filepath = constructPathIfNeed(rootDir, cfg.DynamicConfig.FileBased.Filepath)
-	}
-
-	if err := cfg.ValidateAndFillDefaults(); err != nil {
-		return fmt.Errorf("config validation failed: %w", err)
-	}
-	// cassandra schema version validation
-	if err := cassandra.VerifyCompatibleVersion(cfg.Persistence, gocql.Quorum); err != nil {
-		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)
-	}
-	// sql schema version validation
-	if err := sql.VerifyCompatibleVersion(cfg.Persistence); err != nil {
-		return fmt.Errorf("sql schema version compatibility check failed: %w", err)
-	}
-
-	var daemons []common.Daemon
-	services := getServices(c)
-	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGTERM, syscall.SIGINT)
-	for _, svc := range services {
-		server := newServer(svc, &cfg)
-		daemons = append(daemons, server)
-		server.Start()
-	}
-
-	<-sigc
-	log.Println("Received SIGTERM signal, initiating shutdown.")
-	for _, daemon := range daemons {
-		daemon.Stop()
-	}
-	return nil
-}
-
-func getEnvironment(c *cli.Context) string {
-	return strings.TrimSpace(c.String("env"))
-}
-
-func getZone(c *cli.Context) string {
-	return strings.TrimSpace(c.String("zone"))
-}
-
-// getServices parses the services arg from cli
-// and returns a list of services to start
-func getServices(c *cli.Context) []string {
-
-	val := strings.TrimSpace(c.String("services"))
-	tokens := strings.Split(val, ",")
-
-	if len(tokens) == 0 {
-		log.Fatal("list of services is empty")
-	}
-
-	for _, t := range tokens {
-		if !isValidService(t) {
-			log.Fatalf("invalid service `%v` in service list [%v]", t, val)
-		}
-	}
-
-	return tokens
-}
 
 func isValidService(in string) bool {
 	for _, s := range validServices {
@@ -131,31 +47,6 @@ func isValidService(in string) bool {
 		}
 	}
 	return false
-}
-
-func getConfigDir(c *cli.Context) string {
-	return constructPathIfNeed(getRootDir(c), c.String("config"))
-}
-
-func getRootDir(c *cli.Context) string {
-	dirpath := c.String("root")
-	if len(dirpath) == 0 {
-		cwd, err := os.Getwd()
-		if err != nil {
-			log.Fatalf("os.Getwd() failed, err=%v", err)
-		}
-		return cwd
-	}
-	return dirpath
-}
-
-// constructPathIfNeed would append the dir as the root dir
-// when the file wasn't absolute path.
-func constructPathIfNeed(dir string, file string) string {
-	if !filepath.IsAbs(file) {
-		return dir + "/" + file
-	}
-	return file
 }
 
 // BuildCLI is the main entry point for the cadence server
@@ -217,11 +108,98 @@ func BuildCLI(releaseVersion string, gitRevision string) *cli.App {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return startHandler(c)
+				fxApp := fx.New(
+					config.Module,
+					logfx.Module,
+					fx.Provide(func() appContext {
+						return appContext{
+							CfgContext: config.Context{
+								Environment: getEnvironment(c),
+								Zone:        getZone(c),
+							},
+							ConfigDir: getConfigDir(c),
+							RootDir:   getRootDir(c),
+							Services:  getServices(c),
+						}
+					}),
+					Module,
+				)
+
+				ctx := context.Background()
+				if err := fxApp.Start(ctx); err != nil {
+					return err
+				}
+
+				// Block until FX receives a shutdown signal
+				<-fxApp.Done()
+
+				// Stop the application
+				return fxApp.Stop(ctx)
 			},
 		},
 	}
 
 	return app
 
+}
+
+type appContext struct {
+	fx.Out
+
+	CfgContext config.Context
+	ConfigDir  string   `name:"config-dir"`
+	RootDir    string   `name:"root-dir"`
+	Services   []string `name:"services"`
+}
+
+func getEnvironment(c *cli.Context) string {
+	return strings.TrimSpace(c.String("env"))
+}
+
+func getZone(c *cli.Context) string {
+	return strings.TrimSpace(c.String("zone"))
+}
+
+// getServices parses the services arg from cli
+// and returns a list of services to start
+func getServices(c *cli.Context) []string {
+	val := strings.TrimSpace(c.String("services"))
+	tokens := strings.Split(val, ",")
+
+	if len(tokens) == 0 {
+		stdLog.Fatal("list of services is empty")
+	}
+
+	for _, t := range tokens {
+		if !isValidService(t) {
+			stdLog.Fatalf("invalid service `%v` in service list [%v]", t, val)
+		}
+	}
+
+	return tokens
+}
+
+func getConfigDir(c *cli.Context) string {
+	return constructPathIfNeed(getRootDir(c), c.String("config"))
+}
+
+func getRootDir(c *cli.Context) string {
+	dirpath := c.String("root")
+	if len(dirpath) == 0 {
+		cwd, err := os.Getwd()
+		if err != nil {
+			stdLog.Fatalf("os.Getwd() failed, err=%v", err)
+		}
+		return cwd
+	}
+	return dirpath
+}
+
+// constructPathIfNeed would append the dir as the root dir
+// when the file wasn't absolute path.
+func constructPathIfNeed(dir string, file string) string {
+	if !filepath.IsAbs(file) {
+		return dir + "/" + file
+	}
+	return file
 }

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -1,0 +1,113 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cadence
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/fx"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"github.com/uber/cadence/tools/cassandra"
+	"github.com/uber/cadence/tools/sql"
+)
+
+// Module provides a cadence server initialization with root components.
+// AppParams allows to provide optional/overrides for implementation specific dependencies.
+var Module = fx.Options(
+	fx.Provide(NewApp),
+	// empty invoke so fx won't drop the application from the dependencies.
+	fx.Invoke(func(a *App) {}),
+)
+
+type AppParams struct {
+	fx.In
+
+	RootDir    string   `name:"root-dir"`
+	Services   []string `name:"services"`
+	AppContext config.Context
+	Config     config.Config
+	Logger     log.Logger
+}
+
+// NewApp created a new Application from pre initalized config and logger.
+func NewApp(params AppParams) *App {
+	app := &App{
+		cfg:      params.Config,
+		rootDir:  params.RootDir,
+		logger:   params.Logger,
+		services: params.Services,
+	}
+	return app
+}
+
+// App is a fx application that registers itself into fx.Lifecycle and runs.
+// It is done implicitly, since it provides methods Start and Stop which are picked up by fx.
+type App struct {
+	cfg     config.Config
+	rootDir string
+	logger  log.Logger
+
+	daemons  []common.Daemon
+	services []string
+}
+
+func (a *App) Start(_ context.Context) error {
+	if a.cfg.DynamicConfig.Client == "" {
+		a.cfg.DynamicConfigClient.Filepath = constructPathIfNeed(a.rootDir, a.cfg.DynamicConfigClient.Filepath)
+	} else {
+		a.cfg.DynamicConfig.FileBased.Filepath = constructPathIfNeed(a.rootDir, a.cfg.DynamicConfig.FileBased.Filepath)
+	}
+
+	if err := a.cfg.ValidateAndFillDefaults(); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+	// cassandra schema version validation
+	if err := cassandra.VerifyCompatibleVersion(a.cfg.Persistence, gocql.Quorum); err != nil {
+		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)
+	}
+	// sql schema version validation
+	if err := sql.VerifyCompatibleVersion(a.cfg.Persistence); err != nil {
+		return fmt.Errorf("sql schema version compatibility check failed: %w", err)
+	}
+
+	var daemons []common.Daemon
+	for _, svc := range a.services {
+		server := newServer(svc, a.cfg, a.logger)
+		daemons = append(daemons, server)
+		server.Start()
+	}
+
+	return nil
+}
+
+func (a *App) Stop(ctx context.Context) error {
+	for _, daemon := range a.daemons {
+		daemon.Stop()
+	}
+	return nil
+}

--- a/cmd/server/cadence/fx_test.go
+++ b/cmd/server/cadence/fx_test.go
@@ -1,0 +1,51 @@
+package cadence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log/logfx"
+)
+
+func TestFxDependencies(t *testing.T) {
+	err := fx.ValidateApp(config.Module,
+		logfx.Module,
+		fx.Provide(func() appContext {
+			return appContext{
+				CfgContext: config.Context{
+					Environment: "",
+					Zone:        "",
+				},
+				ConfigDir: "",
+				RootDir:   "",
+				Services:  []string{"frontend"},
+			}
+		}),
+		Module)
+	require.NoError(t, err)
+}
+
+func TestFxStart(t *testing.T) {
+	fxApp := fxtest.New(
+		t,
+		config.Module,
+		logfx.Module,
+		fx.Provide(func() appContext {
+			return appContext{
+				CfgContext: config.Context{
+					Environment: "",
+					Zone:        "",
+				},
+				ConfigDir: "../../../config",
+				RootDir:   ".",
+				Services:  []string{"frontend"},
+			}
+		}),
+		Module)
+
+	fxApp.RequireStart().RequireStop()
+}

--- a/cmd/server/cadence/fx_test.go
+++ b/cmd/server/cadence/fx_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package cadence
 
 import (

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -109,10 +109,12 @@ func (s *ServerSuite) TestServerStartup() {
 		s.logger.Fatal("cassandra schema version compatibility check failed", tag.Error(err))
 	}
 
+	logger := testlogger.New(s.T())
+
 	var daemons []common.Daemon
 	services := service.ShortNames(service.List)
 	for _, svc := range services {
-		server := newServer(svc, &cfg)
+		server := newServer(svc, cfg, logger)
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -51,7 +51,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/cadence v0.19.0
 	go.uber.org/config v1.4.0 // indirect
-	go.uber.org/fx v1.13.1 // indirect
+	go.uber.org/fx v1.13.1
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/thriftrw v1.29.2 // indirect
 	go.uber.org/yarpc v1.70.3 // indirect

--- a/common/archiver/gcloud/go.mod
+++ b/common/archiver/gcloud/go.mod
@@ -94,6 +94,8 @@ require (
 	github.com/uber-common/bark v1.2.1 // indirect
 	github.com/uber-go/mapdecode v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.uber.org/dig v1.10.0 // indirect
+	go.uber.org/fx v1.13.1 // indirect
 	go.uber.org/net/metrics v1.3.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect

--- a/common/config/fx.go
+++ b/common/config/fx.go
@@ -1,0 +1,88 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/fx"
+)
+
+// Module returns a config.Provider that could be used byother components.
+var Module = fx.Options(
+	fx.Provide(New),
+)
+
+type Context struct {
+	Environment string
+	Zone        string
+}
+
+// Params defines the dependencies of the configfx module.
+type Params struct {
+	fx.In
+
+	Context   Context
+	LookupEnv LookupEnvFunc `optional:"true"`
+
+	ConfigDir string `name:"config-dir"`
+
+	Lifecycle fx.Lifecycle `optional:"true"` // required for strict mode
+}
+
+// Result defines the objects that the configfx module provides.
+type Result struct {
+	fx.Out
+
+	Config Config
+}
+
+// LookupEnvFunc returns the value of the environment variable given by key.
+// It should behave the same as `os.LookupEnv`. If a function returns false,
+// an environment variable is looked up using `envfx.Context.LookupEnv`.
+type LookupEnvFunc func(key string) (string, bool)
+
+// New exports functionality similar to Module, but allows the caller to wrap
+// or modify Result. Most users should use Module instead.
+func New(p Params) (Result, error) {
+	lookupFun := os.LookupEnv
+	if p.LookupEnv != nil {
+		lookupFun = func(key string) (string, bool) {
+			if result, ok := p.LookupEnv(key); ok {
+				return result, true
+			}
+			return lookupFun(key)
+		}
+	}
+
+	var cfg Config
+	err := Load(p.Context.Environment, p.ConfigDir, p.Context.Zone, &cfg)
+	if err != nil {
+		return Result{}, fmt.Errorf("load config: %w", err)
+	}
+
+	return Result{
+		Config: cfg,
+	}, nil
+}

--- a/common/config/fx.go
+++ b/common/config/fx.go
@@ -60,7 +60,7 @@ type Result struct {
 
 // LookupEnvFunc returns the value of the environment variable given by key.
 // It should behave the same as `os.LookupEnv`. If a function returns false,
-// an environment variable is looked up using `envfx.Context.LookupEnv`.
+// an environment variable is looked up using `os.LookupEnv`.
 type LookupEnvFunc func(key string) (string, bool)
 
 // New exports functionality similar to Module, but allows the caller to wrap

--- a/common/log/logfx/fx.go
+++ b/common/log/logfx/fx.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package logfx
 
 import (

--- a/common/log/logfx/fx.go
+++ b/common/log/logfx/fx.go
@@ -1,0 +1,34 @@
+package logfx
+
+import (
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+)
+
+// Module provides fx options to initialize logger from configuration.
+var Module = fx.Options(
+	fx.Provide(zapBuilder),
+	ModuleWithoutZap,
+)
+
+// ModuleWithoutZap provides fx options to initialize logger from existing zap logger, which might be provided outside.
+// This is useful for monorepos or any application that uses centralize log configuration like Uber monorepo.
+var ModuleWithoutZap = fx.Options(
+	fx.Provide(log.NewLogger))
+
+type zapBuilderParams struct {
+	fx.In
+
+	Cfg config.Config
+}
+
+func zapBuilder(p zapBuilderParams) (*zap.Logger, error) {
+	logger, err := p.Cfg.Log.NewZapLogger()
+	if err != nil {
+		return nil, err
+	}
+	return logger, nil
+}

--- a/common/log/logfx/fx_test.go
+++ b/common/log/logfx/fx_test.go
@@ -1,0 +1,38 @@
+package logfx
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+)
+
+func TestLogFx(t *testing.T) {
+	app := fxtest.New(t,
+		fx.Provide(func() config.Config {
+			return config.Config{}
+		}),
+		Module,
+		fx.Invoke(func(logger log.Logger) {
+			logger.Info("hello world")
+		}),
+	)
+	app.RequireStart().RequireStop()
+}
+
+func TestLogFxWithExternalZapLogger(t *testing.T) {
+	app := fxtest.New(t,
+		fx.Provide(func() *zap.Logger {
+			return zaptest.NewLogger(t)
+		}),
+		ModuleWithoutZap,
+		fx.Invoke(func(logger log.Logger) {
+			logger.Info("hello world")
+		}))
+	app.RequireStart().RequireStop()
+}

--- a/common/log/logfx/fx_test.go
+++ b/common/log/logfx/fx_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package logfx
 
 import (


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Onboarding server start to usage of fx.

<!-- Tell your future self why have you made these changes -->
**Why?**
Using go.uber.org/fx as a dependency injecvtion allows to simplify initialization of components and help establishing components boundaries. As a long term goal - we should eliminate resource package and rely on fx to connect components. Also, separate optional from mandatory components to simplify service customizations.
It is required for reusable components and allows extraction of components, such as Shard distributor, into a separate repo/internal monorepo.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit/integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Start migration to Dependency injection using go.uber.org/fx

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
