### PR TITLE
[common][dynamicconfig] Move dynamic config to fx Module

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/log/logfx"
 	"github.com/uber/cadence/common/service"
 
@@ -113,6 +114,7 @@ func BuildCLI(releaseVersion string, gitRevision string) *cli.App {
 				fxApp := fx.New(
 					config.Module,
 					logfx.Module,
+					dynamicconfigfx.Module,
 					fx.Provide(func() appContext {
 						return appContext{
 							CfgContext: config.Context{

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/tools/cassandra"
@@ -47,21 +48,23 @@ var Module = fx.Options(
 type AppParams struct {
 	fx.In
 
-	RootDir    string   `name:"root-dir"`
-	Services   []string `name:"services"`
-	AppContext config.Context
-	Config     config.Config
-	Logger     log.Logger
-	LifeCycle  fx.Lifecycle
+	RootDir       string   `name:"root-dir"`
+	Services      []string `name:"services"`
+	AppContext    config.Context
+	Config        config.Config
+	Logger        log.Logger
+	LifeCycle     fx.Lifecycle
+	DynamicConfig dynamicconfig.Client
 }
 
 // NewApp created a new Application from pre initalized config and logger.
 func NewApp(params AppParams) *App {
 	app := &App{
-		cfg:      params.Config,
-		rootDir:  params.RootDir,
-		logger:   params.Logger,
-		services: params.Services,
+		cfg:           params.Config,
+		rootDir:       params.RootDir,
+		logger:        params.Logger,
+		services:      params.Services,
+		dynamicConfig: params.DynamicConfig,
 	}
 	params.LifeCycle.Append(fx.Hook{OnStart: app.Start, OnStop: app.Stop})
 	return app
@@ -70,21 +73,16 @@ func NewApp(params AppParams) *App {
 // App is a fx application that registers itself into fx.Lifecycle and runs.
 // It is done implicitly, since it provides methods Start and Stop which are picked up by fx.
 type App struct {
-	cfg     config.Config
-	rootDir string
-	logger  log.Logger
+	cfg           config.Config
+	rootDir       string
+	logger        log.Logger
+	dynamicConfig dynamicconfig.Client
 
 	daemons  []common.Daemon
 	services []string
 }
 
 func (a *App) Start(_ context.Context) error {
-	if a.cfg.DynamicConfig.Client == "" {
-		a.cfg.DynamicConfigClient.Filepath = constructPathIfNeed(a.rootDir, a.cfg.DynamicConfigClient.Filepath)
-	} else {
-		a.cfg.DynamicConfig.FileBased.Filepath = constructPathIfNeed(a.rootDir, a.cfg.DynamicConfig.FileBased.Filepath)
-	}
-
 	if err := a.cfg.ValidateAndFillDefaults(); err != nil {
 		return fmt.Errorf("config validation failed: %w", err)
 	}
@@ -99,7 +97,7 @@ func (a *App) Start(_ context.Context) error {
 
 	var daemons []common.Daemon
 	for _, svc := range a.services {
-		server := newServer(svc, a.cfg, a.logger)
+		server := newServer(svc, a.cfg, a.logger, a.dynamicConfig)
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -48,7 +48,6 @@ var Module = fx.Options(
 type AppParams struct {
 	fx.In
 
-	RootDir       string   `name:"root-dir"`
 	Services      []string `name:"services"`
 	AppContext    config.Context
 	Config        config.Config
@@ -61,7 +60,6 @@ type AppParams struct {
 func NewApp(params AppParams) *App {
 	app := &App{
 		cfg:           params.Config,
-		rootDir:       params.RootDir,
 		logger:        params.Logger,
 		services:      params.Services,
 		dynamicConfig: params.DynamicConfig,

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -102,7 +102,7 @@ func (s *ServerSuite) TestServerStartup() {
 	var daemons []common.Daemon
 	services := service.ShortNames(service.List)
 	for _, svc := range services {
-		server := newServer(svc, cfg, logger, dynamicconfigfx.New(cfg, logger, lifecycle))
+		server := newServer(svc, cfg, logger, dynamicconfigfx.New(dynamicconfigfx.Params{Logger: logger, Cfg: cfg, Lifecycle: lifecycle}))
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -24,17 +24,20 @@
 package cadence
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/fx/fxtest"
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -94,10 +97,12 @@ func (s *ServerSuite) TestServerStartup() {
 
 	logger := testlogger.New(s.T())
 
+	lifecycle := fxtest.NewLifecycle(s.T())
+
 	var daemons []common.Daemon
 	services := service.ShortNames(service.List)
 	for _, svc := range services {
-		server := newServer(svc, cfg, logger)
+		server := newServer(svc, cfg, logger, dynamicconfigfx.New(cfg, logger, lifecycle))
 		daemons = append(daemons, server)
 		server.Start()
 	}
@@ -105,6 +110,7 @@ func (s *ServerSuite) TestServerStartup() {
 	timer := time.NewTimer(time.Second * 10)
 
 	<-timer.C
+	s.NoError(lifecycle.Stop(context.Background()))
 	for _, daemon := range daemons {
 		daemon.Stop()
 	}

--- a/common/dynamicconfig/dynamicconfigfx/fx.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx.go
@@ -1,0 +1,81 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package dynamicconfigfx
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/configstore"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/persistence"
+)
+
+// Module provides fx options for dynamic config initialization
+var Module = fx.Options(fx.Provide(New))
+
+// New creates dynamicconfig.Client from the configuration
+func New(cfg config.Config, logger log.Logger, lifecycle fx.Lifecycle) dynamicconfig.Client {
+	stopped := make(chan struct{})
+
+	lifecycle.Append(fx.Hook{OnStop: func(_ context.Context) error {
+		close(stopped)
+		return nil
+	}})
+
+	var res dynamicconfig.Client
+
+	var err error
+	if cfg.DynamicConfig.Client == "" {
+		logger.Warn("falling back to legacy file based dynamicClientConfig")
+		res, err = dynamicconfig.NewFileBasedClient(&cfg.DynamicConfigClient, logger, stopped)
+	} else {
+		switch cfg.DynamicConfig.Client {
+		case dynamicconfig.ConfigStoreClient:
+			logger.Info("initialising ConfigStore dynamic config client")
+			res, err = configstore.NewConfigStoreClient(
+				&cfg.DynamicConfig.ConfigStore,
+				&cfg.Persistence,
+				logger,
+				persistence.DynamicConfig,
+			)
+		case dynamicconfig.FileBasedClient:
+			logger.Info("initialising File Based dynamic config client")
+			res, err = dynamicconfig.NewFileBasedClient(&cfg.DynamicConfig.FileBased, logger, stopped)
+		}
+	}
+
+	if res == nil {
+		logger.Info("initialising NOP dynamic config client")
+		res = dynamicconfig.NewNopClient()
+	} else if err != nil {
+		logger.Error("creating dynamic config client failed, using no-op config client instead", tag.Error(err))
+		res = dynamicconfig.NewNopClient()
+	}
+
+	return res
+}

--- a/common/dynamicconfig/dynamicconfigfx/fx_test.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx_test.go
@@ -20,34 +20,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cadence
+package dynamicconfigfx
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log/testlogger"
 )
 
-func TestFxDependencies(t *testing.T) {
-	err := fx.ValidateApp(config.Module,
-		logfx.Module,
-		dynamicconfigfx.Module,
-		fx.Provide(func() appContext {
-			return appContext{
-				CfgContext: config.Context{
-					Environment: "",
-					Zone:        "",
-				},
-				ConfigDir: "",
-				RootDir:   "",
-				Services:  []string{"frontend"},
-			}
-		}),
-		Module)
-	require.NoError(t, err)
+func TestModule(t *testing.T) {
+	app := fxtest.New(t,
+		testlogger.Module(t),
+		fx.Provide(func() config.Config { return config.Config{} }),
+		Module,
+		fx.Invoke(func(c dynamicconfig.Client) {}),
+	)
+	app.RequireStart().RequireStop()
 }

--- a/common/dynamicconfig/dynamicconfigfx/fx_test.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx_test.go
@@ -36,9 +36,20 @@ import (
 func TestModule(t *testing.T) {
 	app := fxtest.New(t,
 		testlogger.Module(t),
-		fx.Provide(func() config.Config { return config.Config{} }),
+		fx.Provide(func() config.Config { return config.Config{} },
+			func() fxRoot {
+				return fxRoot{
+					RootDir: "../../../",
+				}
+			}),
 		Module,
 		fx.Invoke(func(c dynamicconfig.Client) {}),
 	)
 	app.RequireStart().RequireStop()
+}
+
+type fxRoot struct {
+	fx.Out
+
+	RootDir string `name:"root-dir"`
 }

--- a/common/log/testlogger/fx.go
+++ b/common/log/testlogger/fx.go
@@ -20,34 +20,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cadence
+package testlogger
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
-
-	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
 )
 
-func TestFxDependencies(t *testing.T) {
-	err := fx.ValidateApp(config.Module,
-		logfx.Module,
-		dynamicconfigfx.Module,
-		fx.Provide(func() appContext {
-			return appContext{
-				CfgContext: config.Context{
-					Environment: "",
-					Zone:        "",
-				},
-				ConfigDir: "",
-				RootDir:   "",
-				Services:  []string{"frontend"},
-			}
-		}),
-		Module)
-	require.NoError(t, err)
+// Module allows to push testlogger for tests.
+func Module(t *testing.T) fx.Option {
+	return fx.Options(
+		fx.Provide(func() TestingT { return TestingT(t) }),
+		fx.Provide(New),
+	)
 }

--- a/common/log/testlogger/fx_test.go
+++ b/common/log/testlogger/fx_test.go
@@ -20,34 +20,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cadence
+package testlogger
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
 
-	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/common/log"
 )
 
-func TestFxDependencies(t *testing.T) {
-	err := fx.ValidateApp(config.Module,
-		logfx.Module,
-		dynamicconfigfx.Module,
-		fx.Provide(func() appContext {
-			return appContext{
-				CfgContext: config.Context{
-					Environment: "",
-					Zone:        "",
-				},
-				ConfigDir: "",
-				RootDir:   "",
-				Services:  []string{"frontend"},
-			}
-		}),
-		Module)
-	require.NoError(t, err)
+func TestModule(t *testing.T) {
+	app := fxtest.New(t, Module(t), fx.Invoke(func(logger log.Logger) {}))
+	app.RequireStart().RequireStop()
 }

--- a/common/persistence/sql/sql_test_utils.go
+++ b/common/persistence/sql/sql_test_utils.go
@@ -192,8 +192,8 @@ func getCadencePackageDir() (string, error) {
 	if err != nil {
 		panic(err)
 	}
-	cadenceIndex := strings.LastIndex(cadencePackageDir, "/cadence/")
-	cadencePackageDir = cadencePackageDir[:cadenceIndex+len("/cadence/")]
+	cadenceIndex := strings.LastIndex(cadencePackageDir, "cadence/")
+	cadencePackageDir = cadencePackageDir[:cadenceIndex+len("cadence/")]
 	return cadencePackageDir, err
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I introduce dynamicconfigfx.Module to inject dynamic config to fx application.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is one of the few common dependencies that exist outside of the resource and can be initialized separately.
Also, it ensures a single instance that provides consistent reads of dynamic config if there are multiple services running in one binary.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
