### PR TITLE
Bugfix/attempting to fix shutdown issue

### DIFF
--- a/common/errors/shutdownerrors.go
+++ b/common/errors/shutdownerrors.go
@@ -1,0 +1,53 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package errors
+
+import (
+	"errors"
+	"time"
+)
+
+var ErrProcessorShutdown = errors.New("queue processor has been shutdown")
+
+type ErrShardClosed struct {
+	Msg      string
+	ClosedAt time.Time
+}
+
+var _ error = (*ErrShardClosed)(nil)
+
+func (e *ErrShardClosed) Error() string {
+	return e.Msg
+}
+
+// a shutdown error is a type of nonretriable error for task processors
+func IsShutdownError(err error) bool {
+	var errShardClosed *ErrShardClosed
+	if errors.As(err, &errShardClosed) {
+		return true
+	}
+	if errors.Is(err, ErrProcessorShutdown) {
+		return true
+	}
+	return false
+}

--- a/common/errors/shutdownerrors_test.go
+++ b/common/errors/shutdownerrors_test.go
@@ -1,0 +1,56 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShutdownErrors(t *testing.T) {
+	tests := map[string]struct {
+		error        error
+		isShutownErr bool
+	}{
+		"a shutdown error for queue shutdown": {
+			error:        ErrProcessorShutdown,
+			isShutownErr: true,
+		},
+		"a shutdown error for shard closing": {
+			error:        &ErrShardClosed{},
+			isShutownErr: true,
+		},
+		"a non shutdown error": {
+			error:        errors.New("non shutdown error"),
+			isShutownErr: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.isShutownErr, IsShutdownError(tc.error))
+		})
+	}
+}

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/constants"
+	cerrors "github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/locks"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -1212,7 +1213,7 @@ func getWorkflowExecutionWithRetry(
 	default:
 		// If error is shard closed, only log error if shard has been closed for a while,
 		// otherwise always log
-		var shardClosedError *shard.ErrShardClosed
+		var shardClosedError *cerrors.ErrShardClosed
 		if !errors.As(err, &shardClosedError) || shardContext.GetTimeSource().Since(shardClosedError.ClosedAt) > shard.TimeBeforeShardClosedIsError {
 			logger.Error("Persistent fetch operation failure", tag.StoreOperationGetWorkflowExecution, tag.Error(err))
 		}

--- a/service/history/execution/context_test.go
+++ b/service/history/execution/context_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	cerrors "github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -2974,14 +2975,14 @@ func TestGetWorkflowExecutionWithRetry(t *testing.T) {
 				RangeID: 100,
 			},
 			mockSetup: func(mockShard *shard.MockContext, mockLogger *log.MockLogger, timeSource clock.MockedTimeSource) {
-				mockShard.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, &shard.ErrShardClosed{
+				mockShard.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, &cerrors.ErrShardClosed{
 					ClosedAt: timeSource.Now().Add(-shard.TimeBeforeShardClosedIsError / 2),
 				})
 				// We do _not_ expect a log call
 			},
 			wantErr: true,
 			assertErr: func(t *testing.T, err error) {
-				assert.ErrorAs(t, err, new(*shard.ErrShardClosed))
+				assert.ErrorAs(t, err, new(*cerrors.ErrShardClosed))
 			},
 		},
 		{
@@ -2990,7 +2991,7 @@ func TestGetWorkflowExecutionWithRetry(t *testing.T) {
 				RangeID: 100,
 			},
 			mockSetup: func(mockShard *shard.MockContext, mockLogger *log.MockLogger, timeSource clock.MockedTimeSource) {
-				err := &shard.ErrShardClosed{
+				err := &cerrors.ErrShardClosed{
 					ClosedAt: timeSource.Now().Add(-shard.TimeBeforeShardClosedIsError * 2),
 				}
 				mockShard.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, err)
@@ -2998,7 +2999,7 @@ func TestGetWorkflowExecutionWithRetry(t *testing.T) {
 			},
 			wantErr: true,
 			assertErr: func(t *testing.T, err error) {
-				assert.ErrorAs(t, err, new(*shard.ErrShardClosed))
+				assert.ErrorAs(t, err, new(*cerrors.ErrShardClosed))
 			},
 		},
 		{

--- a/service/history/queue/transfer_queue_processor_test.go
+++ b/service/history/queue/transfer_queue_processor_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	cerrors "github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/reconciliation/invariant"
@@ -409,7 +410,7 @@ func TestTransferQueueProcessor_completeTransferLoop_ErrShardClosed(t *testing.T
 	}
 
 	processor.shard.(*shard.TestContext).Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
-		Return(&persistence.RangeCompleteHistoryTaskResponse{}, &shard.ErrShardClosed{}).Once()
+		Return(&persistence.RangeCompleteHistoryTaskResponse{}, &cerrors.ErrShardClosed{}).Once()
 
 	processor.shutdownWG.Add(1)
 
@@ -442,7 +443,7 @@ func TestTransferQueueProcessor_completeTransferLoop_ErrShardClosedNotGraceful(t
 	}
 
 	processor.shard.(*shard.TestContext).Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
-		Return(&persistence.RangeCompleteHistoryTaskResponse{}, &shard.ErrShardClosed{}).Once()
+		Return(&persistence.RangeCompleteHistoryTaskResponse{}, &cerrors.ErrShardClosed{}).Once()
 
 	processor.shutdownWG.Add(1)
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/constants"
+	cerrors "github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -170,17 +171,6 @@ type (
 )
 
 var _ Context = (*contextImpl)(nil)
-
-type ErrShardClosed struct {
-	Msg      string
-	ClosedAt time.Time
-}
-
-var _ error = (*ErrShardClosed)(nil)
-
-func (e *ErrShardClosed) Error() string {
-	return e.Msg
-}
 
 const (
 	TimeBeforeShardClosedIsError = 10 * time.Second
@@ -956,7 +946,7 @@ func (s *contextImpl) closedError() error {
 		return nil
 	}
 
-	return &ErrShardClosed{
+	return &cerrors.ErrShardClosed{
 		Msg:      "shard closed",
 		ClosedAt: *closedAt,
 	}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
+	cerrors "github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
@@ -1057,7 +1058,7 @@ func TestShardClosedGuard(t *testing.T) {
 
 			shardContext.closedAt.Store(&closedAt)
 			err := tc.call()
-			var shardClosedErr *ErrShardClosed
+			var shardClosedErr *cerrors.ErrShardClosed
 			assert.ErrorAs(t, err, &shardClosedErr)
 			assert.Equal(t, closedAt, shardClosedErr.ClosedAt)
 			assert.ErrorContains(t, err, "shard closed")

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -266,7 +266,7 @@ func (t *taskImpl) HandleErr(err error) (retErr error) {
 	}
 
 	// If the shard were recently closed we just return an error, so we retry in a bit.
-	var errShardClosed *shard.ErrShardClosed
+	var errShardClosed *cadence_errors.ErrShardClosed
 	if errors.As(err, &errShardClosed) && time.Since(errShardClosed.ClosedAt) < shard.TimeBeforeShardClosedIsError {
 		return err
 	}
@@ -335,7 +335,7 @@ func (t *taskImpl) HandleErr(err error) (retErr error) {
 }
 
 func (t *taskImpl) RetryErr(err error) bool {
-	var errShardClosed *shard.ErrShardClosed
+	var errShardClosed *cadence_errors.ErrShardClosed
 	if errors.As(err, &errShardClosed) || err == errWorkflowBusy || isRedispatchErr(err) || err == ErrTaskPendingActive || common.IsContextTimeoutError(err) {
 		return false
 	}

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -200,7 +200,7 @@ func (s *taskSuite) TestHandleErr_ErrShardRecentlyClosed() {
 
 	taskBase.submitTime = time.Now()
 
-	shardClosedError := &shard.ErrShardClosed{
+	shardClosedError := &cadence_errors.ErrShardClosed{
 		Msg: "shard closed",
 		// The shard was closed within the TimeBeforeShardClosedIsError interval
 		ClosedAt: time.Now().Add(-shard.TimeBeforeShardClosedIsError / 2),
@@ -328,7 +328,7 @@ func (s *taskSuite) TestRetryErr() {
 		return true, nil
 	}, nil)
 
-	s.Equal(false, taskBase.RetryErr(&shard.ErrShardClosed{}))
+	s.Equal(false, taskBase.RetryErr(&cadence_errors.ErrShardClosed{}))
 	s.Equal(false, taskBase.RetryErr(errWorkflowBusy))
 	s.Equal(false, taskBase.RetryErr(ErrTaskPendingActive))
 	s.Equal(false, taskBase.RetryErr(context.DeadlineExceeded))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Shuffles two existing error types to a common errors folder and adds a small helper
- changes timer processor and transfer processor to use the IsShutdownError to determine whether or not to treat errors like queue shutdown errors as nonretriable.

<!-- Tell your future self why have you made these changes -->
**Why?**

trying to fix an annoying shutdown bug. The intent is to stop it treating the queue shutdown as retriable. I haven't verified this yet fixes it, so draft as yet. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
