### PR TITLE
Document timer task page tokens' risky serialization needs

### DIFF
--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -1007,8 +1007,8 @@ func (m *sqlExecutionStore) CreateFailoverMarkerTasks(
 }
 
 type timerTaskPageToken struct {
-	TaskID    int64
-	Timestamp time.Time
+	TaskID    int64     `json:"TaskID"`    // CAUTION: JSON format is used in replication, this should not be changed without great care
+	Timestamp time.Time `json:"Timestamp"` // CAUTION: JSON format is used in replication, this should not be changed without great care
 }
 
 func (t *timerTaskPageToken) serialize() ([]byte, error) {


### PR DESCRIPTION
Discovered due to a changed test in https://github.com/cadence-workflow/cadence/pull/6800
So I am writing this down so an accidental cleanup doesn't break task replication.

This _can probably_ be changed at some point, and it'd probably be worth it, but it'd need to be done in two or three fully-deployed-and-all-data-updated stages (support both, create in new fomat, remove old support) and I don't feel like doing that right now.