### PR TITLE
Fix flaky integration test in TestDomainReplicationQueue

### DIFF
--- a/common/persistence/persistence-tests/queuePersistenceTest.go
+++ b/common/persistence/persistence-tests/queuePersistenceTest.go
@@ -89,7 +89,7 @@ func (s *QueuePersistenceSuite) TestDomainReplicationQueue() {
 				return nil
 			}
 			lastErr = err
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 		}
 		return lastErr
 	}
@@ -192,7 +192,7 @@ func (s *QueuePersistenceSuite) TestDomainReplicationDLQ() {
 				return nil
 			}
 			lastErr = err
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 		}
 		return lastErr
 	}

--- a/common/persistence/persistence-tests/queuePersistenceTest.go
+++ b/common/persistence/persistence-tests/queuePersistenceTest.go
@@ -66,11 +66,13 @@ func (s *QueuePersistenceSuite) TestDomainReplicationQueue() {
 
 	numMessages := 100
 	concurrentSenders := 10
-	messageChan := make(chan []byte)
+	messageChan := make(chan []byte, numMessages)
+	var publishErrors []error
+	var mu sync.Mutex
 
 	go func() {
 		for i := 0; i < numMessages; i++ {
-			messageChan <- []byte{1}
+			messageChan <- []byte{byte(i)}
 		}
 		close(messageChan)
 	}()
@@ -78,12 +80,31 @@ func (s *QueuePersistenceSuite) TestDomainReplicationQueue() {
 	wg := sync.WaitGroup{}
 	wg.Add(concurrentSenders)
 
+	// Helper function for publishing with retry
+	publishWithRetry := func(message []byte) error {
+		var lastErr error
+		for i := 0; i < 3; i++ {
+			err := s.Publish(ctx, message)
+			if err == nil {
+				return nil
+			}
+			lastErr = err
+			time.Sleep(100 * time.Millisecond)
+		}
+		return lastErr
+	}
+
+	// Concurrent publishing
 	for i := 0; i < concurrentSenders; i++ {
 		go func() {
 			defer wg.Done()
 			for message := range messageChan {
-				err := s.Publish(ctx, message)
-				s.Nil(err, "Enqueue message failed.")
+				err := publishWithRetry(message)
+				if err != nil {
+					mu.Lock()
+					publishErrors = append(publishErrors, err)
+					mu.Unlock()
+				}
 			}
 		}()
 	}
@@ -92,7 +113,14 @@ func (s *QueuePersistenceSuite) TestDomainReplicationQueue() {
 
 	result, err := s.GetReplicationMessages(ctx, -1, numMessages)
 	s.Nil(err, "GetReplicationMessages failed.")
-	s.Len(result, numMessages)
+	s.Len(result, numMessages, "Expected %d messages, got %d", numMessages, len(result))
+
+	// Verify message content
+	messageSet := make(map[byte]bool)
+	for _, msg := range result {
+		messageSet[msg.Payload[0]] = true
+	}
+	s.Len(messageSet, numMessages, "Expected %d unique messages, got %d", numMessages, len(messageSet))
 }
 
 // TestQueueMetadataOperations tests queue metadata operations


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Resolve flakiness in the `TestDomainReplicationQueue` integration test by implementing retry logic for message publishing operations. The test was failing intermittently due to race conditions in concurrent message publishing.

<!-- Tell your future self why have you made these changes -->
**Why?**
Flaky tests cause unwanted delay in testing and can create noise which it makes us unlikely to locate issues detected by tests.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run the integration test for 20 times using following script:
` docker-compose -f docker/buildkite/docker-compose-local.yml run --rm integration-test-cassandra go test ./host/persistence/cassandra/... -run TestCassandraQueuePersistence/TestDomainReplicationQueue -count=20 `

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
