### PR TITLE
Initialize NumHistoryShards in sql test utils

### DIFF
--- a/common/persistence/sql/sql_test_utils.go
+++ b/common/persistence/sql/sql_test_utils.go
@@ -107,6 +107,7 @@ func (s *testCluster) Config() config.Persistence {
 		},
 		TransactionSizeLimit: dynamicproperties.GetIntPropertyFn(constants.DefaultTransactionSizeLimit),
 		ErrorInjectionRate:   dynamicproperties.GetFloatPropertyFn(0),
+		NumHistoryShards:     s.cfg.NumShards,
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

After #6800, more test suites started running as part of `go test` which were previously skipped due to Cassandra dependency. Now they run as unit tests and using sqlite. 
SQL based test util functions use an inline Persistence config which is missing `NumHistoryShards` which causes panics. Fixing that by carrying over the specified config to in-memory object.


<!-- Tell your future self why have you made these changes -->
**Why?**
Fix confusing panic in tests (even though it's recovered from)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go test -v ./cmd/server/cadence >> test.log
```