### PR TITLE
Reenables child workflows to be launched across local domains

### DIFF
--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -660,7 +660,7 @@ func (r *mutableStateTaskGeneratorImpl) validateChildWorkflowParameters(msbDomai
 	//
 	// There is a limited exception for local domains, which do not suffer from this problem can be
 	// handled as an exception where the transfer task may be picked up by another domain in-cluster
-	// without risk of the child workflow may end up in a different cluster
+	// without risk of the child workflow may end up in a different cluster.
 	if thisDomain.IsGlobalDomain() || targetDomain.IsGlobalDomain() {
 		return &types.BadRequestError{
 			Message: fmt.Sprintf("The child workflow is "+

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -461,14 +461,10 @@ func (r *mutableStateTaskGeneratorImpl) GenerateChildWorkflowTasks(
 	if childWorkflowInfo.DomainID == "" {
 		targetDomainID = msbDomainID
 	}
-	// This was formerly supported with the cross cluster feature
-	// but is no longer. So erroring out explicitly here
-	if targetDomainID != msbDomainID {
-		return &types.BadRequestError{
-			Message: fmt.Sprintf("there would appear to be a bug: The child workflow is trying to use domain %s but it's running in domain %s. Cross-cluster child workflows are not supported",
-				childWorkflowInfo.DomainID, msbDomainID),
-		}
 
+	err := r.validateChildWorkflowParameters(msbDomainID, targetDomainID)
+	if err != nil {
+		return err
 	}
 
 	executionInfo := r.mutableState.GetExecutionInfo()
@@ -645,6 +641,35 @@ func (r *mutableStateTaskGeneratorImpl) getTargetDomainID(
 	}
 
 	return r.mutableState.GetExecutionInfo().DomainID, nil
+}
+
+func (r *mutableStateTaskGeneratorImpl) validateChildWorkflowParameters(msbDomainID string, targetDomainID string) error {
+	// standard case
+	if msbDomainID == targetDomainID {
+		return nil
+	}
+
+	thisDomain := r.mutableState.GetDomainEntry()
+	targetDomain, err := r.domainCache.GetDomainByID(targetDomainID)
+	if err != nil {
+		return fmt.Errorf("cannot get target domain for child workflow: %w", err)
+	}
+
+	// Generally, cross-domain calls are not allowed for launching child workflows in global domains due to
+	// the fact that we have removed cross-cluster calls (due to their overhead and limited use).
+	//
+	// There is a limited exception for local domains, which do not suffer from this problem can be
+	// handled as an exception where the transfer task may be picked up by another domain in-cluster
+	// without risk of the child workflow may end up in a different cluster
+	if thisDomain.IsGlobalDomain() || targetDomain.IsGlobalDomain() {
+		return &types.BadRequestError{
+			Message: fmt.Sprintf("The child workflow is "+
+				"trying to use domain %s but it's running in domain %s. "+
+				"Cross-cluster and cross domain child workflows are not supported for global domains",
+				targetDomainID, msbDomainID),
+		}
+	}
+	return nil
 }
 
 func getTargetCluster(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This is changing the behaviour for local domains to be able to launch child workflows (cf https://github.com/cadence-workflow/cadence/issues/6798)

<!-- Tell your future self why have you made these changes -->
**Why?**

When I removed the Cross-cluster feature I was treating cross-domain functionality as similarly being deprecated (since in practice global domains are nearly-always the default option for customers due to the HA requirements and the degree to which few teams wish to handle failover at the application layer). This missed the fact that there was preexisting behaviour to allow local domains to do a cross-domain operations. This PR rectifies that.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I've confirmed locally that:

- [X] works for child workflows across local domains 
- [X] Global domains are not able to perform this (expected behaviour)
- [X] Signaling across domain boundaries 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
