### PR TITLE
Pass logger to redirect policy directly instead of using frontend's config struct

### DIFF
--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -29,8 +29,6 @@ import (
 
 // Config represents configuration for cadence-frontend service
 type Config struct {
-	Logger log.Logger
-
 	NumHistoryShards                int
 	IsAdvancedVisConfigExist        bool
 	DomainConfig                    domain.Config
@@ -124,8 +122,8 @@ type Config struct {
 
 // NewConfig returns new service config with default values
 func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVisConfigExist bool, hostName string, logger log.Logger) *Config {
+	logger.Debugf("Creating new frontend config for host %s, numHistoryShards: %d, isAdvancedVisConfigExist: %t", hostName, numHistoryShards, isAdvancedVisConfigExist)
 	return &Config{
-		Logger:                                      logger,
 		NumHistoryShards:                            numHistoryShards,
 		IsAdvancedVisConfigExist:                    isAdvancedVisConfigExist,
 		PersistenceMaxQPS:                           dc.GetIntProperty(dynamicproperties.FrontendPersistenceMaxQPS),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -43,7 +43,6 @@ var ignoreField = configTestCase{key: dynamicproperties.UnknownIntKey}
 
 func TestNewConfig(t *testing.T) {
 	fields := map[string]configTestCase{
-		"Logger":                                      ignoreField, // Logger is not a config to be compared in test
 		"NumHistoryShards":                            {nil, 1001},
 		"IsAdvancedVisConfigExist":                    {nil, true},
 		"HostName":                                    {nil, "hostname"},

--- a/service/frontend/templates/clusterredirection.tmpl
+++ b/service/frontend/templates/clusterredirection.tmpl
@@ -42,6 +42,7 @@ func NewAPIHandler(
 		config,
 		resource.GetDomainCache(),
 		policy,
+		resource.GetLogger(),
 	)
 
 	return &clusterRedirectionHandler{

--- a/service/frontend/wrappers/clusterredirection/api_generated.go
+++ b/service/frontend/wrappers/clusterredirection/api_generated.go
@@ -65,6 +65,7 @@ func NewAPIHandler(
 		config,
 		resource.GetDomainCache(),
 		policy,
+		resource.GetLogger(),
 	)
 
 	return &clusterRedirectionHandler{

--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/types"
 	frontendcfg "github.com/uber/cadence/service/frontend/config"
@@ -95,6 +96,7 @@ type (
 		allDomainAPIs      bool
 		selectedAPIs       map[string]struct{}
 		targetCluster      string
+		logger             log.Logger
 	}
 )
 
@@ -139,8 +141,13 @@ var allowedAPIsForDeprecatedDomains = map[string]struct{}{
 }
 
 // RedirectionPolicyGenerator generate corresponding redirection policy
-func RedirectionPolicyGenerator(clusterMetadata cluster.Metadata, config *frontendcfg.Config,
-	domainCache cache.DomainCache, policy config.ClusterRedirectionPolicy) ClusterRedirectionPolicy {
+func RedirectionPolicyGenerator(
+	clusterMetadata cluster.Metadata,
+	config *frontendcfg.Config,
+	domainCache cache.DomainCache,
+	policy config.ClusterRedirectionPolicy,
+	logger log.Logger,
+) ClusterRedirectionPolicy {
 	switch policy.Policy {
 	case DCRedirectionPolicyDefault:
 		// default policy, noop
@@ -149,16 +156,16 @@ func RedirectionPolicyGenerator(clusterMetadata cluster.Metadata, config *fronte
 		return newNoopRedirectionPolicy(clusterMetadata.GetCurrentClusterName())
 	case DCRedirectionPolicySelectedAPIsForwarding:
 		currentClusterName := clusterMetadata.GetCurrentClusterName()
-		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, false, selectedAPIsForwardingRedirectionPolicyAPIAllowlist, "")
+		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, false, selectedAPIsForwardingRedirectionPolicyAPIAllowlist, "", logger)
 	case DCRedirectionPolicySelectedAPIsForwardingV2:
 		currentClusterName := clusterMetadata.GetCurrentClusterName()
-		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, false, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, "")
+		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, false, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, "", logger)
 	case DCRedirectionPolicyAllDomainAPIsForwarding:
 		currentClusterName := clusterMetadata.GetCurrentClusterName()
-		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, true, selectedAPIsForwardingRedirectionPolicyAPIAllowlist, policy.AllDomainApisForwardingTargetCluster)
+		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, true, selectedAPIsForwardingRedirectionPolicyAPIAllowlist, policy.AllDomainApisForwardingTargetCluster, logger)
 	case DCRedirectionPolicyAllDomainAPIsForwardingV2:
 		currentClusterName := clusterMetadata.GetCurrentClusterName()
-		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, true, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, policy.AllDomainApisForwardingTargetCluster)
+		return newSelectedOrAllAPIsForwardingPolicy(currentClusterName, config, domainCache, true, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, policy.AllDomainApisForwardingTargetCluster, logger)
 
 	default:
 		panic(fmt.Sprintf("Unknown DC redirection policy %v", policy.Policy))
@@ -190,6 +197,7 @@ func newSelectedOrAllAPIsForwardingPolicy(
 	allDomainAPIs bool,
 	selectedAPIs map[string]struct{},
 	targetCluster string,
+	logger log.Logger,
 ) *selectedOrAllAPIsForwardingRedirectionPolicy {
 	return &selectedOrAllAPIsForwardingRedirectionPolicy{
 		currentClusterName: currentClusterName,
@@ -198,6 +206,7 @@ func newSelectedOrAllAPIsForwardingPolicy(
 		allDomainAPIs:      allDomainAPIs,
 		selectedAPIs:       selectedAPIs,
 		targetCluster:      targetCluster,
+		logger:             logger,
 	}
 }
 
@@ -300,11 +309,11 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) getTargetClusterAndI
 	}
 
 	isActiveActive := domainEntry.GetReplicationConfig().IsActiveActive()
-	policy.config.Logger.Debugf("Domain %v is active-active: %v", domainEntry.GetInfo().Name, isActiveActive)
+	policy.logger.Debugf("Domain %v is active-active: %v", domainEntry.GetInfo().Name, isActiveActive)
 	if isActiveActive {
 		// TODO(active-active):
 		// - Update generated API code to pass workflow id/run id to this callback and lookup active cluster
-		policy.config.Logger.Debug("Handling active-active domain call in the receiving cluster for now", tag.WorkflowDomainName(domainEntry.GetInfo().Name))
+		policy.logger.Debug("Handling active-active domain call in the receiving cluster for now", tag.WorkflowDomainName(domainEntry.GetInfo().Name))
 		return policy.currentClusterName, true
 	}
 

--- a/service/frontend/wrappers/clusterredirection/policy_test.go
+++ b/service/frontend/wrappers/clusterredirection/policy_test.go
@@ -172,6 +172,7 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) SetupTest() {
 		false,
 		selectedAPIsForwardingRedirectionPolicyAPIAllowlist,
 		"",
+		logger,
 	)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I needed logger in redirection policy and passed it there inside frontend's Config. However it's not the right places because it's used solely as dynamicconfig carrier and has special test cases for it. So removing logger from there and passing it to the generated clusterredirection layer.

