### PR TITLE
Improve logs to detect double activity events

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1321,6 +1321,8 @@ const (
 	HistoryExecutionCacheScope
 	// HistoryWorkflowCacheScope is the scope used by history workflow cache
 	HistoryWorkflowCacheScope
+	// HistoryFlushBufferedEventsScope is the scope used by history when flushing buffered events
+	HistoryFlushBufferedEventsScope
 
 	NumHistoryScopes
 )
@@ -2018,6 +2020,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		LargeExecutionBlobShardScope:                                    {operation: "LargeExecutionBlobShard"},
 		HistoryExecutionCacheScope:                                      {operation: "HistoryExecutionCache"},
 		HistoryWorkflowCacheScope:                                       {operation: "HistoryWorkflowCache"},
+		HistoryFlushBufferedEventsScope:                                 {operation: "HistoryFlushBufferedEvents"},
 	},
 	// Matching Scope Names
 	Matching: {
@@ -2420,6 +2423,7 @@ const (
 	DecisionRetriesExceededCounter
 	StaleMutableStateCounter
 	DataInconsistentCounter
+	DuplicateActivityTaskEventCounter
 	TimerResurrectionCounter
 	TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading
 	TimerProcessingDeletionTimerNoopDueToWFRunning

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3156,6 +3156,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		DecisionRetriesExceededCounter:                               {metricName: "decision_retries_exceeded", metricType: Counter},
 		StaleMutableStateCounter:                                     {metricName: "stale_mutable_state", metricType: Counter},
 		DataInconsistentCounter:                                      {metricName: "data_inconsistent", metricType: Counter},
+		DuplicateActivityTaskEventCounter:                            {metricName: "duplicate_activity_task_event", metricType: Counter},
 		TimerResurrectionCounter:                                     {metricName: "timer_resurrection", metricType: Counter},
 		TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading:  {metricName: "timer_processing_skipping_deletion_due_to_missing_mutable_state", metricType: Counter},
 		TimerProcessingDeletionTimerNoopDueToWFRunning:               {metricName: "timer_processing_skipping_deletion_due_to_running", metricType: Counter},

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -501,8 +501,18 @@ func (e *mutableStateBuilder) FlushBufferedEvents() error {
 		}
 	}
 
+	e.logDuplicatedActivityEvents(newBufferedEvents)
+
 	// no decision in-flight, flush all buffered events to committed bucket
 	if !e.HasInFlightDecision() {
+		// adding logs to help identify duplicate activity task events
+		// duplicated activity events can cause DecisionTaskFailed events with cause UNHANDLED_DECISION
+		// and cause workflow to be stuck in decision task failed state
+		// this can be removed after the root cause is identified and fixed
+		// TODO: remove this after the root cause is identified and fixed or add deduplication
+		e.logDuplicatedActivityEvents(e.bufferedEvents)
+		e.logDuplicatedActivityEvents(e.updateBufferedEvents)
+
 		// flush persisted buffered events
 		if len(e.bufferedEvents) > 0 {
 			reorderFunc(e.bufferedEvents)
@@ -517,6 +527,8 @@ func (e *mutableStateBuilder) FlushBufferedEvents() error {
 		// clear pending buffered events
 		e.updateBufferedEvents = nil
 
+		e.logDuplicatedActivityEvents(reorderedEvents)
+
 		// Put back all the reordered buffer events at the end
 		if len(reorderedEvents) > 0 {
 			newCommittedEvents = append(newCommittedEvents, reorderedEvents...)
@@ -529,13 +541,6 @@ func (e *mutableStateBuilder) FlushBufferedEvents() error {
 
 	newCommittedEvents = e.trimEventsAfterWorkflowClose(newCommittedEvents)
 	e.hBuilder.history = newCommittedEvents
-
-	// adding logs to help identify duplicate activity task events
-	// duplicated activity events can cause DecisionTaskFailed events with cause UNHANDLED_DECISION
-	// and cause workflow to be stuck in decision task failed state
-	// this can be removed after the root cause is identified and fixed
-	// TODO: remove this after the root cause is identified and fixed or add deduplication
-	e.logDuplicatedActivityEvents()
 
 	// make sure all new committed events have correct EventID
 	e.assignEventIDToBufferedEvents()
@@ -2261,7 +2266,7 @@ func (e *mutableStateBuilder) logDataInconsistency() {
 		tag.WorkflowRunID(runID),
 	)
 }
-func (e *mutableStateBuilder) logDuplicatedActivityEvents() {
+func (e *mutableStateBuilder) logDuplicatedActivityEvents(events []*types.HistoryEvent) {
 	type activityTaskUniqueEventParams struct {
 		eventType        types.EventType
 		scheduledEventID int64
@@ -2272,33 +2277,46 @@ func (e *mutableStateBuilder) logDuplicatedActivityEvents() {
 	activityTaskUniqueEvents := make(map[activityTaskUniqueEventParams]struct{})
 
 	checkActivityTaskEventUniqueness := func(event *types.HistoryEvent) {
-		uniqueEventParams := activityTaskUniqueEventParams{
-			eventType: event.GetEventType(),
-		}
+		var uniqueEventParams activityTaskUniqueEventParams
 
 		var scheduledEventID int64
 
 		switch event.GetEventType() {
 		case types.EventTypeActivityTaskStarted:
 			scheduledEventID = event.ActivityTaskStartedEventAttributes.GetScheduledEventID()
-			uniqueEventParams.scheduledEventID = scheduledEventID
-			uniqueEventParams.attempt = event.ActivityTaskStartedEventAttributes.Attempt
+			uniqueEventParams = activityTaskUniqueEventParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+				attempt:          event.ActivityTaskStartedEventAttributes.Attempt,
+			}
 		case types.EventTypeActivityTaskCompleted:
 			scheduledEventID = event.ActivityTaskCompletedEventAttributes.GetScheduledEventID()
-			uniqueEventParams.scheduledEventID = scheduledEventID
-			uniqueEventParams.startedEventID = event.ActivityTaskCompletedEventAttributes.GetStartedEventID()
+			uniqueEventParams = activityTaskUniqueEventParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+				startedEventID:   event.ActivityTaskCompletedEventAttributes.GetStartedEventID(),
+			}
 		case types.EventTypeActivityTaskFailed:
 			scheduledEventID = event.ActivityTaskFailedEventAttributes.GetScheduledEventID()
-			uniqueEventParams.scheduledEventID = scheduledEventID
-			uniqueEventParams.startedEventID = event.ActivityTaskFailedEventAttributes.GetStartedEventID()
+			uniqueEventParams = activityTaskUniqueEventParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+				startedEventID:   event.ActivityTaskFailedEventAttributes.GetStartedEventID(),
+			}
 		case types.EventTypeActivityTaskCanceled:
 			scheduledEventID = event.ActivityTaskCanceledEventAttributes.GetScheduledEventID()
-			uniqueEventParams.scheduledEventID = scheduledEventID
-			uniqueEventParams.startedEventID = event.ActivityTaskCanceledEventAttributes.StartedEventID
+			uniqueEventParams = activityTaskUniqueEventParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+				startedEventID:   event.ActivityTaskCanceledEventAttributes.StartedEventID,
+			}
 		case types.EventTypeActivityTaskTimedOut:
 			scheduledEventID = event.ActivityTaskTimedOutEventAttributes.GetScheduledEventID()
-			uniqueEventParams.scheduledEventID = scheduledEventID
-			uniqueEventParams.startedEventID = event.ActivityTaskTimedOutEventAttributes.StartedEventID
+			uniqueEventParams = activityTaskUniqueEventParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+				startedEventID:   event.ActivityTaskTimedOutEventAttributes.StartedEventID,
+			}
 		default:
 			return
 		}
@@ -2316,7 +2334,7 @@ func (e *mutableStateBuilder) logDuplicatedActivityEvents() {
 		}
 	}
 
-	for _, event := range e.hBuilder.history {
+	for _, event := range events {
 		checkActivityTaskEventUniqueness(event)
 	}
 }

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -3604,13 +3604,13 @@ func TestCloseTransactionAsMutation(t *testing.T) {
 
 func Test__logDuplicatedActivityEvents(t *testing.T) {
 	testCases := []struct {
-		name         string
-		buildHistory func(msb *mutableStateBuilder) []*types.HistoryEvent
-		assertions   func(*testing.T, *observer.ObservedLogs)
+		name        string
+		buildEvents func(msb *mutableStateBuilder) []*types.HistoryEvent
+		assertions  func(*testing.T, *observer.ObservedLogs)
 	}{
 		{
 			name: "no duplicates",
-			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+			buildEvents: func(msb *mutableStateBuilder) []*types.HistoryEvent {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskStarted)
 				event1.ActivityTaskStartedEventAttributes = &types.ActivityTaskStartedEventAttributes{
 					ScheduledEventID: 1,
@@ -3629,7 +3629,7 @@ func Test__logDuplicatedActivityEvents(t *testing.T) {
 		},
 		{
 			name: "started event duplicated",
-			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+			buildEvents: func(msb *mutableStateBuilder) []*types.HistoryEvent {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskStarted)
 				event1.ActivityTaskStartedEventAttributes = &types.ActivityTaskStartedEventAttributes{
 					ScheduledEventID: 1,
@@ -3649,7 +3649,7 @@ func Test__logDuplicatedActivityEvents(t *testing.T) {
 		},
 		{
 			name: "completed event duplicated",
-			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+			buildEvents: func(msb *mutableStateBuilder) []*types.HistoryEvent {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCompleted)
 				event1.ActivityTaskCompletedEventAttributes = &types.ActivityTaskCompletedEventAttributes{
 					ScheduledEventID: 1,
@@ -3667,7 +3667,7 @@ func Test__logDuplicatedActivityEvents(t *testing.T) {
 		},
 		{
 			name: "canceled event duplicated",
-			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+			buildEvents: func(msb *mutableStateBuilder) []*types.HistoryEvent {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCanceled)
 				event1.ActivityTaskCanceledEventAttributes = &types.ActivityTaskCanceledEventAttributes{
 					ScheduledEventID: 1,
@@ -3685,7 +3685,7 @@ func Test__logDuplicatedActivityEvents(t *testing.T) {
 		},
 		{
 			name: "failed event duplicated",
-			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+			buildEvents: func(msb *mutableStateBuilder) []*types.HistoryEvent {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskFailed)
 				event1.ActivityTaskFailedEventAttributes = &types.ActivityTaskFailedEventAttributes{
 					ScheduledEventID: 1,
@@ -3703,7 +3703,7 @@ func Test__logDuplicatedActivityEvents(t *testing.T) {
 		},
 		{
 			name: "timed out event duplicated",
-			buildHistory: func(msb *mutableStateBuilder) []*types.HistoryEvent {
+			buildEvents: func(msb *mutableStateBuilder) []*types.HistoryEvent {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskTimedOut)
 				event1.ActivityTaskTimedOutEventAttributes = &types.ActivityTaskTimedOutEventAttributes{
 					ScheduledEventID: 1,
@@ -3740,9 +3740,7 @@ func Test__logDuplicatedActivityEvents(t *testing.T) {
 			msb.executionInfo.WorkflowID = "some-workflow-id"
 			msb.executionInfo.RunID = "some-run-id"
 
-			msb.hBuilder.history = tc.buildHistory(msb)
-
-			msb.logDuplicatedActivityEvents()
+			msb.logDuplicatedActivityEvents(tc.buildEvents(msb))
 
 			tc.assertions(t, observedLogs)
 		})

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -3740,7 +3740,7 @@ func Test__logDuplicatedActivityEvents(t *testing.T) {
 			msb.executionInfo.WorkflowID = "some-workflow-id"
 			msb.executionInfo.RunID = "some-run-id"
 
-			msb.logDuplicatedActivityEvents(tc.buildEvents(msb))
+			msb.logDuplicatedActivityEvents(tc.buildEvents(msb), "test")
 
 			tc.assertions(t, observedLogs)
 		})


### PR DESCRIPTION
**What changed?**
Split down the logs and added them in better locations to be able to identify whether the duplication comes from when the events are added, when they are being buffered or after that.

**Why?**
Previously it would not be possible to know where the duplication came from.

**How did you test it?**
Unit test and local tests

**Potential risks**
There may be some latency added when flushing buffered events, but it shouldn't be significative.

**Release notes**

**Documentation Changes**
