### PR TITLE
[domain deletion]Add validation acitivity after terminating open wfs

### DIFF
--- a/service/worker/domaindeprecation/module.go
+++ b/service/worker/domaindeprecation/module.go
@@ -110,6 +110,7 @@ func (w *domainDeprecator) Start() error {
 	newWorker := worker.New(w.svcClient, constants.SystemLocalDomainName, domainDeprecationTaskListName, workerOpts)
 	newWorker.RegisterWorkflowWithOptions(w.DomainDeprecationWorkflow, workflow.RegisterOptions{Name: domainDeprecationWorkflowTypeName})
 	newWorker.RegisterActivityWithOptions(w.DisableArchivalActivity, activity.RegisterOptions{Name: disableArchivalActivity, EnableAutoHeartbeat: true})
+	newWorker.RegisterActivityWithOptions(w.CheckOpenWorkflowsActivity, activity.RegisterOptions{Name: checkOpenWorkflowsActivity, EnableAutoHeartbeat: true})
 	newWorker.RegisterActivityWithOptions(w.DeprecateDomainActivity, activity.RegisterOptions{Name: deprecateDomainActivity, EnableAutoHeartbeat: true})
 	w.worker = newWorker
 	return newWorker.Start()

--- a/service/worker/domaindeprecation/workflow.go
+++ b/service/worker/domaindeprecation/workflow.go
@@ -38,11 +38,15 @@ const (
 	domainDeprecationTaskListName     = "domain-deprecation-tasklist"
 	domainDeprecationBatchPrefix      = "domain-deprecation-batch"
 
-	disableArchivalActivity = "disableArchival"
-	deprecateDomainActivity = "deprecateDomain"
+	disableArchivalActivity    = "disableArchival"
+	deprecateDomainActivity    = "deprecateDomain"
+	checkOpenWorkflowsActivity = "checkOpenWorkflows"
 
 	workflowStartToCloseTimeout     = time.Hour * 24 * 30
 	workflowTaskStartToCloseTimeout = 5 * time.Minute
+
+	// MaxBatchWorkflowAttempts is the maximum number of attempts to terminate open workflows
+	MaxBatchWorkflowAttempts = 3
 )
 
 var (
@@ -115,17 +119,50 @@ func (w *domainDeprecator) DomainDeprecationWorkflow(ctx workflow.Context, domai
 		},
 	}
 
-	workflowID := uuid.New()
-	childWorkflowOptions := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
-		WorkflowID:                   fmt.Sprintf("%s-%s-%s", domainDeprecationBatchPrefix, domainName, workflowID),
-		ExecutionStartToCloseTimeout: workflowStartToCloseTimeout,
-		TaskStartToCloseTimeout:      workflowTaskStartToCloseTimeout,
-	})
+	for attempt := 1; attempt <= MaxBatchWorkflowAttempts; attempt++ {
+		logger.Info("Starting batch workflow",
+			zap.String("domain", domainName),
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", MaxBatchWorkflowAttempts))
 
-	var result batcher.HeartBeatDetails
-	err = workflow.ExecuteChildWorkflow(childWorkflowOptions, batcher.BatchWorkflow, batchParams).Get(ctx, &result)
-	if err != nil {
-		return fmt.Errorf("batch workflow failed: %v", err)
+		workflowID := uuid.New()
+		childWorkflowOptions := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+			WorkflowID:                   fmt.Sprintf("%s-%s-%s-%d", domainDeprecationBatchPrefix, domainName, workflowID, attempt),
+			ExecutionStartToCloseTimeout: workflowStartToCloseTimeout,
+			TaskStartToCloseTimeout:      workflowTaskStartToCloseTimeout,
+		})
+
+		var result batcher.HeartBeatDetails
+		err = workflow.ExecuteChildWorkflow(childWorkflowOptions, batcher.BatchWorkflow, batchParams).Get(ctx, &result)
+		if err != nil {
+			return fmt.Errorf("batch workflow failed on attempt %d: %v", attempt, err)
+		}
+
+		// Check if there are still open workflows
+		var hasOpenWorkflows bool
+		err = workflow.ExecuteActivity(
+			workflow.WithActivityOptions(ctx, activityOptions),
+			w.CheckOpenWorkflowsActivity,
+			domainParams,
+		).Get(ctx, &hasOpenWorkflows)
+		if err != nil {
+			return fmt.Errorf("failed to check open workflows on attempt %d: %v", attempt, err)
+		}
+
+		if !hasOpenWorkflows {
+			logger.Info("No open workflows found after batch workflow",
+				zap.String("domain", domainName),
+				zap.Int("attempt", attempt))
+			break
+		}
+
+		if attempt == MaxBatchWorkflowAttempts {
+			return fmt.Errorf("failed to terminate all workflows after %d attempts", MaxBatchWorkflowAttempts)
+		}
+
+		logger.Info("Found open workflows after batch workflow, will retry",
+			zap.String("domain", domainName),
+			zap.Int("attempt", attempt))
 	}
 
 	logger.Info("Domain deprecation workflow completed successfully", zap.String("domain", domainName))


### PR DESCRIPTION
This PR adds a validation step to the domain deprecation workflow to ensure all workflows are properly terminated. After running the batch workflow to terminate open workflows, we check if any workflows remain open using the CheckOpenWorkflowsActivity.

**What changed?**
- Added CheckOpenWorkflowsActivity to verify if any workflows remain open after termination
- Implemented retry logic that runs up to 3 times (MaxBatchWorkflowAttempts) if open workflows are found
- Added detailed logging to track the progress of each attempt
- The workflow will fail if open workflows are still found after all attempts

<!-- Tell your future self why have you made these changes -->
**Why?**
This validation step is crucial because:
- It ensures the domain is truly ready for deprecation
- Prevents potential issues from lingering workflows
- Provides clear visibility into the termination process through logging
- Allows for multiple attempts to terminate workflows while maintaining a reasonable limit. If it reached the limit and failed it would require manual investigation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and local testing.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
