### PR TITLE
Add a dynamic property to disable failover queues

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2093,6 +2093,9 @@ const (
 	// Default value: false
 	EnableSizeBasedHistoryEventCache
 
+	DisableTransferFailoverQueue
+	DisableTimerFailoverQueue
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -4543,6 +4546,16 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	EnableSizeBasedHistoryEventCache: {
 		KeyName:      "history.enableSizeBasedHistoryEventCache",
 		Description:  "EnableSizeBasedHistoryEventCache is to enable size based history event cache",
+		DefaultValue: false,
+	},
+	DisableTransferFailoverQueue: {
+		KeyName:      "history.disableTransferFailoverQueue",
+		Description:  "DisableTransferFailoverQueue is to disable transfer failover queue",
+		DefaultValue: false,
+	},
+	DisableTimerFailoverQueue: {
+		KeyName:      "history.disableTimerFailoverQueue",
+		Description:  "DisableTimerFailoverQueue is to disable timer failover queue",
 		DefaultValue: false,
 	},
 }

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -146,6 +146,7 @@ type Config struct {
 	TimerProcessorMaxTimeShift                        dynamicproperties.DurationPropertyFn
 	TimerProcessorHistoryArchivalSizeLimit            dynamicproperties.IntPropertyFn
 	TimerProcessorArchivalTimeLimit                   dynamicproperties.DurationPropertyFn
+	DisableTimerFailoverQueue                         dynamicproperties.BoolPropertyFn
 
 	// TransferQueueProcessor settings
 	TransferTaskBatchSize                                dynamicproperties.IntPropertyFn
@@ -165,7 +166,7 @@ type Config struct {
 	TransferProcessorEnableValidator                     dynamicproperties.BoolPropertyFn
 	TransferProcessorValidationInterval                  dynamicproperties.DurationPropertyFn
 	TransferProcessorVisibilityArchivalTimeLimit         dynamicproperties.DurationPropertyFn
-
+	DisableTransferFailoverQueue                         dynamicproperties.BoolPropertyFn
 	// ReplicatorQueueProcessor settings
 	ReplicatorTaskDeleteBatchSize          dynamicproperties.IntPropertyFn
 	ReplicatorReadTaskMaxRetryCount        dynamicproperties.IntPropertyFn
@@ -414,25 +415,25 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		QueueProcessorEnableLoadQueueStates:                dc.GetBoolProperty(dynamicproperties.QueueProcessorEnableLoadQueueStates),
 		QueueProcessorEnableGracefulSyncShutdown:           dc.GetBoolProperty(dynamicproperties.QueueProcessorEnableGracefulSyncShutdown),
 
-		TimerTaskBatchSize:                                dc.GetIntProperty(dynamicproperties.TimerTaskBatchSize),
-		TimerTaskDeleteBatchSize:                          dc.GetIntProperty(dynamicproperties.TimerTaskDeleteBatchSize),
-		TimerProcessorGetFailureRetryCount:                dc.GetIntProperty(dynamicproperties.TimerProcessorGetFailureRetryCount),
-		TimerProcessorCompleteTimerFailureRetryCount:      dc.GetIntProperty(dynamicproperties.TimerProcessorCompleteTimerFailureRetryCount),
-		TimerProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicproperties.TimerProcessorUpdateAckInterval),
-		TimerProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicproperties.TimerProcessorUpdateAckIntervalJitterCoefficient),
-		TimerProcessorCompleteTimerInterval:               dc.GetDurationProperty(dynamicproperties.TimerProcessorCompleteTimerInterval),
-		TimerProcessorFailoverMaxStartJitterInterval:      dc.GetDurationProperty(dynamicproperties.TimerProcessorFailoverMaxStartJitterInterval),
-		TimerProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicproperties.TimerProcessorFailoverMaxPollRPS),
-		TimerProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicproperties.TimerProcessorMaxPollRPS),
-		TimerProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicproperties.TimerProcessorMaxPollInterval),
-		TimerProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicproperties.TimerProcessorMaxPollIntervalJitterCoefficient),
-		TimerProcessorSplitQueueInterval:                  dc.GetDurationProperty(dynamicproperties.TimerProcessorSplitQueueInterval),
-		TimerProcessorSplitQueueIntervalJitterCoefficient: dc.GetFloat64Property(dynamicproperties.TimerProcessorSplitQueueIntervalJitterCoefficient),
-		TimerProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicproperties.TimerProcessorMaxRedispatchQueueSize),
-		TimerProcessorMaxTimeShift:                        dc.GetDurationProperty(dynamicproperties.TimerProcessorMaxTimeShift),
-		TimerProcessorHistoryArchivalSizeLimit:            dc.GetIntProperty(dynamicproperties.TimerProcessorHistoryArchivalSizeLimit),
-		TimerProcessorArchivalTimeLimit:                   dc.GetDurationProperty(dynamicproperties.TimerProcessorArchivalTimeLimit),
-
+		TimerTaskBatchSize:                                   dc.GetIntProperty(dynamicproperties.TimerTaskBatchSize),
+		TimerTaskDeleteBatchSize:                             dc.GetIntProperty(dynamicproperties.TimerTaskDeleteBatchSize),
+		TimerProcessorGetFailureRetryCount:                   dc.GetIntProperty(dynamicproperties.TimerProcessorGetFailureRetryCount),
+		TimerProcessorCompleteTimerFailureRetryCount:         dc.GetIntProperty(dynamicproperties.TimerProcessorCompleteTimerFailureRetryCount),
+		TimerProcessorUpdateAckInterval:                      dc.GetDurationProperty(dynamicproperties.TimerProcessorUpdateAckInterval),
+		TimerProcessorUpdateAckIntervalJitterCoefficient:     dc.GetFloat64Property(dynamicproperties.TimerProcessorUpdateAckIntervalJitterCoefficient),
+		TimerProcessorCompleteTimerInterval:                  dc.GetDurationProperty(dynamicproperties.TimerProcessorCompleteTimerInterval),
+		TimerProcessorFailoverMaxStartJitterInterval:         dc.GetDurationProperty(dynamicproperties.TimerProcessorFailoverMaxStartJitterInterval),
+		TimerProcessorFailoverMaxPollRPS:                     dc.GetIntProperty(dynamicproperties.TimerProcessorFailoverMaxPollRPS),
+		TimerProcessorMaxPollRPS:                             dc.GetIntProperty(dynamicproperties.TimerProcessorMaxPollRPS),
+		TimerProcessorMaxPollInterval:                        dc.GetDurationProperty(dynamicproperties.TimerProcessorMaxPollInterval),
+		TimerProcessorMaxPollIntervalJitterCoefficient:       dc.GetFloat64Property(dynamicproperties.TimerProcessorMaxPollIntervalJitterCoefficient),
+		TimerProcessorSplitQueueInterval:                     dc.GetDurationProperty(dynamicproperties.TimerProcessorSplitQueueInterval),
+		TimerProcessorSplitQueueIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicproperties.TimerProcessorSplitQueueIntervalJitterCoefficient),
+		TimerProcessorMaxRedispatchQueueSize:                 dc.GetIntProperty(dynamicproperties.TimerProcessorMaxRedispatchQueueSize),
+		TimerProcessorMaxTimeShift:                           dc.GetDurationProperty(dynamicproperties.TimerProcessorMaxTimeShift),
+		TimerProcessorHistoryArchivalSizeLimit:               dc.GetIntProperty(dynamicproperties.TimerProcessorHistoryArchivalSizeLimit),
+		TimerProcessorArchivalTimeLimit:                      dc.GetDurationProperty(dynamicproperties.TimerProcessorArchivalTimeLimit),
+		DisableTimerFailoverQueue:                            dc.GetBoolProperty(dynamicproperties.DisableTimerFailoverQueue),
 		TransferTaskBatchSize:                                dc.GetIntProperty(dynamicproperties.TransferTaskBatchSize),
 		TransferTaskDeleteBatchSize:                          dc.GetIntProperty(dynamicproperties.TransferTaskDeleteBatchSize),
 		TransferProcessorFailoverMaxStartJitterInterval:      dc.GetDurationProperty(dynamicproperties.TransferProcessorFailoverMaxStartJitterInterval),
