### PR TITLE
[cli][jwt] Fix TestCreateJWT flackiness

### DIFF
--- a/tools/cli/utils_test.go
+++ b/tools/cli/utils_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/uber/cadence/common/authorization"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/testing/testdatagen/idlfuzzedtestdata"
 	"github.com/uber/cadence/common/types"
 )
@@ -841,8 +842,10 @@ func TestCreateJWT(t *testing.T) {
 	assert.NoError(t, err)
 	tmpFile.Close()
 
+	timeSource := clock.NewMockedTimeSource()
+
 	// Call createJWT with the path to the temporary private key file
-	tokenString, err := createJWT(tmpFile.Name())
+	tokenString, err := createJWT(tmpFile.Name(), timeSource)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, tokenString)
 
@@ -857,6 +860,6 @@ func TestCreateJWT(t *testing.T) {
 	claims, ok := token.Claims.(*authorization.JWTClaims)
 	assert.True(t, ok)
 	assert.True(t, claims.Admin)
-	assert.WithinDuration(t, time.Now(), claims.IssuedAt.Time, time.Second)
-	assert.WithinDuration(t, time.Now().Add(10*time.Minute), claims.ExpiresAt.Time, time.Second)
+	assert.Equal(t, timeSource.Now().Round(jwt.TimePrecision), claims.IssuedAt.Time)
+	assert.Equal(t, timeSource.Now().Add(10*time.Minute).Round(jwt.TimePrecision), claims.ExpiresAt.Time)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed TestCreateJWT to use mockedTimeSource instead of real time.

<!-- Tell your future self why have you made these changes -->
**Why?**
This test was time sensitive making an assumption of how long will it take for CI worker to process token. Since CI can be running on preemptible machines, the delay can be critical and fail the test.

Example failure:
```
--- FAIL: TestCreateJWT (0.07s)
    utils_test.go:860: 
        	Error Trace:	/home/runner/work/cadence/cadence/tools/cli/utils_test.go:860
        	Error:      	Max difference between 2025-04-16 09:25:41.007383623 +0000 UTC m=+1.357210528 and 2025-04-16 09:25:40 +0000 UTC allowed is 1s, but difference was 1.007383623s
        	Test:       	TestCreateJWT
    utils_test.go:861: 
        	Error Trace:	/home/runner/work/cadence/cadence/tools/cli/utils_test.go:861
        	Error:      	Max difference between 2025-04-16 09:35:41.007476116 +0000 UTC m=+601.357303021 and 2025-04-16 09:35:40 +0000 UTC allowed is 1s, but difference was 1.007476116s
        	Test:       	TestCreateJWT
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
