### PR TITLE
Log duplicated activity events

### DIFF
--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -529,6 +529,14 @@ func (e *mutableStateBuilder) FlushBufferedEvents() error {
 
 	newCommittedEvents = e.trimEventsAfterWorkflowClose(newCommittedEvents)
 	e.hBuilder.history = newCommittedEvents
+
+	// adding logs to help identify duplicate activity task events
+	// duplicated activity events can cause DecisionTaskFailed events with cause UNHANDLED_DECISION
+	// and cause workflow to be stuck in decision task failed state
+	// this can be removed after the root cause is identified and fixed
+	// TODO: remove this after the root cause is identified and fixed or add deduplication
+	e.logDuplicatedActivityEvents()
+
 	// make sure all new committed events have correct EventID
 	e.assignEventIDToBufferedEvents()
 	if err := e.assignTaskIDToEvents(); err != nil {
@@ -2252,6 +2260,65 @@ func (e *mutableStateBuilder) logDataInconsistency() {
 		tag.WorkflowID(workflowID),
 		tag.WorkflowRunID(runID),
 	)
+}
+func (e *mutableStateBuilder) logDuplicatedActivityEvents() {
+	type activityTaskUniqueEventParams struct {
+		eventType        types.EventType
+		scheduledEventID int64
+		attempt          int32
+		startedEventID   int64
+	}
+
+	activityTaskUniqueEvents := make(map[activityTaskUniqueEventParams]struct{})
+
+	checkActivityTaskEventUniqueness := func(event *types.HistoryEvent) {
+		uniqueEventParams := activityTaskUniqueEventParams{
+			eventType: event.GetEventType(),
+		}
+
+		var scheduledEventID int64
+
+		switch event.GetEventType() {
+		case types.EventTypeActivityTaskStarted:
+			scheduledEventID = event.ActivityTaskStartedEventAttributes.GetScheduledEventID()
+			uniqueEventParams.scheduledEventID = scheduledEventID
+			uniqueEventParams.attempt = event.ActivityTaskStartedEventAttributes.Attempt
+		case types.EventTypeActivityTaskCompleted:
+			scheduledEventID = event.ActivityTaskCompletedEventAttributes.GetScheduledEventID()
+			uniqueEventParams.scheduledEventID = scheduledEventID
+			uniqueEventParams.startedEventID = event.ActivityTaskCompletedEventAttributes.GetStartedEventID()
+		case types.EventTypeActivityTaskFailed:
+			scheduledEventID = event.ActivityTaskFailedEventAttributes.GetScheduledEventID()
+			uniqueEventParams.scheduledEventID = scheduledEventID
+			uniqueEventParams.startedEventID = event.ActivityTaskFailedEventAttributes.GetStartedEventID()
+		case types.EventTypeActivityTaskCanceled:
+			scheduledEventID = event.ActivityTaskCanceledEventAttributes.GetScheduledEventID()
+			uniqueEventParams.scheduledEventID = scheduledEventID
+			uniqueEventParams.startedEventID = event.ActivityTaskCanceledEventAttributes.StartedEventID
+		case types.EventTypeActivityTaskTimedOut:
+			scheduledEventID = event.ActivityTaskTimedOutEventAttributes.GetScheduledEventID()
+			uniqueEventParams.scheduledEventID = scheduledEventID
+			uniqueEventParams.startedEventID = event.ActivityTaskTimedOutEventAttributes.StartedEventID
+		default:
+			return
+		}
+
+		if _, ok := activityTaskUniqueEvents[uniqueEventParams]; ok {
+			e.logger.Error("Duplicate activity task event found",
+				tag.WorkflowDomainName(e.GetDomainEntry().GetInfo().Name),
+				tag.WorkflowID(e.GetExecutionInfo().WorkflowID),
+				tag.WorkflowRunID(e.GetExecutionInfo().RunID),
+				tag.WorkflowScheduleID(scheduledEventID),
+				tag.WorkflowEventType(event.GetEventType().String()),
+			)
+		} else {
+			activityTaskUniqueEvents[uniqueEventParams] = struct{}{}
+		}
+	}
+
+	for _, event := range e.hBuilder.history {
+		checkActivityTaskEventUniqueness(event)
+	}
 }
 
 func mergeMapOfByteArray(

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -23,8 +23,6 @@ package execution
 import (
 	"context"
 	"errors"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 	"math/rand"
 	"testing"
 	"time"
@@ -35,6 +33,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -23,6 +23,8 @@ package execution
 import (
 	"context"
 	"errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"math/rand"
 	"testing"
 	"time"
@@ -3596,6 +3598,153 @@ func TestCloseTransactionAsMutation(t *testing.T) {
 			assert.Equal(t, td.expectedMutation, mutation)
 			assert.Equal(t, td.expectedEvent, workflowEvents)
 			assert.Equal(t, td.expectedErr, err)
+		})
+	}
+}
+
+func Test__logDuplicatedActivityEvents(t *testing.T) {
+	testCases := []struct {
+		name         string
+		buildHistory func(msb *mutableStateBuilder) []*types.HistoryEvent
+		assertions   func(*testing.T, *observer.ObservedLogs)
+	}{
+		{
+			name: "no duplicates",
+			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskStarted)
+				event1.ActivityTaskStartedEventAttributes = &types.ActivityTaskStartedEventAttributes{
+					ScheduledEventID: 1,
+					Attempt:          1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCompleted)
+				event2.ActivityTaskCompletedEventAttributes = &types.ActivityTaskCompletedEventAttributes{
+					ScheduledEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 0, logs.FilterMessage("Duplicate activity task event found").Len())
+			},
+		},
+		{
+			name: "started event duplicated",
+			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskStarted)
+				event1.ActivityTaskStartedEventAttributes = &types.ActivityTaskStartedEventAttributes{
+					ScheduledEventID: 1,
+					Attempt:          1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskStarted)
+				event2.ActivityTaskStartedEventAttributes = &types.ActivityTaskStartedEventAttributes{
+					ScheduledEventID: 1,
+					Attempt:          1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+			},
+		},
+		{
+			name: "completed event duplicated",
+			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCompleted)
+				event1.ActivityTaskCompletedEventAttributes = &types.ActivityTaskCompletedEventAttributes{
+					ScheduledEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCompleted)
+				event2.ActivityTaskCompletedEventAttributes = &types.ActivityTaskCompletedEventAttributes{
+					ScheduledEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+			},
+		},
+		{
+			name: "canceled event duplicated",
+			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCanceled)
+				event1.ActivityTaskCanceledEventAttributes = &types.ActivityTaskCanceledEventAttributes{
+					ScheduledEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCanceled)
+				event2.ActivityTaskCanceledEventAttributes = &types.ActivityTaskCanceledEventAttributes{
+					ScheduledEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+			},
+		},
+		{
+			name: "failed event duplicated",
+			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskFailed)
+				event1.ActivityTaskFailedEventAttributes = &types.ActivityTaskFailedEventAttributes{
+					ScheduledEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskFailed)
+				event2.ActivityTaskFailedEventAttributes = &types.ActivityTaskFailedEventAttributes{
+					ScheduledEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+			},
+		},
+		{
+			name: "timed out event duplicated",
+			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskTimedOut)
+				event1.ActivityTaskTimedOutEventAttributes = &types.ActivityTaskTimedOutEventAttributes{
+					ScheduledEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskTimedOut)
+				event2.ActivityTaskTimedOutEventAttributes = &types.ActivityTaskTimedOutEventAttributes{
+					ScheduledEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			core, observedLogs := observer.New(zap.ErrorLevel)
+
+			mockCache := events.NewMockCache(ctrl)
+			shardContext := shard.NewMockContext(ctrl)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+
+			msb := createMSBWithMocks(mockCache, shardContext, mockDomainCache)
+
+			msb.logger = log.NewLogger(zap.New(core))
+
+			msb.executionInfo.DomainID = "some-domain-id"
+			msb.executionInfo.WorkflowID = "some-workflow-id"
+			msb.executionInfo.RunID = "some-run-id"
+
+			msb.hBuilder.history = tc.buildHistory(msb)
+
+			msb.logDuplicatedActivityEvents()
+
+			tc.assertions(t, observedLogs)
 		})
 	}
 }


### PR DESCRIPTION
**What changed?**
Added logs to capture duplicated activity events

**Why?**
There were some cases where started and completed activity events were duplicated, causing the workflows to fail. Couldn't reproduce it locally, so adding logs to try to identify it earlier and debug it.

**How did you test it?**
Tested locally

**Potential risks**

**Release notes**

**Documentation Changes**
