### PR TITLE
Add more logs to improve visibility around shard/engine/queue component lifecycles

### DIFF
--- a/service/history/engine/engineimpl/register_domain_failover_callback.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback.go
@@ -150,13 +150,13 @@ func (e *historyEngineImpl) generateGracefulFailoverTasksForDomainUpdateCallback
 }
 
 func (e *historyEngineImpl) lockProcessingForFailover() {
-	e.logger.Debug("locking processing for failover")
+	e.logger.Info("Locking processing for failover")
 	e.txProcessor.LockTaskProcessing()
 	e.timerProcessor.LockTaskProcessing()
 }
 
 func (e *historyEngineImpl) unlockProcessingForFailover() {
-	e.logger.Debug("unlocking processing for failover")
+	e.logger.Info("Unlocking processing for failover")
 	e.txProcessor.UnlockTaskProcessing()
 	e.timerProcessor.UnlockTaskProcessing()
 }

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -186,6 +186,9 @@ func (t *timerQueueProcessor) Stop() {
 		return
 	}
 
+	t.logger.Info("Stopping timer queue processor")
+	defer t.logger.Info("Timer queue processor stopped")
+
 	if !t.shard.GetConfig().QueueProcessorEnableGracefulSyncShutdown() {
 		t.activeQueueProcessor.Stop()
 		// stop active executor after queue processor
@@ -376,10 +379,12 @@ func (t *timerQueueProcessor) HandleAction(ctx context.Context, clusterName stri
 }
 
 func (t *timerQueueProcessor) LockTaskProcessing() {
+	t.logger.Info("Timer queue processor locking task processing")
 	t.taskAllocator.Lock()
 }
 
 func (t *timerQueueProcessor) UnlockTaskProcessing() {
+	t.logger.Info("Timer queue processor unlocking task processing")
 	t.taskAllocator.Unlock()
 }
 
@@ -424,7 +429,7 @@ func (t *timerQueueProcessor) completeTimerLoop() {
 					break
 				}
 
-				t.logger.Error("Failed to complete timer task", tag.Error(err))
+				t.logger.Error("Failed to complete timer task", tag.Error(err), tag.Attempt(int32(attempt)))
 				var errShardClosed *shard.ErrShardClosed
 				if errors.As(err, &errShardClosed) {
 					if !t.shard.GetConfig().QueueProcessorEnableGracefulSyncShutdown() {

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -172,6 +172,9 @@ func (t *timerQueueProcessor) Start() {
 		return
 	}
 
+	t.logger.Info("Starting timer queue processor")
+	defer t.logger.Info("Timer queue processor started")
+
 	t.activeQueueProcessor.Start()
 	for _, standbyQueueProcessor := range t.standbyQueueProcessors {
 		standbyQueueProcessor.Start()
@@ -405,6 +408,9 @@ func (t *timerQueueProcessor) drain() {
 }
 
 func (t *timerQueueProcessor) completeTimerLoop() {
+	t.logger.Info("Timer queue processor completeTimerLoop")
+	defer t.logger.Info("Timer queue processor completeTimerLoop completed")
+
 	defer t.shutdownWG.Done()
 
 	completeTimer := time.NewTimer(t.config.TimerProcessorCompleteTimerInterval())

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -171,6 +171,9 @@ func (t *transferQueueProcessor) Start() {
 		return
 	}
 
+	t.logger.Info("Starting transfer queue processor")
+	defer t.logger.Info("Transfer queue processor started")
+
 	t.activeQueueProcessor.Start()
 	for _, standbyQueueProcessor := range t.standbyQueueProcessors {
 		standbyQueueProcessor.Start()
@@ -363,6 +366,9 @@ func (t *transferQueueProcessor) drain() {
 }
 
 func (t *transferQueueProcessor) completeTransferLoop() {
+	t.logger.Info("Transfer queue processor completeTransferLoop")
+	defer t.logger.Info("Transfer queue processor completeTransferLoop completed")
+
 	defer t.shutdownWG.Done()
 
 	completeTimer := time.NewTimer(t.config.TransferProcessorCompleteTransferInterval())

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -967,10 +967,9 @@ func (s *contextImpl) closeShard() {
 		return
 	}
 
+	s.logger.Info("Shard context closeShard called")
 	go func() {
-		s.logger.Info("Shard context calling close callback")
 		s.closeCallback(s.shardID, s.shardItem)
-		s.logger.Info("Shard context close callback completed")
 	}()
 
 	// fails any writes that may start after this point.

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -968,7 +968,9 @@ func (s *contextImpl) closeShard() {
 	}
 
 	go func() {
+		s.logger.Info("Shard context calling close callback")
 		s.closeCallback(s.shardID, s.shardItem)
+		s.logger.Info("Shard context close callback completed")
 	}()
 
 	// fails any writes that may start after this point.

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -958,6 +958,7 @@ func TestCloseShard(t *testing.T) {
 		closeCallback: func(i int, item *historyShardsItem) {
 			close(closeCallback)
 		},
+		logger: log.NewNoop(),
 	}
 	shardContext.closeShard()
 

--- a/service/history/shard/controller.go
+++ b/service/history/shard/controller.go
@@ -241,7 +241,8 @@ func (c *controller) ShardIDs() []int32 {
 func (c *controller) removeEngineForShard(shardID int, shardItem *historyShardsItem) {
 	sw := c.metricsScope.StartTimer(metrics.RemoveEngineForShardLatency)
 	defer sw.Stop()
-	currentShardItem, _ := c.removeHistoryShardItem(shardID, shardItem)
+	currentShardItem, err := c.removeHistoryShardItem(shardID, shardItem)
+	c.logger.Error("Failed to remove history shard item", tag.Error(err), tag.ShardID(shardID))
 	if shardItem != nil {
 		// if shardItem is not nil, then currentShardItem either equals to shardItem or is nil
 		// in both cases, we need to stop the engine in shardItem
@@ -257,7 +258,7 @@ func (c *controller) removeEngineForShard(shardID int, shardItem *historyShardsI
 
 func (c *controller) shardClosedCallback(shardID int, shardItem *historyShardsItem) {
 	c.metricsScope.IncCounter(metrics.ShardClosedCounter)
-	c.logger.Info("Shard controller state changed", tag.LifeCycleStopping, tag.ComponentShard, tag.ShardID(shardID))
+	c.logger.Info("Shard controller state changed", tag.LifeCycleStopping, tag.ComponentShard, tag.ShardID(shardID), tag.Reason("shardClosedCallback"))
 	c.removeEngineForShard(shardID, shardItem)
 }
 
@@ -321,7 +322,6 @@ func (c *controller) getOrCreateHistoryShardItem(shardID int) (*historyShardsIte
 }
 
 func (c *controller) removeHistoryShardItem(shardID int, shardItem *historyShardsItem) (*historyShardsItem, error) {
-	nShards := 0
 	c.Lock()
 	defer c.Unlock()
 
@@ -336,11 +336,8 @@ func (c *controller) removeHistoryShardItem(shardID int, shardItem *historyShard
 	}
 
 	delete(c.historyShards, shardID)
-	nShards = len(c.historyShards)
-
 	c.metricsScope.IncCounter(metrics.ShardItemRemovedCounter)
-
-	currentShardItem.logger.Info("Shard item state changed", tag.LifeCycleStopped, tag.ComponentShardItem, tag.Number(int64(nShards)))
+	currentShardItem.logger.Info("Shard item state changed", tag.LifeCycleStopped, tag.ComponentShardItem, tag.Number(int64(len(c.historyShards))))
 	return currentShardItem, nil
 }
 
@@ -425,7 +422,7 @@ func (c *controller) acquireShards() {
 }
 
 func (c *controller) doShutdown() {
-	c.logger.Info("Shard controller state changed", tag.LifeCycleStopping)
+	c.logger.Info("Shard controller state changed", tag.LifeCycleStopping, tag.Reason("shutdown"))
 	c.Lock()
 	defer c.Unlock()
 	for _, item := range c.historyShards {
@@ -482,6 +479,8 @@ func (i *historyShardsItem) getOrCreateEngine(
 func (i *historyShardsItem) stopEngine() {
 	i.Lock()
 	defer i.Unlock()
+
+	i.logger.Info("Shard item stopEngine called", tag.ComponentShardEngine, tag.Dynamic("status", i.status))
 
 	switch i.status {
 	case historyShardsItemStatusInitialized:

--- a/service/history/shard/controller.go
+++ b/service/history/shard/controller.go
@@ -241,8 +241,13 @@ func (c *controller) ShardIDs() []int32 {
 func (c *controller) removeEngineForShard(shardID int, shardItem *historyShardsItem) {
 	sw := c.metricsScope.StartTimer(metrics.RemoveEngineForShardLatency)
 	defer sw.Stop()
+	c.logger.Info("removeEngineForShard called", tag.ShardID(shardID))
+	defer c.logger.Info("removeEngineForShard completed", tag.ShardID(shardID))
+
 	currentShardItem, err := c.removeHistoryShardItem(shardID, shardItem)
-	c.logger.Error("Failed to remove history shard item", tag.Error(err), tag.ShardID(shardID))
+	if err != nil {
+		c.logger.Error("Failed to remove history shard item", tag.Error(err), tag.ShardID(shardID))
+	}
 	if shardItem != nil {
 		// if shardItem is not nil, then currentShardItem either equals to shardItem or is nil
 		// in both cases, we need to stop the engine in shardItem


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We observed an edge case where shard ownership is lost but underlying queues still trying to process logs indefinitely. 

```
2025-04-16T23:00:05.401121696Z		Shard item state changed  Started  	
2025-04-16T23:00:05.401130712Z		Shard engine state changed  Starting  		
2025-04-16T23:00:05.413873782Z		Shard engine state changed  Started 			
2025-04-16T23:00:06.688440842Z		Domain Failover Start.
2025-04-16T23:05:07.432866951Z 		Closing shard: updateShardInfoLocked failed due to stolen shard.    
2025-04-16T23:05:07.432928603Z     	Shard controller state changed	Stopping	
```

The last line above comes from `shardClosedCallback()` which calls `removeEngineForShard()`.
`removeEngineForShard()` calls removeHistoryShardItem() which is supposed to log:
      `["Shard item state changed" Stopped]`. 

That log is missing so either
  a. it fails to acquire lock on shard controller OR
  b. one of [these](https://github.com/cadence-workflow/cadence/blob/034e506d9a3263fceb02438e853f4bb4902426b3/service/history/shard/controller.go#L329-L336) error conditions returns error
	
`removeEngineForShard()` calls `stopEngine()` on given shardItem or currentShardItem. If the code reaches here then condition b above must be true.
	
The `stopEngine()` has a [switch](https://github.com/cadence-workflow/cadence/blob/034e506d9a3263fceb02438e853f4bb4902426b3/service/history/shard/controller.go#L486) statement. It only calls history engine's `Stop()` function if status was Started. Engine is never stopped otherwise it would log `["Shard engine state changed" Stopping]`.

Two possibilities:
1. removeHistoryShardItem() fails to acquire lock because of deadlock OR
2. historyShardsItem's status wasn’t Started so engine.Stop() was never called.


Also notice that domain failover started ~1s before shard was stolen. Domain failover handling locks task processing. This may be cause some deadlock but don't have a clear working theory on it yet.

So adding logs to relevant places to narrow down the issue.