### PR TITLE
Unify methods of history tasks in shard component

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -438,6 +438,15 @@ type (
 		CurrentRunID string
 	}
 
+	// FailoverLevel contains corresponding start / end level
+	FailoverLevel struct {
+		StartTime    time.Time
+		MinLevel     HistoryTaskKey
+		CurrentLevel HistoryTaskKey
+		MaxLevel     HistoryTaskKey
+		DomainIDs    map[string]struct{}
+	}
+
 	// TransferTaskInfo describes a transfer task
 	TransferTaskInfo struct {
 		DomainID                string

--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -200,7 +200,7 @@ func TestHandleDecisionTaskScheduled(t *testing.T) {
 					Times(1).
 					Return(&types.HistoryEvent{}, nil)
 				shardContext.EXPECT().GetShardID().Return(testShardID).Times(1)
-				shardContext.EXPECT().GenerateTransferTaskIDs(gomock.Any()).Times(1).Return([]int64{}, errors.New("some random error to avoid going too deep in call stack unrelated to this unit"))
+				shardContext.EXPECT().GenerateTaskIDs(gomock.Any()).Times(1).Return([]int64{}, errors.New("some random error to avoid going too deep in call stack unrelated to this unit"))
 			},
 			expectErr:       true,
 			isfirstDecision: true,
@@ -222,7 +222,7 @@ func TestHandleDecisionTaskScheduled(t *testing.T) {
 					Times(1).
 					Return(&types.HistoryEvent{}, nil)
 				shardContext.EXPECT().GetShardID().Return(testShardID).Times(1)
-				shardContext.EXPECT().GenerateTransferTaskIDs(gomock.Any()).Times(1).Return([]int64{}, errors.New("some random error to avoid going too deep in call stack unrelated to this unit"))
+				shardContext.EXPECT().GenerateTaskIDs(gomock.Any()).Times(1).Return([]int64{}, errors.New("some random error to avoid going too deep in call stack unrelated to this unit"))
 			},
 			expectErr:       true,
 			isfirstDecision: true,
@@ -301,7 +301,7 @@ func TestHandleDecisionTaskFailed(t *testing.T) {
 				}
 				h.tokenSerializer.(*common.MockTaskTokenSerializer).EXPECT().Deserialize(taskToken).Return(token, nil)
 				h.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(events.NewMockCache(ctrl))
-				h.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(gomock.Any()).Return([]int64{0}, nil)
+				h.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(gomock.Any()).Return([]int64{0}, nil)
 				h.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
@@ -494,7 +494,7 @@ func TestHandleDecisionTaskStarted(t *testing.T) {
 			domainID: constants.TestDomainID,
 			expectCalls: func(ctrl *gomock.Controller, h *handlerImpl) {
 				h.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(events.NewMockCache(ctrl))
-				h.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(gomock.Any()).Times(1).Return([]int64{0}, nil)
+				h.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(gomock.Any()).Times(1).Return([]int64{0}, nil)
 				h.shard.(*shard.MockContext).EXPECT().
 					AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID}).
 					Return(&persistence.AppendHistoryNodesResponse{}, nil)
@@ -639,8 +639,8 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(eventsCache)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, constants.TestRunID, int64(1), gomock.Any())
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(4).Return([]int64{0, 1, 2, 3}, nil)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(6).Return([]int64{0, 1, 2, 3, 4, 5}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(4).Return([]int64{0, 1, 2, 3}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(6).Return([]int64{0, 1, 2, 3, 4, 5}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
@@ -769,7 +769,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				eventsCache := events.NewMockCache(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(eventsCache)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(1).Return([]int64{0}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(1).Return([]int64{0}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
@@ -822,7 +822,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				eventsCache.EXPECT().GetEvent(context.Background(), testShardID, constants.TestDomainID, constants.TestWorkflowID, constants.TestRunID, commonconstants.FirstEventID, commonconstants.FirstEventID, nil).Return(&types.HistoryEvent{}, nil)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
 			},
@@ -863,7 +863,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					}, nil).Times(3)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(3).Return(testShardID)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, execution.NewConflictError(new(testing.T), errors.New("some random conflict error")))
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
 			},
@@ -904,7 +904,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					}, nil).Times(3)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(3).Return(testShardID)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
 				firstGetWfExecutionCall := decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).