@@ -450,6 +451,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		TransferProcessorEnableValidator:                     dc.GetBoolProperty(dynamicproperties.TransferProcessorEnableValidator),
 		TransferProcessorValidationInterval:                  dc.GetDurationProperty(dynamicproperties.TransferProcessorValidationInterval),
 		TransferProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicproperties.TransferProcessorVisibilityArchivalTimeLimit),
+		DisableTransferFailoverQueue:                         dc.GetBoolProperty(dynamicproperties.DisableTransferFailoverQueue),
 
 		ReplicatorTaskDeleteBatchSize:          dc.GetIntProperty(dynamicproperties.ReplicatorTaskDeleteBatchSize),
 		ReplicatorReadTaskMaxRetryCount:        dc.GetIntProperty(dynamicproperties.ReplicatorReadTaskMaxRetryCount),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -266,6 +266,8 @@ func TestNewConfig(t *testing.T) {
 		"HostName":                                             {nil, hostname},
 		"SearchAttributesHiddenValueKeys":                      {dynamicproperties.SearchAttributesHiddenValueKeys, map[string]interface{}{"CustomStringField": true}},
 		"ExecutionCacheMaxByteSize":                            {dynamicproperties.ExecutionCacheMaxByteSize, 98},
+		"DisableTransferFailoverQueue":                         {dynamicproperties.DisableTransferFailoverQueue, true},
+		"DisableTimerFailoverQueue":                            {dynamicproperties.DisableTimerFailoverQueue, true},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -254,6 +254,10 @@ func (t *timerQueueProcessor) NotifyNewTask(clusterName string, info *hcommon.No
 }
 
 func (t *timerQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
+	if t.shard.GetConfig().DisableTimerFailoverQueue() {
+		return
+	}
+
 	// Failover queue is used to scan all inflight tasks, if queue processor is not
 	// started, there's no inflight task and we don't need to create a failover processor.
 	// Also the HandleAction will be blocked if queue processor processing loop is not running.

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -232,6 +232,10 @@ func (t *transferQueueProcessor) NotifyNewTask(clusterName string, info *hcommon
 }
 
 func (t *transferQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
+	if t.shard.GetConfig().DisableTransferFailoverQueue() {
+		return
+	}
+
 	// Failover queue is used to scan all inflight tasks, if queue processor is not
 	// started, there's no inflight task and we don't need to create a failover processor.
 	// Also the HandleAction will be blocked if queue processor processing loop is not running.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a dynamic property to disable failover queues

<!-- Tell your future self why have you made these changes -->
**Why?**
The failover queues seem to cause issues in our staging environments. Add a feature flag to allow us disable it and verify if it's really the cause.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk. It's controlled by a feature flag. And the default behavior is the same as before.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
