### PR TITLE
Active-active domain support - Part 2/N

### DIFF
--- a/common/activecluster/fake.go
+++ b/common/activecluster/fake.go
@@ -33,7 +33,7 @@ var (
 	cluster0Result = &LookupResult{
 		Region:          "region0",
 		ClusterName:     "cluster0",
-		FailoverVersion: 1,
+		FailoverVersion: 0,
 	}
 
 	cluster1Result = &LookupResult{

--- a/common/resource/resource_mock.go
+++ b/common/resource/resource_mock.go
@@ -43,6 +43,7 @@ import (
 	frontend "github.com/uber/cadence/client/frontend"
 	history "github.com/uber/cadence/client/history"
 	matching "github.com/uber/cadence/client/matching"
+	activecluster "github.com/uber/cadence/common/activecluster"
 	archiver "github.com/uber/cadence/common/archiver"
 	provider "github.com/uber/cadence/common/archiver/provider"
 	queue "github.com/uber/cadence/common/asyncworkflow/queue"
@@ -124,6 +125,20 @@ func NewMockResource(ctrl *gomock.Controller) *MockResource {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResource) EXPECT() *MockResourceMockRecorder {
 	return m.recorder
+}
+
+// GetActiveClusterManager mocks base method.
+func (m *MockResource) GetActiveClusterManager() activecluster.Manager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveClusterManager")
+	ret0, _ := ret[0].(activecluster.Manager)
+	return ret0
+}
+
+// GetActiveClusterManager indicates an expected call of GetActiveClusterManager.
+func (mr *MockResourceMockRecorder) GetActiveClusterManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveClusterManager", reflect.TypeOf((*MockResource)(nil).GetActiveClusterManager))
 }
 
 // GetArchivalMetadata mocks base method.

--- a/common/resource/resource_test_utils.go
+++ b/common/resource/resource_test_utils.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/asyncworkflow/queue"
@@ -68,6 +69,7 @@ type (
 
 		DomainCache             *cache.MockDomainCache
 		DomainMetricsScopeCache cache.DomainMetricsScopeCache
+		ActiveClusterMgr        *activecluster.MockManager
 		DomainReplicationQueue  *domain.MockReplicationQueue
 		TimeSource              clock.TimeSource
 		PayloadSerializer       persistence.PayloadSerializer
@@ -177,6 +179,7 @@ func NewTest(
 		DomainCache:             cache.NewMockDomainCache(controller),
 		DomainMetricsScopeCache: cache.NewDomainMetricsScopeCache(),
 		DomainReplicationQueue:  domainReplicationQueue,
+		ActiveClusterMgr:        activecluster.NewMockManager(controller),
 		TimeSource:              clock.NewRealTimeSource(),
 		PayloadSerializer:       persistence.NewPayloadSerializer(),
 		MetricsClient:           metrics.NewClient(scope, serviceMetricsIndex),
@@ -261,6 +264,10 @@ func (s *Test) GetDomainMetricsScopeCache() cache.DomainMetricsScopeCache {
 func (s *Test) GetDomainReplicationQueue() domain.ReplicationQueue {
 	// user should implement this method for test
 	return s.DomainReplicationQueue
+}
+
+func (s *Test) GetActiveClusterManager() activecluster.Manager {
+	return s.ActiveClusterMgr
 }
 
 // GetTimeSource for testing

--- a/common/resource/types.go
+++ b/common/resource/types.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/asyncworkflow/queue"
@@ -74,6 +75,7 @@ type Resource interface {
 
 	GetDomainCache() cache.DomainCache
 	GetDomainMetricsScopeCache() cache.DomainMetricsScopeCache
+	GetActiveClusterManager() activecluster.Manager
 	GetTimeSource() clock.TimeSource
 	GetPayloadSerializer() persistence.PayloadSerializer
 	GetMetricsClient() metrics.Client

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -2177,6 +2177,8 @@ type EntityNotExistsError struct {
 	Message        string `json:"message,required"`
 	CurrentCluster string `json:"currentCluster,omitempty"`
 	ActiveCluster  string `json:"activeCluster,omitempty"`
+	// TODO(active-active): Add ActiveClusters field
+	// ActiveClusters []string `json:"activeClusters,omitempty"`
 }
 
 // WorkflowExecutionAlreadyCompletedError is an internal type (TBD...)

--- a/config/dynamicconfig/replication_simulation_activeactive.yml
+++ b/config/dynamicconfig/replication_simulation_activeactive.yml
@@ -1,0 +1,18 @@
+# This file is used as dynamicconfig override for "activeactive" replication simulation scenario configured via host/testdata/replication_simulation_activeactive.yaml
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"
+history.replicatorTaskBatchSize:
+  - value: 25
+    constraints: {}
+frontend.failoverCoolDown:
+  - value: 5s
+history.ReplicationTaskProcessorStartWait: # default is 5s. repl task processor sleeps this much before processing received messages.
+  - value: 10ms
+history.standbyTaskMissingEventsResendDelay:
+  - value: 5s
+history.standbyTaskMissingEventsDiscardDelay:
+  - value: 10s
+history.standbyClusterDelay:
+  - value: 10s

--- a/docker/buildkite/docker-compose-local-replication-simulation.yml
+++ b/docker/buildkite/docker-compose-local-replication-simulation.yml
@@ -71,6 +71,7 @@ services:
       - "SECONDARY_FRONTEND_SERVICE=cadence-cluster1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ENABLE_GLOBAL_DOMAIN=true"
+      - "ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN=true"
       - "KEYSPACE=cadence_primary"
       - "VISIBILITY_KEYSPACE=cadence_visibility_primary"
       - "LOG_LEVEL=debug"
@@ -118,6 +119,7 @@ services:
       - "CASSANDRA_SEEDS=cassandra"
       - "IS_NOT_PRIMARY=true"
       - "ENABLE_GLOBAL_DOMAIN=true"
+      - "ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN=true"
       - "KEYSPACE=cadence_secondary"
       - "VISIBILITY_KEYSPACE=cadence_visibility_secondary"
       - "LOG_LEVEL=debug"
@@ -163,6 +165,8 @@ services:
       - -c
       - >
         go run *.go --cluster cluster0 | tee worker0.log
+    environment:
+      - REPLICATION_SIMULATION_CONFIG=testdata/replication_simulation_${SCENARIO}.yaml
     depends_on:
       cadence-cluster0:
         condition: service_started
@@ -194,6 +198,8 @@ services:
       - -c
       - >
         go run *.go --cluster cluster1 | tee worker1.log
+    environment:
+      - REPLICATION_SIMULATION_CONFIG=testdata/replication_simulation_${SCENARIO}.yaml
     depends_on:
       cadence-cluster0:
         condition: service_started

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -246,7 +246,10 @@ clusterGroupMetadata:
                 enable: {{ default .Env.ENABLE_OAUTH "false" }}
                 type: "OAuthAuthorization"
                 privateKey: {{ default .Env.OAUTH_PRIVATE_KEY "" }}
-        {{- if .Env.ENABLE_GLOBAL_DOMAIN }}
+            {{- if .Env.ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN }}
+            region: "region0"
+            {{- end }}
+        {{- if or .Env.ENABLE_GLOBAL_DOMAIN .Env.ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN }}
         cluster1:
             enabled: true
             initialFailoverVersion: 2
@@ -257,7 +260,17 @@ clusterGroupMetadata:
                 enable: {{ default .Env.ENABLE_OAUTH "false" }}
                 type: "OAuthAuthorization"
                 privateKey: {{ default .Env.OAUTH_PRIVATE_KEY "" }}
+            {{- if .Env.ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN }}
+            region: "region1"
+            {{- end }}
         {{- end }}
+    {{- if .Env.ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN }}
+    regions:
+        region0:
+            initialFailoverVersion: 1
+        region1:
+            initialFailoverVersion: 3
+    {{- end }}
 
 archival:
   history:

--- a/service/frontend/api/handler_test.go
+++ b/service/frontend/api/handler_test.go
@@ -1050,6 +1050,7 @@ func TestRespondActivityTaskFailed(t *testing.T) {
 				numHistoryShards,
 				false,
 				"hostname",
+				mockResource.GetLogger(),
 			)
 
 			wh := NewWorkflowHandler(mockResource, config, mockVersionChecker, nil)
@@ -1903,6 +1904,7 @@ func (s *workflowHandlerSuite) TestRestartWorkflowExecution__Success() {
 			numHistoryShards,
 			false,
 			"hostname",
+			s.mockResource.GetLogger(),
 		),
 	)
 	ctx := context.Background()
@@ -1969,6 +1971,7 @@ func (s *workflowHandlerSuite) getWorkflowExecutionHistory(nextEventID int64, tr
 			numHistoryShards,
 			false,
 			"hostname",
+			s.mockResource.GetLogger(),
 		),
 	)
 	ctx := context.Background()
@@ -2223,6 +2226,7 @@ func (s *workflowHandlerSuite) newConfig(dynamicClient dc.Client) *frontendcfg.C
 		numHistoryShards,
 		false,
 		"hostname",
+		s.mockResource.GetLogger(),
 	)
 	config.EmitSignalNameMetricsTag = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
 	return config
@@ -3502,6 +3506,7 @@ func TestStartWorkflowExecutionAsync(t *testing.T) {
 				numHistoryShards,
 				false,
 				"hostname",
+				mockResource.GetLogger(),
 			)
 			wh := NewWorkflowHandler(mockResource, cfg, mockVersionChecker, nil)
 			wh.producerManager = mockProducerManager
@@ -3622,6 +3627,7 @@ func TestSignalWithStartWorkflowExecutionAsync(t *testing.T) {
 				numHistoryShards,
 				false,
 				"hostname",
+				mockResource.GetLogger(),
 			)
 			wh := NewWorkflowHandler(mockResource, cfg, mockVersionChecker, nil)
 			wh.producerManager = mockProducerManager
@@ -3734,6 +3740,7 @@ func TestRequestCancelWorkflowExecution(t *testing.T) {
 				numHistoryShards,
 				false,
 				"hostname",
+				mockResource.GetLogger(),
 			)
 			wh := NewWorkflowHandler(mockResource, cfg, mockVersionChecker, nil)
 			wh.shuttingDown = tc.shuttingDown
@@ -3934,6 +3941,7 @@ func TestQueryWorkflow(t *testing.T) {
 				numHistoryShards,
 				false,
 				"hostname",
+				mockResource.GetLogger(),
 			)
 			cfg.BlobSizeLimitError = func(domain string) int { return 10 }
 			cfg.BlobSizeLimitWarn = func(domain string) int { return 9 }
@@ -4059,6 +4067,7 @@ func TestDescribeWorkflowExecution(t *testing.T) {
 				numHistoryShards,
 				false,
 				"hostname",
+				mockResource.GetLogger(),
 			)
 
 			wh := NewWorkflowHandler(mockResource, cfg, mockVersionChecker, nil)

--- a/service/frontend/api/refresh_workflow_tasks_test.go
+++ b/service/frontend/api/refresh_workflow_tasks_test.go
@@ -103,14 +103,16 @@ func setupMocksForWorkflowHandler(t *testing.T) (*WorkflowHandler, *mockDeps) {
 		dynamicClient:          dynamicClient,
 	}
 
+	logger := testlogger.New(t)
 	config := frontendcfg.NewConfig(
 		dynamicconfig.NewCollection(
 			dynamicClient,
-			testlogger.New(t),
+			logger,
 		),
 		numHistoryShards,
 		false,
 		"hostname",
+		logger,
 	)
 	wh := NewWorkflowHandler(deps.mockResource, config, deps.mockVersionChecker, deps.mockDomainHandler)
 	wh.requestValidator = deps.mockRequestValidator

--- a/service/frontend/api/request_validator_test.go
+++ b/service/frontend/api/request_validator_test.go
@@ -50,6 +50,7 @@ func setupMocksForRequestValidator(t *testing.T) (*requestValidatorImpl, *mockDe
 		numHistoryShards,
 		true,
 		"hostname",
+		logger,
 	)
 	deps := &mockDeps{
 		dynamicClient: dynamicClient,

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -24,10 +24,13 @@ import (
 	"github.com/uber/cadence/common/domain"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log"
 )
 
 // Config represents configuration for cadence-frontend service
 type Config struct {
+	Logger log.Logger
+
 	NumHistoryShards                int
 	IsAdvancedVisConfigExist        bool
 	DomainConfig                    domain.Config
@@ -120,8 +123,9 @@ type Config struct {
 }
 
 // NewConfig returns new service config with default values
-func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVisConfigExist bool, hostName string) *Config {
+func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVisConfigExist bool, hostName string, logger log.Logger) *Config {
 	return &Config{
+		Logger:                                      logger,
 		NumHistoryShards:                            numHistoryShards,
 		IsAdvancedVisConfigExist:                    isAdvancedVisConfigExist,
 		PersistenceMaxQPS:                           dc.GetIntProperty(dynamicproperties.FrontendPersistenceMaxQPS),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -43,6 +43,7 @@ var ignoreField = configTestCase{key: dynamicproperties.UnknownIntKey}
 
 func TestNewConfig(t *testing.T) {
 	fields := map[string]configTestCase{
+		"Logger":                                      ignoreField, // Logger is not a config to be compared in test
 		"NumHistoryShards":                            {nil, 1001},
 		"IsAdvancedVisConfigExist":                    {nil, true},
 		"HostName":                                    {nil, "hostname"},
@@ -116,9 +117,10 @@ func TestNewConfig(t *testing.T) {
 		"FailoverHistoryMaxSize": {dynamicproperties.FrontendFailoverHistoryMaxSize, 44},
 	}
 	client := dynamicconfig.NewInMemoryClient()
-	dc := dynamicconfig.NewCollection(client, testlogger.New(t))
+	logger := testlogger.New(t)
+	dc := dynamicconfig.NewCollection(client, logger)
 
-	config := NewConfig(dc, 1001, true, "hostname")
+	config := NewConfig(dc, 1001, true, "hostname", logger)
 
 	assertFieldsMatch(t, *config, client, fields)
 	assertFieldsMatch(t, config.DomainConfig, client, domainFields)

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -79,6 +79,7 @@ func NewService(
 		params.PersistenceConfig.NumHistoryShards,
 		isAdvancedVisExistInConfig,
 		params.HostName,
+		params.Logger,
 	)
 
 	serviceResource, err := resource.New(

--- a/service/frontend/wrappers/clusterredirection/api_test.go
+++ b/service/frontend/wrappers/clusterredirection/api_test.go
@@ -100,6 +100,7 @@ func (s *clusterRedirectionHandlerSuite) SetupTest() {
 		0,
 		false,
 		"hostname",
+		s.mockResource.GetLogger(),
 	)
 	dh := domain.NewMockHandler(s.controller)
 	frontendHandler := api.NewWorkflowHandler(s.mockResource, s.config, client.NewVersionChecker(), dh)

--- a/service/frontend/wrappers/clusterredirection/policy_test.go
+++ b/service/frontend/wrappers/clusterredirection/policy_test.go
@@ -163,6 +163,7 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) SetupTest() {
 		0,
 		false,
 		"hostname",
+		logger,
 	)
 	s.policy = newSelectedOrAllAPIsForwardingPolicy(
 		s.currentClusterName,

--- a/service/history/resource/resource_mock.go
+++ b/service/history/resource/resource_mock.go
@@ -43,6 +43,7 @@ import (
 	frontend "github.com/uber/cadence/client/frontend"
 	history "github.com/uber/cadence/client/history"
 	matching "github.com/uber/cadence/client/matching"
+	activecluster "github.com/uber/cadence/common/activecluster"
 	archiver "github.com/uber/cadence/common/archiver"
 	provider "github.com/uber/cadence/common/archiver/provider"
 	queue "github.com/uber/cadence/common/asyncworkflow/queue"
@@ -86,6 +87,20 @@ func NewMockResource(ctrl *gomock.Controller) *MockResource {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResource) EXPECT() *MockResourceMockRecorder {
 	return m.recorder
+}
+
+// GetActiveClusterManager mocks base method.
+func (m *MockResource) GetActiveClusterManager() activecluster.Manager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveClusterManager")
+	ret0, _ := ret[0].(activecluster.Manager)
+	return ret0
+}
+
+// GetActiveClusterManager indicates an expected call of GetActiveClusterManager.
+func (mr *MockResourceMockRecorder) GetActiveClusterManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveClusterManager", reflect.TypeOf((*MockResource)(nil).GetActiveClusterManager))
 }
 
 // GetArchivalMetadata mocks base method.

--- a/simulation/matching/run.sh
+++ b/simulation/matching/run.sh
@@ -22,11 +22,13 @@ docker-compose -f docker/buildkite/docker-compose-local-matching-simulation.yml 
 function check_test_failure()
 {
   faillog=$(grep 'FAIL: TestMatchingSimulationSuite' -B 10 test.log 2>/dev/null || true)
-  if [ -z "$faillog" ]; then
+  timeoutlog=$(grep 'test timed out' test.log 2>/dev/null || true)
+  if [ -z "$faillog" ] && [ -z "$timeoutlog" ]; then
     echo "Passed"
   else
     echo 'Test failed!!!'
-    echo "$faillog"
+    echo "Fail log: $faillog"
+    echo "Timeout log: $timeoutlog"
     echo "Check test.log file for more details"
     exit 1
   fi

--- a/simulation/replication/run.sh
+++ b/simulation/replication/run.sh
@@ -12,32 +12,38 @@ set -eo pipefail
 testCase="${1:-default}"
 testCfg="testdata/replication_simulation_$testCase.yaml"
 now="$(date '+%Y-%m-%d-%H-%M-%S')"
-timestamp="${2:-$now}"
+rerun="${2:-}"
+timestamp="${3:-$now}"
 testName="test-$testCase-$timestamp"
 resultFolder="replication-simulator-output"
 mkdir -p "$resultFolder"
 eventLogsFile="$resultFolder/$testName-events.json"
 testSummaryFile="$resultFolder/$testName-summary.txt"
 
-echo "Removing some of the previous containers (if exists) to start fresh"
-docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
-  down cassandra cadence-cluster0 cadence-cluster1 replication-simulator
+# Prune everything and rebuild images unless rerun is specified
+if [ "$rerun" != "rerun" ]; then
+  echo "Removing some of the previous containers (if exists) to start fresh"
+  docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
+    down cassandra cadence-cluster0 cadence-cluster1 cadence-worker0 cadence-worker1 replication-simulator
 
-echo "Each simulation run creates multiple new giant container images. Running docker system prune to avoid disk space issues"
-docker system prune -f
+  echo "Each simulation run creates multiple new giant container images. Running docker system prune to avoid disk space issues"
+  docker system prune -f
 
-echo "Building test images"
-docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
-  build cadence-cluster0 cadence-cluster1 replication-simulator cadence-worker0 cadence-worker1
+  echo "Building test images"
+  docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
+    build cadence-cluster0 cadence-cluster1 cadence-worker0 cadence-worker1 replication-simulator
+fi
 
 function check_test_failure()
 {
   faillog=$(grep 'FAIL: TestReplicationSimulation' -B 10 test.log 2>/dev/null || true)
-  if [ -z "$faillog" ]; then
+  timeoutlog=$(grep 'test timed out' test.log 2>/dev/null || true)
+  if [ -z "$faillog" ] && [ -z "$timeoutlog" ]; then
     echo "Passed"
   else
     echo 'Test failed!!!'
-    echo "$faillog"
+    echo "Fail log: $faillog"
+    echo "Timeout log: $timeoutlog"
     echo "Check test.log file for more details"
     exit 1
   fi

--- a/simulation/replication/testdata/replication_simulation_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive.yaml
@@ -1,0 +1,49 @@
+# This file is a replication simulation scenario spec.
+# It is parsed into ReplicationSimulationConfig struct.
+# Replication simulation for this file can be run via ./simulation/replication/run.sh activeactive
+# Dynamic config overrides can be set via config/dynamicconfig/replication_simulation_activeactive.yml
+clusters:
+  cluster0:
+    grpcEndpoint: "cadence-cluster0:7833"
+  cluster1:
+    grpcEndpoint: "cadence-cluster1:7833"
+
+# primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
+primaryCluster: "cluster0"
+
+domain:
+  name: test-domain-aa
+  activeClusters:
+  - cluster0
+  - cluster1
+
+operations:
+  - op: start_workflow
+    at: 0s
+    workflowID: wf1
+    cluster: cluster0
+    workflowDuration: 60s
+
+  - op: start_workflow
+    at: 0s
+    workflowID: wf2
+    cluster: cluster1
+    workflowDuration: 60s
+
+  - op: validate
+    at: 70s
+    workflowID: wf1
+    cluster: cluster0
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster0
+      completedByWorkersInCluster: cluster1 # it should complete in cluster1 because of fake logic in activecluster/manager.go
+
+  - op: validate
+    at: 70s
+    workflowID: wf2
+    cluster: cluster1
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster1
+      completedByWorkersInCluster: cluster1

--- a/simulation/replication/testdata/replication_simulation_default.yaml
+++ b/simulation/replication/testdata/replication_simulation_default.yaml
@@ -10,6 +10,12 @@ clusters:
 # primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
 primaryCluster: "cluster0"
 
+
+domain:
+  name: test-domain
+  activeClusters:
+  - cluster0
+
 operations:
   - op: start_workflow
     at: 0s
@@ -17,9 +23,9 @@ operations:
     cluster: cluster0
     workflowDuration: 35s
 
-  - op: failover # failover from cluster0 to cluster1
+  - op: change_active_clusters # failover from cluster0 to cluster1
     at: 20s
-    newActiveCluster: cluster1
+    newActiveClusters: ["cluster1"]
     # failoverTimeoutSec: 5 # unset means force failover. setting it means graceful failover request
 
   - op: validate

--- a/simulation/replication/types/types.go
+++ b/simulation/replication/types/types.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	DefaultTestCase = "testdata/replication_simulation_default.yaml"
-	DomainName      = "test-domain"
 	TasklistName    = "test-tasklist"
 	WorkflowName    = "test-workflow"
 	ActivityName    = "test-activity"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This PR is continuation of active-active domain mode introduction ([design](https://github.com/cadence-workflow/cadence/blob/master/docs/design/active-active/active-active.md)). A few slightly related changes bundled together:

- Resource implementation changes to include `activecluster.Manager` which is the new component to be passed around in follow up PRs
- Frontend changes
	- Custom redirection policy override for active-active domains. This is temporary implementation. It will be changed in follow up PR.
	- Pass around logger up to the redirection policy code so we can actually log things there.
- Config template changes:
	- Introduce `ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN`. We had `ENABLE_GLOBAL_DOMAIN` before which will be interpreted as is but for active-passive domains.
	- Add region section to the config when the above is enabled. Don't expect anyone to use it yet.
- Replication simulation changes:
	- Support for active-active domain
	- Rename "failover" operation to "change_active_cluster"
	- Support different simulation scenarios via env variable. Corresponding docker compose file updates to pick dynamicconfig file based on scenario.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- unit tests
- normal replication simulation via `./simulation/replication/run.sh default`

**What's next?**
- Change history/matching to use `activecluster.Manager` so all cluster and failover version lookups go thru it
- IDL changes for domain data and a few error types
- Start workflow handler populates workflow activeness metadata in execution table
- EntityActiveRegion lookup db table schema change and corresponding persistence CRUD impl.
- Example entity watcher implementation
- Remove fake impl. in `activecluster.Manager` and use actual db table records
- Update frontend redirection lookup to decide where to forward based on `activecluster.Manager`
- Test failover scenarios and flush out details etc.
- TBD