### PR TITLE
Active-active domain support - Part 3/N 

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -2207,6 +2207,7 @@ func (p *TaskListPartition) ToInternalType() *types.TaskListPartition {
 	return &types.TaskListPartition{IsolationGroups: p.IsolationGroups}
 }
 
+// TODO(active-active): Update unit tests of all components that use this function to cover active-active case
 func (d *DomainReplicationConfig) IsActiveActive() bool {
 	return d != nil && d.ActiveClusters != nil
 }

--- a/common/resource/resource_test_utils.go
+++ b/common/resource/resource_test_utils.go
@@ -168,6 +168,11 @@ func NewTest(
 
 	asyncWorkflowQueueProvider := queue.NewMockProvider(controller)
 
+	activeClusterMgr := activecluster.NewMockManager(controller)
+	activeClusterMgr.EXPECT().ClusterNameForFailoverVersion(gomock.Any(), gomock.Any()).DoAndReturn(func(version int64, domainID string) (string, error) {
+		return cluster.TestActiveClusterMetadata.ClusterNameForFailoverVersion(version)
+	}).AnyTimes()
+
 	return &Test{
 		MetricsScope: scope,
 
@@ -179,7 +184,7 @@ func NewTest(
 		DomainCache:             cache.NewMockDomainCache(controller),
 		DomainMetricsScopeCache: cache.NewDomainMetricsScopeCache(),
 		DomainReplicationQueue:  domainReplicationQueue,
-		ActiveClusterMgr:        activecluster.NewMockManager(controller),
+		ActiveClusterMgr:        activeClusterMgr,
 		TimeSource:              clock.NewRealTimeSource(),
 		PayloadSerializer:       persistence.NewPayloadSerializer(),
 		MetricsClient:           metrics.NewClient(scope, serviceMetricsIndex),

--- a/service/history/decision/handler.go
+++ b/service/history/decision/handler.go
@@ -553,9 +553,7 @@ Update_History_Loop:
 				continueAsNewBuilder,
 			)
 		} else {
-			handler.logger.Debugf("HandleDecisionTaskCompleted calling UpdateWorkflowExecutionAsActive for wfID %s",
-				msBuilder.GetExecutionInfo().WorkflowID,
-			)
+			handler.logger.Debug("HandleDecisionTaskCompleted calling UpdateWorkflowExecutionAsActive", tag.WorkflowID(msBuilder.GetExecutionInfo().WorkflowID))
 			updateErr = wfContext.UpdateWorkflowExecutionAsActive(ctx, handler.shard.GetTimeSource().Now())
 		}
 
@@ -586,9 +584,7 @@ Update_History_Loop:
 					return nil, err
 				}
 