@@ -955,8 +955,8 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					}, nil).Times(3)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(3)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(3).Return(testShardID)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(2).Times(2).Return([]int64{0, 1}, nil)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(1).Times(1).Return([]int64{0}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(2).Return([]int64{0, 1}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(1).Times(1).Return([]int64{0}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(&persistence.AppendHistoryNodesResponse{}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
@@ -999,7 +999,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				eventsCache := events.NewMockCache(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(3).Return(eventsCache)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, constants.TestRunID, int64(0), gomock.Any())
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(1).Return([]int64{0}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(1).Return([]int64{0}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, errors.New("some error updating continue as new info"))
 				domainEntry := cache.NewLocalDomainCacheEntryForTest(
 					&persistence.DomainInfo{ID: constants.TestDomainID, Name: constants.TestDomainName},
@@ -1146,7 +1146,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.tokenSerializer.(*common.MockTaskTokenSerializer).EXPECT().Deserialize(serializedTestToken).Return(deserializedTestToken, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(events.NewMockCache(ctrl))
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTransferTaskIDs(3).Return([]int64{0, 1, 2}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(3).Return([]int64{0, 1, 2}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -798,7 +798,7 @@ func (e *mutableStateBuilder) assignTaskIDToEvents() error {
 	// first transient events
 	numTaskIDs := len(e.hBuilder.transientHistory)
 	if numTaskIDs > 0 {
-		taskIDs, err := e.shard.GenerateTransferTaskIDs(numTaskIDs)
+		taskIDs, err := e.shard.GenerateTaskIDs(numTaskIDs)
 		if err != nil {
 			return err
 		}
@@ -815,7 +815,7 @@ func (e *mutableStateBuilder) assignTaskIDToEvents() error {
 	// then normal events
 	numTaskIDs = len(e.hBuilder.history)
 	if numTaskIDs > 0 {
-		taskIDs, err := e.shard.GenerateTransferTaskIDs(numTaskIDs)
+		taskIDs, err := e.shard.GenerateTaskIDs(numTaskIDs)
 		if err != nil {
 			return err
 		}

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -3139,7 +3139,7 @@ func TestAssignTaskIDToTransientHistoryEvents(t *testing.T) {
 			},
 			taskID: 123,
 			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
-				shardContext.EXPECT().GenerateTransferTaskIDs(1).Return([]int64{123}, nil).Times(1)
+				shardContext.EXPECT().GenerateTaskIDs(1).Return([]int64{123}, nil).Times(1)
 			},
 			expectedEvents: []*types.HistoryEvent{
 				{
@@ -3164,7 +3164,7 @@ func TestAssignTaskIDToTransientHistoryEvents(t *testing.T) {
 			},
 			taskID: 456,
 			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
-				shardContext.EXPECT().GenerateTransferTaskIDs(2).Return([]int64{123, 124}, nil).Times(1)
+				shardContext.EXPECT().GenerateTaskIDs(2).Return([]int64{123, 124}, nil).Times(1)
 			},
 			expectedEvents: []*types.HistoryEvent{
 				{
@@ -3196,7 +3196,7 @@ func TestAssignTaskIDToTransientHistoryEvents(t *testing.T) {
 			},
 			taskID: 456,
 			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
-				shardContext.EXPECT().GenerateTransferTaskIDs(1).Return(nil, assert.AnError).Times(1)
+				shardContext.EXPECT().GenerateTaskIDs(1).Return(nil, assert.AnError).Times(1)
 			},
 			expectedEvents: []*types.HistoryEvent{
 				{
@@ -3252,7 +3252,7 @@ func TestAssignTaskIDToHistoryEvents(t *testing.T) {
 			},
 			taskID: 123,
 			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
-				shardContext.EXPECT().GenerateTransferTaskIDs(1).Return([]int64{123}, nil).Times(1)
+				shardContext.EXPECT().GenerateTaskIDs(1).Return([]int64{123}, nil).Times(1)
 			},
 			expectedEvents: []*types.HistoryEvent{
 				{
@@ -3277,7 +3277,7 @@ func TestAssignTaskIDToHistoryEvents(t *testing.T) {
 			},
 			taskID: 456,
 			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
-				shardContext.EXPECT().GenerateTransferTaskIDs(2).Return([]int64{123, 124}, nil).Times(1)
+				shardContext.EXPECT().GenerateTaskIDs(2).Return([]int64{123, 124}, nil).Times(1)
 			},
 			expectedEvents: []*types.HistoryEvent{
 				{
@@ -3309,7 +3309,7 @@ func TestAssignTaskIDToHistoryEvents(t *testing.T) {
 			},
 			taskID: 456,
 			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
-				shardContext.EXPECT().GenerateTransferTaskIDs(1).Return(nil, assert.AnError).Times(1)
+				shardContext.EXPECT().GenerateTaskIDs(1).Return(nil, assert.AnError).Times(1)
 			},
 			expectedEvents: []*types.HistoryEvent{
 				{
@@ -3535,7 +3535,7 @@ func TestCloseTransactionAsMutation(t *testing.T) {
 					MaximumBufferedEventsBatch:            func(...dynamicproperties.FilterOption) int { return 100 },
 				}).Times(3)
 
-				shardContext.EXPECT().GenerateTransferTaskIDs(1).Return([]int64{123}, nil).Times(1)
+				shardContext.EXPECT().GenerateTaskIDs(1).Return([]int64{123}, nil).Times(1)
 				shardContext.EXPECT().GetDomainCache().Return(mockDomainCache).Times(1)
 				mockDomainCache.EXPECT().GetDomainByID("some-domain-id").Return(mockDomain, nil)
 

--- a/service/history/queue/timer_queue_active_processor.go
+++ b/service/history/queue/timer_queue_active_processor.go
@@ -66,7 +66,9 @@ func newTimerQueueActiveProcessor(
 	}
 
 	updateClusterAckLevel := func(ackLevel task.Key) error {
-		return shard.UpdateTimerClusterAckLevel(clusterName, ackLevel.(timerTaskKey).visibilityTimestamp)
+		return shard.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryTimer, clusterName, persistence.HistoryTaskKey{
+			ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
+		})
 	}
 
 	updateProcessingQueueStates := func(states []ProcessingQueueState) error {

--- a/service/history/queue/timer_queue_failover_processor.go
+++ b/service/history/queue/timer_queue_failover_processor.go
@@ -77,20 +77,30 @@ func newTimerQueueFailoverProcessor(
 	}
 
 	updateClusterAckLevel := func(ackLevel task.Key) error {
-		return shardContext.UpdateTimerFailoverLevel(
+		return shardContext.UpdateFailoverLevel(
+			persistence.HistoryTaskCategoryTimer,
 			failoverUUID,
-			shard.TimerFailoverLevel{
-				StartTime:    failoverStartTime,
-				MinLevel:     minLevel,
-				CurrentLevel: ackLevel.(timerTaskKey).visibilityTimestamp,
-				MaxLevel:     maxLevel,
-				DomainIDs:    domainIDs,
+			persistence.FailoverLevel{
+				StartTime: failoverStartTime,
+				MinLevel: persistence.HistoryTaskKey{
+					ScheduledTime: minLevel,
+				},
+				CurrentLevel: persistence.HistoryTaskKey{
+					ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
+				},
+				MaxLevel: persistence.HistoryTaskKey{
+					ScheduledTime: maxLevel,
+				},
+				DomainIDs: domainIDs,
 			},
 		)
 	}
 
 	queueShutdown := func() error {
-		return shardContext.DeleteTimerFailoverLevel(failoverUUID)
+		return shardContext.DeleteFailoverLevel(
+			persistence.HistoryTaskCategoryTimer,
+			failoverUUID,
+		)
 	}
 
 	processingQueueStates := []ProcessingQueueState{

--- a/service/history/queue/timer_queue_standby_processor.go
+++ b/service/history/queue/timer_queue_standby_processor.go
@@ -84,7 +84,9 @@ func newTimerQueueStandbyProcessor(
 	}
 
 	updateClusterAckLevel := func(ackLevel task.Key) error {
-		return shard.UpdateTimerClusterAckLevel(clusterName, ackLevel.(timerTaskKey).visibilityTimestamp)
+		return shard.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryTimer, clusterName, persistence.HistoryTaskKey{
+			ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
+		})
 	}
 
 	updateProcessingQueueStates := func(states []ProcessingQueueState) error {

--- a/service/history/queue/transfer_queue_processor_test.go
+++ b/service/history/queue/transfer_queue_processor_test.go
@@ -950,14 +950,14 @@ func Test_loadTransferProcessingQueueStates(t *testing.T) {
 			enableLoadQueueStates: true,
 			clusterName:           constants.TestClusterMetadata.GetCurrentClusterName(),
 			taskID: func(testContext *shard.TestContext) int64 {
-				return testContext.GetTransferClusterAckLevel(constants.TestClusterMetadata.GetCurrentClusterName())
+				return testContext.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryTransfer, constants.TestClusterMetadata.GetCurrentClusterName()).TaskID
 			},
 		},
 		"load queue states false": {
 			enableLoadQueueStates: false,
 			clusterName:           "standby",
 			taskID: func(testContext *shard.TestContext) int64 {
-				return testContext.GetTransferClusterAckLevel("standby")
+				return testContext.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryTransfer, "standby").TaskID
 			},
 		},
 	}

--- a/service/history/replication/metrics_emitter.go
+++ b/service/history/replication/metrics_emitter.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
 )
 
 const (
@@ -64,7 +65,7 @@ type (
 	metricsEmitterShardData interface {
 		GetLogger() log.Logger
 		GetClusterMetadata() cluster.Metadata
-		GetClusterReplicationLevel(cluster string) int64
+		GetQueueClusterAckLevel(category persistence.HistoryTaskCategory, cluster string) persistence.HistoryTaskKey
 		GetTimeSource() clock.TimeSource
 	}
 )
@@ -160,7 +161,7 @@ func (m *MetricsEmitterImpl) emitMetrics() {
 
 func (m *MetricsEmitterImpl) determineReplicationLatency(remoteClusterName string) (time.Duration, error) {
 	logger := m.logger.WithTags(tag.RemoteCluster(remoteClusterName))
-	lastReadTaskID := m.shardData.GetClusterReplicationLevel(remoteClusterName)
+	lastReadTaskID := m.shardData.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, remoteClusterName).TaskID
 
 	tasks, _, err := m.reader.Read(m.ctx, lastReadTaskID, lastReadTaskID+1, 1)
 	if err != nil {

--- a/service/history/replication/task_ack_manager_test.go
+++ b/service/history/replication/task_ack_manager_test.go
@@ -127,7 +127,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - no replication tasks",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
 			reader:         fakeTaskReader{},
@@ -147,7 +147,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - continues on recoverable error",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -172,7 +172,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - stops at non recoverable error",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -197,7 +197,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - stops at second task, batch size is 2",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -222,7 +222,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - stops at a message exceeded max response size",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -253,7 +253,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - fail at a message exceeded max response size",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -277,7 +277,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "skips tasks for domains non belonging to polling cluster",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
 			reader:         fakeTaskReader{&testTask11},
@@ -297,7 +297,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "uses remote ack level for first fetch (empty task ID)",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 12},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 12}},
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
 			reader:         fakeTaskReader{&testTask11, &testTask12},
@@ -317,7 +317,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "failed to read replication tasks - return error",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			reader:         (fakeTaskReader)(nil),
 			pollingCluster: testClusterA,
@@ -330,7 +330,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "failed to get domain - stops",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 			},
 			domains:        fakeDomainCache{},
 			reader:         fakeTaskReader{&testTask11},
@@ -349,7 +349,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "failed to update ack level - no error, return response anyway",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]int64{testClusterA: 2},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
 				updateErr: errors.New("error update ack level"),
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
@@ -392,14 +392,14 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			}
 
 			if tt.expectAckLevel != 0 {
-				assert.Equal(t, tt.expectAckLevel, tt.ackLevels.remote[tt.pollingCluster])
+				assert.Equal(t, tt.expectAckLevel, tt.ackLevels.remote[tt.pollingCluster].TaskID)
 			}
 		})
 	}
 }
 
 type fakeAckLevelStore struct {
-	remote    map[string]int64
+	remote    map[string]persistence.HistoryTaskKey
 	readLevel int64
 	updateErr error
 }
@@ -407,10 +407,10 @@ type fakeAckLevelStore struct {
 func (s *fakeAckLevelStore) GetTransferMaxReadLevel() int64 {
 	return s.readLevel
 }
-func (s *fakeAckLevelStore) GetClusterReplicationLevel(cluster string) int64 {
+func (s *fakeAckLevelStore) GetQueueClusterAckLevel(category persistence.HistoryTaskCategory, cluster string) persistence.HistoryTaskKey {
 	return s.remote[cluster]
 }
-func (s *fakeAckLevelStore) UpdateClusterReplicationLevel(cluster string, lastTaskID int64) error {
+func (s *fakeAckLevelStore) UpdateQueueClusterAckLevel(category persistence.HistoryTaskCategory, cluster string, lastTaskID persistence.HistoryTaskKey) error {
 	s.remote[cluster] = lastTaskID
 	return s.updateErr
 }

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -265,7 +265,7 @@ func (p *taskProcessorImpl) cleanupReplicationTaskLoop() {
 func (p *taskProcessorImpl) cleanupAckedReplicationTasks() error {
 	minAckLevel := int64(math.MaxInt64)
 	for clusterName := range p.shard.GetClusterMetadata().GetRemoteClusterInfo() {
-		ackLevel := p.shard.GetClusterReplicationLevel(clusterName)
+		ackLevel := p.shard.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, clusterName).TaskID
 		if ackLevel < minAckLevel {
 			minAckLevel = ackLevel
 		}

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -135,62 +135,48 @@ func (mr *MockContextMockRecorder) CreateWorkflowExecution(ctx, request any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockContext)(nil).CreateWorkflowExecution), ctx, request)
 }
 
-// DeleteTimerFailoverLevel mocks base method.
-func (m *MockContext) DeleteTimerFailoverLevel(failoverID string) error {
+// DeleteFailoverLevel mocks base method.
+func (m *MockContext) DeleteFailoverLevel(category persistence.HistoryTaskCategory, failoverID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTimerFailoverLevel", failoverID)
+	ret := m.ctrl.Call(m, "DeleteFailoverLevel", category, failoverID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteTimerFailoverLevel indicates an expected call of DeleteTimerFailoverLevel.
-func (mr *MockContextMockRecorder) DeleteTimerFailoverLevel(failoverID any) *gomock.Call {
+// DeleteFailoverLevel indicates an expected call of DeleteFailoverLevel.
+func (mr *MockContextMockRecorder) DeleteFailoverLevel(category, failoverID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTimerFailoverLevel", reflect.TypeOf((*MockContext)(nil).DeleteTimerFailoverLevel), failoverID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFailoverLevel", reflect.TypeOf((*MockContext)(nil).DeleteFailoverLevel), category, failoverID)
 }
 
-// DeleteTransferFailoverLevel mocks base method.
-func (m *MockContext) DeleteTransferFailoverLevel(failoverID string) error {
+// GenerateTaskID mocks base method.
+func (m *MockContext) GenerateTaskID() (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTransferFailoverLevel", failoverID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTransferFailoverLevel indicates an expected call of DeleteTransferFailoverLevel.
-func (mr *MockContextMockRecorder) DeleteTransferFailoverLevel(failoverID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransferFailoverLevel", reflect.TypeOf((*MockContext)(nil).DeleteTransferFailoverLevel), failoverID)
-}
-
-// GenerateTransferTaskID mocks base method.
-func (m *MockContext) GenerateTransferTaskID() (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateTransferTaskID")
+	ret := m.ctrl.Call(m, "GenerateTaskID")
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GenerateTransferTaskID indicates an expected call of GenerateTransferTaskID.
-func (mr *MockContextMockRecorder) GenerateTransferTaskID() *gomock.Call {
+// GenerateTaskID indicates an expected call of GenerateTaskID.
+func (mr *MockContextMockRecorder) GenerateTaskID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTransferTaskID", reflect.TypeOf((*MockContext)(nil).GenerateTransferTaskID))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTaskID", reflect.TypeOf((*MockContext)(nil).GenerateTaskID))
 }
 
-// GenerateTransferTaskIDs mocks base method.
-func (m *MockContext) GenerateTransferTaskIDs(number int) ([]int64, error) {
+// GenerateTaskIDs mocks base method.
+func (m *MockContext) GenerateTaskIDs(number int) ([]int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateTransferTaskIDs", number)
+	ret := m.ctrl.Call(m, "GenerateTaskIDs", number)
 	ret0, _ := ret[0].([]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GenerateTransferTaskIDs indicates an expected call of GenerateTransferTaskIDs.
-func (mr *MockContextMockRecorder) GenerateTransferTaskIDs(number any) *gomock.Call {
+// GenerateTaskIDs indicates an expected call of GenerateTaskIDs.
+func (mr *MockContextMockRecorder) GenerateTaskIDs(number any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTransferTaskIDs", reflect.TypeOf((*MockContext)(nil).GenerateTransferTaskIDs), number)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTaskIDs", reflect.TypeOf((*MockContext)(nil).GenerateTaskIDs), number)
 }
 
 // GetActiveClusterManager mocks base method.
@@ -207,32 +193,18 @@ func (mr *MockContextMockRecorder) GetActiveClusterManager() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveClusterManager", reflect.TypeOf((*MockContext)(nil).GetActiveClusterManager))
 }
 
-// GetAllTimerFailoverLevels mocks base method.
-func (m *MockContext) GetAllTimerFailoverLevels() map[string]TimerFailoverLevel {
+// GetAllFailoverLevels mocks base method.
+func (m *MockContext) GetAllFailoverLevels(category persistence.HistoryTaskCategory) map[string]persistence.FailoverLevel {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllTimerFailoverLevels")
-	ret0, _ := ret[0].(map[string]TimerFailoverLevel)
+	ret := m.ctrl.Call(m, "GetAllFailoverLevels", category)
+	ret0, _ := ret[0].(map[string]persistence.FailoverLevel)
 	return ret0
 }
 
-// GetAllTimerFailoverLevels indicates an expected call of GetAllTimerFailoverLevels.
-func (mr *MockContextMockRecorder) GetAllTimerFailoverLevels() *gomock.Call {
+// GetAllFailoverLevels indicates an expected call of GetAllFailoverLevels.
+func (mr *MockContextMockRecorder) GetAllFailoverLevels(category any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTimerFailoverLevels", reflect.TypeOf((*MockContext)(nil).GetAllTimerFailoverLevels))
-}
-
-// GetAllTransferFailoverLevels mocks base method.
-func (m *MockContext) GetAllTransferFailoverLevels() map[string]TransferFailoverLevel {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllTransferFailoverLevels")
-	ret0, _ := ret[0].(map[string]TransferFailoverLevel)
-	return ret0
-}
-
-// GetAllTransferFailoverLevels indicates an expected call of GetAllTransferFailoverLevels.
-func (mr *MockContextMockRecorder) GetAllTransferFailoverLevels() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTransferFailoverLevels", reflect.TypeOf((*MockContext)(nil).GetAllTransferFailoverLevels))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFailoverLevels", reflect.TypeOf((*MockContext)(nil).GetAllFailoverLevels), category)
 }
 
 // GetClusterMetadata mocks base method.
@@ -247,20 +219,6 @@ func (m *MockContext) GetClusterMetadata() cluster.Metadata {
 func (mr *MockContextMockRecorder) GetClusterMetadata() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockContext)(nil).GetClusterMetadata))
-}
-
-// GetClusterReplicationLevel mocks base method.
-func (m *MockContext) GetClusterReplicationLevel(cluster string) int64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterReplicationLevel", cluster)
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-// GetClusterReplicationLevel indicates an expected call of GetClusterReplicationLevel.
-func (mr *MockContextMockRecorder) GetClusterReplicationLevel(cluster any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterReplicationLevel", reflect.TypeOf((*MockContext)(nil).GetClusterReplicationLevel), cluster)
 }
 
 // GetConfig mocks base method.
@@ -417,6 +375,34 @@ func (mr *MockContextMockRecorder) GetMetricsClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsClient", reflect.TypeOf((*MockContext)(nil).GetMetricsClient))
 }
 
+// GetQueueAckLevel mocks base method.
+func (m *MockContext) GetQueueAckLevel(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueueAckLevel", category)
+	ret0, _ := ret[0].(persistence.HistoryTaskKey)
+	return ret0
+}
+
+// GetQueueAckLevel indicates an expected call of GetQueueAckLevel.
+func (mr *MockContextMockRecorder) GetQueueAckLevel(category any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueueAckLevel", reflect.TypeOf((*MockContext)(nil).GetQueueAckLevel), category)
+}
+
+// GetQueueClusterAckLevel mocks base method.
+func (m *MockContext) GetQueueClusterAckLevel(category persistence.HistoryTaskCategory, cluster string) persistence.HistoryTaskKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueueClusterAckLevel", category, cluster)
+	ret0, _ := ret[0].(persistence.HistoryTaskKey)
+	return ret0
+}
+
+// GetQueueClusterAckLevel indicates an expected call of GetQueueClusterAckLevel.
+func (mr *MockContextMockRecorder) GetQueueClusterAckLevel(category, cluster any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueueClusterAckLevel", reflect.TypeOf((*MockContext)(nil).GetQueueClusterAckLevel), category, cluster)
+}
+
 // GetService mocks base method.
 func (m *MockContext) GetService() resource.Resource {
 	m.ctrl.T.Helper()
@@ -473,34 +459,6 @@ func (mr *MockContextMockRecorder) GetTimeSource() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeSource", reflect.TypeOf((*MockContext)(nil).GetTimeSource))
 }
 
-// GetTimerAckLevel mocks base method.
-func (m *MockContext) GetTimerAckLevel() time.Time {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTimerAckLevel")
-	ret0, _ := ret[0].(time.Time)
-	return ret0
-}
-
-// GetTimerAckLevel indicates an expected call of GetTimerAckLevel.
-func (mr *MockContextMockRecorder) GetTimerAckLevel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimerAckLevel", reflect.TypeOf((*MockContext)(nil).GetTimerAckLevel))
-}
-
-// GetTimerClusterAckLevel mocks base method.
-func (m *MockContext) GetTimerClusterAckLevel(cluster string) time.Time {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTimerClusterAckLevel", cluster)
-	ret0, _ := ret[0].(time.Time)
-	return ret0
-}
-
-// GetTimerClusterAckLevel indicates an expected call of GetTimerClusterAckLevel.
-func (mr *MockContextMockRecorder) GetTimerClusterAckLevel(cluster any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimerClusterAckLevel", reflect.TypeOf((*MockContext)(nil).GetTimerClusterAckLevel), cluster)
-}
-
 // GetTimerMaxReadLevel mocks base method.
 func (m *MockContext) GetTimerMaxReadLevel(cluster string) time.Time {
 	m.ctrl.T.Helper()
@@ -527,34 +485,6 @@ func (m *MockContext) GetTimerProcessingQueueStates(cluster string) []*types.Pro
 func (mr *MockContextMockRecorder) GetTimerProcessingQueueStates(cluster any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimerProcessingQueueStates", reflect.TypeOf((*MockContext)(nil).GetTimerProcessingQueueStates), cluster)
-}
-
-// GetTransferAckLevel mocks base method.
-func (m *MockContext) GetTransferAckLevel() int64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTransferAckLevel")
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-// GetTransferAckLevel indicates an expected call of GetTransferAckLevel.
-func (mr *MockContextMockRecorder) GetTransferAckLevel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransferAckLevel", reflect.TypeOf((*MockContext)(nil).GetTransferAckLevel))
-}
-
-// GetTransferClusterAckLevel mocks base method.
-func (m *MockContext) GetTransferClusterAckLevel(cluster string) int64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTransferClusterAckLevel", cluster)
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-// GetTransferClusterAckLevel indicates an expected call of GetTransferClusterAckLevel.
-func (mr *MockContextMockRecorder) GetTransferClusterAckLevel(cluster any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransferClusterAckLevel", reflect.TypeOf((*MockContext)(nil).GetTransferClusterAckLevel), cluster)
 }
 
 // GetTransferMaxReadLevel mocks base method.
@@ -652,20 +582,6 @@ func (mr *MockContextMockRecorder) SetEngine(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEngine", reflect.TypeOf((*MockContext)(nil).SetEngine), arg0)
 }
 
-// UpdateClusterReplicationLevel mocks base method.
-func (m *MockContext) UpdateClusterReplicationLevel(cluster string, lastTaskID int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateClusterReplicationLevel", cluster, lastTaskID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateClusterReplicationLevel indicates an expected call of UpdateClusterReplicationLevel.
-func (mr *MockContextMockRecorder) UpdateClusterReplicationLevel(cluster, lastTaskID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterReplicationLevel", reflect.TypeOf((*MockContext)(nil).UpdateClusterReplicationLevel), cluster, lastTaskID)
-}
-
 // UpdateDomainNotificationVersion mocks base method.
 func (m *MockContext) UpdateDomainNotificationVersion(domainNotificationVersion int64) error {
 	m.ctrl.T.Helper()
@@ -680,46 +596,46 @@ func (mr *MockContextMockRecorder) UpdateDomainNotificationVersion(domainNotific
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomainNotificationVersion", reflect.TypeOf((*MockContext)(nil).UpdateDomainNotificationVersion), domainNotificationVersion)
 }
 
-// UpdateTimerAckLevel mocks base method.
-func (m *MockContext) UpdateTimerAckLevel(ackLevel time.Time) error {
+// UpdateFailoverLevel mocks base method.
+func (m *MockContext) UpdateFailoverLevel(category persistence.HistoryTaskCategory, failoverID string, level persistence.FailoverLevel) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTimerAckLevel", ackLevel)
+	ret := m.ctrl.Call(m, "UpdateFailoverLevel", category, failoverID, level)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateTimerAckLevel indicates an expected call of UpdateTimerAckLevel.
-func (mr *MockContextMockRecorder) UpdateTimerAckLevel(ackLevel any) *gomock.Call {
+// UpdateFailoverLevel indicates an expected call of UpdateFailoverLevel.
+func (mr *MockContextMockRecorder) UpdateFailoverLevel(category, failoverID, level any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTimerAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateTimerAckLevel), ackLevel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFailoverLevel", reflect.TypeOf((*MockContext)(nil).UpdateFailoverLevel), category, failoverID, level)
 }
 
-// UpdateTimerClusterAckLevel mocks base method.
-func (m *MockContext) UpdateTimerClusterAckLevel(cluster string, ackLevel time.Time) error {
+// UpdateQueueAckLevel mocks base method.
+func (m *MockContext) UpdateQueueAckLevel(category persistence.HistoryTaskCategory, ackLevel persistence.HistoryTaskKey) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTimerClusterAckLevel", cluster, ackLevel)
+	ret := m.ctrl.Call(m, "UpdateQueueAckLevel", category, ackLevel)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateTimerClusterAckLevel indicates an expected call of UpdateTimerClusterAckLevel.
-func (mr *MockContextMockRecorder) UpdateTimerClusterAckLevel(cluster, ackLevel any) *gomock.Call {
+// UpdateQueueAckLevel indicates an expected call of UpdateQueueAckLevel.
+func (mr *MockContextMockRecorder) UpdateQueueAckLevel(category, ackLevel any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTimerClusterAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateTimerClusterAckLevel), cluster, ackLevel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueueAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateQueueAckLevel), category, ackLevel)
 }
 
-// UpdateTimerFailoverLevel mocks base method.
-func (m *MockContext) UpdateTimerFailoverLevel(failoverID string, level TimerFailoverLevel) error {
+// UpdateQueueClusterAckLevel mocks base method.
+func (m *MockContext) UpdateQueueClusterAckLevel(category persistence.HistoryTaskCategory, cluster string, ackLevel persistence.HistoryTaskKey) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTimerFailoverLevel", failoverID, level)
+	ret := m.ctrl.Call(m, "UpdateQueueClusterAckLevel", category, cluster, ackLevel)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateTimerFailoverLevel indicates an expected call of UpdateTimerFailoverLevel.
-func (mr *MockContextMockRecorder) UpdateTimerFailoverLevel(failoverID, level any) *gomock.Call {
+// UpdateQueueClusterAckLevel indicates an expected call of UpdateQueueClusterAckLevel.
+func (mr *MockContextMockRecorder) UpdateQueueClusterAckLevel(category, cluster, ackLevel any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTimerFailoverLevel", reflect.TypeOf((*MockContext)(nil).UpdateTimerFailoverLevel), failoverID, level)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueueClusterAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateQueueClusterAckLevel), category, cluster, ackLevel)
 }
 
 // UpdateTimerMaxReadLevel mocks base method.
@@ -748,48 +664,6 @@ func (m *MockContext) UpdateTimerProcessingQueueStates(cluster string, states []
 func (mr *MockContextMockRecorder) UpdateTimerProcessingQueueStates(cluster, states any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTimerProcessingQueueStates", reflect.TypeOf((*MockContext)(nil).UpdateTimerProcessingQueueStates), cluster, states)
-}
-
-// UpdateTransferAckLevel mocks base method.
-func (m *MockContext) UpdateTransferAckLevel(ackLevel int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTransferAckLevel", ackLevel)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateTransferAckLevel indicates an expected call of UpdateTransferAckLevel.
-func (mr *MockContextMockRecorder) UpdateTransferAckLevel(ackLevel any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTransferAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateTransferAckLevel), ackLevel)
-}
-
-// UpdateTransferClusterAckLevel mocks base method.
-func (m *MockContext) UpdateTransferClusterAckLevel(cluster string, ackLevel int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTransferClusterAckLevel", cluster, ackLevel)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateTransferClusterAckLevel indicates an expected call of UpdateTransferClusterAckLevel.
-func (mr *MockContextMockRecorder) UpdateTransferClusterAckLevel(cluster, ackLevel any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTransferClusterAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateTransferClusterAckLevel), cluster, ackLevel)
-}
-
-// UpdateTransferFailoverLevel mocks base method.
-func (m *MockContext) UpdateTransferFailoverLevel(failoverID string, level TransferFailoverLevel) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTransferFailoverLevel", failoverID, level)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateTransferFailoverLevel indicates an expected call of UpdateTransferFailoverLevel.
-func (mr *MockContextMockRecorder) UpdateTransferFailoverLevel(failoverID, level any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTransferFailoverLevel", reflect.TypeOf((*MockContext)(nil).UpdateTransferFailoverLevel), failoverID, level)
 }
 
 // UpdateTransferProcessingQueueStates mocks base method.

--- a/service/history/shard/context_test_utils.go
+++ b/service/history/shard/context_test_utils.go
@@ -81,7 +81,7 @@ func NewTestContext(
 		transferMaxReadLevel:      0,
 		maxTransferSequenceNumber: 100000,
 		timerMaxReadLevelMap:      make(map[string]time.Time),
-		transferFailoverLevels:    make(map[string]TransferFailoverLevel),
+		failoverLevels:            make(map[persistence.HistoryTaskCategory]map[string]persistence.FailoverLevel),
 		remoteClusterCurrentTime:  make(map[string]time.Time),
 		eventsCache:               eventsCache,
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Unify methods of history tasks in shard component

<!-- Tell your future self why have you made these changes -->
**Why?**
Code refactoring

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there is a mistake, the ack level, read level of history queues will not be retrieved or stored correctly.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
