### PR TITLE
Fix warnings in replication simulation

### DIFF
--- a/simulation/replication/run.sh
+++ b/simulation/replication/run.sh
@@ -23,14 +23,14 @@ testSummaryFile="$resultFolder/$testName-summary.txt"
 # Prune everything and rebuild images unless rerun is specified
 if [ "$rerun" != "rerun" ]; then
   echo "Removing some of the previous containers (if exists) to start fresh"
-  docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
+  SCENARIO=$testCase docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
     down cassandra cadence-cluster0 cadence-cluster1 cadence-worker0 cadence-worker1 replication-simulator
 
   echo "Each simulation run creates multiple new giant container images. Running docker system prune to avoid disk space issues"
   docker system prune -f
 
   echo "Building test images"
-  docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
+  SCENARIO=$testCase docker-compose -f docker/buildkite/docker-compose-local-replication-simulation.yml \
     build cadence-cluster0 cadence-cluster1 cadence-worker0 cadence-worker1 replication-simulator
 fi
 


### PR DESCRIPTION
**What changed?**
Add scenario to docker-compose executions to prevent docker warnings for SCENARIO variable not set in replication simulation.

**Why?**
Prevent docker warnings as it could confuse users when running replication simulation.

**How did you test it?**
Tested locally

**Potential risks**
No risk

**Release notes**

**Documentation Changes**
