### PR TITLE
Fix exp value for GroupQPS values

### DIFF
--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -61,6 +61,7 @@ func NewEmaFixedWindowQPSTracker(timeSource clock.TimeSource, exp float64, bucke
 	return &emaFixedWindowQPSTracker{
 		root:           newEmaFixedWindowState(exp, bucketInterval, baseEvent),
 		timeSource:     timeSource,
+		exp:            exp,
 		bucketInterval: bucketInterval,
 		done:           make(chan struct{}),
 		status:         atomic.NewInt32(common.DaemonStatusInitialized),


### PR DESCRIPTION
Because exp was not initialized in the struct, it defaulted to 0. A value of 0 puts all weight on the previous observation, which means the per-group trackers would permanently report their initial observation.

<!-- Describe what has changed in this PR -->
**What changed?**
- Correct the value of exp used for each group's QPS reporter.

<!-- Tell your future self why have you made these changes -->
**Why?**
- So Isolation Group QPS is correctly reported.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests and matching simulator.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
