### PR TITLE
Expose DebugOn to prevent expensive computations needed only to enrich debug logs

### DIFF
--- a/common/log/interface.go
+++ b/common/log/interface.go
@@ -47,6 +47,7 @@ type Logger interface {
 	Fatal(msg string, tags ...tag.Tag)
 	WithTags(tags ...tag.Tag) Logger
 	SampleInfo(msg string, sampleRate int, tags ...tag.Tag)
+	DebugOn() bool
 }
 
 type noop struct{}
@@ -65,4 +66,7 @@ func (n *noop) Fatal(msg string, tags ...tag.Tag)                      {}
 func (n *noop) SampleInfo(msg string, sampleRate int, tags ...tag.Tag) {}
 func (n *noop) WithTags(tags ...tag.Tag) Logger {
 	return n
+}
+func (n *noop) DebugOn() bool {
+	return true
 }

--- a/common/log/logger_mock.go
+++ b/common/log/logger_mock.go
@@ -79,3 +79,7 @@ func (_m *MockLogger) WithTags(tags ...tag.Tag) Logger {
 
 	return r0
 }
+
+func (_m *MockLogger) DebugOn() bool {
+	return _m.Called().Bool(0)
+}

--- a/common/log/options.go
+++ b/common/log/options.go
@@ -22,6 +22,8 @@
 
 package log
 
+import "time"
+
 // Option is used to set options for the logger.
 type Option func(impl *loggerImpl)
 
@@ -29,5 +31,11 @@ type Option func(impl *loggerImpl)
 func WithSampleFunc(fn func(int) bool) Option {
 	return func(impl *loggerImpl) {
 		impl.sampleLocalFn = fn
+	}
+}
+
+func WithDebugCheckInterval(interval time.Duration) Option {
+	return func(impl *loggerImpl) {
+		impl.debugCheckInterval = interval
 	}
 }

--- a/common/log/replay.go
+++ b/common/log/replay.go
@@ -108,6 +108,10 @@ func (r *replayLogger) SampleInfo(msg string, sampleRate int, tags ...tag.Tag) {
 	}
 }
 
+func (r *replayLogger) DebugOn() bool {
+	return r.logger.DebugOn()
+}
+
 func (r *replayLogger) WithTags(tags ...tag.Tag) Logger {
 	return &replayLogger{
 		logger:            r.logger.WithTags(tags...),

--- a/common/log/throttle.go
+++ b/common/log/throttle.go
@@ -112,6 +112,10 @@ func (tl *throttledLogger) SampleInfo(msg string, sampleRate int, tags ...tag.Ta
 	}
 }
 
+func (tl *throttledLogger) DebugOn() bool {
+	return tl.log.DebugOn()
+}
+
 // Return a logger with the specified key-value pairs set, to be included in a subsequent normal logging call
 func (tl *throttledLogger) WithTags(tags ...tag.Tag) Logger {
 	result := &throttledLogger{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Sometimes, especially when debugging locally, it's super useful to dump JSONified objects, stacktraces etc to the debug logs. However, these are not supposed to happen in production when debug log is turned off because they can consume valuable cpu/memory resources. So exposing `DebugOn()` to prevent expensive computations needed only to enrich debug logs. 

e.g.
```
// somewhere in the hot path
if logger.DebugOn() {
  data, _ := json.Marshal(someBigInput)
  logger.Debugf("something happened, input: %s, stack: %s", data, debug.Stack() )
}
```

**Implementation:** 
By default, log level of Cadence services can only be set in service yml config. Technically zap log level can be changed in runtime via `zap.LevelEnablerFunc` which is not exposed today. However, advanced users might be leveraging it (via wrapping cadence server binary and passing custom zap logger). So in order to support runtime level changes, debug level check is performed every 10s as opposed to doing it once in constructor. No background goroutines. Calculated on-demand. Used atomics to do best effort redundancy prevention.  See logger.go.


<!-- Tell your future self why have you made these changes -->
**Why?**
I was tracing various operations in mutable state functions, task processing, replication etc. while prepping for active-active and had to add a lot of debug logs to achieve sufficient visibility. Instead of removing such logs and losing valuable information, I will put those behind `DebugOn()` so that debug level can be toggled whenever that level of visibility is desired. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test
