### PR TITLE
Fix dynamicConfig naming inconsistency for ExecutionCacheMaxByteSize

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -872,7 +872,7 @@ const (
 	// Allowed filters: N/A
 	HistoryCacheMaxSize
 	// ExecutionCacheMaxByteSize is the max byte size of history cache
-	// KeyName: history.executionCacheMaxSize
+	// KeyName: history.executionCacheMaxByteSize
 	// Value type: Int
 	// Default value: 0
 	// Allowed filters: N/A
@@ -3437,7 +3437,7 @@ var IntKeys = map[IntKey]DynamicInt{
 		DefaultValue: 512,
 	},
 	ExecutionCacheMaxByteSize: {
-		KeyName:      "history.executionCacheMaxSizeInBytes",
+		KeyName:      "history.executionCacheMaxByteSize",
 		Description:  "ExecutionCacheMaxByteSize is max size of execution cache in bytes",
 		DefaultValue: 0,
 	},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed naming inconsistency where ExecutionCacheMaxByteSize's dynamic config name didn't match its variable name, updating related comments for consistency.

<!-- Tell your future self why have you made these changes -->
**Why?**
Addresses a naming inconsistency in [PR](https://github.com/cadence-workflow/cadence/pull/6817) tthat could cause configuration confusion.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Just naming changes

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Must be bundled with above [PR](https://github.com/cadence-workflow/cadence/pull/6817) in the same release to avoid issues 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
