### PR TITLE
Address test races caused by deferred logs

### DIFF
--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -412,10 +412,10 @@ func (t *timerQueueProcessor) drain() {
 }
 
 func (t *timerQueueProcessor) completeTimerLoop() {
+	defer t.shutdownWG.Done()
+
 	t.logger.Info("Timer queue processor completeTimerLoop")
 	defer t.logger.Info("Timer queue processor completeTimerLoop completed")
-
-	defer t.shutdownWG.Done()
 
 	completeTimer := time.NewTimer(t.config.TimerProcessorCompleteTimerInterval())
 	defer completeTimer.Stop()

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -185,7 +185,6 @@ func (t *timerQueueProcessorBase) Stop() {
 	}
 
 	t.logger.Info("Timer queue processor state changed", tag.LifeCycleStopping)
-	defer t.logger.Info("Timer queue processor state changed", tag.LifeCycleStopped)
 
 	t.timerGate.Stop()
 	close(t.shutdownCh)
@@ -200,6 +199,7 @@ func (t *timerQueueProcessorBase) Stop() {
 	}
 
 	t.redispatcher.Stop()
+	t.logger.Info("Timer queue processor state changed", tag.LifeCycleStopped)
 }
 
 func (t *timerQueueProcessorBase) processorPump() {

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -370,10 +370,10 @@ func (t *transferQueueProcessor) drain() {
 }
 
 func (t *transferQueueProcessor) completeTransferLoop() {
+	defer t.shutdownWG.Done()
+
 	t.logger.Info("Transfer queue processor completeTransferLoop")
 	defer t.logger.Info("Transfer queue processor completeTransferLoop completed")
-
-	defer t.shutdownWG.Done()
 
 	completeTimer := time.NewTimer(t.config.TransferProcessorCompleteTransferInterval())
 	defer completeTimer.Stop()

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -184,7 +184,6 @@ func (t *transferQueueProcessorBase) Stop() {
 	}
 
 	t.logger.Info("Transfer queue processor state changed", tag.LifeCycleStopping)
-	defer t.logger.Info("Transfer queue processor state changed", tag.LifeCycleStopped)
 
 	close(t.shutdownCh)
 	if t.startJitterTimer != nil {
@@ -204,6 +203,7 @@ func (t *transferQueueProcessorBase) Stop() {
 	}
 
 	t.redispatcher.Stop()
+	t.logger.Info("Transfer queue processor state changed", tag.LifeCycleStopped)
 }
 
 func (t *transferQueueProcessorBase) notifyNewTask(info *hcommon.NotifyTaskInfo) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

The recently added deferred lifecycle logs (#6838) caused races during tests because
1. `shutdownWG` was marked as done before the final log due to missoredered defers in queue processors
2. Stop implementation in queue processor base is not leak free (doesn't wait for underlying goroutines to return) which causes late logs so changed those by moving the log line to the bottom instead of deferring. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Reduce test flakiness

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`go test -timeout 90s github.com/uber/cadence/service/history/queue -race -count 10`
