### PR TITLE
Track Isolation Group state even when there's only one partition

### DIFF
--- a/service/matching/tasklist/isolation_balancer_test.go
+++ b/service/matching/tasklist/isolation_balancer_test.go
@@ -89,6 +89,76 @@ func TestAdjustWritePartitions(t *testing.T) {
 			},
 		},
 		{
+			name: "initial balance - from one partition",
+			cycles: []*testCycle{
+				{
+					metrics: &aggregatePartitionMetrics{
+						qpsByIsolationGroup: map[string]float64{
+							"a": 100,
+							"b": 99,
+						},
+						hasPollersByIsolationGroup: map[string]bool{
+							"a": true,
+							"b": true,
+						},
+					},
+					partitions: map[int]*types.TaskListPartition{
+						0: {},
+					},
+				},
+				{},
+				{},
+				{},
+				{
+					partitions: map[int]*types.TaskListPartition{
+						0: {},
+						1: {},
+					},
+					expected: map[int]*types.TaskListPartition{
+						0: {IsolationGroups: []string{"a", "b"}},
+						1: {IsolationGroups: []string{"a", "b"}},
+					},
+				},
+			},
+		},
+		{
+			name: "initial balance - from one partition skewed",
+			cycles: []*testCycle{
+				{
+					metrics: &aggregatePartitionMetrics{
+						qpsByIsolationGroup: map[string]float64{
+							"a": 300,
+							"b": 75,
+							"c": 2,
+							"d": 1,
+						},
+						hasPollersByIsolationGroup: map[string]bool{
+							"a": true,
+							"b": true,
+							"c": true,
+							"d": true,
+						},
+					},
+					partitions: map[int]*types.TaskListPartition{
+						0: {},
+					},
+				},
+				{},
+				{},
+				{},
+				{
+					partitions: map[int]*types.TaskListPartition{
+						0: {},
+						1: {},
+					},
+					expected: map[int]*types.TaskListPartition{
+						0: {IsolationGroups: []string{"a", "b"}},
+						1: {IsolationGroups: []string{"a", "c", "d"}},
+					},
+				},
+			},
+		},
+		{
 			name:               "one partition minimum",
 			groupsPerPartition: 1,
 			cycles: []*testCycle{


### PR DESCRIPTION
Currently we skip processing all isolation groups if there's a single partition, since we can't assign isolation groups between different partitions. This means that we don't track poller presence, requiring the partition to be upscaled, then the poller sustain duration to complete, then we reassign isolation groups between the partitions. This increases the frequency of config updates and makes isolation assignment less responsive. We should be able to assign isolation groups as soon as the partition count increases.

Always calculate the goal state for isolation groups and only apply it if there's more than one partition.

Allow isolation groups scaling up from 0 (newly added pollers) to be assigned more than the minimum number of partitions, despite not having a sustained overload.

<!-- Describe what has changed in this PR -->
**What changed?**
- Change isolation assignment logic to be more responsive when scaling from 1 -> N partitions

<!-- Tell your future self why have you made these changes -->
**Why?**
- Reduce the frequency of partition config changes

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests and matching simulation

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