-				handler.logger.Debugf("HandleDecisionTaskCompleted calling UpdateWorkflowExecutionAsActive for wfID %s",
-					msBuilder.GetExecutionInfo().WorkflowID,
-				)
+				handler.logger.Debug("HandleDecisionTaskCompleted calling UpdateWorkflowExecutionAsActive", tag.WorkflowID(msBuilder.GetExecutionInfo().WorkflowID))
 				if err := wfContext.UpdateWorkflowExecutionAsActive(
 					ctx,
 					handler.shard.GetTimeSource().Now(),

--- a/service/history/decision/handler.go
+++ b/service/history/decision/handler.go
@@ -118,6 +118,7 @@ func (handler *handlerImpl) HandleDecisionTaskScheduled(
 
 	return workflow.UpdateWithActionFunc(
 		ctx,
+		handler.logger,
 		handler.executionCache,
 		domainID,
 		workflowExecution,
@@ -170,6 +171,7 @@ func (handler *handlerImpl) HandleDecisionTaskStarted(
 	var resp *types.RecordDecisionTaskStartedResponse
 	err = workflow.UpdateWithActionFunc(
 		ctx,
+		handler.logger,
 		handler.executionCache,
 		domainID,
 		workflowExecution,
@@ -265,7 +267,7 @@ func (handler *handlerImpl) HandleDecisionTaskFailed(
 		RunID:      token.RunID,
 	}
 
-	return workflow.UpdateWithAction(ctx, handler.executionCache, domainID, workflowExecution, true, handler.timeSource.Now(),
+	return workflow.UpdateWithAction(ctx, handler.logger, handler.executionCache, domainID, workflowExecution, true, handler.timeSource.Now(),
 		func(context execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return workflow.ErrAlreadyCompleted
@@ -548,6 +550,7 @@ Update_History_Loop:
 				continueAsNewBuilder,
 			)
 		} else {
+			handler.logger.Debug("HandleDecisionTaskCompleted calling UpdateWorkflowExecutionAsActive", tag.WorkflowID(msBuilder.GetExecutionInfo().WorkflowID))
 			updateErr = wfContext.UpdateWorkflowExecutionAsActive(ctx, handler.shard.GetTimeSource().Now())
 		}
 
@@ -577,6 +580,8 @@ Update_History_Loop:
 				); err != nil {
 					return nil, err
 				}
+
+				handler.logger.Debug("HandleDecisionTaskCompleted calling UpdateWorkflowExecutionAsActive", tag.WorkflowID(msBuilder.GetExecutionInfo().WorkflowID))
 				if err := wfContext.UpdateWorkflowExecutionAsActive(
 					ctx,
 					handler.shard.GetTimeSource().Now(),

--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -36,6 +36,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/checksum"
 	"github.com/uber/cadence/common/client"
@@ -112,6 +113,7 @@ func (s *DecisionHandlerSuite) TestNewHandler() {
 	shardContext.EXPECT().GetDomainCache().Times(2)
 	shardContext.EXPECT().GetMetricsClient().Times(2)
 	shardContext.EXPECT().GetThrottledLogger().Times(1).Return(testlogger.New(s.T()))
+	shardContext.EXPECT().GetActiveClusterManager().Times(1).Return(activecluster.NewMockManager(s.controller))
 	h := NewHandler(shardContext, execution.NewMockCache(s.controller), tokenSerializer)
 	s.NotNil(h)
 	s.Equal("handlerImpl", reflect.ValueOf(h).Elem().Type().Name())

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/client/wrappers/retryable"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/clock"
@@ -100,6 +101,7 @@ type historyEngineImpl struct {
 	metricsClient             metrics.Client
 	logger                    log.Logger
 	throttledLogger           log.Logger
+	activeClusterManager      activecluster.Manager
 	config                    *config.Config
 	archivalClient            warchiver.Client
 	workflowResetter          reset.WorkflowResetter
@@ -187,6 +189,7 @@ func NewEngineWithShardContext(
 		executionCache:       executionCache,
 		logger:               logger.WithTags(tag.ComponentHistoryEngine),
 		throttledLogger:      shard.GetThrottledLogger().WithTags(tag.ComponentHistoryEngine),
+		activeClusterManager: shard.GetActiveClusterManager(),
 		metricsClient:        shard.GetMetricsClient(),
 		historyEventNotifier: historyEventNotifier,
 		config:               config,

--- a/service/history/engine/engineimpl/history_engine3_eventsv2_test.go
+++ b/service/history/engine/engineimpl/history_engine3_eventsv2_test.go
@@ -113,6 +113,10 @@ func (s *engine3Suite) SetupTest() {
 
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().ClusterNameForFailoverVersion(gomock.Any(), gomock.Any()).DoAndReturn(func(version int64, domainID string) (string, error) {
+		return s.mockShard.GetClusterMetadata().ClusterNameForFailoverVersion(version)
+	}).AnyTimes()
+
 	s.logger = s.mockShard.GetLogger()
 
 	h := &historyEngineImpl{

--- a/service/history/engine/engineimpl/notify_tasks.go
+++ b/service/history/engine/engineimpl/notify_tasks.go
@@ -44,7 +44,7 @@ func (e *historyEngineImpl) NotifyNewTransferTasks(info *hcommon.NotifyTaskInfo)
 	}
 
 	task := info.Tasks[0]
-	clusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
+	clusterName, err := e.shard.GetActiveClusterManager().ClusterNameForFailoverVersion(task.GetVersion(), info.ExecutionInfo.DomainID)
 	if err == nil {
 		e.txProcessor.NotifyNewTask(clusterName, info)
 	}
@@ -56,7 +56,7 @@ func (e *historyEngineImpl) NotifyNewTimerTasks(info *hcommon.NotifyTaskInfo) {
 	}
 
 	task := info.Tasks[0]
-	clusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
+	clusterName, err := e.shard.GetActiveClusterManager().ClusterNameForFailoverVersion(task.GetVersion(), info.ExecutionInfo.DomainID)
 	if err == nil {
 		e.timerProcessor.NotifyNewTask(clusterName, info)
 	}

--- a/service/history/engine/engineimpl/poll_mutable_state.go
+++ b/service/history/engine/engineimpl/poll_mutable_state.go
@@ -137,6 +137,7 @@ func (e *historyEngineImpl) updateEntityNotExistsErrorOnPassiveCluster(err error
 				Message:        "Workflow execution not found in non-active cluster",
 				ActiveCluster:  domainNotActiveErrCasted.GetActiveCluster(),
 				CurrentCluster: domainNotActiveErrCasted.GetCurrentCluster(),
+				// TODO(active-active): Add ActiveClusters field
 			}
 		}
 	}

--- a/service/history/engine/engineimpl/reapply_events.go
+++ b/service/history/engine/engineimpl/reapply_events.go
@@ -61,6 +61,7 @@ func (e *historyEngineImpl) ReapplyEvents(
 
 	return workflow.UpdateWithActionFunc(
 		ctx,
+		e.logger,
 		e.executionCache,
 		domainID,
 		currentExecution,
@@ -137,9 +138,11 @@ func (e *historyEngineImpl) ReapplyEvents(
 					execution.NewWorkflow(
 						ctx,
 						e.shard.GetClusterMetadata(),
+						e.shard.GetActiveClusterManager(),
 						wfContext,
 						mutableState,
 						execution.NoopReleaseFn,
+						e.logger,
 					),
 					ndc.EventsReapplicationResetWorkflowReason,
 					toReapplyEvents,

--- a/service/history/engine/engineimpl/record_activity_task_started.go
+++ b/service/history/engine/engineimpl/record_activity_task_started.go
@@ -57,7 +57,7 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 
 	var resurrectError error
 	response := &types.RecordActivityTaskStartedResponse{}
-	err = workflow.UpdateWithAction(ctx, e.executionCache, domainID, workflowExecution, false, e.timeSource.Now(),
+	err = workflow.UpdateWithAction(ctx, e.logger, e.executionCache, domainID, workflowExecution, false, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return workflow.ErrNotExists

--- a/service/history/engine/engineimpl/record_child_execution_completed.go
+++ b/service/history/engine/engineimpl/record_child_execution_completed.go
@@ -49,7 +49,7 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(
 		RunID:      completionRequest.WorkflowExecution.GetRunID(),
 	}
 
-	return e.updateWithActionFn(ctx, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
+	return e.updateWithActionFn(ctx, e.logger, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return workflow.ErrNotExists

--- a/service/history/engine/engineimpl/refresh_workflow_tasks.go
+++ b/service/history/engine/engineimpl/refresh_workflow_tasks.go
@@ -56,6 +56,7 @@ func (e *historyEngineImpl) RefreshWorkflowTasks(
 		e.shard.GetDomainCache(),
 		e.shard.GetEventsCache(),
 		e.shard.GetShardID(),
+		e.logger,
 	)
 
 	err = mutableStateTaskRefresher.RefreshTasks(ctx, mutableState.GetExecutionInfo().StartTimestamp, mutableState)

--- a/service/history/engine/engineimpl/remove_signal_mutable_state.go
+++ b/service/history/engine/engineimpl/remove_signal_mutable_state.go
@@ -46,7 +46,7 @@ func (e *historyEngineImpl) RemoveSignalMutableState(
 		RunID:      request.WorkflowExecution.RunID,
 	}
 
-	return workflow.UpdateWithAction(ctx, e.executionCache, domainID, workflowExecution, false, e.timeSource.Now(),
+	return workflow.UpdateWithAction(ctx, e.logger, e.executionCache, domainID, workflowExecution, false, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return workflow.ErrNotExists

--- a/service/history/engine/engineimpl/request_cancel_workflow_execution.go
+++ b/service/history/engine/engineimpl/request_cancel_workflow_execution.go
@@ -53,7 +53,7 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(
 		workflowExecution.RunID = request.WorkflowExecution.RunID
 	}
 
-	return workflow.UpdateCurrentWithActionFunc(ctx, e.executionCache, e.executionManager, domainID, e.shard.GetDomainCache(), workflowExecution, e.timeSource.Now(),
+	return workflow.UpdateCurrentWithActionFunc(ctx, e.logger, e.executionCache, e.executionManager, domainID, e.shard.GetDomainCache(), workflowExecution, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) (*workflow.UpdateAction, error) {
 			isCancelRequested, cancelRequestID := mutableState.IsCancelRequested()
 			if !mutableState.IsWorkflowExecutionRunning() {

--- a/service/history/engine/engineimpl/reset_sticky_tasklist.go
+++ b/service/history/engine/engineimpl/reset_sticky_tasklist.go
@@ -47,7 +47,7 @@ func (e *historyEngineImpl) ResetStickyTaskList(
 	}
 	domainID := resetRequest.DomainUUID
 
-	err := workflow.UpdateWithAction(ctx, e.executionCache, domainID, *resetRequest.Execution, false, e.timeSource.Now(),
+	err := workflow.UpdateWithAction(ctx, e.logger, e.executionCache, domainID, *resetRequest.Execution, false, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return workflow.ErrAlreadyCompleted

--- a/service/history/engine/engineimpl/reset_workflow_execution.go
+++ b/service/history/engine/engineimpl/reset_workflow_execution.go
@@ -167,9 +167,11 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 		execution.NewWorkflow(
 			ctx,
 			e.shard.GetClusterMetadata(),
+			e.shard.GetActiveClusterManager(),
 			currentContext,
 			currentMutableState,
 			currentReleaseFn,
+			e.logger,
 		),
 		request.GetReason(),
 		nil,
@@ -200,13 +202,13 @@ func (e *historyEngineImpl) isWorkflowResettable(baseMutableState execution.Muta
 		return fmt.Errorf("fail to get failover version of workflow start event: %w", err)
 	}
 
-	startClusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(startVersion)
+	startCluster, err := e.shard.GetActiveClusterManager().ClusterNameForFailoverVersion(startVersion, domainID)
 	if err != nil {
 		return fmt.Errorf("fail to get cluster name for failover version: %w", err)
 	}
 
-	if currentCluster := e.clusterMetadata.GetCurrentClusterName(); currentCluster != startClusterName {
-		return fmt.Errorf("workflow was not started in the current cluster: failover to workflow start cluster %s before reset", startClusterName)
+	if currentCluster := e.clusterMetadata.GetCurrentClusterName(); currentCluster != startCluster {
+		return fmt.Errorf("workflow was not started in the current cluster: failover to workflow start cluster %s before reset", startCluster)
 	}
 
 	return nil

--- a/service/history/engine/engineimpl/respond_activity_task_canceled.go
+++ b/service/history/engine/engineimpl/respond_activity_task_canceled.go
@@ -59,7 +59,7 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(
 
 	var activityStartedTime time.Time
 	var taskList string
-	err = workflow.UpdateWithAction(ctx, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
+	err = workflow.UpdateWithAction(ctx, e.logger, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return workflow.ErrAlreadyCompleted

--- a/service/history/engine/engineimpl/respond_activity_task_completed.go
+++ b/service/history/engine/engineimpl/respond_activity_task_completed.go
@@ -60,7 +60,7 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(
 
 	var activityStartedTime time.Time
 	var taskList string
-	err = workflow.UpdateWithAction(ctx, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
+	err = workflow.UpdateWithAction(ctx, e.logger, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return workflow.ErrAlreadyCompleted

--- a/service/history/engine/engineimpl/respond_activity_task_failed.go
+++ b/service/history/engine/engineimpl/respond_activity_task_failed.go
@@ -62,6 +62,7 @@ func (e *historyEngineImpl) RespondActivityTaskFailed(
 	var taskList string
 	err = workflow.UpdateWithActionFunc(
 		ctx,
+		e.logger,
 		e.executionCache,
 		domainID,
 		workflowExecution,

--- a/service/history/engine/engineimpl/respond_activity_task_heartbeat.go
+++ b/service/history/engine/engineimpl/respond_activity_task_heartbeat.go
@@ -60,7 +60,7 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
 	}
 
 	var cancelRequested bool
-	err = workflow.UpdateWithAction(ctx, e.executionCache, domainID, workflowExecution, false, e.timeSource.Now(),
+	err = workflow.UpdateWithAction(ctx, e.logger, e.executionCache, domainID, workflowExecution, false, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				e.logger.Debug("Heartbeat failed")

--- a/service/history/engine/engineimpl/signal_workflow_execution.go
+++ b/service/history/engine/engineimpl/signal_workflow_execution.go
@@ -54,6 +54,7 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 
 	return workflow.UpdateCurrentWithActionFunc(
 		ctx,
+		e.logger,
 		e.executionCache,
 		e.executionManager,
 		domainID,

--- a/service/history/engine/engineimpl/terminate_workflow_execution.go
+++ b/service/history/engine/engineimpl/terminate_workflow_execution.go
@@ -53,6 +53,7 @@ func (e *historyEngineImpl) TerminateWorkflowExecution(
 
 	return workflow.UpdateCurrentWithActionFunc(
 		ctx,
+		e.logger,
 		e.executionCache,
 		e.executionManager,
 		domainID,

--- a/service/history/engine/testdata/engine_for_tests.go
+++ b/service/history/engine/testdata/engine_for_tests.go
@@ -89,6 +89,13 @@ func NewEngineForTest(t *testing.T, newEngineFn NewEngineFn) *EngineForTest {
 	domainCache.EXPECT().RegisterDomainChangeCallback(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	domainCache.EXPECT().UnregisterDomainChangeCallback(gomock.Any()).Times(1)
 
+	activeClusterMgr := shardCtx.Resource.ActiveClusterMgr
+	activeClusterMgr.EXPECT().RegisterChangeCallback(gomock.Any(), gomock.Any()).AnyTimes()
+
+	activeClusterMgr.EXPECT().ClusterNameForFailoverVersion(gomock.Any(), gomock.Any()).DoAndReturn(func(version int64, domainID string) (string, error) {
+		return shardCtx.GetClusterMetadata().ClusterNameForFailoverVersion(version)
+	}).AnyTimes()
+
 	executionMgr := shardCtx.Resource.ExecutionMgr
 	// RangeCompleteReplicationTask is called by taskProcessorImpl's background loop
 	executionMgr.

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -394,9 +394,7 @@ func (c *contextImpl) LoadWorkflowExecutionWithTaskVersion(
 	if !flushBeforeReady {
 		return c.mutableState, nil
 	}
-	c.logger.Debugf("LoadWorkflowExecutionWithTaskVersion calling UpdateWorkflowExecutionAsActive for wfID %s",
-		c.workflowExecution.GetWorkflowID(),
-	)
+	c.logger.Debug("LoadWorkflowExecutionWithTaskVersion calling UpdateWorkflowExecutionAsActive", tag.WorkflowID(c.workflowExecution.GetWorkflowID()))
 	if err = c.UpdateWorkflowExecutionAsActive(ctx, c.shard.GetTimeSource().Now()); err != nil {
 		return nil, err
 	}
@@ -570,11 +568,7 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 				currentContext.Clear()
 			}
 		}()
-		c.logger.Debugf("ConflictResolveWorkflowExecution calling CloseTransactionAsMutation for domain %s, wfID %s, policy %v",
-			c.domainID,
-			c.workflowExecution.GetWorkflowID(),
-			*currentTransactionPolicy,
-		)
+		c.logger.Debug("ConflictResolveWorkflowExecution calling CloseTransactionAsMutation", tag.WorkflowID(c.workflowExecution.GetWorkflowID()), tag.Dynamic("policy", *currentTransactionPolicy))
 		currentWorkflow, currentWorkflowEventsSeq, err = currentMutableState.CloseTransactionAsMutation(now, *currentTransactionPolicy)
 		if err != nil {
 			return err
@@ -662,10 +656,10 @@ func (c *contextImpl) UpdateWorkflowExecutionAsActive(
 	ctx context.Context,
 	now time.Time,
 ) error {
-	c.logger.Debugf("UpdateWorkflowExecutionAsActive calling UpdateWorkflowExecutionWithNew for wfID %s, current policy %v, new policy %v",
-		c.workflowExecution.GetWorkflowID(),
-		TransactionPolicyPassive,
-		nil,
+	c.logger.Debug("UpdateWorkflowExecutionAsActive calling UpdateWorkflowExecutionWithNew",
+		tag.WorkflowID(c.workflowExecution.GetWorkflowID()),
+		tag.Dynamic("current policy", TransactionPolicyPassive),
+		tag.Dynamic("new policy", nil),
 	)
 	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, TransactionPolicyActive, nil, persistence.CreateWorkflowRequestModeNew)
 }
@@ -676,10 +670,10 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNewAsActive(
 	newContext Context,
 	newMutableState MutableState,
 ) error {
-	c.logger.Debugf("UpdateWorkflowExecutionWithNewAsActive calling UpdateWorkflowExecutionWithNew for wfID %s, current policy %v, new policy %v",
-		c.workflowExecution.GetWorkflowID(),
-		TransactionPolicyPassive,
-		TransactionPolicyActive,
+	c.logger.Debug("UpdateWorkflowExecutionWithNewAsActive calling UpdateWorkflowExecutionWithNew",
+		tag.WorkflowID(c.workflowExecution.GetWorkflowID()),
+		tag.Dynamic("current policy", TransactionPolicyPassive),
+		tag.Dynamic("new policy", TransactionPolicyActive),
 	)
 	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, newContext, newMutableState, TransactionPolicyActive, TransactionPolicyActive.Ptr(), persistence.CreateWorkflowRequestModeNew)
 }
@@ -688,10 +682,10 @@ func (c *contextImpl) UpdateWorkflowExecutionAsPassive(
 	ctx context.Context,
 	now time.Time,
 ) error {
-	c.logger.Debugf("UpdateWorkflowExecutionAsPassive calling UpdateWorkflowExecutionWithNew for wfID %s, current policy %v, new policy %v",
-		c.workflowExecution.GetWorkflowID(),
-		TransactionPolicyPassive,
-		nil,
+	c.logger.Debug("UpdateWorkflowExecutionAsPassive calling UpdateWorkflowExecutionWithNew",
+		tag.WorkflowID(c.workflowExecution.GetWorkflowID()),
+		tag.Dynamic("current policy", TransactionPolicyPassive),
+		tag.Dynamic("new policy", nil),
 	)
 	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, TransactionPolicyPassive, nil, persistence.CreateWorkflowRequestModeReplicated)
 }
@@ -702,10 +696,10 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNewAsPassive(
 	newContext Context,
 	newMutableState MutableState,
 ) error {
-	c.logger.Debugf("UpdateWorkflowExecutionWithNewAsPassive calling UpdateWorkflowExecutionWithNew for wfID %s, current policy %v, new policy %v",
-		c.workflowExecution.GetWorkflowID(),
-		TransactionPolicyPassive,
-		TransactionPolicyPassive,
+	c.logger.Debug("UpdateWorkflowExecutionWithNewAsPassive calling UpdateWorkflowExecutionWithNew",
+		tag.WorkflowID(c.workflowExecution.GetWorkflowID()),
+		tag.Dynamic("current policy", TransactionPolicyPassive),
+		tag.Dynamic("new policy", TransactionPolicyPassive),
 	)
 	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, newContext, newMutableState, TransactionPolicyPassive, TransactionPolicyPassive.Ptr(), persistence.CreateWorkflowRequestModeReplicated)
 }
@@ -720,10 +714,7 @@ func (c *contextImpl) UpdateWorkflowExecutionTasks(
 		}
 	}()
 
-	c.logger.Debugf("UpdateWorkflowExecutionTask calling CloseTransactionAsMutation for domain %s, wfID %s",
-		c.domainID,
-		c.workflowExecution.GetWorkflowID(),
-	)
+	c.logger.Debug("UpdateWorkflowExecutionTask calling CloseTransactionAsMutation", tag.WorkflowID(c.workflowExecution.GetWorkflowID()))
 	currentWorkflow, currentWorkflowEventsSeq, err := c.mutableState.CloseTransactionAsMutation(now, TransactionPolicyPassive)
 	if err != nil {
 		return err
@@ -782,11 +773,8 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 		}
 	}()
 
-	c.logger.Debugf("UpdateWorkflowExecutionWithNew calling CloseTransactionAsMutation for domain %s, wfID %s, policy %v",
-		c.domainID,
-		c.workflowExecution.GetWorkflowID(),
-		currentWorkflowTransactionPolicy,
-	)
+	c.logger.Debug("UpdateWorkflowExecutionWithNew calling CloseTransactionAsMutation", tag.WorkflowID(c.workflowExecution.GetWorkflowID()), tag.Dynamic("policy", currentWorkflowTransactionPolicy))
+
 	currentWorkflow, currentWorkflowEventsSeq, err := c.mutableState.CloseTransactionAsMutation(now, currentWorkflowTransactionPolicy)
 	if err != nil {
 		return err

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -38,7 +38,7 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/log"
+	log "github.com/uber/cadence/common/log"
 	persistence "github.com/uber/cadence/common/persistence"
 	types "github.com/uber/cadence/common/types"
 	events "github.com/uber/cadence/service/history/events"

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -38,7 +38,6 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 
-	log "github.com/uber/cadence/common/log"
 	persistence "github.com/uber/cadence/common/persistence"
 	types "github.com/uber/cadence/common/types"
 	events "github.com/uber/cadence/service/history/events"
@@ -186,24 +185,10 @@ func (m *MockContext) GetWorkflowExecution() MutableState {
 	return ret0
 }
 
-// GetLogger mocks base method.
-func (m *MockContext) GetLogger() log.Logger {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogger")
-	ret0, _ := ret[0].(log.Logger)
-	return ret0
-}
-
 // GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
 func (mr *MockContextMockRecorder) GetWorkflowExecution() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockContext)(nil).GetWorkflowExecution))
-}
-
-// GetLogger indicates an expected call of GetLogger.
-func (mr *MockContextMockRecorder) GetLogger() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockContext)(nil).GetLogger))
 }
 
 // LoadExecutionStats mocks base method.

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -38,6 +38,7 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/log"
 	persistence "github.com/uber/cadence/common/persistence"
 	types "github.com/uber/cadence/common/types"
 	events "github.com/uber/cadence/service/history/events"
@@ -185,10 +186,24 @@ func (m *MockContext) GetWorkflowExecution() MutableState {
 	return ret0
 }
 
+// GetLogger mocks base method.
+func (m *MockContext) GetLogger() log.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogger")
+	ret0, _ := ret[0].(log.Logger)
+	return ret0
+}
+
 // GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
 func (mr *MockContextMockRecorder) GetWorkflowExecution() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockContext)(nil).GetWorkflowExecution))
+}
+
+// GetLogger indicates an expected call of GetLogger.
+func (mr *MockContextMockRecorder) GetLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockContext)(nil).GetLogger))
 }
 
 // LoadExecutionStats mocks base method.

--- a/service/history/execution/context_test.go
+++ b/service/history/execution/context_test.go
@@ -3116,8 +3116,8 @@ func TestLoadWorkflowExecutionWithTaskVersion(t *testing.T) {
 				mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{
 					Name: "test-domain",
 				}, nil, true, nil, 0, nil, 0, 0, 0), nil)
-				mockMutableState.EXPECT().Load(gomock.Any()).Return(errors.New("some error"))
-				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any()).Return(false, errors.New("some error"))
+				mockMutableState.EXPECT().Load(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, errors.New("some error"))
 			},
 			mockGetWorkflowExecutionFn: func(context.Context, *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error) {
 				return &persistence.GetWorkflowExecutionResponse{
@@ -3155,8 +3155,8 @@ func TestLoadWorkflowExecutionWithTaskVersion(t *testing.T) {
 					0,
 					0,
 					0), nil)
-				mockMutableState.EXPECT().Load(gomock.Any()).Return(errors.New("some error"))
-				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any()).Return(false, nil)
+				mockMutableState.EXPECT().Load(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 			},
 			mockGetWorkflowExecutionFn: func(context.Context, *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error) {
 				return &persistence.GetWorkflowExecutionResponse{
@@ -3185,9 +3185,9 @@ func TestLoadWorkflowExecutionWithTaskVersion(t *testing.T) {
 				mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{
 					Name: "test-domain",
 				}, nil, true, nil, 0, nil, 0, 0, 0), nil)
-				mockMutableState.EXPECT().Load(gomock.Any()).Return(errors.New("some error"))
-				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any()).Return(true, nil)
-				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any()).Return(false, nil)
+				mockMutableState.EXPECT().Load(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+				mockMutableState.EXPECT().StartTransaction(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 				mockShard.EXPECT().GetTimeSource().Return(clock.NewMockedTimeSource())
 			},
 			mockGetWorkflowExecutionFn: func(context.Context, *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error) {
@@ -3278,6 +3278,11 @@ func TestUpdateWorkflowExecutionAsActive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &contextImpl{
 				updateWorkflowExecutionWithNewFn: tc.mockUpdateWorkflowExecutionWithNewFn,
+				logger:                           testlogger.New(t),
+				workflowExecution: types.WorkflowExecution{
+					WorkflowID: "test-workflow-id",
+					RunID:      "test-run-id",
+				},
 			}
 			err := ctx.UpdateWorkflowExecutionAsActive(context.Background(), time.Now())
 			if tc.wantErr {
@@ -3321,6 +3326,11 @@ func TestUpdateWorkflowExecutionWithNewAsActive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &contextImpl{
 				updateWorkflowExecutionWithNewFn: tc.mockUpdateWorkflowExecutionWithNewFn,
+				logger:                           testlogger.New(t),
+				workflowExecution: types.WorkflowExecution{
+					WorkflowID: "test-workflow-id",
+					RunID:      "test-run-id",
+				},
 			}
 			err := ctx.UpdateWorkflowExecutionWithNewAsActive(context.Background(), time.Now(), &contextImpl{}, &mutableStateBuilder{})
 			if tc.wantErr {
@@ -3364,6 +3374,11 @@ func TestUpdateWorkflowExecutionAsPassive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &contextImpl{
 				updateWorkflowExecutionWithNewFn: tc.mockUpdateWorkflowExecutionWithNewFn,
+				logger:                           testlogger.New(t),
+				workflowExecution: types.WorkflowExecution{
+					WorkflowID: "test-workflow-id",
+					RunID:      "test-run-id",
+				},
 			}
 			err := ctx.UpdateWorkflowExecutionAsPassive(context.Background(), time.Now())
 			if tc.wantErr {
@@ -3407,6 +3422,11 @@ func TestUpdateWorkflowExecutionWithNewAsPassive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &contextImpl{
 				updateWorkflowExecutionWithNewFn: tc.mockUpdateWorkflowExecutionWithNewFn,
+				logger:                           testlogger.New(t),
+				workflowExecution: types.WorkflowExecution{
+					WorkflowID: "test-workflow-id",
+					RunID:      "test-run-id",
+				},
 			}
 			err := ctx.UpdateWorkflowExecutionWithNewAsPassive(context.Background(), time.Now(), &contextImpl{}, &mutableStateBuilder{})
 			if tc.wantErr {

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -167,7 +167,7 @@ type (
 		IsWorkflowCompleted() bool
 		IsResourceDuplicated(resourceDedupKey definition.DeduplicationID) bool
 		UpdateDuplicatedResource(resourceDedupKey definition.DeduplicationID)
-		Load(*persistence.WorkflowMutableState) error
+		Load(context.Context, *persistence.WorkflowMutableState) error
 		ReplicateActivityInfo(*types.SyncActivityRequest, bool) error
 		ReplicateActivityTaskCancelRequestedEvent(*types.HistoryEvent) error
 		ReplicateActivityTaskCanceledEvent(*types.HistoryEvent) error
@@ -230,7 +230,7 @@ type (
 		SetUpdateCondition(int64)
 		GetUpdateCondition() int64
 
-		StartTransaction(entry *cache.DomainCacheEntry, incomingTaskVersion int64) (bool, error)
+		StartTransaction(ctx context.Context, entry *cache.DomainCacheEntry, incomingTaskVersion int64) (bool, error)
 		CloseTransactionAsMutation(now time.Time, transactionPolicy TransactionPolicy) (*persistence.WorkflowMutation, []*persistence.WorkflowEvents, error)
 		CloseTransactionAsSnapshot(now time.Time, transactionPolicy TransactionPolicy) (*persistence.WorkflowSnapshot, []*persistence.WorkflowEvents, error)
 

--- a/service/history/execution/mutable_state_builder_add_continue_as_new_event_test.go
+++ b/service/history/execution/mutable_state_builder_add_continue_as_new_event_test.go
@@ -323,7 +323,7 @@ func TestAddContinueAsNewEvent(t *testing.T) {
 	for name, td := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-
+			logger := log.NewNoop()
 			msb := &mutableStateBuilder{
 				domainEntry: cache.NewDomainCacheEntryForTest(
 					&persistence.DomainInfo{ID: domainID},
@@ -337,11 +337,12 @@ func TestAddContinueAsNewEvent(t *testing.T) {
 					0,
 				),
 				executionInfo: td.startingState,
-				logger:        log.NewNoop(),
+				logger:        logger,
 				config:        config.NewForTest(),
 			}
 
 			shardContext := shardCtx.NewMockContext(ctrl)
+			shardContext.EXPECT().GetLogger().Return(logger).AnyTimes()
 			historyManager := persistence.NewMockHistoryManager(ctrl)
 			domainCache := cache.NewMockDomainCache(ctrl)
 			taskGenerator := NewMockMutableStateTaskGenerator(ctrl)
@@ -350,7 +351,7 @@ func TestAddContinueAsNewEvent(t *testing.T) {
 			msb.eventsCache = events.NewCache(shardID,
 				historyManager,
 				config.NewForTest(),
-				log.NewNoop(),
+				logger,
 				metrics.NewNoopMetricsClient(),
 				domainCache)
 			msb.shard = shardContext

--- a/service/history/execution/mutable_state_builder_methods_child_workflow_test.go
+++ b/service/history/execution/mutable_state_builder_methods_child_workflow_test.go
@@ -738,8 +738,9 @@ func loadMutableState(t *testing.T, ctx *shard.TestContext, state *persistence.W
 	ctx.Resource.DomainCache.EXPECT().GetDomainName(constants.TestDomainID).Return(constants.TestDomainName, nil).AnyTimes()
 	m := newMutableStateBuilder(ctx,
 		log.NewNoop(),
-		domain)
-	err := m.Load(state)
+		domain,
+	)
+	err := m.Load(context.Background(), state)
 	assert.NoError(t, err)
 	return m
 }

--- a/service/history/execution/mutable_state_decision_task_manager.go
+++ b/service/history/execution/mutable_state_decision_task_manager.go
@@ -741,7 +741,7 @@ func (m *mutableStateDecisionTaskManagerImpl) UpdateDecision(
 	// NOTE: do not update tasklist in execution info
 
 	if m.msb.logger.DebugOn() {
-		m.msb.logger.Debug(fmt.Sprintf(
+		m.msb.logger.Debugf(
 			"Decision Updated: {Schedule: %v, Started: %v, ID: %v, Timeout: %v, Attempt: %v, Timestamp: %v}, Stacktrace: %v",
 			decision.ScheduleID,
 			decision.StartedID,
@@ -750,7 +750,7 @@ func (m *mutableStateDecisionTaskManagerImpl) UpdateDecision(
 			decision.Attempt,
 			decision.StartedTimestamp,
 			debug.Stack(),
-		))
+		)
 	}
 }
 

--- a/service/history/execution/mutable_state_decision_task_manager.go
+++ b/service/history/execution/mutable_state_decision_task_manager.go
@@ -26,6 +26,7 @@ package execution
 
 import (
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -739,15 +740,18 @@ func (m *mutableStateDecisionTaskManagerImpl) UpdateDecision(
 
 	// NOTE: do not update tasklist in execution info
 
-	m.msb.logger.Debug(fmt.Sprintf(
-		"Decision Updated: {Schedule: %v, Started: %v, ID: %v, Timeout: %v, Attempt: %v, Timestamp: %v}",
-		decision.ScheduleID,
-		decision.StartedID,
-		decision.RequestID,
-		decision.DecisionTimeout,
-		decision.Attempt,
-		decision.StartedTimestamp,
-	))
+	if m.msb.logger.DebugOn() {
+		m.msb.logger.Debug(fmt.Sprintf(
+			"Decision Updated: {Schedule: %v, Started: %v, ID: %v, Timeout: %v, Attempt: %v, Timestamp: %v}, Stacktrace: %v",
+			decision.ScheduleID,
+			decision.StartedID,
+			decision.RequestID,
+			decision.DecisionTimeout,
+			decision.Attempt,
+			decision.StartedTimestamp,
+			debug.Stack(),
+		))
+	}
 }
 
 func (m *mutableStateDecisionTaskManagerImpl) HasPendingDecision() bool {

--- a/service/history/execution/mutable_state_decision_task_manager_test.go
+++ b/service/history/execution/mutable_state_decision_task_manager_test.go
@@ -119,7 +119,7 @@ func TestReplicateDecisionTaskScheduledEvent(t *testing.T) {
 				assert.Equal(t, attempt, info.Attempt)
 				assert.Equal(t, scheduleTimestamp, info.ScheduledTimestamp)
 				assert.Equal(t, originalScheduledTimestamp, info.OriginalScheduledTimestamp)
-				assert.Equal(t, 1, observedLogs.FilterMessage(fmt.Sprintf(
+				assert.Equal(t, 1, observedLogs.FilterMessageSnippet(fmt.Sprintf(
 					"Decision Updated: {Schedule: %v, Started: %v, ID: %v, Timeout: %v, Attempt: %v, Timestamp: %v}",
 					scheduleID,
 					commonconstants.EmptyEventID,
@@ -161,7 +161,7 @@ func TestReplicateDecisionTaskScheduledEvent(t *testing.T) {
 			assertions: func(t *testing.T, info *DecisionInfo, err error, observedLogs *observer.ObservedLogs) {
 				assert.ErrorContains(t, err, "some error")
 				assert.Nil(t, info)
-				assert.Equal(t, 1, observedLogs.FilterMessage(fmt.Sprintf(
+				assert.Equal(t, 1, observedLogs.FilterMessageSnippet(fmt.Sprintf(
 					"Decision Updated: {Schedule: %v, Started: %v, ID: %v, Timeout: %v, Attempt: %v, Timestamp: %v}",
 					scheduleID,
 					commonconstants.EmptyEventID,
@@ -211,7 +211,7 @@ func TestReplicateTransientDecisionTaskScheduled(t *testing.T) {
 			},
 			assertions: func(t *testing.T, err error, observedLogs *observer.ObservedLogs) {
 				require.NoError(t, err)
-				assert.Equal(t, 1, observedLogs.FilterMessage(fmt.Sprintf(
+				assert.Equal(t, 1, observedLogs.FilterMessageSnippet(fmt.Sprintf(
 					"Decision Updated: {Schedule: %v, Started: %v, ID: %v, Timeout: %v, Attempt: %v, Timestamp: %v}",
 					0, commonconstants.EmptyEventID, commonconstants.EmptyUUID, 0, 1, 0)).Len())
 			},
@@ -416,7 +416,7 @@ func TestReplicateDecisionTaskStartedEvent(t *testing.T) {
 		result, err := m.ReplicateDecisionTaskStartedEvent(decision, version, scheduleID, startedID, requestID, timeStamp)
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		assert.Equal(t, 1, observedLogs.FilterMessage(fmt.Sprintf(
+		assert.Equal(t, 1, observedLogs.FilterMessageSnippet(fmt.Sprintf(
 			"Decision Updated: {Schedule: %v, Started: %v, ID: %v, Timeout: %v, Attempt: %v, Timestamp: %v}",
 			scheduleID, startedID, requestID, 0, m.msb.executionInfo.Attempt, timeStamp)).Len())
 		assert.Equal(t, version, result.Version)

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -1793,17 +1793,17 @@ func (mr *MockMutableStateMockRecorder) IsWorkflowExecutionRunning() *gomock.Cal
 }
 
 // Load mocks base method.
-func (m *MockMutableState) Load(arg0 *persistence.WorkflowMutableState) error {
+func (m *MockMutableState) Load(arg0 context.Context, arg1 *persistence.WorkflowMutableState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Load", arg0)
+	ret := m.ctrl.Call(m, "Load", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Load indicates an expected call of Load.
-func (mr *MockMutableStateMockRecorder) Load(arg0 any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) Load(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockMutableState)(nil).Load), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockMutableState)(nil).Load), arg0, arg1)
 }
 
 // ReplicateActivityInfo mocks base method.
@@ -2493,18 +2493,18 @@ func (mr *MockMutableStateMockRecorder) SetVersionHistories(arg0 any) *gomock.Ca
 }
 
 // StartTransaction mocks base method.
-func (m *MockMutableState) StartTransaction(entry *cache.DomainCacheEntry, incomingTaskVersion int64) (bool, error) {
+func (m *MockMutableState) StartTransaction(ctx context.Context, entry *cache.DomainCacheEntry, incomingTaskVersion int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartTransaction", entry, incomingTaskVersion)
+	ret := m.ctrl.Call(m, "StartTransaction", ctx, entry, incomingTaskVersion)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StartTransaction indicates an expected call of StartTransaction.
-func (mr *MockMutableStateMockRecorder) StartTransaction(entry, incomingTaskVersion any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) StartTransaction(ctx, entry, incomingTaskVersion any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTransaction", reflect.TypeOf((*MockMutableState)(nil).StartTransaction), entry, incomingTaskVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTransaction", reflect.TypeOf((*MockMutableState)(nil).StartTransaction), ctx, entry, incomingTaskVersion)
 }
 
 // UpdateActivity mocks base method.

--- a/service/history/execution/mutable_state_task_generator_test.go
+++ b/service/history/execution/mutable_state_task_generator_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/constants"
@@ -68,6 +69,7 @@ func (s *mutableStateTaskGeneratorSuite) SetupTest() {
 	s.mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalDomainEntry, nil).AnyTimes()
 
 	s.taskGenerator = NewMutableStateTaskGenerator(
+		log.NewNoop(),
 		constants.TestClusterMetadata,
 		s.mockDomainCache,
 		s.mockMutableState,
@@ -95,6 +97,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowCloseTasks_Jittered
 		// create new mockMutableState so can we can setup separete mock for each test case
 		mockMutableState := NewMockMutableState(s.controller)
 		taskGenerator := NewMutableStateTaskGenerator(
+			log.NewNoop(),
 			constants.TestClusterMetadata,
 			s.mockDomainCache,
 			mockMutableState,
@@ -150,6 +153,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowCloseTasks() {
 		// create new mockMutableState so can we can setup separete mock for each test case
 		mockMutableState := NewMockMutableState(s.controller)
 		taskGenerator := NewMutableStateTaskGenerator(
+			log.NewNoop(),
 			constants.TestClusterMetadata,
 			s.mockDomainCache,
 			mockMutableState,

--- a/service/history/execution/mutable_state_task_refresher_test.go
+++ b/service/history/execution/mutable_state_task_refresher_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
@@ -664,7 +665,7 @@ func TestRefreshTasks(t *testing.T) {
 					WorkflowDeletionJitterRange: dynamicproperties.GetIntPropertyFilteredByDomain(1),
 					IsAdvancedVisConfigExist:    true,
 				},
-				newMutableStateTaskGeneratorFn: func(cluster.Metadata, cache.DomainCache, MutableState) MutableStateTaskGenerator {
+				newMutableStateTaskGeneratorFn: func(log.Logger, cluster.Metadata, cache.DomainCache, MutableState) MutableStateTaskGenerator {
 					return mtg
 				},
 				refreshTasksForWorkflowStartFn:                 tc.refreshTasksForWorkflowStartFn,

--- a/service/history/execution/mutable_state_util_test.go
+++ b/service/history/execution/mutable_state_util_test.go
@@ -341,6 +341,7 @@ func TestCreatePersistenceMutableState(t *testing.T) {
 	mockShardContext.EXPECT().GetTimeSource().Return(clock.NewMockedTimeSource())
 	mockShardContext.EXPECT().GetMetricsClient().Return(metrics.NewClient(tally.NoopScope, metrics.History))
 	mockShardContext.EXPECT().GetDomainCache().Return(mockDomainCache)
+	mockShardContext.EXPECT().GetLogger().Return(logger).AnyTimes()
 
 	builder := newMutableStateBuilder(mockShardContext, logger, constants.TestLocalDomainEntry)
 	builder.pendingActivityInfoIDs[0] = &persistence.ActivityInfo{}

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -52,8 +52,7 @@ type (
 		mockEventsCache  *events.MockCache
 		mockDomainCache  *cache.MockDomainCache
 		mockMutableState *MockMutableState
-
-		logger log.Logger
+		logger           log.Logger
 
 		sourceCluster string
 		stateBuilder  *stateBuilderImpl
@@ -97,6 +96,10 @@ func (s *stateBuilderSuite) SetupTest() {
 	s.logger = s.mockShard.GetLogger()
 
 	s.mockMutableState.EXPECT().GetVersionHistories().Return(persistence.NewVersionHistories(&persistence.VersionHistory{})).AnyTimes()
+
+	// TODO: add mock expectations
+	// s.mockShard.Resource.ActiveClusterMgr.EXPECT()....
+
 	s.stateBuilder = NewStateBuilder(
 		s.mockShard,
 		s.logger,

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -97,9 +97,6 @@ func (s *stateBuilderSuite) SetupTest() {
 
 	s.mockMutableState.EXPECT().GetVersionHistories().Return(persistence.NewVersionHistories(&persistence.VersionHistory{})).AnyTimes()
 
-	// TODO: add mock expectations
-	// s.mockShard.Resource.ActiveClusterMgr.EXPECT()....
-
 	s.stateBuilder = NewStateBuilder(
 		s.mockShard,
 		s.logger,

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -63,12 +63,11 @@ type (
 	}
 
 	stateRebuilderImpl struct {
-		shard           shard.Context
-		domainCache     cache.DomainCache
-		clusterMetadata cluster.Metadata
-		historyV2Mgr    persistence.HistoryManager
-		taskRefresher   MutableStateTaskRefresher
-
+		shard              shard.Context
+		domainCache        cache.DomainCache
+		clusterMetadata    cluster.Metadata
+		historyV2Mgr       persistence.HistoryManager
+		taskRefresher      MutableStateTaskRefresher
 		rebuiltHistorySize int64
 		logger             log.Logger
 	}
@@ -93,6 +92,7 @@ func NewStateRebuilder(
 			shard.GetDomainCache(),
 			shard.GetEventsCache(),
 			shard.GetShardID(),
+			logger,
 		),
 		rebuiltHistorySize: 0,
 		logger:             logger,

--- a/service/history/execution/state_rebuilder_test.go
+++ b/service/history/execution/state_rebuilder_test.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/collection"
@@ -52,14 +53,14 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller        *gomock.Controller
-		mockShard         *shard.TestContext
-		mockEventsCache   *events.MockCache
-		mockTaskRefresher *MockMutableStateTaskRefresher
-		mockDomainCache   *cache.MockDomainCache
-
-		mockHistoryV2Mgr *mocks.HistoryV2Manager
-		logger           log.Logger
+		controller               *gomock.Controller
+		mockShard                *shard.TestContext
+		mockEventsCache          *events.MockCache
+		mockTaskRefresher        *MockMutableStateTaskRefresher
+		mockDomainCache          *cache.MockDomainCache
+		mockActiveClusterManager *activecluster.MockManager
+		mockHistoryV2Mgr         *mocks.HistoryV2Manager
+		logger                   log.Logger
 
 		domainID   string
 		workflowID string
@@ -101,7 +102,8 @@ func (s *stateRebuilderSuite) SetupTest() {
 	s.workflowID = "some random workflow ID"
 	s.runID = uuid.New()
 	s.nDCStateRebuilder = NewStateRebuilder(
-		s.mockShard, s.logger,
+		s.mockShard,
+		s.logger,
 	).(*stateRebuilderImpl)
 	s.nDCStateRebuilder.taskRefresher = s.mockTaskRefresher
 }

--- a/service/history/execution/workflow.go
+++ b/service/history/execution/workflow.go
@@ -26,7 +26,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
@@ -54,7 +56,9 @@ type (
 	}
 
 	workflowImpl struct {
-		clusterMetadata cluster.Metadata
+		logger               log.Logger
+		clusterMetadata      cluster.Metadata
+		activeClusterManager activecluster.Manager
 
 		ctx          context.Context
 		context      Context
@@ -67,18 +71,21 @@ type (
 func NewWorkflow(
 	ctx context.Context,
 	clusterMetadata cluster.Metadata,
+	activeClusterManager activecluster.Manager,
 	context Context,
 	mutableState MutableState,
 	releaseFn ReleaseFunc,
+	logger log.Logger,
 ) Workflow {
 
 	return &workflowImpl{
-		ctx:             ctx,
-		clusterMetadata: clusterMetadata,
-
-		context:      context,
-		mutableState: mutableState,
-		releaseFn:    releaseFn,
+		ctx:                  ctx,
+		clusterMetadata:      clusterMetadata,
+		activeClusterManager: activeClusterManager,
+		logger:               logger,
+		context:              context,
+		mutableState:         mutableState,
+		releaseFn:            releaseFn,
 	}
 }
 
@@ -182,7 +189,7 @@ func (r *workflowImpl) SuppressBy(
 		return TransactionPolicyPassive, nil
 	}
 
-	lastWriteCluster, err := r.clusterMetadata.ClusterNameForFailoverVersion(lastWriteVersion)
+	lastWriteCluster, err := r.activeClusterManager.ClusterNameForFailoverVersion(lastWriteVersion, r.mutableState.GetExecutionInfo().DomainID)
 	if err != nil {
 		return TransactionPolicyActive, err
 	}
@@ -209,13 +216,15 @@ func (r *workflowImpl) FlushBufferedEvents() error {
 		return err
 	}
 
-	lastWriteCluster, err := r.clusterMetadata.ClusterNameForFailoverVersion(lastWriteVersion)
+	lastWriteCluster, err := r.activeClusterManager.ClusterNameForFailoverVersion(lastWriteVersion, r.mutableState.GetExecutionInfo().DomainID)
 	if err != nil {
+		// TODO: add a test for this
 		return err
 	}
 	currentCluster := r.clusterMetadata.GetCurrentClusterName()
 
 	if lastWriteCluster != currentCluster {
+		// TODO: add a test for this
 		return &types.InternalServiceError{
 			Message: "nDCWorkflow encounter workflow with buffered events but last write not from current cluster",
 		}
@@ -230,6 +239,8 @@ func (r *workflowImpl) failDecision(
 ) error {
 
 	// do not persist the change right now, NDC requires transaction
+	r.logger.Debugf("failDecision calling UpdateCurrentVersion for domain %s, wfID %v, lastWriteVersion %v",
+		r.mutableState.GetExecutionInfo().DomainID, r.mutableState.GetExecutionInfo().WorkflowID, lastWriteVersion)
 	if err := r.mutableState.UpdateCurrentVersion(lastWriteVersion, true); err != nil {
 		return err
 	}
@@ -260,6 +271,8 @@ func (r *workflowImpl) terminateWorkflow(
 	}
 
 	// do not persist the change right now, NDC requires transaction
+	r.logger.Debugf("terminateWorkflow calling UpdateCurrentVersion for domain %s, wfID %v, lastWriteVersion %v",
+		r.mutableState.GetExecutionInfo().DomainID, r.mutableState.GetExecutionInfo().WorkflowID, lastWriteVersion)
 	if err := r.mutableState.UpdateCurrentVersion(lastWriteVersion, true); err != nil {
 		return err
 	}

--- a/service/history/execution/workflow_test.go
+++ b/service/history/execution/workflow_test.go
@@ -65,6 +65,7 @@ func (s *workflowSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 	s.mockContext = NewMockContext(s.controller)
+	s.mockContext.EXPECT().GetLogger().Return(testlogger.New(s.T())).AnyTimes()
 	s.mockMutableState = NewMockMutableState(s.controller)
 	s.domainID = uuid.New()
 	s.domainName = "domain-name"
@@ -420,7 +421,7 @@ func (s *workflowSuite) TestFlushBufferedEvents_Success() {
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(true)
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastWriteVersion, nil)
-	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{LastEventTaskID: lastEventTaskID})
+	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{LastEventTaskID: lastEventTaskID}).AnyTimes()
 	s.mockMutableState.EXPECT().UpdateCurrentVersion(lastWriteVersion, true).Return(nil)
 	s.mockMutableState.EXPECT().GetInFlightDecision().Return(decision, true)
 	s.mockMutableState.EXPECT().AddDecisionTaskFailedEvent(decision.ScheduleID, decision.StartedID, types.DecisionTaskFailedCauseFailoverCloseDecision, nil, IdentityHistoryService, "", "", "", "", int64(0), "").Return(&types.HistoryEvent{}, nil)

--- a/service/history/execution/workflow_test.go
+++ b/service/history/execution/workflow_test.go
@@ -65,7 +65,6 @@ func (s *workflowSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 	s.mockContext = NewMockContext(s.controller)
-	s.mockContext.EXPECT().GetLogger().Return(testlogger.New(s.T())).AnyTimes()
 	s.mockMutableState = NewMockMutableState(s.controller)
 	s.domainID = uuid.New()
 	s.domainName = "domain-name"

--- a/service/history/execution/workflow_test.go
+++ b/service/history/execution/workflow_test.go
@@ -31,7 +31,10 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/activecluster"
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
@@ -46,6 +49,7 @@ type (
 		mockMutableState *MockMutableState
 
 		domainID   string
+		domainName string
 		workflowID string
 		runID      string
 	}
@@ -62,8 +66,8 @@ func (s *workflowSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockContext = NewMockContext(s.controller)
 	s.mockMutableState = NewMockMutableState(s.controller)
-
 	s.domainID = uuid.New()
+	s.domainName = "domain-name"
 	s.workflowID = "some random workflow ID"
 	s.runID = uuid.New()
 }
@@ -86,9 +90,11 @@ func (s *workflowSuite) TestGetMethods() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 
 	s.Equal(s.mockContext, nDCWorkflow.GetContext())
@@ -165,9 +171,11 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Error() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 
 	incomingMockContext := NewMockContext(s.controller)
@@ -175,9 +183,11 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Error() {
 	incomingNDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		incomingMockContext,
 		incomingMockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 
 	// cannot suppress by older workflow
@@ -221,9 +231,11 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 
 	incomingRunID := uuid.New()
@@ -234,9 +246,11 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	incomingNDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		incomingMockContext,
 		incomingMockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	incomingMockMutableState.EXPECT().GetLastWriteVersion().Return(incomingLastEventVersion, nil).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
@@ -300,9 +314,11 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Zombiefy() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 
 	incomingRunID := uuid.New()
@@ -313,9 +329,11 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Zombiefy() {
 	incomingNDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		incomingMockContext,
 		incomingMockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	incomingMockMutableState.EXPECT().GetLastWriteVersion().Return(incomingLastEventVersion, nil).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
@@ -347,9 +365,11 @@ func (s *workflowSuite) TestRevive_Zombie_Error() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	err := nDCWorkflow.Revive()
 	s.Error(err)
@@ -363,9 +383,11 @@ func (s *workflowSuite) TestRevive_Zombie_Success() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	err := nDCWorkflow.Revive()
 	s.NoError(err)
@@ -377,9 +399,11 @@ func (s *workflowSuite) TestRevive_NonZombie_Success() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	err := nDCWorkflow.Revive()
 	s.NoError(err)
@@ -407,9 +431,11 @@ func (s *workflowSuite) TestFlushBufferedEvents_Success() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	err := nDCWorkflow.FlushBufferedEvents()
 	s.NoError(err)
@@ -422,9 +448,11 @@ func (s *workflowSuite) TestFlushBufferedEvents_NoBuffer_Success() {
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	err := nDCWorkflow.FlushBufferedEvents()
 	s.NoError(err)
@@ -437,17 +465,54 @@ func (s *workflowSuite) TestFlushBufferedEvents_NoDecision_Success() {
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(true)
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastWriteVersion, nil)
-	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{LastEventTaskID: lastEventTaskID})
+	s.mockMutableState.EXPECT().GetExecutionInfo().Return(
+		&persistence.WorkflowExecutionInfo{
+			DomainID:        s.domainID,
+			WorkflowID:      s.workflowID,
+			RunID:           s.runID,
+			LastEventTaskID: lastEventTaskID,
+		},
+	).AnyTimes()
 	s.mockMutableState.EXPECT().UpdateCurrentVersion(lastWriteVersion, true).Return(nil)
 	s.mockMutableState.EXPECT().GetInFlightDecision().Return(nil, false)
 
 	nDCWorkflow := NewWorkflow(
 		context.Background(),
 		cluster.TestActiveClusterMetadata,
+		s.newTestActiveClusterManager(cluster.TestActiveClusterMetadata),
 		s.mockContext,
 		s.mockMutableState,
 		NoopReleaseFn,
+		testlogger.New(s.T()),
 	)
 	err := nDCWorkflow.FlushBufferedEvents()
 	s.NoError(err)
+}
+
+func (s *workflowSuite) newTestActiveClusterManager(clusterMetadata cluster.Metadata) activecluster.Manager {
+	domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
+		return cache.NewGlobalDomainCacheEntryForTest(
+			&persistence.DomainInfo{
+				ID:   s.domainID,
+				Name: s.domainName,
+			},
+			&persistence.DomainConfig{},
+			&persistence.DomainReplicationConfig{
+				ActiveClusterName: cluster.TestCurrentClusterName,
+				Clusters: []*persistence.ClusterReplicationConfig{
+					{ClusterName: cluster.TestCurrentClusterName},
+					{ClusterName: cluster.TestAlternativeClusterName},
+				},
+			},
+			clusterMetadata.GetAllClusterInfo()[cluster.TestCurrentClusterName].InitialFailoverVersion,
+		), nil
+	}
+
+	// Create and return the active cluster manager
+	return activecluster.NewManager(
+		domainIDToDomainFn,
+		clusterMetadata,
+		nil,
+		testlogger.New(s.T()),
+	)
 }

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -161,8 +161,6 @@ func (h *handlerImpl) Start() {
 	// events notifier must starts before controller
 	h.historyEventNotifier.Start()
 
-	// TODO(taylan): Learn about failover markers and various components involved in this.
-	// There's a replication task type for failover markers.
 	h.failoverCoordinator = failover.NewCoordinator(
 		h.GetDomainManager(),
 		h.GetHistoryClient(),

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -82,7 +82,6 @@ type (
 		queueTaskProcessor      task.Processor
 		failoverCoordinator     failover.Coordinator
 		workflowIDCache         workflowcache.WFCache
-		queueProcessorFactory   queue.ProcessorFactory
 		ratelimitAggregator     algorithm.RequestWeighted
 	}
 )
@@ -162,6 +161,8 @@ func (h *handlerImpl) Start() {
 	// events notifier must starts before controller
 	h.historyEventNotifier.Start()
 
+	// TODO(taylan): Learn about failover markers and various components involved in this.
+	// There's a replication task type for failover markers.
 	h.failoverCoordinator = failover.NewCoordinator(
 		h.GetDomainManager(),
 		h.GetHistoryClient(),

--- a/service/history/ndc/activity_replicator.go
+++ b/service/history/ndc/activity_replicator.go
@@ -196,6 +196,12 @@ func (r *activityReplicatorImpl) SyncActivity(
 		updateMode = persistence.UpdateWorkflowModeBypassCurrent
 	}
 
+	r.logger.Debugf("SyncActivity calling UpdateWorkflowExecutionWithNew for wfID %s, updateMode %v, current policy %v, new policy %v",
+		workflowExecution.GetWorkflowID(),
+		updateMode,
+		execution.TransactionPolicyPassive,
+		nil,
+	)
 	return context.UpdateWorkflowExecutionWithNew(
 		ctx,
 		now,

--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/execution"
@@ -180,9 +181,7 @@ func (r *branchManagerImpl) flushBufferedEvents(
 		return 0, nil, err
 	}
 	// the workflow must be updated as active, to send out replication tasks
-	r.logger.Debugf("flushBufferedEvents calling UpdateWorkflowExecutionAsActive for wfID %s",
-		r.mutableState.GetExecutionInfo().WorkflowID,
-	)
+	r.logger.Debug("flushBufferedEvents calling UpdateWorkflowExecutionAsActive", tag.WorkflowID(r.mutableState.GetExecutionInfo().WorkflowID))
 	if err := targetWorkflow.GetContext().UpdateWorkflowExecutionAsActive(
 		ctx,
 		r.shard.GetTimeSource().Now(),

--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -170,14 +170,19 @@ func (r *branchManagerImpl) flushBufferedEvents(
 	targetWorkflow := execution.NewWorkflow(
 		ctx,
 		r.clusterMetadata,
+		r.shard.GetActiveClusterManager(),
 		r.context,
 		r.mutableState,
 		execution.NoopReleaseFn,
+		r.logger,
 	)
 	if err := targetWorkflow.FlushBufferedEvents(); err != nil {
 		return 0, nil, err
 	}
 	// the workflow must be updated as active, to send out replication tasks
+	r.logger.Debugf("flushBufferedEvents calling UpdateWorkflowExecutionAsActive for wfID %s",
+		r.mutableState.GetExecutionInfo().WorkflowID,
+	)
 	if err := targetWorkflow.GetContext().UpdateWorkflowExecutionAsActive(
 		ctx,
 		r.shard.GetTimeSource().Now(),

--- a/service/history/ndc/branch_manager_test.go
+++ b/service/history/ndc/branch_manager_test.go
@@ -188,7 +188,7 @@ func (s *branchManagerSuite) TestFlushBufferedEvents() {
 	}
 	s.mockMutableState.EXPECT().GetInFlightDecision().Return(decisionInfo, true).Times(1)
 	// GetExecutionInfo's return value is not used by this test
-	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).Times(1)
+	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockMutableState.EXPECT().AddDecisionTaskFailedEvent(
 		decisionInfo.ScheduleID,
 		decisionInfo.StartedID,

--- a/service/history/ndc/existing_workflow_transaction_manager_test.go
+++ b/service/history/ndc/existing_workflow_transaction_manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/execution"
 )
@@ -58,6 +59,7 @@ func (s *transactionManagerForExistingWorkflowSuite) SetupTest() {
 
 	s.updateMgr = newTransactionManagerForExistingWorkflow(
 		s.mockTransactionMgr,
+		testlogger.New(s.T()),
 	).(*transactionManagerForExistingWorkflowImpl)
 }
 

--- a/service/history/ndc/history_replicator_test.go
+++ b/service/history/ndc/history_replicator_test.go
@@ -51,8 +51,7 @@ import (
 )
 
 var (
-	testStopwatch = metrics.NoopScope(metrics.ReplicateHistoryEventsScope).StartTimer(metrics.CacheLatency)
-	testShardID   = 1234
+	testShardID = 1234
 )
 
 func createTestHistoryReplicator(t *testing.T, domainID string) historyReplicatorImpl {
@@ -154,6 +153,9 @@ func TestNewHistoryReplicator_newBranchManager(t *testing.T) {
 	mockShard.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(testShardID).AnyTimes()
 
+	mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+	mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).Times(1)
+
 	testExecutionCache := execution.NewCache(mockShard)
 	mockEventsReapplier := NewMockEventsReapplier(ctrl)
 
@@ -204,6 +206,9 @@ func TestNewHistoryReplicator_newConflictResolver(t *testing.T) {
 	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(testShardID).AnyTimes()
+
+	mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+	mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).Times(1)
 
 	testExecutionCache := execution.NewCache(mockShard)
 	mockEventsReapplier := NewMockEventsReapplier(ctrl)
@@ -258,6 +263,9 @@ func TestNewHistoryReplicator_newWorkflowResetter(t *testing.T) {
 	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(testShardID).AnyTimes()
+
+	mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+	mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).Times(1)
 
 	testExecutionCache := execution.NewCache(mockShard)
 	mockEventsReapplier := NewMockEventsReapplier(ctrl)
@@ -320,6 +328,9 @@ func TestNewHistoryReplicator_newStateBuilder(t *testing.T) {
 	mockShard.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(testShardID).AnyTimes()
 
+	mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+	mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).Times(1)
+
 	testExecutionCache := execution.NewCache(mockShard)
 	mockEventsReapplier := NewMockEventsReapplier(ctrl)
 
@@ -369,6 +380,9 @@ func TestNewHistoryReplicator_newMutableState(t *testing.T) {
 	mockShard.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
 	mockShard.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(testShardID).AnyTimes()
+
+	mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+	mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).Times(1)
 
 	testExecutionCache := execution.NewCache(mockShard)
 	mockEventsReapplier := NewMockEventsReapplier(ctrl)
@@ -1194,6 +1208,8 @@ func Test_applyStartEvents(t *testing.T) {
 			mockReplicationTask := NewMockreplicationTask(ctrl)
 			mockTransactionManager := NewMocktransactionManager(ctrl)
 			mockShard := shard.NewMockContext(ctrl)
+			mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+			mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).AnyTimes()
 			logger := log.NewNoop()
 
 			// Mock affordances
@@ -1594,6 +1610,8 @@ func Test_applyNonStartEventsToCurrentBranch(t *testing.T) {
 			mockMutableState := execution.NewMockMutableState(ctrl)
 			mockTransactionManager := NewMocktransactionManager(ctrl)
 			mockShard := shard.NewMockContext(ctrl)
+			mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+			mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).AnyTimes()
 			logger := log.NewNoop()
 
 			// Mock affordances
@@ -2179,6 +2197,8 @@ func Test_applyNonStartEventsResetWorkflow(t *testing.T) {
 			mockStateBuilder := execution.NewMockStateBuilder(ctrl)
 			mockTransactionManager := NewMocktransactionManager(ctrl)
 			mockShard := shard.NewMockContext(ctrl)
+			mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+			mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).AnyTimes()
 			logger := log.NewNoop()
 
 			// Mock affordances
@@ -2273,6 +2293,8 @@ func Test_notify(t *testing.T) {
 
 			// Mock Shard Context
 			mockShard := shard.NewMockContext(ctrl)
+			mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+			mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).AnyTimes()
 			if test.expectSetCurrentTime {
 				mockShard.EXPECT().GetConfig().Return(&config.Config{
 					StandbyClusterDelay: dynamicproperties.GetDurationPropertyFn(5 * time.Minute),

--- a/service/history/ndc/history_replicator_test.go
+++ b/service/history/ndc/history_replicator_test.go
@@ -28,15 +28,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	commonConfig "github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
@@ -52,7 +55,7 @@ var (
 	testShardID   = 1234
 )
 
-func createTestHistoryReplicator(t *testing.T) historyReplicatorImpl {
+func createTestHistoryReplicator(t *testing.T, domainID string) historyReplicatorImpl {
 	ctrl := gomock.NewController(t)
 
 	mockShard := shard.NewMockContext(ctrl)
@@ -79,7 +82,8 @@ func createTestHistoryReplicator(t *testing.T) historyReplicatorImpl {
 	mockEventsReapplier := NewMockEventsReapplier(ctrl)
 
 	// going into NewHistoryReplicator -> newTransactionManager()
-	mockShard.EXPECT().GetClusterMetadata().Return(cluster.Metadata{}).Times(2)
+	clusterMetadata := cluster.Metadata{}
+	mockShard.EXPECT().GetClusterMetadata().Return(clusterMetadata).Times(2)
 	mockHistoryManager := persistence.NewMockHistoryManager(ctrl)
 	mockShard.EXPECT().GetHistoryManager().Return(mockHistoryManager).Times(3)
 
@@ -93,15 +97,39 @@ func createTestHistoryReplicator(t *testing.T) historyReplicatorImpl {
 	mockShard.EXPECT().GetDomainCache().Return(mockDomainCache).Times(2)
 
 	// going back to NewHistoryReplicator
-	mockHistoryResource.EXPECT().GetClusterMetadata().Return(cluster.Metadata{}).Times(1)
+	mockHistoryResource.EXPECT().GetClusterMetadata().Return(clusterMetadata).Times(1)
+
+	activeClusterManager := newActiveClusterManager(clusterMetadata, domainID, log.NewNoop())
+	mockShard.EXPECT().GetActiveClusterManager().Return(activeClusterManager).AnyTimes()
 
 	replicator := NewHistoryReplicator(mockShard, testExecutionCache, mockEventsReapplier, log.NewNoop())
 	replicatorImpl := replicator.(*historyReplicatorImpl)
 	return *replicatorImpl
 }
 
+func newActiveClusterManager(clusterMetadata cluster.Metadata, domainID string, logger log.Logger) activecluster.Manager {
+	domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
+		return cache.NewGlobalDomainCacheEntryForTest(
+			&persistence.DomainInfo{
+				ID:   domainID,
+				Name: "test",
+			},
+			&persistence.DomainConfig{},
+			&persistence.DomainReplicationConfig{
+				ActiveClusterName: cluster.TestCurrentClusterName,
+				Clusters: []*persistence.ClusterReplicationConfig{
+					{ClusterName: cluster.TestCurrentClusterName},
+					{ClusterName: cluster.TestAlternativeClusterName},
+				},
+			},
+			clusterMetadata.GetAllClusterInfo()[cluster.TestCurrentClusterName].InitialFailoverVersion,
+		), nil
+	}
+	return activecluster.NewManager(domainIDToDomainFn, clusterMetadata, nil, logger)
+}
+
 func TestNewHistoryReplicator(t *testing.T) {
-	assert.NotNil(t, createTestHistoryReplicator(t))
+	assert.NotNil(t, createTestHistoryReplicator(t, uuid.New()))
 }
 
 func TestNewHistoryReplicator_newBranchManager(t *testing.T) {
@@ -383,9 +411,9 @@ func TestNewHistoryReplicator_newMutableState(t *testing.T) {
 }
 
 func TestApplyEvents(t *testing.T) {
-	replicator := createTestHistoryReplicator(t)
+	replicator := createTestHistoryReplicator(t, uuid.New())
 	replicator.newReplicationTaskFn = func(
-		clusterMetadata cluster.Metadata,
+		activeClusterManager activecluster.Manager,
 		historySerializer persistence.PayloadSerializer,
 		taskStartTime time.Time,
 		logger log.Logger,
@@ -443,7 +471,7 @@ func Test_applyEvents_EventTypeWorkflowExecutionStarted(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			// mock objects
-			replicator := createTestHistoryReplicator(t)
+			replicator := createTestHistoryReplicator(t, uuid.New())
 			mockReplicationTask := NewMockreplicationTask(ctrl)
 			mockExecutionCache := execution.NewMockCache(ctrl)
 			replicator.executionCache = mockExecutionCache
@@ -826,7 +854,7 @@ func Test_applyEvents_defaultCase_noErrorBranch(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			// mock objects
-			replicator := createTestHistoryReplicator(t)
+			replicator := createTestHistoryReplicator(t, uuid.New())
 			mockReplicationTask := NewMockreplicationTask(ctrl)
 			mockExecutionCache := execution.NewMockCache(ctrl)
 			mockExecutionContext := execution.NewMockContext(ctrl)
@@ -865,6 +893,7 @@ func Test_applyEvents_defaultCase_noErrorBranch(t *testing.T) {
 				releaseFn execution.ReleaseFunc,
 				task replicationTask,
 				r *historyReplicatorImpl,
+				logger log.Logger,
 			) error {
 				return nil
 			}
@@ -990,7 +1019,7 @@ func Test_applyEvents_defaultCase_errorAndDefault(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			// mock objects
-			replicator := createTestHistoryReplicator(t)
+			replicator := createTestHistoryReplicator(t, uuid.New())
 			mockReplicationTask := NewMockreplicationTask(ctrl)
 			mockExecutionCache := execution.NewMockCache(ctrl)
 			mockExecutionContext := execution.NewMockContext(ctrl)
@@ -1628,6 +1657,8 @@ func Test_applyNonStartEventsToNoneCurrentBranch(t *testing.T) {
 					task replicationTask,
 					transactionManager transactionManager,
 					clusterMetadata cluster.Metadata,
+					shard shard.Context,
+					logger log.Logger,
 				) error {
 					return nil
 				}
@@ -1667,6 +1698,8 @@ func Test_applyNonStartEventsToNoneCurrentBranch(t *testing.T) {
 					task replicationTask,
 					transactionManager transactionManager,
 					clusterMetadata cluster.Metadata,
+					shard shard.Context,
+					logger log.Logger,
 				) error {
 					return fmt.Errorf("test error")
 				}
@@ -1687,7 +1720,7 @@ func Test_applyNonStartEventsToNoneCurrentBranch(t *testing.T) {
 			mockReleaseFn := func(error) {}
 
 			// Create the replicator using createTestHistoryReplicator
-			replicator := createTestHistoryReplicator(t)
+			replicator := createTestHistoryReplicator(t, uuid.New())
 
 			// Mock affordances
 			test.mockTaskAffordance(mockTask)
@@ -1695,7 +1728,7 @@ func Test_applyNonStartEventsToNoneCurrentBranch(t *testing.T) {
 			test.mockApplyNonStartEventsWithoutContinueAsNewAffordance(&replicator)
 
 			// Call the function under test
-			err := applyNonStartEventsToNoneCurrentBranch(ctx.Background(), mockExecutionContext, mockMutableState, 1, mockReleaseFn, mockTask, &replicator)
+			err := applyNonStartEventsToNoneCurrentBranch(ctx.Background(), mockExecutionContext, mockMutableState, 1, mockReleaseFn, mockTask, &replicator, replicator.logger)
 
 			// Assertions
 			assert.Equal(t, test.expectError, err)
@@ -1860,6 +1893,9 @@ func Test_applyNonStartEventsToNoneCurrentBranchWithoutContinueAsNew(t *testing.
 			test.mockTaskAffordance(mockTask)
 			test.mockTransactionManagerAffordance(mockTransactionManager)
 
+			mockShard := shard.NewMockContext(ctrl)
+			activeClusterManager := activecluster.NewMockManager(ctrl)
+			mockShard.EXPECT().GetActiveClusterManager().Return(activeClusterManager).AnyTimes()
 			// Call the function under test
 			err := applyNonStartEventsToNoneCurrentBranchWithoutContinueAsNew(
 				ctx.Background(),
@@ -1870,6 +1906,8 @@ func Test_applyNonStartEventsToNoneCurrentBranchWithoutContinueAsNew(t *testing.
 				mockTask,
 				mockTransactionManager,
 				cluster.Metadata{},
+				mockShard,
+				testlogger.New(t),
 			)
 
 			// Assertions

--- a/service/history/ndc/new_workflow_transaction_manager.go
+++ b/service/history/ndc/new_workflow_transaction_manager.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/events"
@@ -44,6 +45,7 @@ type (
 
 	transactionManagerForNewWorkflowImpl struct {
 		transactionManager transactionManager
+		logger             log.Logger
 	}
 )
 
@@ -51,10 +53,12 @@ var _ transactionManagerForNewWorkflow = (*transactionManagerForNewWorkflowImpl)
 
 func newTransactionManagerForNewWorkflow(
 	transactionManager transactionManager,
+	logger log.Logger,
 ) transactionManagerForNewWorkflow {
 
 	return &transactionManagerForNewWorkflowImpl{
 		transactionManager: transactionManager,
+		logger:             logger,
 	}
 }
 
@@ -308,6 +312,11 @@ func (r *transactionManagerForNewWorkflowImpl) suppressCurrentAndCreateAsCurrent
 		return err
 	}
 
+	r.logger.Debugf("suppressCurrentAndCreateAsCurrent calling UpdateWorkflowExecutionWithNew for wfID %s, current policy %v, new policy %v",
+		currentWorkflow.GetMutableState().GetExecutionInfo().WorkflowID,
+		currentWorkflowPolicy,
+		execution.TransactionPolicyPassive,
+	)
 	return currentWorkflow.GetContext().UpdateWorkflowExecutionWithNew(
 		ctx,
 		now,

--- a/service/history/ndc/new_workflow_transaction_manager_test.go
+++ b/service/history/ndc/new_workflow_transaction_manager_test.go
@@ -412,6 +412,10 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Suppr
 	currentWorkflow := execution.NewMockWorkflow(s.controller)
 	currentContext := execution.NewMockContext(s.controller)
 	currentMutableState := execution.NewMockMutableState(s.controller)
+	currentMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+	}).AnyTimes()
 	var currentReleaseFn execution.ReleaseFunc = func(error) { currentReleaseCalled = true }
 	currentWorkflow.EXPECT().GetContext().Return(currentContext).AnyTimes()
 	currentWorkflow.EXPECT().GetMutableState().Return(currentMutableState).AnyTimes()

--- a/service/history/ndc/new_workflow_transaction_manager_test.go
+++ b/service/history/ndc/new_workflow_transaction_manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/events"
@@ -60,6 +61,7 @@ func (s *transactionManagerForNewWorkflowSuite) SetupTest() {
 
 	s.createManager = newTransactionManagerForNewWorkflow(
 		s.mockTransactionManager,
+		testlogger.New(s.T()),
 	).(*transactionManagerForNewWorkflowImpl)
 }
 

--- a/service/history/ndc/replication_task.go
+++ b/service/history/ndc/replication_task.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/pborman/uuid"
 
-	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -93,7 +93,7 @@ var (
 )
 
 func newReplicationTask(
-	clusterMetadata cluster.Metadata,
+	activeClusterManager activecluster.Manager,
 	historySerializer persistence.PayloadSerializer,
 	taskStartTime time.Time,
 	logger log.Logger,
@@ -119,7 +119,7 @@ func newReplicationTask(
 	lastEvent := events[len(events)-1]
 	version := firstEvent.Version
 
-	sourceCluster, err := clusterMetadata.ClusterNameForFailoverVersion(version)
+	sourceCluster, err := activeClusterManager.ClusterNameForFailoverVersion(version, domainID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -159,7 +159,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Op
 	mutableState.EXPECT().IsCurrentWorkflowGuaranteed().Return(true).AnyTimes()
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetDomainEntry().Return(s.domainEntry).AnyTimes()
-	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{RunID: runID}).Times(1)
+	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{RunID: runID}).AnyTimes()
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyActive, (*execution.TransactionPolicy)(nil), persistence.CreateWorkflowRequestModeReplicated,
@@ -266,6 +266,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_O
 	mutableState.EXPECT().IsCurrentWorkflowGuaranteed().Return(true).AnyTimes()
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetDomainEntry().Return(s.domainEntry).AnyTimes()
+	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(

--- a/service/history/queue/task_allocator.go
+++ b/service/history/queue/task_allocator.go
@@ -94,7 +94,7 @@ func (t *taskAllocatorImpl) VerifyStandbyTask(standbyCluster string, domainID, w
 //   - If domain is not found, it returns (false, nil) indicating the task should be skipped
 //   - If domain is pending active, it returns (false, ErrTaskPendingActive) indicating the task should be retried
 //   - If domain is active in the given cluster, it returns (true, nil) indicating the task should be processed
-//     Special case: if it's a failover queue, it returns (true, nil) indicating the task should be processed
+//     Special case: if it's a failover queue (cluster == ""), it returns (true, nil) indicating the task should be processed in any cluster
 func (t *taskAllocatorImpl) verifyTaskActiveness(cluster string, domainID, wfID, rID string, task interface{}) (b bool, e error) {
 	if t.logger.DebugOn() {
 		defer func() {

--- a/service/history/queue/task_allocator_test.go
+++ b/service/history/queue/task_allocator_test.go
@@ -86,6 +86,7 @@ func TestTaskAllocatorSuite(t *testing.T) {
 	suite.Run(t, new(TaskAllocatorSuite))
 }
 
+// TODO(active-active): add test cases for active-active domains
 func (s *TaskAllocatorSuite) TestVerifyActiveTask() {
 	tests := []struct {
 		name                string
@@ -145,7 +146,7 @@ func (s *TaskAllocatorSuite) TestVerifyActiveTask() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			tt.setupMocks()
-			result, err := s.allocator.VerifyActiveTask(s.taskDomainID, s.task)
+			result, err := s.allocator.VerifyActiveTask(s.taskDomainID, "TODO", "TODO", s.task)
 			assert.Equal(s.T(), tt.expectedResult, result)
 			if tt.expectedErrorString != "" {
 				assert.Contains(s.T(), err.Error(), tt.expectedErrorString)
@@ -156,6 +157,7 @@ func (s *TaskAllocatorSuite) TestVerifyActiveTask() {
 	}
 }
 
+// TODO(active-active): add test cases for active-active domains
 func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 	tests := []struct {
 		name                string
@@ -251,7 +253,7 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			tt.setupMocks()
-			result, err := s.allocator.VerifyFailoverActiveTask(tt.targetDomainIDs, s.taskDomainID, s.task)
+			result, err := s.allocator.VerifyFailoverActiveTask(tt.targetDomainIDs, s.taskDomainID, "TODO", "TODO", s.task)
 			assert.Equal(s.T(), tt.expectedResult, result)
 			if tt.expectedError != nil {
 				assert.Equal(s.T(), tt.expectedError, err)
@@ -264,6 +266,7 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 	}
 }
 
+// TODO(active-active): add test cases for active-active domains
 func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 	tests := []struct {
 		name                string
@@ -357,7 +360,7 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			tt.setupMocks()
-			result, err := s.allocator.VerifyStandbyTask(tt.standbyCluster, s.taskDomainID, s.task)
+			result, err := s.allocator.VerifyStandbyTask(tt.standbyCluster, s.taskDomainID, "TODO", "TODO", s.task)
 			assert.Equal(s.T(), tt.expectedResult, result)
 			if tt.expectedError != nil {
 				assert.Equal(s.T(), tt.expectedError, err)

--- a/service/history/queue/task_allocator_test.go
+++ b/service/history/queue/task_allocator_test.go
@@ -29,9 +29,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
@@ -40,96 +40,51 @@ import (
 	htask "github.com/uber/cadence/service/history/task"
 )
 
-// TaskAllocatorSuite defines the suite for TaskAllocator tests
-type TaskAllocatorSuite struct {
-	suite.Suite
-	controller      *gomock.Controller
-	mockShard       *shard.MockContext
-	mockDomainCache *cache.MockDomainCache
-	allocator       *taskAllocatorImpl
-	taskDomainID    string
-	task            interface{}
-}
-
-func (s *TaskAllocatorSuite) SetupTest() {
-	s.controller = gomock.NewController(s.T())
-
-	s.taskDomainID = "testDomainID"
-	s.task = "testTask"
-
-	// Create mocks
-	s.mockShard = shard.NewMockContext(s.controller)
-	s.mockDomainCache = cache.NewMockDomainCache(s.controller)
-
-	// Setup mock shard to return mock domain cache and logger
-	s.mockShard.EXPECT().GetDomainCache().Return(s.mockDomainCache).AnyTimes()
-	s.mockShard.EXPECT().GetService().Return(nil).AnyTimes() // Adjust based on your implementation
-
-	// Create the task allocator
-	s.allocator = &taskAllocatorImpl{
-		currentClusterName: "currentCluster",
-		shard:              s.mockShard,
-		domainCache:        s.mockDomainCache,
-		logger:             log.NewNoop(),
-	}
-
-	s.allocator.Lock()
-	defer s.allocator.Unlock()
-}
-
-func (s *TaskAllocatorSuite) TearDownTest() {
-	s.controller.Finish()
-}
-
-// Run the test suite
-func TestTaskAllocatorSuite(t *testing.T) {
-	suite.Run(t, new(TaskAllocatorSuite))
-}
-
-// TODO(active-active): add test cases for active-active domains
-func (s *TaskAllocatorSuite) TestVerifyActiveTask() {
+func TestVerifyActiveTask(t *testing.T) {
+	domainID := "testDomainID"
+	task := "testTask"
 	tests := []struct {
 		name                string
-		setupMocks          func()
+		setupMocks          func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager)
 		expectedResult      bool
 		expectedErrorString string
 	}{
 		{
 			name: "Failed to get domain from cache, non-EntityNotExistsError",
-			setupMocks: func() {
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(nil, errors.New("some error"))
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(nil, errors.New("some error"))
 			},
 			expectedResult:      false,
 			expectedErrorString: "some error",
 		},
 		{
 			name: "Domain not found, EntityNotExistsError",
-			setupMocks: func() {
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(nil, &types.EntityNotExistsError{})
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(nil, &types.EntityNotExistsError{})
 			},
 			expectedResult: false,
 		},
 		{
 			name: "Domain is global and not active in current cluster",
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
 				domainEntry := cache.NewGlobalDomainCacheEntryForTest(
-					&persistence.DomainInfo{Name: s.taskDomainID + "name"},
+					&persistence.DomainInfo{Name: domainID + "name"},
 					nil,
 					&persistence.DomainReplicationConfig{
 						ActiveClusterName: "otherCluster",
 					},
 					1,
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			expectedResult: false,
 		},
 		{
 			name: "Domain is global and pending active in current cluster",
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
 				endtime := int64(1)
 				domainEntry := cache.NewDomainCacheEntryForTest(
-					&persistence.DomainInfo{Name: s.taskDomainID + "name"},
+					&persistence.DomainInfo{Name: domainID + "name"},
 					nil,
 					true,
 					&persistence.DomainReplicationConfig{
@@ -138,47 +93,148 @@ func (s *TaskAllocatorSuite) TestVerifyActiveTask() {
 					1,
 					&endtime, 1, 1, 1,
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			expectedResult:      false,
 			expectedErrorString: "the domain is pending-active",
 		},
 		{
 			name: "Domain is global and active in current cluster",
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
 				domainEntry := cache.NewGlobalDomainCacheEntryForTest(
-					&persistence.DomainInfo{Name: s.taskDomainID + "name"},
+					&persistence.DomainInfo{Name: domainID + "name"},
 					nil,
 					&persistence.DomainReplicationConfig{
 						ActiveClusterName: "currentCluster",
 					},
 					1,
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			expectedResult: true,
+		},
+		{
+			name: "Domain is active-active mode, task is not active in current cluster so should be skipped",
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					true,
+					&persistence.DomainReplicationConfig{
+						// ActiveClusters is not nil which means it's active-active
+						ActiveClusters: &persistence.ActiveClustersConfig{},
+					},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+				activeClusterMgr.EXPECT().LookupWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&activecluster.LookupResult{
+						ClusterName: "another-cluster",
+					}, nil)
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Domain is active-active mode, task is active in current cluster so should be processed",
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					true,
+					&persistence.DomainReplicationConfig{
+						// ActiveClusters is not nil which means it's active-active
+						ActiveClusters: &persistence.ActiveClustersConfig{},
+					},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+				activeClusterMgr.EXPECT().LookupWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&activecluster.LookupResult{
+						ClusterName: "currentCluster",
+					}, nil)
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Domain is active-active mode, activeness lookup returns error",
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					true,
+					&persistence.DomainReplicationConfig{
+						// ActiveClusters is not nil which means it's active-active
+						ActiveClusters: &persistence.ActiveClustersConfig{},
+					},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+				activeClusterMgr.EXPECT().LookupWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("some error"))
+			},
+			expectedResult:      false,
+			expectedErrorString: "some error",
 		},
 	}
 
 	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			tt.setupMocks()
-			result, err := s.allocator.VerifyActiveTask(s.taskDomainID, "TODO", "TODO", s.task)
-			assert.Equal(s.T(), tt.expectedResult, result)
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			// Create mocks
+			mockShard := shard.NewMockContext(ctrl)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+
+			// Setup mock shard to return mock domain cache and logger
+			mockShard.EXPECT().GetDomainCache().Return(mockDomainCache).AnyTimes()
+			mockShard.EXPECT().GetService().Return(nil).AnyTimes() // Adjust based on your implementation
+
+			activeClusterMgr := activecluster.NewMockManager(ctrl)
+
+			// Create the task allocator
+			allocator := &taskAllocatorImpl{
+				currentClusterName: "currentCluster",
+				shard:              mockShard,
+				domainCache:        mockDomainCache,
+				logger:             log.NewNoop(),
+				activeClusterMgr:   activeClusterMgr,
+			}
+
+			tt.setupMocks(mockDomainCache, activeClusterMgr)
+			result, err := allocator.VerifyActiveTask(domainID, "wfid", "rid", task)
+			assert.Equal(t, tt.expectedResult, result)
 			if tt.expectedErrorString != "" {
-				assert.Contains(s.T(), err.Error(), tt.expectedErrorString)
+				assert.Contains(t, err.Error(), tt.expectedErrorString)
 			} else {
-				assert.NoError(s.T(), err)
+				assert.NoError(t, err)
 			}
 		})
 	}
 }
 
-func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
+func TestVerifyFailoverActiveTask(t *testing.T) {
+	domainID := "testDomainID"
+	task := "testTask"
+
 	tests := []struct {
 		name                string
 		targetDomainIDs     map[string]struct{}
-		setupMocks          func()
+		setupMocks          func(mockDomainCache *cache.MockDomainCache)
 		expectedResult      bool
 		expectedError       error
 		expectedErrorString string
@@ -188,7 +244,7 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 			targetDomainIDs: map[string]struct{}{
 				"someOtherDomainID": {},
 			},
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache) {
 				// No mocks needed since the domain is not in targetDomainIDs
 			},
 			expectedResult: false,
@@ -197,10 +253,10 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 		{
 			name: "Domain in targetDomainIDs, GetDomainByID returns non-EntityNotExistsError",
 			targetDomainIDs: map[string]struct{}{
-				s.taskDomainID: {},
+				domainID: {},
 			},
-			setupMocks: func() {
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(nil, errors.New("some error"))
+			setupMocks: func(mockDomainCache *cache.MockDomainCache) {
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(nil, errors.New("some error"))
 			},
 			expectedResult:      false,
 			expectedError:       errors.New("some error"),
@@ -209,10 +265,10 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 		{
 			name: "Domain in targetDomainIDs, GetDomainByID returns EntityNotExistsError",
 			targetDomainIDs: map[string]struct{}{
-				s.taskDomainID: {},
+				domainID: {},
 			},
-			setupMocks: func() {
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(nil, &types.EntityNotExistsError{})
+			setupMocks: func(mockDomainCache *cache.MockDomainCache) {
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(nil, &types.EntityNotExistsError{})
 			},
 			expectedResult: false,
 			expectedError:  nil,
@@ -220,9 +276,9 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 		{
 			name: "Domain in targetDomainIDs, domain is pending active",
 			targetDomainIDs: map[string]struct{}{
-				s.taskDomainID: {},
+				domainID: {},
 			},
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache) {
 				// Set up a domainEntry that is global and has a non-nil FailoverEndTime
 				endtime := int64(1)
 				domainEntry := cache.NewDomainCacheEntryForTest(
@@ -236,7 +292,7 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 					1,
 					1,
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			expectedResult: false,
 			expectedError:  htask.ErrTaskPendingActive,
@@ -244,9 +300,9 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 		{
 			name: "Domain in targetDomainIDs, checkDomainPendingActive returns nil",
 			targetDomainIDs: map[string]struct{}{
-				s.taskDomainID: {},
+				domainID: {},
 			},
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache) {
 				// Set up a domainEntry that is global and has a nil FailoverEndTime
 				domainEntry := cache.NewDomainCacheEntryForTest(
 					nil,
@@ -259,34 +315,76 @@ func (s *TaskAllocatorSuite) TestVerifyFailoverActiveTask() {
 					1,
 					1,
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name: "Domain is local, should be skipped",
+			targetDomainIDs: map[string]struct{}{
+				domainID: {},
+			},
+			setupMocks: func(mockDomainCache *cache.MockDomainCache) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					false, // IsGlobalDomain
+					&persistence.DomainReplicationConfig{},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+			},
+			expectedResult: false,
 			expectedError:  nil,
 		},
 	}
 
 	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			tt.setupMocks()
-			result, err := s.allocator.VerifyFailoverActiveTask(tt.targetDomainIDs, s.taskDomainID, "TODO", "TODO", s.task)
-			assert.Equal(s.T(), tt.expectedResult, result)
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			// Create mocks
+			mockShard := shard.NewMockContext(ctrl)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+
+			// Setup mock shard to return mock domain cache and logger
+			mockShard.EXPECT().GetDomainCache().Return(mockDomainCache).AnyTimes()
+			mockShard.EXPECT().GetService().Return(nil).AnyTimes() // Adjust based on your implementation
+
+			// Create the task allocator
+			allocator := &taskAllocatorImpl{
+				currentClusterName: "currentCluster",
+				shard:              mockShard,
+				domainCache:        mockDomainCache,
+				logger:             log.NewNoop(),
+			}
+
+			tt.setupMocks(mockDomainCache)
+			result, err := allocator.VerifyFailoverActiveTask(tt.targetDomainIDs, domainID, "wfid", "rid", task)
+			assert.Equal(t, tt.expectedResult, result)
 			if tt.expectedError != nil {
-				assert.Equal(s.T(), tt.expectedError, err)
+				assert.Equal(t, tt.expectedError, err)
 			} else if tt.expectedErrorString != "" {
-				assert.Contains(s.T(), err.Error(), tt.expectedErrorString)
+				assert.Contains(t, err.Error(), tt.expectedErrorString)
 			} else {
-				assert.NoError(s.T(), err)
+				assert.NoError(t, err)
 			}
 		})
 	}
 }
 
-// TODO(active-active): add test cases for active-active domains
-func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
+func TestVerifyStandbyTask(t *testing.T) {
+	domainID := "testDomainID"
+	task := "testTask"
 	tests := []struct {
 		name                string
-		setupMocks          func()
+		setupMocks          func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager)
 		standbyCluster      string
 		expectedResult      bool
 		expectedError       error
@@ -294,8 +392,8 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 	}{
 		{
 			name: "GetDomainByID returns non-EntityNotExistsError",
-			setupMocks: func() {
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(nil, errors.New("some error"))
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(nil, errors.New("some error"))
 			},
 			standbyCluster:      "standbyCluster",
 			expectedResult:      false,
@@ -303,8 +401,8 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 		},
 		{
 			name: "GetDomainByID returns EntityNotExistsError",
-			setupMocks: func() {
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(nil, &types.EntityNotExistsError{})
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(nil, &types.EntityNotExistsError{})
 			},
 			standbyCluster: "standbyCluster",
 			expectedResult: false,
@@ -312,13 +410,13 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 		},
 		{
 			name: "Domain is not global",
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
 				domainEntry := cache.NewLocalDomainCacheEntryForTest(
 					&persistence.DomainInfo{},
 					&persistence.DomainConfig{},
 					"",
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			standbyCluster: "standbyCluster",
 			expectedResult: false,
@@ -326,7 +424,7 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 		},
 		{
 			name: "Domain is global but not standby (active cluster name does not match standbyCluster)",
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
 				domainEntry := cache.NewGlobalDomainCacheEntryForTest(
 					&persistence.DomainInfo{},
 					&persistence.DomainConfig{},
@@ -335,7 +433,7 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 					},
 					0,
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			standbyCluster: "standbyCluster",
 			expectedResult: false,
@@ -343,12 +441,12 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 		},
 		{
 			name: "Domain is global and standby, but checkDomainPendingActive returns error",
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
 				endTime := time.Now().Add(time.Hour).UnixNano()
 				domainEntry := cache.NewDomainCacheEntryForTest(nil, nil, true, &persistence.DomainReplicationConfig{
 					ActiveClusterName: "currentCluster",
 				}, 1, &endTime, 1, 1, 1)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			standbyCluster:      "currentCluster",
 			expectedResult:      false,
@@ -356,7 +454,7 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 		},
 		{
 			name: "Domain is global and standby, checkDomainPendingActive returns nil",
-			setupMocks: func() {
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
 				domainEntry := cache.NewGlobalDomainCacheEntryForTest(
 					&persistence.DomainInfo{},
 					&persistence.DomainConfig{},
@@ -365,41 +463,165 @@ func (s *TaskAllocatorSuite) TestVerifyStandbyTask() {
 					},
 					0, // FailoverEndTime is zero
 				)
-				s.mockDomainCache.EXPECT().GetDomainByID(s.taskDomainID).Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
 			},
 			standbyCluster: "standbyCluster",
 			expectedResult: true,
 			expectedError:  nil,
 		},
+		{
+			name: "Domain is local, should be skipped",
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					false, // IsGlobalDomain
+					&persistence.DomainReplicationConfig{},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+			},
+			standbyCluster: "standbyCluster",
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			name: "Domain is active-active mode, task is not active in standby cluster so should be skipped",
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					true,
+					&persistence.DomainReplicationConfig{
+						// ActiveClusters is not nil which means it's active-active
+						ActiveClusters: &persistence.ActiveClustersConfig{},
+					},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+				activeClusterMgr.EXPECT().LookupWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&activecluster.LookupResult{
+						ClusterName: "another-cluster",
+					}, nil)
+			},
+			standbyCluster: "standbyCluster",
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			name: "Domain is active-active mode, task is active in standby cluster so should be processed",
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					true,
+					&persistence.DomainReplicationConfig{
+						// ActiveClusters is not nil which means it's active-active
+						ActiveClusters: &persistence.ActiveClustersConfig{},
+					},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+				activeClusterMgr.EXPECT().LookupWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&activecluster.LookupResult{
+						ClusterName: "standbyCluster",
+					}, nil)
+			},
+			standbyCluster: "standbyCluster",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name: "Domain is active-active mode, activeness lookup returns error",
+			setupMocks: func(mockDomainCache *cache.MockDomainCache, activeClusterMgr *activecluster.MockManager) {
+				// Set up a domainEntry that is global and has a nil FailoverEndTime
+				domainEntry := cache.NewDomainCacheEntryForTest(
+					nil,
+					nil,
+					true,
+					&persistence.DomainReplicationConfig{
+						// ActiveClusters is not nil which means it's active-active
+						ActiveClusters: &persistence.ActiveClustersConfig{},
+					},
+					1,
+					nil,
+					1,
+					1,
+					1,
+				)
+				mockDomainCache.EXPECT().GetDomainByID(domainID).Return(domainEntry, nil)
+				activeClusterMgr.EXPECT().LookupWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("some error"))
+			},
+			standbyCluster: "standbyCluster",
+			expectedResult: false,
+			expectedError:  errors.New("some error"),
+		},
 	}
 
 	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			tt.setupMocks()
-			result, err := s.allocator.VerifyStandbyTask(tt.standbyCluster, s.taskDomainID, "TODO", "TODO", s.task)
-			assert.Equal(s.T(), tt.expectedResult, result)
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			// Create mocks
+			mockShard := shard.NewMockContext(ctrl)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+
+			// Setup mock shard to return mock domain cache and logger
+			mockShard.EXPECT().GetDomainCache().Return(mockDomainCache).AnyTimes()
+			mockShard.EXPECT().GetService().Return(nil).AnyTimes() // Adjust based on your implementation
+
+			activeClusterMgr := activecluster.NewMockManager(ctrl)
+
+			// Create the task allocator
+			allocator := &taskAllocatorImpl{
+				currentClusterName: "currentCluster",
+				shard:              mockShard,
+				domainCache:        mockDomainCache,
+				logger:             log.NewNoop(),
+				activeClusterMgr:   activeClusterMgr,
+			}
+
+			tt.setupMocks(mockDomainCache, activeClusterMgr)
+			result, err := allocator.VerifyStandbyTask(tt.standbyCluster, domainID, "wfid", "rid", task)
+			assert.Equal(t, tt.expectedResult, result)
 			if tt.expectedError != nil {
-				assert.Equal(s.T(), tt.expectedError, err)
+				assert.Equal(t, tt.expectedError, err)
 			} else if tt.expectedErrorString != "" {
-				assert.Contains(s.T(), err.Error(), tt.expectedErrorString)
+				assert.Contains(t, err.Error(), tt.expectedErrorString)
 			} else {
-				assert.NoError(s.T(), err)
+				assert.NoError(t, err)
 			}
 		})
 	}
 }
 
-func (s *TaskAllocatorSuite) TestIsDomainNotRegistered() {
+func TestIsDomainNotRegistered(t *testing.T) {
 	tests := []struct {
 		name                string
 		domainID            string
-		mockFn              func()
+		mockFn              func(mockDomainCache *cache.MockDomainCache)
 		expectedErrorString string
 	}{
 		{
 			name: "domainID return error",
-			mockFn: func() {
-				s.mockDomainCache.EXPECT().GetDomainByID("").Return(nil, fmt.Errorf("testError"))
+			mockFn: func(mockDomainCache *cache.MockDomainCache) {
+				mockDomainCache.EXPECT().GetDomainByID("").Return(nil, fmt.Errorf("testError"))
 			},
 			domainID:            "",
 			expectedErrorString: "testError",
@@ -407,35 +629,49 @@ func (s *TaskAllocatorSuite) TestIsDomainNotRegistered() {
 		{
 			name:     "cannot get info",
 			domainID: "testDomainID",
-			mockFn: func() {
+			mockFn: func(mockDomainCache *cache.MockDomainCache) {
 				domainEntry := cache.NewDomainCacheEntryForTest(nil, nil, false, nil, 0, nil, 0, 0, 0)
-				s.mockDomainCache.EXPECT().GetDomainByID("testDomainID").Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID("testDomainID").Return(domainEntry, nil)
 			},
 			expectedErrorString: "domain info is nil in cache",
 		},
 		{
 			name:     "domain is deprecated",
 			domainID: "testDomainID",
-			mockFn: func() {
+			mockFn: func(mockDomainCache *cache.MockDomainCache) {
 				domainEntry := cache.NewDomainCacheEntryForTest(
 					&persistence.DomainInfo{Status: persistence.DomainStatusDeprecated}, nil, false, nil, 0, nil, 0, 0, 0)
-				s.mockDomainCache.EXPECT().GetDomainByID("testDomainID").Return(domainEntry, nil)
+				mockDomainCache.EXPECT().GetDomainByID("testDomainID").Return(domainEntry, nil)
 			},
 			expectedErrorString: "",
 		},
 	}
 
 	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			tt.mockFn()
-			res, err := isDomainNotRegistered(s.mockShard, tt.domainID)
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			// Create mocks
+			mockShard := shard.NewMockContext(ctrl)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+
+			// Setup mock shard to return mock domain cache and logger
+			mockShard.EXPECT().GetDomainCache().Return(mockDomainCache).AnyTimes()
+			mockShard.EXPECT().GetService().Return(nil).AnyTimes() // Adjust based on your implementation
+
+			tt.mockFn(mockDomainCache)
+			res, err := isDomainNotRegistered(mockShard, tt.domainID)
 			if tt.expectedErrorString != "" {
-				assert.ErrorContains(s.T(), err, tt.expectedErrorString)
-				assert.False(s.T(), res)
+				assert.ErrorContains(t, err, tt.expectedErrorString)
+				assert.False(t, res)
 			} else {
-				assert.NoError(s.T(), err)
-				assert.True(s.T(), res)
+				assert.NoError(t, err)
+				assert.True(t, res)
 			}
 		})
 	}
+}
+
+func TstLockUnlock(t *testing.T) {
+
 }

--- a/service/history/queue/timer_queue_active_processor.go
+++ b/service/history/queue/timer_queue_active_processor.go
@@ -58,7 +58,7 @@ func newTimerQueueActiveProcessor(
 			return false, nil
 		}
 
-		return taskAllocator.VerifyActiveTask(timer.GetDomainID(), timer)
+		return taskAllocator.VerifyActiveTask(timer.GetDomainID(), timer.GetWorkflowID(), timer.GetRunID(), timer)
 	}
 
 	updateMaxReadLevel := func() task.Key {

--- a/service/history/queue/timer_queue_failover_processor.go
+++ b/service/history/queue/timer_queue_failover_processor.go
@@ -68,7 +68,7 @@ func newTimerQueueFailoverProcessor(
 			logger.Info("Domain is not in registered status, skip task in failover timer queue.", tag.WorkflowDomainID(timer.GetDomainID()), tag.Value(timer))
 			return false, nil
 		}
-		return taskAllocator.VerifyFailoverActiveTask(domainIDs, timer.GetDomainID(), timer)
+		return taskAllocator.VerifyFailoverActiveTask(domainIDs, timer.GetDomainID(), timer.GetWorkflowID(), timer.GetRunID(), timer)
 	}
 
 	maxReadLevelTaskKey := newTimerTaskKey(maxLevel, 0)

--- a/service/history/queue/timer_queue_standby_processor.go
+++ b/service/history/queue/timer_queue_standby_processor.go
@@ -76,7 +76,7 @@ func newTimerQueueStandbyProcessor(
 				return false, nil
 			}
 		}
-		return taskAllocator.VerifyStandbyTask(clusterName, timer.GetDomainID(), timer)
+		return taskAllocator.VerifyStandbyTask(clusterName, timer.GetDomainID(), timer.GetWorkflowID(), timer.GetRunID(), timer)
 	}
 
 	updateMaxReadLevel := func() task.Key {

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -524,7 +524,7 @@ func newTransferQueueActiveProcessor(
 			logger.Info("Domain is not in registered status, skip task in active transfer queue.", tag.WorkflowDomainID(task.GetDomainID()), tag.Value(task))
 			return false, nil
 		}
-		return taskAllocator.VerifyActiveTask(task.GetDomainID(), task)
+		return taskAllocator.VerifyActiveTask(task.GetDomainID(), task.GetWorkflowID(), task.GetRunID(), task)
 	}
 
 	updateMaxReadLevel := func() task.Key {
@@ -600,7 +600,7 @@ func newTransferQueueStandbyProcessor(
 				return false, nil
 			}
 		}
-		return taskAllocator.VerifyStandbyTask(clusterName, task.GetDomainID(), task)
+		return taskAllocator.VerifyStandbyTask(clusterName, task.GetDomainID(), task.GetWorkflowID(), task.GetRunID(), task)
 	}
 
 	updateMaxReadLevel := func() task.Key {
@@ -666,7 +666,7 @@ func newTransferQueueFailoverProcessor(
 			logger.Info("Domain is not in registered status, skip task in failover transfer queue.", tag.WorkflowDomainID(task.GetDomainID()), tag.Value(task))
 			return false, nil
 		}
-		return taskAllocator.VerifyFailoverActiveTask(domainIDs, task.GetDomainID(), task)
+		return taskAllocator.VerifyFailoverActiveTask(domainIDs, task.GetDomainID(), task.GetWorkflowID(), task.GetRunID(), task)
 	}
 
 	maxReadLevelTaskKey := newTransferTaskKey(maxLevel)

--- a/service/history/replication/task_hydrator_test.go
+++ b/service/history/replication/task_hydrator_test.go
@@ -614,7 +614,7 @@ func TestMutableStateLoader_GetMutableState(t *testing.T) {
 
 	// Happy path
 	domainCache.EXPECT().GetDomainByID(testDomainID).Return(&cache.DomainCacheEntry{}, nil)
-	expectedMS.EXPECT().StartTransaction(gomock.Any(), gomock.Any()).Return(false, nil)
+	expectedMS.EXPECT().StartTransaction(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	exec.SetWorkflowExecution(expectedMS)
 	ms, release, err := msLoader.GetMutableState(ctx, testDomainID, testWorkflowID, testRunID)
 	assert.NoError(t, err)

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -424,7 +424,7 @@ func (p *taskProcessorImpl) processSingleTask(replicationTask *types.Replication
 		return err
 	case err == execution.ErrMissingVersionHistories:
 		// skip the workflow without version histories
-		p.logger.Warn("Encounter workflow withour version histories")
+		p.logger.Warn("Encounter workflow without version histories")
 		return nil
 	default:
 		// handle error
@@ -436,9 +436,9 @@ func (p *taskProcessorImpl) processSingleTask(replicationTask *types.Replication
 		p.logger.Warn("Skip adding new messages to DLQ.", tag.Error(err))
 		return err
 	default:
-		request, err := p.generateDLQRequest(replicationTask)
-		if err != nil {
-			p.logger.Error("Failed to generate DLQ replication task.", tag.Error(err))
+		request, err2 := p.generateDLQRequest(replicationTask)
+		if err2 != nil {
+			p.logger.Error("Failed to generate DLQ replication task.", tag.Error(err2))
 			// We cannot deserialize the task. Dropping it.
 			return nil
 		}

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -190,6 +190,8 @@ func (m *TaskStore) Put(task *types.ReplicationTask) {
 			// This will help debug which shard is full. Logger already has ShardID tag attached.
 			// Log only once a minute to not flood the logs.
 			if time.Since(m.lastLogTime) > time.Minute {
+				// TODO(active-active): I see this log in production a lot. Consider improving this cache's size limit and/or change log level to debug if no action needed.
+				// Check CacheHitCounter and CacheMissCounter to see utilization.
 				m.logger.Warn("Replication cache is full")
 				m.lastLogTime = time.Now()
 			}

--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -369,9 +369,11 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 	return execution.NewWorkflow(
 		ctx,
 		r.clusterMetadata,
+		r.shard.GetActiveClusterManager(),
 		resetContext,
 		resetMutableState,
 		execution.NoopReleaseFn,
+		r.logger,
 	), nil
 }
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1253,11 +1253,7 @@ func (s *contextImpl) allocateTimerIDsLocked(
 			// or otherwise, failover + active processing logic may not pick up the task.
 			cluster = domainEntry.GetReplicationConfig().ActiveClusterName
 
-<<<<<<< HEAD
 			// if domain is active-active, lookup the workflow to determine the corresponding cluster
-=======
-			// if domain is active-active and the current cluster is one of those active clusters, then use the current cluster
->>>>>>> f21e8db03 (Active-Active prototype remaining changes as of apr 22)
 			if domainEntry.GetReplicationConfig().IsActiveActive() {
 				lookupRes, err := s.GetActiveClusterManager().LookupWorkflow(context.Background(), task.GetDomainID(), task.GetWorkflowID(), task.GetRunID())
 				if err != nil {

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1253,7 +1253,11 @@ func (s *contextImpl) allocateTimerIDsLocked(
 			// or otherwise, failover + active processing logic may not pick up the task.
 			cluster = domainEntry.GetReplicationConfig().ActiveClusterName
 
+<<<<<<< HEAD
 			// if domain is active-active, lookup the workflow to determine the corresponding cluster
+=======
+			// if domain is active-active and the current cluster is one of those active clusters, then use the current cluster
+>>>>>>> f21e8db03 (Active-Active prototype remaining changes as of apr 22)
 			if domainEntry.GetReplicationConfig().IsActiveActive() {
 				lookupRes, err := s.GetActiveClusterManager().LookupWorkflow(context.Background(), task.GetDomainID(), task.GetWorkflowID(), task.GetRunID())
 				if err != nil {

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -38,6 +38,7 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 
+	activecluster "github.com/uber/cadence/common/activecluster"
 	cache "github.com/uber/cadence/common/cache"
 	clock "github.com/uber/cadence/common/clock"
 	cluster "github.com/uber/cadence/common/cluster"
@@ -190,6 +191,20 @@ func (m *MockContext) GenerateTransferTaskIDs(number int) ([]int64, error) {
 func (mr *MockContextMockRecorder) GenerateTransferTaskIDs(number any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTransferTaskIDs", reflect.TypeOf((*MockContext)(nil).GenerateTransferTaskIDs), number)
+}
+
+// GetActiveClusterManager mocks base method.
+func (m *MockContext) GetActiveClusterManager() activecluster.Manager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveClusterManager")
+	ret0, _ := ret[0].(activecluster.Manager)
+	return ret0
+}
+
+// GetActiveClusterManager indicates an expected call of GetActiveClusterManager.
+func (mr *MockContextMockRecorder) GetActiveClusterManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveClusterManager", reflect.TypeOf((*MockContext)(nil).GetActiveClusterManager))
 }
 
 // GetAllTimerFailoverLevels mocks base method.

--- a/service/history/shard/context_test_utils.go
+++ b/service/history/shard/context_test_utils.go
@@ -73,6 +73,7 @@ func NewTestContext(
 		rangeID:                   shardInfo.RangeID,
 		shardInfo:                 shardInfo,
 		executionManager:          resource.ExecutionMgr,
+		activeClusterManager:      resource.ActiveClusterMgr,
 		config:                    config,
 		logger:                    resource.GetLogger(),
 		throttledLogger:           resource.GetThrottledLogger(),

--- a/service/history/task/priority_assigner.go
+++ b/service/history/task/priority_assigner.go
@@ -145,6 +145,15 @@ func (a *priorityAssignerImpl) getDomainInfo(domainID string) (string, bool, err
 		return "", true, nil
 	}
 
+	if domainEntry.GetReplicationConfig().IsActiveActive() {
+		active, _ := domainEntry.IsActiveIn(a.currentClusterName)
+		return domainEntry.GetInfo().Name, active, nil
+	}
+
+	// TODO(active-active): The logic below ignores pending active case for active-passive domains.
+	// However IsActiveIn() that is used above for active-active domains returns false for pending active domains.
+	// What should be the behavior for pending active domains?
+
 	if domainEntry.IsGlobalDomain() && a.currentClusterName != domainEntry.GetReplicationConfig().ActiveClusterName {
 		return domainEntry.GetInfo().Name, false, nil
 	}

--- a/service/history/task/standby_task_util.go
+++ b/service/history/task/standby_task_util.go
@@ -44,7 +44,7 @@ func standbyTaskPostActionNoOp(
 	ctx context.Context,
 	taskInfo persistence.Task,
 	postActionInfo interface{},
-	_ log.Logger,
+	logger log.Logger,
 ) error {
 
 	if postActionInfo == nil {
@@ -52,6 +52,14 @@ func standbyTaskPostActionNoOp(
 	}
 
 	// return error so task processing logic will retry
+	logger.Debug("standbyTaskPostActionNoOp return redispatch error so task processing logic will retry",
+		tag.WorkflowID(taskInfo.GetWorkflowID()),
+		tag.WorkflowRunID(taskInfo.GetRunID()),
+		tag.WorkflowDomainID(taskInfo.GetDomainID()),
+		tag.TaskID(taskInfo.GetTaskID()),
+		tag.TaskType(taskInfo.GetTaskType()),
+		tag.FailoverVersion(taskInfo.GetVersion()),
+		tag.Timestamp(taskInfo.GetVisibilityTimestamp()))
 	return &redispatchError{Reason: fmt.Sprintf("post action is %T", postActionInfo)}
 }
 
@@ -143,6 +151,7 @@ func getHistoryResendInfo(
 }
 
 func getStandbyPostActionFn(
+	logger log.Logger,
 	taskInfo persistence.Task,
 	standbyNow standbyCurrentTimeFn,
 	standbyTaskMissingEventsResendDelay time.Duration,
@@ -157,16 +166,28 @@ func getStandbyPostActionFn(
 	resendTime := taskTime.Add(standbyTaskMissingEventsResendDelay)
 	discardTime := taskTime.Add(standbyTaskMissingEventsDiscardDelay)
 
+	tags := []tag.Tag{
+		tag.WorkflowID(taskInfo.GetWorkflowID()),
+		tag.WorkflowRunID(taskInfo.GetRunID()),
+		tag.WorkflowDomainID(taskInfo.GetDomainID()),
+		tag.TaskID(taskInfo.GetTaskID()),
+		tag.TaskType(int(taskInfo.GetTaskType())),
+		tag.Timestamp(taskInfo.GetVisibilityTimestamp()),
+	}
+
 	// now < task start time + StandbyTaskMissingEventsResendDelay
 	if now.Before(resendTime) {
+		logger.Debug("getStandbyPostActionFn returning standbyTaskPostActionNoOp because now < task start time + StandbyTaskMissingEventsResendDelay", tags...)
 		return standbyTaskPostActionNoOp
 	}
 
 	// task start time + StandbyTaskMissingEventsResendDelay <= now < task start time + StandbyTaskMissingEventsResendDelay
 	if now.Before(discardTime) {
+		logger.Debug("getStandbyPostActionFn returning fetchHistoryStandbyPostActionFn because task start time + StandbyTaskMissingEventsResendDelay <= now < task start time + StandbyTaskMissingEventsResendDelay", tags...)
 		return fetchHistoryStandbyPostActionFn
 	}
 
 	// task start time + StandbyTaskMissingEventsResendDelay <= now
+	logger.Debug("getStandbyPostActionFn returning discardTaskStandbyPostActionFn because task start time + StandbyTaskMissingEventsResendDelay <= now", tags...)
 	return discardTaskStandbyPostActionFn
 }

--- a/service/history/task/task_util.go
+++ b/service/history/task/task_util.go
@@ -327,6 +327,7 @@ func getWorkflowExecution(
 	}
 }
 
+// TODO(active-active): Write unit tests for this
 func shouldPushToMatching(
 	ctx context.Context,
 	shard shard.Context,

--- a/service/history/task/task_util.go
+++ b/service/history/task/task_util.go
@@ -327,7 +327,6 @@ func getWorkflowExecution(
 	}
 }
 
-// TODO(active-active): Write unit tests for this
 func shouldPushToMatching(
 	ctx context.Context,
 	shard shard.Context,

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -158,6 +158,7 @@ func (t *timerStandbyTaskExecutor) executeUserTimerTimeoutTask(
 		timerTask.EventID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			timerTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -249,6 +250,8 @@ func (t *timerStandbyTaskExecutor) executeActivityTimeoutTask(
 		// we need to handcraft some of the variables
 		// since the job being done here is update the activity and possibly write a timer task to DB
 		// also need to reset the current version.
+		t.logger.Debugf("executeActivityTimeoutTask calling UpdateCurrentVersion for domain %s, wfID %v, lastWriteVersion %v",
+			timerTask.DomainID, timerTask.WorkflowID, lastWriteVersion)
 		if err := mutableState.UpdateCurrentVersion(lastWriteVersion, true); err != nil {
 			return nil, err
 		}
@@ -263,6 +266,7 @@ func (t *timerStandbyTaskExecutor) executeActivityTimeoutTask(
 		timerTask.EventID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			timerTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -312,6 +316,7 @@ func (t *timerStandbyTaskExecutor) executeDecisionTimeoutTask(
 		timerTask.EventID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			timerTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -354,6 +359,7 @@ func (t *timerStandbyTaskExecutor) executeWorkflowBackoffTimerTask(
 		0,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			timerTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -392,6 +398,7 @@ func (t *timerStandbyTaskExecutor) executeWorkflowTimeoutTask(
 		0,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			timerTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -444,13 +451,36 @@ func (t *timerStandbyTaskExecutor) processTimer(
 	}
 
 	if !mutableState.IsWorkflowExecutionRunning() {
+		// TODO: Check if workflow timeout timer comes to this point and then discarded.
 		// workflow already finished, no need to process the timer
 		return nil
 	}
 
 	historyResendInfo, err := actionFn(ctx, wfContext, mutableState)
 	if err != nil {
+		if t.logger.DebugOn() {
+			t.logger.Debug("processTimer got error from actionFn",
+				tag.Error(err),
+				tag.WorkflowID(timerTask.GetWorkflowID()),
+				tag.WorkflowRunID(timerTask.GetRunID()),
+				tag.WorkflowDomainID(timerTask.GetDomainID()),
+				tag.TaskID(timerTask.GetTaskID()),
+				tag.TaskType(int(timerTask.GetTaskType())),
+				tag.Timestamp(timerTask.GetVisibilityTimestamp()),
+			)
+		}
 		return err
+	} else {
+		if t.logger.DebugOn() {
+			t.logger.Debug("processTimer got historyResendInfo from actionFn",
+				tag.WorkflowID(timerTask.GetWorkflowID()),
+				tag.WorkflowRunID(timerTask.GetRunID()),
+				tag.WorkflowDomainID(timerTask.GetDomainID()),
+				tag.TaskID(timerTask.GetTaskID()),
+				tag.TaskType(int(timerTask.GetTaskType())),
+				tag.Timestamp(timerTask.GetVisibilityTimestamp()),
+			)
+		}
 	}
 
 	release(nil)
@@ -501,6 +531,15 @@ func (t *timerStandbyTaskExecutor) fetchHistoryFromRemote(
 			tag.WorkflowRunID(taskInfo.GetRunID()),
 			tag.SourceCluster(t.clusterName),
 			tag.Error(err),
+		)
+	} else if t.logger.DebugOn() {
+		t.logger.Debug("Successfully re-replicated history from remote.",
+			tag.WorkflowID(taskInfo.GetWorkflowID()),
+			tag.WorkflowRunID(taskInfo.GetRunID()),
+			tag.WorkflowDomainID(taskInfo.GetDomainID()),
+			tag.TaskID(taskInfo.GetTaskID()),
+			tag.TaskType(int(taskInfo.GetTaskType())),
+			tag.SourceCluster(t.clusterName),
 		)
 	}
 

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -470,17 +470,17 @@ func (t *timerStandbyTaskExecutor) processTimer(
 			)
 		}
 		return err
-	} else {
-		if t.logger.DebugOn() {
-			t.logger.Debug("processTimer got historyResendInfo from actionFn",
-				tag.WorkflowID(timerTask.GetWorkflowID()),
-				tag.WorkflowRunID(timerTask.GetRunID()),
-				tag.WorkflowDomainID(timerTask.GetDomainID()),
-				tag.TaskID(timerTask.GetTaskID()),
-				tag.TaskType(int(timerTask.GetTaskType())),
-				tag.Timestamp(timerTask.GetVisibilityTimestamp()),
-			)
-		}
+	}
+
+	if t.logger.DebugOn() {
+		t.logger.Debug("processTimer got historyResendInfo from actionFn",
+			tag.WorkflowID(timerTask.GetWorkflowID()),
+			tag.WorkflowRunID(timerTask.GetRunID()),
+			tag.WorkflowDomainID(timerTask.GetDomainID()),
+			tag.TaskID(timerTask.GetTaskID()),
+			tag.TaskType(int(timerTask.GetTaskType())),
+			tag.Timestamp(timerTask.GetVisibilityTimestamp()),
+		)
 	}
 
 	release(nil)

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -154,6 +154,7 @@ func (t *transferStandbyTaskExecutor) processActivityTask(
 		transferTask.ScheduleID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			transferTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -210,6 +211,7 @@ func (t *transferStandbyTaskExecutor) processDecisionTask(
 		transferTask.ScheduleID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			transferTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -333,6 +335,7 @@ func (t *transferStandbyTaskExecutor) processCancelExecution(
 		transferTask.InitiatedID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			transferTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -371,6 +374,7 @@ func (t *transferStandbyTaskExecutor) processSignalExecution(
 		transferTask.InitiatedID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			transferTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),
@@ -413,6 +417,7 @@ func (t *transferStandbyTaskExecutor) processStartChildExecution(
 		transferTask.InitiatedID,
 		actionFn,
 		getStandbyPostActionFn(
+			t.logger,
 			transferTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsResendDelay(),

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -105,7 +105,15 @@ func (t *transferTaskExecutorBase) pushActivity(
 		t.logger.Fatal("Cannot process non activity task", tag.TaskType(task.GetTaskType()))
 	}
 
-	_, err := t.matchingClient.AddActivityTask(ctx, &types.AddActivityTaskRequest{
+	shouldPush, err := shouldPushToMatching(ctx, t.shard, task)
+	if err != nil {
+		return err
+	}
+	if !shouldPush {
+		return nil
+	}
+
+	_, err = t.matchingClient.AddActivityTask(ctx, &types.AddActivityTaskRequest{
 		DomainUUID:       task.TargetDomainID,
 		SourceDomainUUID: task.DomainID,
 		Execution: &types.WorkflowExecution{
@@ -135,7 +143,15 @@ func (t *transferTaskExecutorBase) pushDecision(
 		t.logger.Fatal("Cannot process non decision task", tag.TaskType(task.GetTaskType()))
 	}
 
-	_, err := t.matchingClient.AddDecisionTask(ctx, &types.AddDecisionTaskRequest{
+	shouldPush, err := shouldPushToMatching(ctx, t.shard, task)
+	if err != nil {
+		return err
+	}
+	if !shouldPush {
+		return nil
+	}
+
+	_, err = t.matchingClient.AddDecisionTask(ctx, &types.AddDecisionTaskRequest{
 		DomainUUID: task.DomainID,
 		Execution: &types.WorkflowExecution{
 			WorkflowID: task.WorkflowID,

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/execution"
@@ -266,9 +267,7 @@ UpdateHistoryLoop:
 			}
 		}
 
-		logger.Debugf("updateHelper calling UpdateWorkflowExecutionAsActive for wfID %s",
-			mutableState.GetExecutionInfo().WorkflowID,
-		)
+		logger.Debug("updateHelper calling UpdateWorkflowExecutionAsActive", tag.WorkflowID(mutableState.GetExecutionInfo().WorkflowID))
 		err = workflowContext.GetContext().UpdateWorkflowExecutionAsActive(ctx, now)
 		if _, ok := err.(*persistence.DuplicateRequestError); ok {
 			return nil

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
@@ -77,6 +78,7 @@ type (
 		mockTimeSource       clock.MockedTimeSource
 		logger               log.Logger
 		handlerContext       *handlerContext
+		mockActiveClusterMgr activecluster.MockManager
 		sync.Mutex
 	}
 )
@@ -151,6 +153,7 @@ func (s *matchingEngineSuite) SetupTest() {
 		metrics.MatchingTaskListMgrScope,
 		testlogger.New(s.Suite.T()),
 	)
+	s.mockActiveClusterMgr = *activecluster.NewMockManager(s.controller)
 
 	s.matchingEngine = s.newMatchingEngine(defaultTestConfig(), s.taskManager)
 	s.matchingEngine.Start()

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -610,7 +610,7 @@ func (c *taskListManagerImpl) DispatchTask(ctx context.Context, task *InternalTa
 	}
 
 	// optional configuration to enable cleanup of tasks, in the standby cluster, that have already been started
-	if c.config.EnableStandbyTaskCompletion() {
+	if c.config.EnableStandbyTaskCompletion() && !domainEntry.GetReplicationConfig().IsActiveActive() {
 		if err := c.taskCompleter.CompleteTaskIfStarted(ctx, task); err != nil {
 			if errors.Is(err, errDomainIsActive) {
 				return c.matcher.MustOffer(ctx, task)

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -240,7 +240,22 @@ func createTestTaskListManagerWithConfig(t *testing.T, logger log.Logger, contro
 		panic(err)
 	}
 	tlKind := types.TaskListKindNormal
-	tlMgr, err := NewManager(mockDomainCache, logger, metrics.NewClient(tally.NoopScope, metrics.Matching), tm, cluster.GetTestClusterMetadata(true), mockIsolationState, nil, func(Manager) {}, tlID, &tlKind, cfg, timeSource, timeSource.Now(), mockHistoryService)
+	tlMgr, err := NewManager(
+		mockDomainCache,
+		logger,
+		metrics.NewClient(tally.NoopScope, metrics.Matching),
+		tm,
+		cluster.GetTestClusterMetadata(true),
+		mockIsolationState,
+		nil,
+		func(Manager) {},
+		tlID,
+		&tlKind,
+		cfg,
+		timeSource,
+		timeSource.Now(),
+		mockHistoryService,
+	)
 	if err != nil {
 		logger.Fatal("error when createTestTaskListManager", tag.Error(err))
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Replace all `clusterMetadata.ClusterNameForFailoverVersion` usages with `activeClusterMgr.ClusterNameForFailoverVersion` which is the new interface that works for all domain modes. No behavior change for local and active-passive domains.
- Added debug logs in various places in history which required a lot of signature changes.
- Pass start request to `createMutableState` so it can be used to determine active cluster metadata of new active-active domain workflows.
- Left `TODO(active-active)` in a lot of places to be addressed in follow up PRs.

P.S. I tried to break down the changes by package but history sub packages are so interconnected that it was almost impossible to break this down further.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Make sure existing test cases pass
- I will add unit tests for active-active case in follow up PRs so they can be reviewed without getting lost in these boilerplate-heavy PR