### PR TITLE
[cadence][server] Fix server start missing lifecycle

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -52,6 +52,7 @@ type AppParams struct {
 	AppContext config.Context
 	Config     config.Config
 	Logger     log.Logger
+	LifeCycle  fx.Lifecycle
 }
 
 // NewApp created a new Application from pre initalized config and logger.
@@ -62,6 +63,7 @@ func NewApp(params AppParams) *App {
 		logger:   params.Logger,
 		services: params.Services,
 	}
+	params.LifeCycle.Append(fx.Hook{OnStart: app.Start, OnStop: app.Stop})
 	return app
 }
 

--- a/cmd/server/cadence/fx_test.go
+++ b/cmd/server/cadence/fx_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/testflags"
 )
 
 func TestFxDependencies(t *testing.T) {
@@ -52,6 +53,8 @@ func TestFxDependencies(t *testing.T) {
 }
 
 func TestFxStart(t *testing.T) {
+	testflags.RequireCassandra(t)
+
 	fxApp := fxtest.New(
 		t,
 		config.Module,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added server start lifecycle registration so that application is started.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fixing an issue that binary starts, but does not start the application

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test, also added requirement of cassandra for the fx start/stop test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
