### PR TITLE
[ci][buidlkite] Try leveraging go modules to cache dependencies across runs

### DIFF
--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -40,6 +40,7 @@ WORKDIR /cadence
 
 # Copy go mod dependencies and try to share the module download cache
 COPY go.* /cadence
+COPY internal/tools/go.* /cadence/internal/tools/
 COPY cmd/server/go.* /cadence/cmd/server/
 COPY common/archiver/gcloud/go.* /cadence/common/archiver/gcloud/
 # go.work means this downloads everything, not just the top module

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -34,6 +34,13 @@ ENV V=0
 # allow git-status and similar to work
 RUN git config --global --add safe.directory /cadence
 
+# Copy go mod dependencies and try to share the module download cache
+COPY go.* ./
+COPY cmd/server/go.* ./cmd/server/
+COPY common/archiver/gcloud/go.* ./common/archiver/gcloud/
+# go.work means this downloads everything, not just the top module
+RUN go mod download
+
 # https://github.com/docker-library/golang/blob/c1baf037d71331eb0b8d4c70cff4c29cf124c5e0/1.4/Dockerfile
 RUN mkdir -p /cadence
 WORKDIR /cadence

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -34,13 +34,13 @@ ENV V=0
 # allow git-status and similar to work
 RUN git config --global --add safe.directory /cadence
 
-# Copy go mod dependencies and try to share the module download cache
-COPY go.* ./
-COPY cmd/server/go.* ./cmd/server/
-COPY common/archiver/gcloud/go.* ./common/archiver/gcloud/
-# go.work means this downloads everything, not just the top module
-RUN go mod download
-
 # https://github.com/docker-library/golang/blob/c1baf037d71331eb0b8d4c70cff4c29cf124c5e0/1.4/Dockerfile
 RUN mkdir -p /cadence
 WORKDIR /cadence
+
+# Copy go mod dependencies and try to share the module download cache
+COPY go.* /cadence
+COPY cmd/server/go.* /cadence/cmd/server/
+COPY common/archiver/gcloud/go.* /cadence/common/archiver/gcloud/
+# go.work means this downloads everything, not just the top module
+RUN go mod download

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       - BUILDKITE_BUILD_NUMBER
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -122,6 +123,7 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -149,6 +151,7 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -176,6 +179,7 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -194,6 +198,7 @@ services:
       - BUILDKITE_BUILD_NUMBER
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -222,6 +227,7 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -249,6 +255,7 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -276,6 +283,7 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -303,6 +311,7 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -332,8 +341,12 @@ services:
       - BUILDKITE_PULL_REQUEST_REPO
     volumes:
       - ../../:/cadence
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
 
 networks:
   services-network:
     name: services-network
     driver: bridge
+
+volumes:
+  go-modules: # Define the volume

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -94,7 +94,6 @@ services:
       - BUILDKITE_BUILD_NUMBER
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -123,7 +122,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -151,7 +149,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -179,7 +176,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -198,7 +194,6 @@ services:
       - BUILDKITE_BUILD_NUMBER
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -227,7 +222,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -255,7 +249,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -283,7 +276,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -311,7 +303,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     networks:
       services-network:
         aliases:
@@ -341,7 +332,6 @@ services:
       - BUILDKITE_PULL_REQUEST_REPO
     volumes:
       - ../../:/cadence
-      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
 
 networks:
   services-network:

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -337,6 +337,3 @@ networks:
   services-network:
     name: services-network
     driver: bridge
-
-volumes:
-  go-modules: # Define the volume


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move go mod download step to Dockerfile so that all runs utilize it.

<!-- Tell your future self why have you made these changes -->
**Why?**
Trying to leverage caching to eliminate time spent on downloading dependencies. Also, provide a cleaner output in the buildkite logs that only focuses on the tests.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local buildkite test run

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
CI failures

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
