### PR TITLE
Async workflow API not enabled should be user-error

### DIFF
--- a/service/frontend/api/producer_manager.go
+++ b/service/frontend/api/producer_manager.go
@@ -26,6 +26,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/uber/cadence/common/types"
 	"time"
 
 	"github.com/uber/cadence/common/asyncworkflow/queue"
@@ -84,7 +85,7 @@ func (q *producerManagerImpl) GetProducerByDomain(
 		return nil, err
 	}
 	if !domainEntry.GetConfig().AsyncWorkflowConfig.Enabled {
-		return nil, fmt.Errorf("async workflow is not enabled for domain %v", domain)
+		return nil, &types.BadRequestError{Message: fmt.Sprintf("async workflow is not enabled for domain %v", domain)}
 	}
 	queueName := domainEntry.GetConfig().AsyncWorkflowConfig.PredefinedQueueName
 	var queue provider.Queue

--- a/service/frontend/api/producer_manager.go
+++ b/service/frontend/api/producer_manager.go
@@ -26,7 +26,6 @@ package api
 
 import (
 	"fmt"
-	"github.com/uber/cadence/common/types"
 	"time"
 
 	"github.com/uber/cadence/common/asyncworkflow/queue"
@@ -35,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
 )
 
 type (

--- a/service/frontend/api/producer_manager_test.go
+++ b/service/frontend/api/producer_manager_test.go
@@ -203,6 +203,23 @@ func TestGetProducerByDomain(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:   "Error case - async wf not enabled",
+			domain: "test-domain",
+			mockSetup: func(mockDomainCache *cache.MockDomainCache, mockProvider *queue.MockProvider, mockQueue *provider.MockQueue, mockProducerCache *cache.MockCache) {
+				mockDomainCache.EXPECT().GetDomain("test-domain").Return(cache.NewGlobalDomainCacheEntryForTest(
+					nil,
+					&persistence.DomainConfig{
+						AsyncWorkflowConfig: types.AsyncWorkflowConfiguration{
+							Enabled: false,
+						},
+					},
+					nil,
+					0,
+				), nil)
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The error returned when a domain is not enabled for async wf is specified to be a user error

<!-- Tell your future self why have you made these changes -->
**Why?**
Without the categorisation, the error will be considered as availability drop

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
