### PR TITLE
Add size-based cache config flags for history event and execution cache

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -871,6 +871,12 @@ const (
 	// Default value: 512
 	// Allowed filters: N/A
 	HistoryCacheMaxSize
+	// ExecutionCacheMaxByteSize is the max byte size of history cache
+	// KeyName: history.executionCacheMaxSize
+	// Value type: Int
+	// Default value: 0
+	// Allowed filters: N/A
+	ExecutionCacheMaxByteSize
 	// EventsCacheInitialCount is initial count of events cache
 	// KeyName: history.eventsCacheInitialSize
 	// Value type: Int
@@ -2074,6 +2080,18 @@ const (
 
 	EnableNoSQLHistoryTaskDualWriteMode
 	ReadNoSQLHistoryTaskFromDataBlob
+
+	// EnableSizeBasedHistoryExecutionCache is the feature flag to enable size based cache for execution cache
+	// KeyName: history.enableSizeBasedHistoryExecutionCache
+	// Value type: Bool
+	// Default value: false
+	EnableSizeBasedHistoryExecutionCache
+
+	// EnableSizeBasedHistoryEventCache is the feature flag to enable size based cache for event cache
+	// KeyName: history.enableSizeBasedHistoryEventCache
+	// Value type: Bool
+	// Default value: false
+	EnableSizeBasedHistoryEventCache
 
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
@@ -3418,6 +3436,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "HistoryCacheMaxSize is max size of history cache",
 		DefaultValue: 512,
 	},
+	ExecutionCacheMaxByteSize: {
+		KeyName:      "history.executionCacheMaxSizeInBytes",
+		Description:  "ExecutionCacheMaxByteSize is max size of execution cache in bytes",
+		DefaultValue: 0,
+	},
 	EventsCacheInitialCount: {
 		KeyName:      "history.eventsCacheInitialSize",
 		Description:  "EventsCacheInitialCount is initial count of events cache",
@@ -4510,6 +4533,16 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	ReadNoSQLHistoryTaskFromDataBlob: {
 		KeyName:      "history.readNoSQLHistoryTaskFromDataBlob",
 		Description:  "ReadNoSQLHistoryTaskFromDataBlob is to read history tasks from data blob",
+		DefaultValue: false,
+	},
+	EnableSizeBasedHistoryExecutionCache: {
+		KeyName:      "history.enableSizeBasedHistoryExecutionCache",
+		Description:  "EnableSizeBasedHistoryExecutionCache is to enable size based history execution cache",
+		DefaultValue: false,
+	},
+	EnableSizeBasedHistoryEventCache: {
+		KeyName:      "history.enableSizeBasedHistoryEventCache",
+		Description:  "EnableSizeBasedHistoryEventCache is to enable size based history event cache",
 		DefaultValue: false,
 	},
 }

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -64,19 +64,22 @@ type Config struct {
 
 	// HistoryCache settings
 	// Change of these configs require shard restart
-	HistoryCacheInitialSize dynamicproperties.IntPropertyFn
-	HistoryCacheMaxSize     dynamicproperties.IntPropertyFn
-	HistoryCacheTTL         dynamicproperties.DurationPropertyFn
+	HistoryCacheInitialSize              dynamicproperties.IntPropertyFn
+	HistoryCacheMaxSize                  dynamicproperties.IntPropertyFn
+	HistoryCacheTTL                      dynamicproperties.DurationPropertyFn
+	EnableSizeBasedHistoryExecutionCache dynamicproperties.BoolPropertyFn
+	ExecutionCacheMaxByteSize            dynamicproperties.IntPropertyFn
 
 	// EventsCache settings
 	// Change of these configs require shard restart
-	EventsCacheInitialCount       dynamicproperties.IntPropertyFn
-	EventsCacheMaxCount           dynamicproperties.IntPropertyFn
-	EventsCacheMaxSize            dynamicproperties.IntPropertyFn
-	EventsCacheTTL                dynamicproperties.DurationPropertyFn
-	EventsCacheGlobalEnable       dynamicproperties.BoolPropertyFn
-	EventsCacheGlobalInitialCount dynamicproperties.IntPropertyFn
-	EventsCacheGlobalMaxCount     dynamicproperties.IntPropertyFn
+	EventsCacheInitialCount          dynamicproperties.IntPropertyFn
+	EventsCacheMaxCount              dynamicproperties.IntPropertyFn
+	EventsCacheMaxSize               dynamicproperties.IntPropertyFn
+	EventsCacheTTL                   dynamicproperties.DurationPropertyFn
+	EventsCacheGlobalEnable          dynamicproperties.BoolPropertyFn
+	EventsCacheGlobalInitialCount    dynamicproperties.IntPropertyFn
+	EventsCacheGlobalMaxCount        dynamicproperties.IntPropertyFn
+	EnableSizeBasedHistoryEventCache dynamicproperties.BoolPropertyFn
 
 	// ShardController settings
 	RangeSizeBits           uint
@@ -356,7 +359,9 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		EmitShardDiffLog:                     dc.GetBoolProperty(dynamicproperties.EmitShardDiffLog),
 		HistoryCacheInitialSize:              dc.GetIntProperty(dynamicproperties.HistoryCacheInitialSize),
 		HistoryCacheMaxSize:                  dc.GetIntProperty(dynamicproperties.HistoryCacheMaxSize),
+		ExecutionCacheMaxByteSize:            dc.GetIntProperty(dynamicproperties.ExecutionCacheMaxByteSize),
 		HistoryCacheTTL:                      dc.GetDurationProperty(dynamicproperties.HistoryCacheTTL),
+		EnableSizeBasedHistoryExecutionCache: dc.GetBoolProperty(dynamicproperties.EnableSizeBasedHistoryExecutionCache),
 		EventsCacheInitialCount:              dc.GetIntProperty(dynamicproperties.EventsCacheInitialCount),
 		EventsCacheMaxCount:                  dc.GetIntProperty(dynamicproperties.EventsCacheMaxCount),
 		EventsCacheMaxSize:                   dc.GetIntProperty(dynamicproperties.EventsCacheMaxSize),
@@ -364,6 +369,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		EventsCacheGlobalEnable:              dc.GetBoolProperty(dynamicproperties.EventsCacheGlobalEnable),
 		EventsCacheGlobalInitialCount:        dc.GetIntProperty(dynamicproperties.EventsCacheGlobalInitialCount),
 		EventsCacheGlobalMaxCount:            dc.GetIntProperty(dynamicproperties.EventsCacheGlobalMaxCount),
+		EnableSizeBasedHistoryEventCache:     dc.GetBoolProperty(dynamicproperties.EnableSizeBasedHistoryEventCache),
 		RangeSizeBits:                        20, // 20 bits for sequencer, 2^20 sequence number for any range
 		AcquireShardInterval:                 dc.GetDurationProperty(dynamicproperties.AcquireShardInterval),
 		AcquireShardConcurrency:              dc.GetIntProperty(dynamicproperties.AcquireShardConcurrency),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -79,6 +79,7 @@ func TestNewConfig(t *testing.T) {
 		"HistoryCacheInitialSize":                              {dynamicproperties.HistoryCacheInitialSize, 22},
 		"HistoryCacheMaxSize":                                  {dynamicproperties.HistoryCacheMaxSize, 23},
 		"HistoryCacheTTL":                                      {dynamicproperties.HistoryCacheTTL, time.Second},
+		"EnableSizeBasedHistoryExecutionCache":                 {dynamicproperties.EnableSizeBasedHistoryExecutionCache, true},
 		"EventsCacheInitialCount":                              {dynamicproperties.EventsCacheInitialCount, 24},
 		"EventsCacheMaxCount":                                  {dynamicproperties.EventsCacheMaxCount, 25},
 		"EventsCacheMaxSize":                                   {dynamicproperties.EventsCacheMaxSize, 26},
@@ -86,6 +87,7 @@ func TestNewConfig(t *testing.T) {
 		"EventsCacheGlobalEnable":                              {dynamicproperties.EventsCacheGlobalEnable, true},
 		"EventsCacheGlobalInitialCount":                        {dynamicproperties.EventsCacheGlobalInitialCount, 27},
 		"EventsCacheGlobalMaxCount":                            {dynamicproperties.EventsCacheGlobalMaxCount, 28},
+		"EnableSizeBasedHistoryEventCache":                     {dynamicproperties.EnableSizeBasedHistoryEventCache, true},
 		"RangeSizeBits":                                        {nil, uint(20)},
 		"AcquireShardInterval":                                 {dynamicproperties.AcquireShardInterval, time.Second},
 		"AcquireShardConcurrency":                              {dynamicproperties.AcquireShardConcurrency, 29},
@@ -263,6 +265,7 @@ func TestNewConfig(t *testing.T) {
 		"TaskSchedulerEnableRateLimiter":                       {dynamicproperties.TaskSchedulerEnableRateLimiter, true},
 		"HostName":                                             {nil, hostname},
 		"SearchAttributesHiddenValueKeys":                      {dynamicproperties.SearchAttributesHiddenValueKeys, map[string]interface{}{"CustomStringField": true}},
+		"ExecutionCacheMaxByteSize":                            {dynamicproperties.ExecutionCacheMaxByteSize, 98},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/history/events/cache_test.go
+++ b/service/history/events/cache_test.go
@@ -89,7 +89,7 @@ func (s *eventsCacheSuite) TearDownTest() {
 
 func (s *eventsCacheSuite) newTestEventsCache() *cacheImpl {
 	return newCacheWithOption(common.IntPtr(10), 16, 32, time.Minute, s.mockHistoryManager, false, s.logger,
-		metrics.NewClient(tally.NoopScope, metrics.History), dynamicproperties.GetIntPropertyFn(0), s.domainCache)
+		metrics.NewClient(tally.NoopScope, metrics.History), dynamicproperties.GetBoolPropertyFn(false), dynamicproperties.GetIntPropertyFn(0), s.domainCache)
 }
 
 func (s *eventsCacheSuite) TestEventsCacheHitSuccess() {

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -118,6 +118,7 @@ func NewCache(shard shard.Context) Cache {
 	opts.MaxCount = config.HistoryCacheMaxSize()
 	opts.MetricsScope = shard.GetMetricsClient().Scope(metrics.HistoryExecutionCacheScope).Tagged(metrics.ShardIDTag(shard.GetShardID()))
 	opts.Logger = shard.GetLogger().WithTags(tag.ComponentHistoryCache)
+	opts.IsSizeBased = config.EnableSizeBasedHistoryExecutionCache()
 
 	return &cacheImpl{
 		Cache:            cache.New(opts),

--- a/service/history/ndc/history_replicator_test.go
+++ b/service/history/ndc/history_replicator_test.go
@@ -57,13 +57,14 @@ func createTestHistoryReplicator(t *testing.T) historyReplicatorImpl {
 
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetConfig().Return(&config.Config{
-		NumberOfShards:           0,
-		IsAdvancedVisConfigExist: false,
-		MaxResponseSize:          0,
-		HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-		HostName:                 "test-host",
+		NumberOfShards:                       0,
+		IsAdvancedVisConfigExist:             false,
+		MaxResponseSize:                      0,
+		HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+		HostName:                             "test-host",
+		EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 	}).Times(1)
 
 	// before going into NewHistoryReplicator
@@ -108,13 +109,14 @@ func TestNewHistoryReplicator_newBranchManager(t *testing.T) {
 
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetConfig().Return(&config.Config{
-		NumberOfShards:           0,
-		IsAdvancedVisConfigExist: false,
-		MaxResponseSize:          0,
-		HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-		HostName:                 "test-host",
+		NumberOfShards:                       0,
+		IsAdvancedVisConfigExist:             false,
+		MaxResponseSize:                      0,
+		HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+		HostName:                             "test-host",
+		EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 	}).Times(1)
 
 	// before going into NewHistoryReplicator
@@ -158,13 +160,14 @@ func TestNewHistoryReplicator_newConflictResolver(t *testing.T) {
 
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetConfig().Return(&config.Config{
-		NumberOfShards:           0,
-		IsAdvancedVisConfigExist: false,
-		MaxResponseSize:          0,
-		HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-		HostName:                 "test-host",
+		NumberOfShards:                       0,
+		IsAdvancedVisConfigExist:             false,
+		MaxResponseSize:                      0,
+		HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+		HostName:                             "test-host",
+		EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 	}).Times(2)
 
 	// before going into NewHistoryReplicator
@@ -211,13 +214,14 @@ func TestNewHistoryReplicator_newWorkflowResetter(t *testing.T) {
 
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetConfig().Return(&config.Config{
-		NumberOfShards:           0,
-		IsAdvancedVisConfigExist: false,
-		MaxResponseSize:          0,
-		HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-		HostName:                 "test-host",
+		NumberOfShards:                       0,
+		IsAdvancedVisConfigExist:             false,
+		MaxResponseSize:                      0,
+		HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+		HostName:                             "test-host",
+		EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 	}).Times(2)
 
 	// before going into NewHistoryReplicator
@@ -271,13 +275,14 @@ func TestNewHistoryReplicator_newStateBuilder(t *testing.T) {
 
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetConfig().Return(&config.Config{
-		NumberOfShards:           0,
-		IsAdvancedVisConfigExist: false,
-		MaxResponseSize:          0,
-		HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-		HostName:                 "test-host",
+		NumberOfShards:                       0,
+		IsAdvancedVisConfigExist:             false,
+		MaxResponseSize:                      0,
+		HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+		HostName:                             "test-host",
+		EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 	}).Times(1)
 
 	// before going into NewHistoryReplicator
@@ -320,13 +325,14 @@ func TestNewHistoryReplicator_newMutableState(t *testing.T) {
 
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetConfig().Return(&config.Config{
-		NumberOfShards:           0,
-		IsAdvancedVisConfigExist: false,
-		MaxResponseSize:          0,
-		HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-		HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-		HostName:                 "test-host",
+		NumberOfShards:                       0,
+		IsAdvancedVisConfigExist:             false,
+		MaxResponseSize:                      0,
+		HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+		HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+		HostName:                             "test-host",
+		EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 	}).Times(2)
 
 	// before going into NewHistoryReplicator
@@ -1057,14 +1063,15 @@ func Test_applyStartEvents(t *testing.T) {
 			},
 			mockShardContextAffordance: func(mockShard *shard.MockContext) {
 				mockShard.EXPECT().GetConfig().Return(&config.Config{
-					NumberOfShards:           0,
-					IsAdvancedVisConfigExist: false,
-					MaxResponseSize:          0,
-					HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-					HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-					HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-					HostName:                 "test-host",
-					StandbyClusterDelay:      dynamicproperties.GetDurationPropertyFn(10),
+					NumberOfShards:                       0,
+					IsAdvancedVisConfigExist:             false,
+					MaxResponseSize:                      0,
+					HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+					HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+					HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+					HostName:                             "test-host",
+					StandbyClusterDelay:                  dynamicproperties.GetDurationPropertyFn(10),
+					EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 				}).Times(1)
 				mockShard.EXPECT().SetCurrentTime(gomock.Any(), gomock.Any()).Times(1)
 			},
@@ -1448,14 +1455,15 @@ func Test_applyNonStartEventsToCurrentBranch(t *testing.T) {
 				mockShard.EXPECT().GetExecutionManager().Return(nil).Times(1)
 				mockShard.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).Times(1)
 				mockShard.EXPECT().GetConfig().Return(&config.Config{
-					NumberOfShards:           0,
-					IsAdvancedVisConfigExist: false,
-					MaxResponseSize:          0,
-					HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-					HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-					HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-					HostName:                 "test-host",
-					StandbyClusterDelay:      dynamicproperties.GetDurationPropertyFn(10),
+					NumberOfShards:                       0,
+					IsAdvancedVisConfigExist:             false,
+					MaxResponseSize:                      0,
+					HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+					HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+					HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+					HostName:                             "test-host",
+					StandbyClusterDelay:                  dynamicproperties.GetDurationPropertyFn(10),
+					EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 				}).Times(1)
 				mockShard.EXPECT().SetCurrentTime(gomock.Any(), gomock.Any()).Times(1)
 			},
@@ -2044,14 +2052,15 @@ func Test_applyNonStartEventsResetWorkflow(t *testing.T) {
 			},
 			mockShardContextAffordance: func(mockShard *shard.MockContext) {
 				mockShard.EXPECT().GetConfig().Return(&config.Config{
-					NumberOfShards:           0,
-					IsAdvancedVisConfigExist: false,
-					MaxResponseSize:          0,
-					HistoryCacheInitialSize:  dynamicproperties.GetIntPropertyFn(10),
-					HistoryCacheMaxSize:      dynamicproperties.GetIntPropertyFn(10),
-					HistoryCacheTTL:          dynamicproperties.GetDurationPropertyFn(10),
-					HostName:                 "test-host",
-					StandbyClusterDelay:      dynamicproperties.GetDurationPropertyFn(10),
+					NumberOfShards:                       0,
+					IsAdvancedVisConfigExist:             false,
+					MaxResponseSize:                      0,
+					HistoryCacheInitialSize:              dynamicproperties.GetIntPropertyFn(10),
+					HistoryCacheMaxSize:                  dynamicproperties.GetIntPropertyFn(10),
+					HistoryCacheTTL:                      dynamicproperties.GetDurationPropertyFn(10),
+					HostName:                             "test-host",
+					StandbyClusterDelay:                  dynamicproperties.GetDurationPropertyFn(10),
+					EnableSizeBasedHistoryExecutionCache: dynamicproperties.GetBoolPropertyFn(false),
 				}).Times(1)
 				mockShard.EXPECT().SetCurrentTime(gomock.Any(), gomock.Any()).Times(1)
 			},

--- a/service/history/resource/resource.go
+++ b/service/history/resource/resource.go
@@ -129,6 +129,7 @@ func New(
 		serviceResource.GetHistoryManager(),
 		params.Logger,
 		params.MetricsClient,
+		config.EnableSizeBasedHistoryEventCache,
 		config.EventsCacheMaxSize,
 		serviceResource.GetDomainCache(),
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added dynamic config flags for enabling size-based caching in the history event and execution caches. These flags propagate to the cache layer and activate size-based behavior when enabled. A new config for controlling the byte size of the execution cache was also introduced (the event size config already exists).

<!-- Tell your future self why have you made these changes -->
**Why?**
This allows us to gradually roll out size-based caching per component and provides a quick rollback mechanism if needed. Without feature flags, every change would require a PR and release, which is inefficient and time-consuming.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local env tests as well as unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minimal risk, as the new flags default to false and won’t impact behavior unless explicitly enabled.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
