### PR TITLE
Remove Task Isolation from Forwarder

### DIFF
--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -83,7 +83,7 @@ type (
 		ForwardQueryTask(ctx context.Context, task *InternalTask) (*types.QueryWorkflowResponse, error)
 		ForwardPoll(ctx context.Context) (*InternalTask, error)
 		AddReqTokenC() <-chan *ForwarderReqToken
-		PollReqTokenC(isolationGroup string) <-chan *ForwarderReqToken
+		PollReqTokenC() <-chan *ForwarderReqToken
 	}
 
 	TaskCompleter interface {

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -536,17 +536,17 @@ func (mr *MockForwarderMockRecorder) ForwardTask(ctx, task any) *gomock.Call {
 }
 
 // PollReqTokenC mocks base method.
-func (m *MockForwarder) PollReqTokenC(isolationGroup string) <-chan *ForwarderReqToken {
+func (m *MockForwarder) PollReqTokenC() <-chan *ForwarderReqToken {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PollReqTokenC", isolationGroup)
+	ret := m.ctrl.Call(m, "PollReqTokenC")
 	ret0, _ := ret[0].(<-chan *ForwarderReqToken)
 	return ret0
 }
 
 // PollReqTokenC indicates an expected call of PollReqTokenC.
-func (mr *MockForwarderMockRecorder) PollReqTokenC(isolationGroup any) *gomock.Call {
+func (mr *MockForwarderMockRecorder) PollReqTokenC() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollReqTokenC", reflect.TypeOf((*MockForwarder)(nil).PollReqTokenC), isolationGroup)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollReqTokenC", reflect.TypeOf((*MockForwarder)(nil).PollReqTokenC))
 }
 
 // MockTaskCompleter is a mock of TaskCompleter interface.

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -225,7 +225,7 @@ func NewManager(
 	}
 	var fwdr Forwarder
 	if tlMgr.isFowardingAllowed(taskList, *taskListKind) {
-		fwdr = newForwarder(&taskListConfig.ForwarderConfig, taskList, *taskListKind, matchingClient, isolationGroups, scope)
+		fwdr = newForwarder(&taskListConfig.ForwarderConfig, taskList, *taskListKind, matchingClient, scope)
 	}
 	numReadPartitionsFn := func(cfg *config.TaskListConfig) int {
 		if cfg.EnableGetNumberOfPartitionsFromCache() {


### PR DESCRIPTION
Remove all functionality from Forwarder around TaskList isolation.

Changing the task forwarding concurrency limit is effectively a no-op. Task forwarding will almost always be limited by the task forwarding rate limit (10/s) before the concurrency ever becomes a concern.

Providing a concurrency limit per isolation group for pollers meanwhile results in some degree of starvation outside of the root partition. Unless a poller is matched with a task within the local wait duration, we end up forwarding one per isolation group to the root. As the number of partitions and isolation groups increase this sends a disproportionate amount of pollers to the root, reducing the sync match rate in every other partition.

<!-- Describe what has changed in this PR -->
**What changed?**
- Removed isolation behavior from Forwarder

<!-- Tell your future self why have you made these changes -->
**Why?**
- Increase sync match rate when zonal isolation is enabled
- Simplify forwarding and align it more clearly with the flipr properties that control it

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests, integration tests, and matching simulation.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
