### PR TITLE
Simplify debug level check

### DIFF
--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -197,21 +196,18 @@ func TestDebugOn(t *testing.T) {
 		EncodeDuration: zapcore.StringDurationEncoder,
 	}), zapcore.AddSync(buf), l))
 
-	logger := NewLogger(zapLogger, WithDebugCheckInterval(time.Millisecond))
+	logger := NewLogger(zapLogger)
 
 	// Set level to debug and check if debugOn is true
 	l.SetLevel(zap.DebugLevel)
-	time.Sleep(time.Millisecond)
 	assert.True(t, logger.DebugOn())
 
 	// Set level to info and check if debugOn is false
 	l.SetLevel(zap.InfoLevel)
-	time.Sleep(time.Millisecond)
 	assert.False(t, logger.DebugOn())
 
 	// Set level to debug again and check if debugOn is true
 	l.SetLevel(zap.DebugLevel)
-	time.Sleep(time.Millisecond)
 	assert.True(t, logger.DebugOn())
 }
 

--- a/common/log/options.go
+++ b/common/log/options.go
@@ -22,8 +22,6 @@
 
 package log
 
-import "time"
-
 // Option is used to set options for the logger.
 type Option func(impl *loggerImpl)
 
@@ -31,11 +29,5 @@ type Option func(impl *loggerImpl)
 func WithSampleFunc(fn func(int) bool) Option {
 	return func(impl *loggerImpl) {
 		impl.sampleLocalFn = fn
-	}
-}
-
-func WithDebugCheckInterval(interval time.Duration) Option {
-	return func(impl *loggerImpl) {
-		impl.debugCheckInterval = interval
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

The recently added `DebugOn()` had some basic caching but benchmarks show that it doesn't matter much when debug level is not enabled. It helps save some cycles when log level is debug but is not worth the additional complexity (2 atomic operations etc.). Thanks @Groxx for pointing this out.

Benchmark results with level = debug
```
BenchmarkDebugOnCheckCached-12    	30902576	        38.90 ns/op	       0 B/op	       0 allocs/op
BenchmarkDebugOnCheckEachTime-12   	2618984	       		439.8 ns/op	     488 B/op	       4 allocs/op
```

Benchmark results with level = info
```
BenchmarkDebugOnCheckCached-12    	30820993	        38.28 ns/op	       0 B/op	       0 allocs/op
BenchmarkDebugOnCheckEachTime-12    30134168	        39.27 ns/op	       0 B/op	       0 allocs/op
```

So removing the cache and asking zap to check level each time. 