### PR TITLE
sharddistributorfx

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -32,23 +32,38 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/membership/membershipfx"
+	"github.com/uber/cadence/common/peerprovider/ringpopprovider/ringpopfx"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"github.com/uber/cadence/common/rpc/rpcfx"
+	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/service/sharddistributor/sharddistributorfx"
 	"github.com/uber/cadence/tools/cassandra"
 	"github.com/uber/cadence/tools/sql"
 )
 
 // Module provides a cadence server initialization with root components.
 // AppParams allows to provide optional/overrides for implementation specific dependencies.
-var Module = fx.Options(
-	fx.Provide(NewApp),
-	// empty invoke so fx won't drop the application from the dependencies.
-	fx.Invoke(func(a *App) {}),
-)
+func Module(serviceName string) fx.Option {
+	if serviceName == service.ShortName(service.ShardDistributor) {
+		return fx.Options(
+			rpcfx.Module,
+			// PeerProvider could be overriden. Inside Uber we use DNS based internal solution.
+			ringpopfx.Module,
+			membershipfx.Module,
+			sharddistributorfx.Module)
+	}
+	return fx.Options(
+		fx.Provide(NewApp),
+		// empty invoke so fx won't drop the application from the dependencies.
+		fx.Invoke(func(a *App) {}),
+	)
+}
 
 type AppParams struct {
 	fx.In
 
-	Services      []string `name:"services"`
+	Service       string `name:"service"`
 	AppContext    config.Context
 	Config        config.Config
 	Logger        log.Logger
@@ -61,10 +76,12 @@ func NewApp(params AppParams) *App {
 	app := &App{
 		cfg:           params.Config,
 		logger:        params.Logger,
-		services:      params.Services,
+		service:       params.Service,
 		dynamicConfig: params.DynamicConfig,
 	}
-	params.LifeCycle.Append(fx.Hook{OnStart: app.Start, OnStop: app.Stop})
+
+	params.LifeCycle.Append(fx.StartHook(app.verifySchema))
+	params.LifeCycle.Append(fx.StartStopHook(app.Start, app.Stop))
 	return app
 }
 
@@ -76,14 +93,22 @@ type App struct {
 	logger        log.Logger
 	dynamicConfig dynamicconfig.Client
 
-	daemons  []common.Daemon
-	services []string
+	daemon  common.Daemon
+	service string
 }
 
 func (a *App) Start(_ context.Context) error {
-	if err := a.cfg.ValidateAndFillDefaults(); err != nil {
-		return fmt.Errorf("config validation failed: %w", err)
-	}
+	a.daemon = newServer(a.service, a.cfg, a.logger, a.dynamicConfig)
+	a.daemon.Start()
+	return nil
+}
+
+func (a *App) Stop(ctx context.Context) error {
+	a.daemon.Stop()
+	return nil
+}
+
+func (a *App) verifySchema(ctx context.Context) error {
 	// cassandra schema version validation
 	if err := cassandra.VerifyCompatibleVersion(a.cfg.Persistence, gocql.Quorum); err != nil {
 		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)
@@ -91,21 +116,6 @@ func (a *App) Start(_ context.Context) error {
 	// sql schema version validation
 	if err := sql.VerifyCompatibleVersion(a.cfg.Persistence); err != nil {
 		return fmt.Errorf("sql schema version compatibility check failed: %w", err)
-	}
-
-	var daemons []common.Daemon
-	for _, svc := range a.services {
-		server := newServer(svc, a.cfg, a.logger, a.dynamicConfig)
-		daemons = append(daemons, server)
-		server.Start()
-	}
-
-	return nil
-}
-
-func (a *App) Stop(ctx context.Context) error {
-	for _, daemon := range a.daemons {
-		daemon.Stop()
 	}
 	return nil
 }

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -100,9 +99,10 @@ func (s *ServerSuite) TestServerStartup() {
 	lifecycle := fxtest.NewLifecycle(s.T())
 
 	var daemons []common.Daemon
-	services := service.ShortNames(service.List)
+	// Shard distributor should be tested separately
+	services := service.ShortNames(service.List[:len(service.List)-1])
 	for _, svc := range services {
-		server := newServer(svc, cfg, logger, dynamicconfigfx.New(dynamicconfigfx.Params{Logger: logger, Cfg: cfg, Lifecycle: lifecycle}))
+		server := newServer(svc, cfg, logger, dynamicconfig.NewNopClient())
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/common/clock/clockfx/clockfx.go
+++ b/common/clock/clockfx/clockfx.go
@@ -1,0 +1,10 @@
+package clockfx
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/uber/cadence/common/clock"
+)
+
+// Module provides real time source for fx application.
+var Module = fx.Module("clock", fx.Provide(clock.NewRealTimeSource))

--- a/common/clock/clockfx/clockfx.go
+++ b/common/clock/clockfx/clockfx.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package clockfx
 
 import (

--- a/common/config/fx.go
+++ b/common/config/fx.go
@@ -23,7 +23,6 @@
 package config
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -93,13 +92,7 @@ func New(p Params) (Result, error) {
 		return Result{}, fmt.Errorf("get service config: %w", err)
 	}
 
-	p.Lifecycle.Append(fx.Hook{OnStart: func(ctx context.Context) error {
-		err := cfg.validate()
-		if err != nil {
-			return fmt.Errorf("validate config: %w", err)
-		}
-		return nil
-	}})
+	p.Lifecycle.Append(fx.StartHook(cfg.validate))
 
 	return Result{
 		Config:        cfg,

--- a/common/dynamicconfig/dynamicconfigfx/fx.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx.go
@@ -23,7 +23,6 @@
 package dynamicconfigfx
 
 import (
-	"context"
 	"path/filepath"
 
 	"go.uber.org/fx"
@@ -68,10 +67,9 @@ func New(p Params) Result {
 		p.Cfg.DynamicConfig.FileBased.Filepath = constructPathIfNeed(p.RootDir, p.Cfg.DynamicConfig.FileBased.Filepath)
 	}
 
-	p.Lifecycle.Append(fx.Hook{OnStop: func(_ context.Context) error {
+	p.Lifecycle.Append(fx.StopHook(func() {
 		close(stopped)
-		return nil
-	}})
+	}))
 
 	var res dynamicconfig.Client
 

--- a/common/dynamicconfig/dynamicconfigfx/fx_test.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx_test.go
@@ -36,7 +36,11 @@ import (
 func TestModule(t *testing.T) {
 	app := fxtest.New(t,
 		testlogger.Module(t),
-		fx.Provide(func() config.Config { return config.Config{} },
+		fx.Provide(func() config.Config {
+			return config.Config{
+				ClusterGroupMetadata: &config.ClusterGroupMetadata{},
+			}
+		},
 			func() fxRoot {
 				return fxRoot{
 					RootDir: "../../../",

--- a/common/membership/membershipfx/membershipfx.go
+++ b/common/membership/membershipfx/membershipfx.go
@@ -1,0 +1,56 @@
+package membershipfx
+
+import (
+	"fmt"
+
+	"go.uber.org/fx"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/service"
+)
+
+// Module provides membership components for fx app.
+var Module = fx.Module("membership", fx.Provide(buildMembership))
+
+type buildMembershipParams struct {
+	fx.In
+
+	Clock         clock.TimeSource
+	PeerProvider  membership.PeerProvider
+	Logger        log.Logger
+	MetricsClient metrics.Client
+	Lifecycle     fx.Lifecycle
+}
+
+type buildMembershipResult struct {
+	fx.Out
+
+	Rings    map[string]membership.SingleProvider
+	Resolver membership.Resolver
+}
+
+func buildMembership(params buildMembershipParams) (buildMembershipResult, error) {
+	rings := make(map[string]membership.SingleProvider)
+	for _, s := range service.ListWithRing {
+		rings[s] = membership.NewHashring(s, params.PeerProvider, params.Clock, params.Logger, params.MetricsClient.Scope(metrics.HashringScope))
+	}
+
+	resolver, err := membership.NewResolver(
+		params.PeerProvider,
+		params.MetricsClient,
+		rings,
+	)
+	if err != nil {
+		return buildMembershipResult{}, fmt.Errorf("create resolver: %w", err)
+	}
+
+	params.Lifecycle.Append(fx.StartStopHook(resolver.Start, resolver.Stop))
+
+	return buildMembershipResult{
+		Rings:    rings,
+		Resolver: resolver,
+	}, nil
+}

--- a/common/membership/membershipfx/membershipfx.go
+++ b/common/membership/membershipfx/membershipfx.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package membershipfx
 
 import (

--- a/common/membership/membershipfx/membershipfx.go
+++ b/common/membership/membershipfx/membershipfx.go
@@ -63,6 +63,7 @@ func buildMembership(params buildMembershipParams) (buildMembershipResult, error
 	resolver, err := membership.NewResolver(
 		params.PeerProvider,
 		params.MetricsClient,
+		params.Logger,
 		rings,
 	)
 	if err != nil {

--- a/common/membership/membershipfx/memebershipfx_test.go
+++ b/common/membership/membershipfx/memebershipfx_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package membershipfx
 
 import (

--- a/common/membership/membershipfx/memebershipfx_test.go
+++ b/common/membership/membershipfx/memebershipfx_test.go
@@ -1,0 +1,38 @@
+package membershipfx
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/metrics"
+)
+
+func TestFxStartStop(t *testing.T) {
+	app := fxtest.New(t, fx.Provide(func() appParams {
+		ctrl := gomock.NewController(t)
+		provider := membership.NewMockPeerProvider(ctrl)
+		return appParams{
+			Clock:         clock.NewMockedTimeSource(),
+			PeerProvider:  provider,
+			Logger:        testlogger.New(t),
+			MetricsClient: metrics.NewNoopMetricsClient(),
+		}
+	}), Module)
+	app.RequireStart().RequireStop()
+}
+
+type appParams struct {
+	fx.Out
+
+	Clock         clock.TimeSource
+	PeerProvider  membership.PeerProvider
+	Logger        log.Logger
+	MetricsClient metrics.Client
+}

--- a/common/metrics/metricsfx/metricsfx.go
+++ b/common/metrics/metricsfx/metricsfx.go
@@ -20,39 +20,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cadence
+package metricsfx
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"go.uber.org/fx"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/service"
 )
 
-func TestFxDependencies(t *testing.T) {
-	err := fx.ValidateApp(config.Module,
-		logfx.Module,
-		dynamicconfigfx.Module,
-		fx.Provide(func() appContext {
-			return appContext{
-				CfgContext: config.Context{
-					Environment: "",
-					Zone:        "",
-				},
-				ConfigDir: "",
-				RootDir:   "",
-			}
-		},
-			func() serviceContext {
-				return serviceContext{
-					Name:     "",
-					FullName: "",
-				}
-			}),
-		Module(""))
-	require.NoError(t, err)
+// Module provides metrics client for fx application.
+var Module = fx.Module("metricfx",
+	fx.Provide(buildClient))
+
+type clientParams struct {
+	fx.In
+
+	Logger          log.Logger
+	ServiceFullName string `name:"service-full-name"`
+	SvcCfg          config.Service
+	Scope           tally.Scope `optional:"true"` // maybe filled outside
+}
+
+func buildClient(params clientParams) metrics.Client {
+	if params.Scope == nil {
+		params.Scope = params.SvcCfg.Metrics.NewScope(params.Logger, params.ServiceFullName)
+	}
+	return metrics.NewClient(params.Scope, service.GetMetricsServiceIdx(params.ServiceFullName, params.Logger))
 }

--- a/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx.go
+++ b/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package ringpopfx
 
 import (

--- a/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx.go
+++ b/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx.go
@@ -1,0 +1,37 @@
+package ringpopfx
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/peerprovider/ringpopprovider"
+	"github.com/uber/cadence/common/rpc"
+)
+
+// Module provides a peer resolver based on ringpop for fx app.
+var Module = fx.Module("ringpop", fx.Provide(buildRingpopProvider))
+
+type Params struct {
+	fx.In
+
+	Service       string `name:"service"`
+	Config        config.Config
+	ServiceConfig config.Service
+	Logger        log.Logger
+	RPCFactory    rpc.Factory
+	Lifecycle     fx.Lifecycle
+}
+
+func buildRingpopProvider(params Params) (membership.PeerProvider, error) {
+	provider, err := ringpopprovider.New(params.Service, &params.Config.Ringpop, params.RPCFactory.GetTChannel(), membership.PortMap{
+		membership.PortGRPC:     params.ServiceConfig.RPC.GRPCPort,
+		membership.PortTchannel: params.ServiceConfig.RPC.Port,
+	}, params.Logger)
+	if err != nil {
+		return nil, err
+	}
+	params.Lifecycle.Append(fx.StartStopHook(provider.Start, provider.Stop))
+	return provider, nil
+}

--- a/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx_test.go
+++ b/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package ringpopfx
 
 import (

--- a/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx_test.go
+++ b/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx_test.go
@@ -1,0 +1,43 @@
+package ringpopfx
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/rpc"
+)
+
+func TestFxApp(t *testing.T) {
+	app := fxtest.New(t,
+		fx.Provide(
+			func() testSetupParams {
+				ctrl := gomock.NewController(t)
+				factory := rpc.NewMockFactory(ctrl)
+				factory.EXPECT().GetTChannel().Return(nil)
+
+				return testSetupParams{
+					Service:    "test",
+					Logger:     testlogger.New(t),
+					RPCFactory: factory,
+				}
+			}),
+		Module,
+	)
+	app.RequireStart().RequireStop()
+}
+
+type testSetupParams struct {
+	fx.Out
+
+	Service       string `name:"service"`
+	Config        config.Config
+	ServiceConfig config.Service
+	Logger        log.Logger
+	RPCFactory    rpc.Factory
+}

--- a/common/resource/params.go
+++ b/common/resource/params.go
@@ -61,7 +61,7 @@ type (
 
 		MetricScope        tally.Scope
 		MembershipResolver membership.Resolver
-		HashRings          map[string]*membership.Ring
+		HashRings          map[string]membership.SingleProvider
 		RPCFactory         rpc.Factory
 		PProfInitializer   common.PProfInitializer
 		PersistenceConfig  config.Persistence

--- a/common/rpc/factory.go
+++ b/common/rpc/factory.go
@@ -65,7 +65,7 @@ type FactoryImpl struct {
 }
 
 // NewFactory builds a new rpc.Factory
-func NewFactory(logger log.Logger, p Params) *FactoryImpl {
+func NewFactory(logger log.Logger, p Params) Factory {
 	logger = logger.WithTags(tag.ComponentRPCFactory)
 
 	inbounds := yarpc.Inbounds{}
@@ -169,7 +169,7 @@ func (d *FactoryImpl) GetDispatcher() *yarpc.Dispatcher {
 	return d.dispatcher
 }
 
-// GetChannel returns Tchannel Channel used by Ringpop
+// GetTChannel GetChannel returns Tchannel Channel used by Ringpop
 func (d *FactoryImpl) GetTChannel() tchannel.Channel {
 	return d.channel
 }

--- a/common/rpc/rpcfx/rpcfx.go
+++ b/common/rpc/rpcfx/rpcfx.go
@@ -20,39 +20,40 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cadence
+package rpcfx
 
 import (
-	"testing"
+	"fmt"
 
-	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/rpc"
 )
 
-func TestFxDependencies(t *testing.T) {
-	err := fx.ValidateApp(config.Module,
-		logfx.Module,
-		dynamicconfigfx.Module,
-		fx.Provide(func() appContext {
-			return appContext{
-				CfgContext: config.Context{
-					Environment: "",
-					Zone:        "",
-				},
-				ConfigDir: "",
-				RootDir:   "",
-			}
-		},
-			func() serviceContext {
-				return serviceContext{
-					Name:     "",
-					FullName: "",
-				}
-			}),
-		Module(""))
-	require.NoError(t, err)
+// Module provides rpc.Params and rpc.Factory for fx application.
+var Module = fx.Module("rpcfx",
+	fx.Provide(paramsBuilder),
+	fx.Provide(rpc.NewFactory),
+)
+
+type paramsBuilderParams struct {
+	fx.In
+
+	ServiceFullName   string `name:"service-full-name"`
+	Cfg               config.Config
+	Logger            log.Logger
+	DynamicCollection *dynamicconfig.Collection
+	MetricsClient     metrics.Client
+}
+
+func paramsBuilder(p paramsBuilderParams) (rpc.Params, error) {
+	res, err := rpc.NewParams(p.ServiceFullName, &p.Cfg, p.DynamicCollection, p.Logger, p.MetricsClient)
+	if err != nil {
+		return rpc.Params{}, fmt.Errorf("create rpc params: %w", err)
+	}
+	return res, nil
 }

--- a/common/rpc/rpcfx/rpcfx.go
+++ b/common/rpc/rpcfx/rpcfx.go
@@ -37,7 +37,7 @@ import (
 // Module provides rpc.Params and rpc.Factory for fx application.
 var Module = fx.Module("rpcfx",
 	fx.Provide(paramsBuilder),
-	fx.Provide(rpc.NewFactory),
+	fx.Provide(buildFactory),
 )
 
 type paramsBuilderParams struct {
@@ -56,4 +56,19 @@ func paramsBuilder(p paramsBuilderParams) (rpc.Params, error) {
 		return rpc.Params{}, fmt.Errorf("create rpc params: %w", err)
 	}
 	return res, nil
+}
+
+type factoryParams struct {
+	fx.In
+
+	Logger    log.Logger
+	RPCParams rpc.Params
+
+	Lifecycle fx.Lifecycle
+}
+
+func buildFactory(p factoryParams) rpc.Factory {
+	res := rpc.NewFactory(p.Logger, p.RPCParams)
+	p.Lifecycle.Append(fx.StartStopHook(res.GetDispatcher().Start, res.GetDispatcher().Stop))
+	return res
 }

--- a/service/sharddistributor/service.go
+++ b/service/sharddistributor/service.go
@@ -23,11 +23,19 @@ package sharddistributor
 import (
 	"sync/atomic"
 
+	"go.uber.org/fx"
+	"go.uber.org/yarpc"
+
 	"github.com/uber/cadence/common"
+	commonConfig "github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/rpc"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/service/sharddistributor/config"
 	"github.com/uber/cadence/service/sharddistributor/handler"
@@ -37,58 +45,94 @@ import (
 
 // Service represents the shard distributor service
 type Service struct {
-	resource.Resource
+	logger        log.Logger
+	metricsClient metrics.Client
+	dispatcher    *yarpc.Dispatcher
 
-	status           int32
 	handler          handler.Handler
-	stopC            chan struct{}
 	config           *config.Config
 	numHistoryShards int
 	peerProvider     membership.PeerProvider
 
-	matchingRing *membership.Ring
-	historyRing  *membership.Ring
+	matchingRing membership.SingleProvider
+	historyRing  membership.SingleProvider
+
+	// DEPRECATED: does not affect fx lifecycle.
+	stopC  chan struct{}
+	status int32
 }
 
-// NewService builds a new task manager service
+type ServiceParams struct {
+	fx.In
+
+	Logger            log.Logger
+	MetricsClient     metrics.Client
+	RPCFactory        rpc.Factory
+	DynamicCollection *dynamicconfig.Collection
+	Config            commonConfig.Config
+
+	Lifecycle fx.Lifecycle
+
+	HostName string `name:"hostname"`
+
+	MembershipRings map[string]membership.SingleProvider
+}
+
+// FXService builds a new shard distributor service
+func FXService(params ServiceParams) *Service {
+	serviceConfig := config.NewConfig(params.DynamicCollection, params.HostName)
+
+	logger := params.Logger.WithTags(tag.Service("shard-distributor"))
+
+	svc := &Service{
+		config: serviceConfig,
+
+		logger:           logger,
+		metricsClient:    params.MetricsClient,
+		dispatcher:       params.RPCFactory.GetDispatcher(),
+		numHistoryShards: params.Config.Persistence.NumHistoryShards,
+
+		matchingRing: params.MembershipRings[service.Matching],
+		historyRing:  params.MembershipRings[service.History],
+	}
+
+	rawHandler := handler.NewHandler(logger, params.MetricsClient, svc.matchingRing, svc.historyRing)
+	svc.handler = metered.NewMetricsHandler(rawHandler, logger, params.MetricsClient)
+
+	params.Lifecycle.Append(fx.StartStopHook(svc.Start, svc.Stop))
+	return svc
+}
+
+// NewService is an adapter for legacy initialization without fx.
 func NewService(
 	params *resource.Params,
-	factory resource.ResourceFactory,
-) (resource.Resource, error) {
+) (*Service, error) {
+	logger := params.Logger.WithTags(tag.Service("shard-distributor"))
 
 	serviceConfig := config.NewConfig(
 		dynamicconfig.NewCollection(
 			params.DynamicConfig,
-			params.Logger,
+			logger,
 			dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
 		),
 		params.HostName,
 	)
 
-	serviceResource, err := factory.NewResource(
-		params,
-		service.ShardDistributor,
-		&service.Config{
-			PersistenceMaxQPS:        serviceConfig.PersistenceMaxQPS,
-			PersistenceGlobalMaxQPS:  serviceConfig.PersistenceGlobalMaxQPS,
-			ThrottledLoggerMaxRPS:    serviceConfig.ThrottledLogRPS,
-			IsErrorRetryableFunction: common.IsServiceTransientError,
-			// shard distributor doesn't need visibility config as it never read or write visibility
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	matchingRing := params.HashRings[service.Matching]
 	historyRing := params.HashRings[service.History]
 
+	rawHandler := handler.NewHandler(logger, params.MetricsClient, matchingRing, historyRing)
+	meteredHandler := metered.NewMetricsHandler(rawHandler, logger, params.MetricsClient)
+
 	return &Service{
-		Resource:         serviceResource,
 		status:           common.DaemonStatusInitialized,
 		config:           serviceConfig,
 		stopC:            make(chan struct{}),
 		numHistoryShards: params.PersistenceConfig.NumHistoryShards,
+		logger:           logger,
+		metricsClient:    params.MetricsClient,
+		dispatcher:       params.RPCFactory.GetDispatcher(),
+		handler:          meteredHandler,
 
 		matchingRing: matchingRing,
 		historyRing:  historyRing,
@@ -101,23 +145,21 @@ func (s *Service) Start() {
 		return
 	}
 
-	logger := s.GetLogger()
-	logger.Info("shard distributor starting")
-
-	rawHandler := handler.NewHandler(s.GetLogger(), s.GetMetricsClient(), s.matchingRing, s.historyRing)
-	meteredHandler := metered.NewMetricsHandler(rawHandler, s.GetLogger(), s.GetMetricsClient())
-
-	s.handler = meteredHandler
+	s.logger.Info("starting")
 
 	grpcHandler := grpc.NewGRPCHandler(s.handler)
-	grpcHandler.Register(s.GetDispatcher())
+	grpcHandler.Register(s.dispatcher)
 
-	s.Resource.Start()
 	s.handler.Start()
 
-	logger.Info("shard distributor started")
+	s.logger.Info("started")
 
-	<-s.stopC
+	// legacy mode, fx Lifecyle requires component to start and return nil
+	if s.stopC != nil {
+		<-s.stopC
+	}
+
+	return
 }
 
 func (s *Service) Stop() {
@@ -125,10 +167,12 @@ func (s *Service) Stop() {
 		return
 	}
 
-	close(s.stopC)
+	// legacy mode, fx stops the component and ensures order/wait time between dependent components.
+	if s.stopC != nil {
+		close(s.stopC)
+	}
 
 	s.handler.Stop()
-	s.Resource.Stop()
 
-	s.GetLogger().Info("shard distributor stopped")
+	s.logger.Info("stopped")
 }

--- a/service/sharddistributor/service_test.go
+++ b/service/sharddistributor/service_test.go
@@ -23,70 +23,87 @@
 package sharddistributor
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/rpc"
 )
 
-func TestNewService(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	resourceMock := resource.NewMockResource(ctrl)
-	factoryMock := resource.NewMockResourceFactory(ctrl)
-	factoryMock.EXPECT().NewResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(resourceMock, nil).AnyTimes()
-
-	service, err := NewService(&resource.Params{}, factoryMock)
-	assert.NoError(t, err)
-	assert.NotNil(t, service)
-}
-
-func TestServiceStartStop(t *testing.T) {
+func TestLegacyServiceStartStop(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	ctrl := gomock.NewController(t)
-
 	testDispatcher := yarpc.NewDispatcher(yarpc.Config{Name: "test"})
+	ctrl := gomock.NewController(t)
+	factory := rpc.NewMockFactory(ctrl)
+	factory.EXPECT().GetDispatcher().Return(testDispatcher)
 
-	resourceMock := resource.NewMockResource(ctrl)
-	resourceMock.EXPECT().GetLogger().Return(log.NewNoop()).AnyTimes()
-	resourceMock.EXPECT().GetMembershipResolver().Return(nil).AnyTimes()
-	resourceMock.EXPECT().GetMetricsClient().Return(nil).AnyTimes()
-	resourceMock.EXPECT().GetDispatcher().Return(testDispatcher).AnyTimes()
-	resourceMock.EXPECT().Start().Return()
-	resourceMock.EXPECT().Stop().Return()
-
-	service := &Service{
-		Resource: resourceMock,
-		status:   common.DaemonStatusInitialized,
-		stopC:    make(chan struct{}),
+	params := &resource.Params{
+		Logger:        testlogger.New(t),
+		MetricsClient: metrics.NewNoopMetricsClient(),
+		RPCFactory:    factory,
 	}
 
-	go service.Start()
+	service, err := NewService(params)
+	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond) // The code assumes the service is started when calling Stop
-	assert.Equal(t, int32(common.DaemonStatusStarted), atomic.LoadInt32(&service.status))
+	doneWG := sync.WaitGroup{}
+	doneWG.Add(1)
+
+	go func() {
+		defer doneWG.Done()
+		service.Start()
+	}()
+
+	time.Sleep(time.Millisecond) // The code assumes the service is started when calling Stop
+	assert.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&service.status))
 
 	service.Stop()
-	assert.Equal(t, int32(common.DaemonStatusStopped), atomic.LoadInt32(&service.status))
+	success := common.AwaitWaitGroup(&doneWG, time.Second)
+	assert.True(t, success)
 }
 
-func TestStartAndStopDoesNotChangeStatusWhenAlreadyStopped(t *testing.T) {
+func TestFxServiceStartStop(t *testing.T) {
+	defer goleak.VerifyNone(t)
 
-	service := &Service{
-		status: common.DaemonStatusStopped,
-	}
+	testDispatcher := yarpc.NewDispatcher(yarpc.Config{Name: "test"})
+	ctrl := gomock.NewController(t)
+	app := fxtest.New(t,
+		testlogger.Module(t),
+		fx.Provide(
+			func() metrics.Client { return metrics.NewNoopMetricsClient() },
+			func() rpc.Factory {
+				factory := rpc.NewMockFactory(ctrl)
+				factory.EXPECT().GetDispatcher().Return(testDispatcher)
+				return factory
+			},
+			func() *dynamicconfig.Collection {
+				return &dynamicconfig.Collection{}
+			},
+			func() hostResult { return hostResult{} },
+			func() map[string]membership.SingleProvider { return make(map[string]membership.SingleProvider) },
+		),
+		fx.Provide(FXService))
+	app.RequireStart().RequireStop()
+}
 
-	service.Start()
-	assert.Equal(t, int32(common.DaemonStatusStopped), atomic.LoadInt32(&service.status))
+type hostResult struct {
+	fx.Out
 
-	service.Stop()
-	assert.Equal(t, int32(common.DaemonStatusStopped), atomic.LoadInt32(&service.status))
+	HostName string `name:"hostname"`
 }

--- a/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
+++ b/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
@@ -20,39 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package cadence
+package sharddistributorfx
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/service/sharddistributor"
 )
 
-func TestFxDependencies(t *testing.T) {
-	err := fx.ValidateApp(config.Module,
-		logfx.Module,
-		dynamicconfigfx.Module,
-		fx.Provide(func() appContext {
-			return appContext{
-				CfgContext: config.Context{
-					Environment: "",
-					Zone:        "",
-				},
-				ConfigDir: "",
-				RootDir:   "",
-			}
-		},
-			func() serviceContext {
-				return serviceContext{
-					Name:     "",
-					FullName: "",
-				}
-			}),
-		Module(""))
-	require.NoError(t, err)
-}
+var Module = fx.Module("sharddistributor", fx.Provide(sharddistributor.FXService))

--- a/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
+++ b/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
@@ -28,4 +28,4 @@ import (
 	"github.com/uber/cadence/service/sharddistributor"
 )
 
-var Module = fx.Module("sharddistributor", fx.Provide(sharddistributor.FXService))
+var Module = fx.Module("sharddistributor", fx.Provide(sharddistributor.FXService), fx.Invoke(func(*sharddistributor.Service) {}))


### PR DESCRIPTION
- **[service][fx] Move a few more components to fx and make shard distributor service have it's own dependencies**

<!-- Describe what has changed in this PR -->
**What changed?**
Onboarded shard distributor to usage of fx instead of relying on resource god object for components dependencies. Old way of running things is still supported, but could be cleaned up later.

<!-- Tell your future self why have you made these changes -->
**Why?**
It allows services and components to define dependencies dynamically. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests/local runs/integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Shard distributor can fail to start or fail on start.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
