### PR TITLE
Allow execution of the delete history event task for deprecated domains

### DIFF
--- a/service/history/queue/timer_queue_active_processor.go
+++ b/service/history/queue/timer_queue_active_processor.go
@@ -49,6 +49,11 @@ func newTimerQueueActiveProcessor(
 			return false, errUnexpectedQueueTask
 		}
 		if notRegistered, err := isDomainNotRegistered(shard, timer.GetDomainID()); notRegistered && err == nil {
+			// Allow deletion tasks for deprecated domains
+			if timer.GetTaskType() == persistence.TaskTypeDeleteHistoryEvent {
+				return true, nil
+			}
+
 			logger.Info("Domain is not in registered status, skip task in active timer queue.", tag.WorkflowDomainID(timer.GetDomainID()), tag.Value(timer))
 			return false, nil
 		}

--- a/service/history/queue/timer_queue_failover_processor.go
+++ b/service/history/queue/timer_queue_failover_processor.go
@@ -60,6 +60,11 @@ func newTimerQueueFailoverProcessor(
 			return false, errUnexpectedQueueTask
 		}
 		if notRegistered, err := isDomainNotRegistered(shardContext, timer.GetDomainID()); notRegistered && err == nil {
+			// Allow deletion tasks for deprecated domains
+			if timer.GetTaskType() == persistence.TaskTypeDeleteHistoryEvent {
+				return true, nil
+			}
+
 			logger.Info("Domain is not in registered status, skip task in failover timer queue.", tag.WorkflowDomainID(timer.GetDomainID()), tag.Value(timer))
 			return false, nil
 		}

--- a/service/history/queue/timer_queue_standby_processor.go
+++ b/service/history/queue/timer_queue_standby_processor.go
@@ -50,6 +50,11 @@ func newTimerQueueStandbyProcessor(
 			return false, errUnexpectedQueueTask
 		}
 		if notRegistered, err := isDomainNotRegistered(shard, timer.GetDomainID()); notRegistered && err == nil {
+			// Allow deletion tasks for deprecated domains
+			if timer.GetTaskType() == persistence.TaskTypeDeleteHistoryEvent {
+				return true, nil
+			}
+
 			logger.Info("Domain is not in registered status, skip task in standby timer queue.", tag.WorkflowDomainID(timer.GetDomainID()), tag.Value(timer))
 			return false, nil
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added a special case in the task filter to check for deletion tasks
If the task is a deletion task (TaskTypeDeleteHistoryEvent), it is allowed to proceed even for deprecated domains
All other timer tasks continue to be skipped for deprecated domains
The deletion process remains unchanged, just allowing it to proceed for deprecated domains

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, when a domain is deprecated, all timer tasks (including workflow deletion tasks) are skipped. This prevents workflows from being deleted after their retention period expires, which can lead to unnecessary storage usage and also it prevents removing the domain metadata records.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local testing with cadence-samples

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
