### PR TITLE
Serialize shard data

### DIFF
--- a/cmd/server/cadence/fx_test.go
+++ b/cmd/server/cadence/fx_test.go
@@ -31,11 +31,13 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/common/metrics/metricsfx"
 )
 
 func TestFxDependencies(t *testing.T) {
 	err := fx.ValidateApp(config.Module,
 		logfx.Module,
+		metricsfx.Module,
 		dynamicconfigfx.Module,
 		fx.Supply(appContext{
 			CfgContext: config.Context{

--- a/common/dynamicconfig/configstore/config_store_client_test.go
+++ b/common/dynamicconfig/configstore/config_store_client_test.go
@@ -36,6 +36,7 @@ import (
 	c "github.com/uber/cadence/common/dynamicconfig/configstore/config"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
@@ -318,7 +319,7 @@ func (s *configStoreClientSuite) SetupTest() {
 				DefaultShard: config.NonShardedStoreName,
 				Connections:  connections,
 			},
-		}, log.NewNoop(), p.DynamicConfig)
+		}, log.NewNoop(), metrics.NewNoopMetricsClient(), p.DynamicConfig)
 	s.Require().NoError(err)
 
 	s.mockManager = p.NewMockConfigStoreManager(s.mockController)
@@ -984,7 +985,7 @@ func (s *configStoreClientSuite) TestValidateKeyDataBlobPair() {
 }
 
 func (s *configStoreClientSuite) TestNewConfigStoreClient_NilPersistenceConfig() {
-	_, err := NewConfigStoreClient(&c.ClientConfig{}, nil, log.NewNoop(), p.DynamicConfig)
+	_, err := NewConfigStoreClient(&c.ClientConfig{}, nil, log.NewNoop(), metrics.NewNoopMetricsClient(), p.DynamicConfig)
 	s.Require().Error(err, "should fail when persistence config is nil")
 	s.Require().EqualError(err, "persistence cfg is nil")
 }
@@ -993,7 +994,7 @@ func (s *configStoreClientSuite) TestNewConfigStoreClient_MissingDefaultPersiste
 	persistenceCfg := &config.Persistence{
 		DataStores: map[string]config.DataStore{},
 	}
-	_, err := NewConfigStoreClient(&c.ClientConfig{}, persistenceCfg, log.NewNoop(), p.DynamicConfig)
+	_, err := NewConfigStoreClient(&c.ClientConfig{}, persistenceCfg, log.NewNoop(), metrics.NewNoopMetricsClient(), p.DynamicConfig)
 	s.Require().Error(err, "should fail when default persistence config is missing")
 	s.Require().EqualError(err, "default persistence config missing")
 }
@@ -1009,7 +1010,7 @@ func (s *configStoreClientSuite) TestNewConfigStoreClient_InvalidClientConfig() 
 		PollInterval: time.Millisecond,
 	}
 	logger := log.NewNoop()
-	_, err := NewConfigStoreClient(clientCfg, persistenceCfg, logger, p.DynamicConfig)
+	_, err := NewConfigStoreClient(clientCfg, persistenceCfg, logger, metrics.NewNoopMetricsClient(), p.DynamicConfig)
 	s.Require().Error(err, "should fail when client config is invalid")
 }
 

--- a/common/dynamicconfig/dynamicconfigfx/fx.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -43,9 +44,10 @@ var Module = fx.Options(fx.Provide(New))
 type Params struct {
 	fx.In
 
-	Cfg     config.Config
-	Logger  log.Logger
-	RootDir string `name:"root-dir"`
+	Cfg           config.Config
+	Logger        log.Logger
+	MetricsClient metrics.Client
+	RootDir       string `name:"root-dir"`
 
 	Lifecycle fx.Lifecycle
 }
@@ -85,6 +87,7 @@ func New(p Params) Result {
 				&p.Cfg.DynamicConfig.ConfigStore,
 				&p.Cfg.Persistence,
 				p.Logger,
+				p.MetricsClient,
 				persistence.DynamicConfig,
 			)
 		case dynamicconfig.FileBasedClient:

--- a/common/dynamicconfig/dynamicconfigfx/fx_test.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx_test.go
@@ -31,21 +31,25 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 )
 
 func TestModule(t *testing.T) {
 	app := fxtest.New(t,
 		testlogger.Module(t),
-		fx.Provide(func() config.Config {
-			return config.Config{
-				ClusterGroupMetadata: &config.ClusterGroupMetadata{},
-			}
-		},
+		fx.Provide(
+			func() config.Config {
+				return config.Config{
+					ClusterGroupMetadata: &config.ClusterGroupMetadata{},
+				}
+			},
 			func() fxRoot {
 				return fxRoot{
 					RootDir: "../../../",
 				}
-			}),
+			},
+			metrics.NewNoopMetricsClient,
+		),
 		Module,
 		fx.Invoke(func(c dynamicconfig.Client) {}),
 	)

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2080,7 +2080,7 @@ const (
 
 	EnableNoSQLHistoryTaskDualWriteMode
 	ReadNoSQLHistoryTaskFromDataBlob
-
+	ReadNoSQLShardFromDataBlob
 	// EnableSizeBasedHistoryExecutionCache is the feature flag to enable size based cache for execution cache
 	// KeyName: history.enableSizeBasedHistoryExecutionCache
 	// Value type: Bool
@@ -4536,6 +4536,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	ReadNoSQLHistoryTaskFromDataBlob: {
 		KeyName:      "history.readNoSQLHistoryTaskFromDataBlob",
 		Description:  "ReadNoSQLHistoryTaskFromDataBlob is to read history tasks from data blob",
+		DefaultValue: false,
+	},
+	ReadNoSQLShardFromDataBlob: {
+		KeyName:      "history.readNoSQLShardFromDataBlob",
+		Description:  "ReadNoSQLShardFromDataBlob is to read shards from data blob",
 		DefaultValue: false,
 	},
 	EnableSizeBasedHistoryExecutionCache: {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2146,6 +2146,9 @@ const (
 	PersistenceSampledCounterPerDomain
 	PersistenceEmptyResponseCounterPerDomain
 
+	NoSQLShardStoreReadFromOriginalColumnCounter
+	NoSQLShardStoreReadFromDataBlobCounter
+
 	CadenceClientRequests
 	CadenceClientFailures
 	CadenceClientLatency
@@ -2874,6 +2877,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PersistenceErrDBUnavailableCounterPerDomain:                  {metricName: "persistence_errors_db_unavailable_per_domain", metricRollupName: "persistence_errors_db_unavailable", metricType: Counter},
 		PersistenceSampledCounterPerDomain:                           {metricName: "persistence_sampled_per_domain", metricRollupName: "persistence_sampled", metricType: Counter},
 		PersistenceEmptyResponseCounterPerDomain:                     {metricName: "persistence_empty_response_per_domain", metricRollupName: "persistence_empty_response", metricType: Counter},
+		NoSQLShardStoreReadFromOriginalColumnCounter:                 {metricName: "nosql_shard_store_read_from_original_column", metricType: Counter},
+		NoSQLShardStoreReadFromDataBlobCounter:                       {metricName: "nosql_shard_store_read_from_data_blob", metricType: Counter},
 		CadenceClientRequests:                                        {metricName: "cadence_client_requests", metricType: Counter},
 		CadenceClientFailures:                                        {metricName: "cadence_client_errors", metricType: Counter},
 		CadenceClientLatency:                                         {metricName: "cadence_client_latency", metricType: Timer},

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -529,11 +529,11 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 		parser := getParser(f.logger, constants.EncodingTypeThriftRW, constants.EncodingTypeThriftRW)
 		taskSerializer := serialization.NewTaskSerializer(parser)
 		shardedNoSQLConfig := defaultCfg.NoSQL.ConvertToShardedNoSQLConfig()
-		defaultDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, taskSerializer, f.dc)
+		defaultDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, taskSerializer, parser, f.dc)
 	case defaultCfg.ShardedNoSQL != nil:
 		parser := getParser(f.logger, constants.EncodingTypeThriftRW, constants.EncodingTypeThriftRW)
 		taskSerializer := serialization.NewTaskSerializer(parser)
-		defaultDataStore.factory = nosql.NewFactory(*defaultCfg.ShardedNoSQL, clusterName, f.logger, taskSerializer, f.dc)
+		defaultDataStore.factory = nosql.NewFactory(*defaultCfg.ShardedNoSQL, clusterName, f.logger, taskSerializer, parser, f.dc)
 	case defaultCfg.SQL != nil:
 		if defaultCfg.SQL.EncodingType == "" {
 			defaultCfg.SQL.EncodingType = string(constants.EncodingTypeThriftRW)
@@ -579,7 +579,7 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 		parser := getParser(f.logger, constants.EncodingTypeThriftRW, constants.EncodingTypeThriftRW)
 		taskSerializer := serialization.NewTaskSerializer(parser)
 		shardedNoSQLConfig := visibilityCfg.NoSQL.ConvertToShardedNoSQLConfig()
-		visibilityDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, taskSerializer, f.dc)
+		visibilityDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, taskSerializer, parser, f.dc)
 	case visibilityCfg.SQL != nil:
 		var decodingTypes []constants.EncodingType
 		for _, dt := range visibilityCfg.SQL.DecodingTypes {

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -529,11 +529,11 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 		parser := getParser(f.logger, constants.EncodingTypeThriftRW, constants.EncodingTypeThriftRW)
 		taskSerializer := serialization.NewTaskSerializer(parser)
 		shardedNoSQLConfig := defaultCfg.NoSQL.ConvertToShardedNoSQLConfig()
-		defaultDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, taskSerializer, parser, f.dc)
+		defaultDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, f.metricsClient, taskSerializer, parser, f.dc)
 	case defaultCfg.ShardedNoSQL != nil:
 		parser := getParser(f.logger, constants.EncodingTypeThriftRW, constants.EncodingTypeThriftRW)
 		taskSerializer := serialization.NewTaskSerializer(parser)
-		defaultDataStore.factory = nosql.NewFactory(*defaultCfg.ShardedNoSQL, clusterName, f.logger, taskSerializer, parser, f.dc)
+		defaultDataStore.factory = nosql.NewFactory(*defaultCfg.ShardedNoSQL, clusterName, f.logger, f.metricsClient, taskSerializer, parser, f.dc)
 	case defaultCfg.SQL != nil:
 		if defaultCfg.SQL.EncodingType == "" {
 			defaultCfg.SQL.EncodingType = string(constants.EncodingTypeThriftRW)
@@ -579,7 +579,7 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 		parser := getParser(f.logger, constants.EncodingTypeThriftRW, constants.EncodingTypeThriftRW)
 		taskSerializer := serialization.NewTaskSerializer(parser)
 		shardedNoSQLConfig := visibilityCfg.NoSQL.ConvertToShardedNoSQLConfig()
-		visibilityDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, taskSerializer, parser, f.dc)
+		visibilityDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, f.metricsClient, taskSerializer, parser, f.dc)
 	case visibilityCfg.SQL != nil:
 		var decodingTypes []constants.EncodingType
 		for _, dt := range visibilityCfg.SQL.DecodingTypes {

--- a/common/persistence/config.go
+++ b/common/persistence/config.go
@@ -34,6 +34,7 @@ type (
 		EnableShardIDMetrics                     dynamicproperties.BoolPropertyFn
 		EnableHistoryTaskDualWriteMode           dynamicproperties.BoolPropertyFn
 		ReadNoSQLHistoryTaskFromDataBlob         dynamicproperties.BoolPropertyFn
+		ReadNoSQLShardFromDataBlob               dynamicproperties.BoolPropertyFn
 	}
 )
 
@@ -46,5 +47,6 @@ func NewDynamicConfiguration(dc *dynamicconfig.Collection) *DynamicConfiguration
 		EnableShardIDMetrics:                     dc.GetBoolProperty(dynamicproperties.EnableShardIDMetrics),
 		EnableHistoryTaskDualWriteMode:           dc.GetBoolProperty(dynamicproperties.EnableNoSQLHistoryTaskDualWriteMode),
 		ReadNoSQLHistoryTaskFromDataBlob:         dc.GetBoolProperty(dynamicproperties.ReadNoSQLHistoryTaskFromDataBlob),
+		ReadNoSQLShardFromDataBlob:               dc.GetBoolProperty(dynamicproperties.ReadNoSQLShardFromDataBlob),
 	}
 }

--- a/common/persistence/nosql/factory.go
+++ b/common/persistence/nosql/factory.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/serialization"
 )
@@ -36,6 +37,7 @@ type (
 		cfg              config.ShardedNoSQL
 		clusterName      string
 		logger           log.Logger
+		metricsClient    metrics.Client
 		execStoreFactory *executionStoreFactory
 		dc               *persistence.DynamicConfiguration
 		parser           serialization.Parser
@@ -51,11 +53,12 @@ type (
 
 // NewFactory returns an instance of a factory object which can be used to create
 // datastores that are backed by cassandra
-func NewFactory(cfg config.ShardedNoSQL, clusterName string, logger log.Logger, taskSerializer serialization.TaskSerializer, parser serialization.Parser, dc *persistence.DynamicConfiguration) *Factory {
+func NewFactory(cfg config.ShardedNoSQL, clusterName string, logger log.Logger, metricsClient metrics.Client, taskSerializer serialization.TaskSerializer, parser serialization.Parser, dc *persistence.DynamicConfiguration) *Factory {
 	return &Factory{
 		cfg:            cfg,
 		clusterName:    clusterName,
 		logger:         logger,
+		metricsClient:  metricsClient,
 		taskSerializer: taskSerializer,
 		dc:             dc,
 		parser:         parser,
@@ -64,22 +67,22 @@ func NewFactory(cfg config.ShardedNoSQL, clusterName string, logger log.Logger, 
 
 // NewTaskStore returns a new task store
 func (f *Factory) NewTaskStore() (persistence.TaskStore, error) {
-	return newNoSQLTaskStore(f.cfg, f.logger, f.dc)
+	return newNoSQLTaskStore(f.cfg, f.logger, f.metricsClient, f.dc)
 }
 
 // NewShardStore returns a new shard store
 func (f *Factory) NewShardStore() (persistence.ShardStore, error) {
-	return newNoSQLShardStore(f.cfg, f.clusterName, f.logger, f.dc, f.parser)
+	return newNoSQLShardStore(f.cfg, f.clusterName, f.logger, f.metricsClient, f.dc, f.parser)
 }
 
 // NewHistoryStore returns a new history store
 func (f *Factory) NewHistoryStore() (persistence.HistoryStore, error) {
-	return newNoSQLHistoryStore(f.cfg, f.logger, f.dc)
+	return newNoSQLHistoryStore(f.cfg, f.logger, f.metricsClient, f.dc)
 }
 
 // NewDomainStore returns a metadata store that understands only v2
 func (f *Factory) NewDomainStore() (persistence.DomainStore, error) {
-	return newNoSQLDomainStore(f.cfg, f.clusterName, f.logger, f.dc)
+	return newNoSQLDomainStore(f.cfg, f.clusterName, f.logger, f.metricsClient, f.dc)
 }
 
 // NewExecutionStore returns an ExecutionStore for a given shardID
@@ -93,17 +96,17 @@ func (f *Factory) NewExecutionStore(shardID int) (persistence.ExecutionStore, er
 
 // NewVisibilityStore returns a visibility store
 func (f *Factory) NewVisibilityStore(sortByCloseTime bool) (persistence.VisibilityStore, error) {
-	return newNoSQLVisibilityStore(sortByCloseTime, f.cfg, f.logger, f.dc)
+	return newNoSQLVisibilityStore(sortByCloseTime, f.cfg, f.logger, f.metricsClient, f.dc)
 }
 
 // NewQueue returns a new queue backed by cassandra
 func (f *Factory) NewQueue(queueType persistence.QueueType) (persistence.Queue, error) {
-	return newNoSQLQueueStore(f.cfg, f.logger, queueType, f.dc)
+	return newNoSQLQueueStore(f.cfg, f.logger, f.metricsClient, queueType, f.dc)
 }
 
 // NewConfigStore returns a new config store
 func (f *Factory) NewConfigStore() (persistence.ConfigStore, error) {
-	return NewNoSQLConfigStore(f.cfg, f.logger, f.dc)
+	return NewNoSQLConfigStore(f.cfg, f.logger, f.metricsClient, f.dc)
 }
 
 // Close closes the factory
@@ -128,7 +131,7 @@ func (f *Factory) executionStoreFactory() (*executionStoreFactory, error) {
 		return f.execStoreFactory, nil
 	}
 
-	factory, err := newExecutionStoreFactory(f.cfg, f.logger, f.taskSerializer, f.dc)
+	factory, err := newExecutionStoreFactory(f.cfg, f.logger, f.metricsClient, f.taskSerializer, f.dc)
 	if err != nil {
 		return nil, err
 	}
@@ -140,10 +143,11 @@ func (f *Factory) executionStoreFactory() (*executionStoreFactory, error) {
 func newExecutionStoreFactory(
 	cfg config.ShardedNoSQL,
 	logger log.Logger,
+	metricsClient metrics.Client,
 	taskSerializer serialization.TaskSerializer,
 	dc *persistence.DynamicConfiguration,
 ) (*executionStoreFactory, error) {
-	s, err := newShardedNosqlStore(cfg, logger, dc)
+	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/factory.go
+++ b/common/persistence/nosql/factory.go
@@ -38,6 +38,7 @@ type (
 		logger           log.Logger
 		execStoreFactory *executionStoreFactory
 		dc               *persistence.DynamicConfiguration
+		parser           serialization.Parser
 		taskSerializer   serialization.TaskSerializer
 	}
 
@@ -50,13 +51,14 @@ type (
 
 // NewFactory returns an instance of a factory object which can be used to create
 // datastores that are backed by cassandra
-func NewFactory(cfg config.ShardedNoSQL, clusterName string, logger log.Logger, taskSerializer serialization.TaskSerializer, dc *persistence.DynamicConfiguration) *Factory {
+func NewFactory(cfg config.ShardedNoSQL, clusterName string, logger log.Logger, taskSerializer serialization.TaskSerializer, parser serialization.Parser, dc *persistence.DynamicConfiguration) *Factory {
 	return &Factory{
 		cfg:            cfg,
 		clusterName:    clusterName,
 		logger:         logger,
 		taskSerializer: taskSerializer,
 		dc:             dc,
+		parser:         parser,
 	}
 }
 
@@ -67,7 +69,7 @@ func (f *Factory) NewTaskStore() (persistence.TaskStore, error) {
 
 // NewShardStore returns a new shard store
 func (f *Factory) NewShardStore() (persistence.ShardStore, error) {
-	return newNoSQLShardStore(f.cfg, f.clusterName, f.logger, f.dc)
+	return newNoSQLShardStore(f.cfg, f.clusterName, f.logger, f.dc, f.parser)
 }
 
 // NewHistoryStore returns a new history store

--- a/common/persistence/nosql/nosql_config_store.go
+++ b/common/persistence/nosql/nosql_config_store.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
@@ -37,9 +38,10 @@ type nosqlConfigStore struct {
 func NewNoSQLConfigStore(
 	cfg config.ShardedNoSQL,
 	logger log.Logger,
+	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.ConfigStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_domain_store.go
+++ b/common/persistence/nosql/nosql_domain_store.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/types"
@@ -44,9 +45,10 @@ func newNoSQLDomainStore(
 	cfg config.ShardedNoSQL,
 	currentClusterName string,
 	logger log.Logger,
+	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.DomainStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_history_store.go
+++ b/common/persistence/nosql/nosql_history_store.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	persistenceutils "github.com/uber/cadence/common/persistence/persistence-utils"
@@ -42,9 +43,10 @@ type nosqlHistoryStore struct {
 func newNoSQLHistoryStore(
 	cfg config.ShardedNoSQL,
 	logger log.Logger,
+	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.HistoryStore, error) {
-	s, err := newShardedNosqlStore(cfg, logger, dc)
+	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_history_store_test.go
+++ b/common/persistence/nosql/nosql_history_store_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/types"
@@ -100,7 +101,7 @@ func TestNewNoSQLHistoryStore(t *testing.T) {
 	registerCassandraMock(t)
 	cfg := getValidShardedNoSQLConfig()
 
-	store, err := newNoSQLHistoryStore(cfg, log.NewNoop(), nil)
+	store, err := newNoSQLHistoryStore(cfg, log.NewNoop(), metrics.NewNoopMetricsClient(), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 }

--- a/common/persistence/nosql/nosql_queue_store.go
+++ b/common/persistence/nosql/nosql_queue_store.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/types"
@@ -46,10 +47,11 @@ type nosqlQueueStore struct {
 func newNoSQLQueueStore(
 	cfg config.ShardedNoSQL,
 	logger log.Logger,
+	metricsClient metrics.Client,
 	queueType persistence.QueueType,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.Queue, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_queue_store_test.go
+++ b/common/persistence/nosql/nosql_queue_store_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
@@ -61,7 +62,7 @@ func newQueueStoreTestData(t *testing.T) *queueStoreTestData {
 
 func (td *queueStoreTestData) newQueueStore() (persistence.Queue, error) {
 	cfg := getValidShardedNoSQLConfig()
-	return newNoSQLQueueStore(cfg, log.NewNoop(), testQueueType, nil)
+	return newNoSQLQueueStore(cfg, log.NewNoop(), metrics.NewNoopMetricsClient(), testQueueType, nil)
 }
 
 func (td *queueStoreTestData) createValidQueueStore(t *testing.T) persistence.Queue {

--- a/common/persistence/nosql/nosql_shard_store.go
+++ b/common/persistence/nosql/nosql_shard_store.go
@@ -23,12 +23,15 @@ package nosql
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
+	"github.com/uber/cadence/common/persistence/serialization"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -36,6 +39,7 @@ import (
 type nosqlShardStore struct {
 	shardedNosqlStore
 	currentClusterName string
+	parser             serialization.Parser
 }
 
 // newNoSQLShardStore is used to create an instance of ShardStore implementation
@@ -44,6 +48,7 @@ func newNoSQLShardStore(
 	clusterName string,
 	logger log.Logger,
 	dc *persistence.DynamicConfiguration,
+	parser serialization.Parser,
 ) (persistence.ShardStore, error) {
 	s, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
@@ -52,6 +57,7 @@ func newNoSQLShardStore(
 	return &nosqlShardStore{
 		shardedNosqlStore:  s,
 		currentClusterName: clusterName,
+		parser:             parser,
 	}, nil
 }
 
@@ -63,7 +69,11 @@ func (sh *nosqlShardStore) CreateShard(
 	if err != nil {
 		return err
 	}
-	err = storeShard.db.InsertShard(ctx, request.ShardInfo)
+	shardRow, err := sh.shardInfoToShardsRow(request.ShardInfo)
+	if err != nil {
+		return err
+	}
+	err = storeShard.db.InsertShard(ctx, shardRow)
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
 		if ok {
@@ -87,7 +97,7 @@ func (sh *nosqlShardStore) GetShard(
 	if err != nil {
 		return nil, err
 	}
-	rangeID, shardInfo, err := storeShard.db.SelectShard(ctx, shardID, sh.currentClusterName)
+	rangeID, shardRow, err := storeShard.db.SelectShard(ctx, shardID, sh.currentClusterName)
 
 	if err != nil {
 		if storeShard.db.IsNotFoundError(err) {
@@ -99,7 +109,7 @@ func (sh *nosqlShardStore) GetShard(
 		return nil, convertCommonErrors(storeShard.db, "GetShard", err)
 	}
 
-	shardInfoRangeID := shardInfo.RangeID
+	shardInfoRangeID := shardRow.RangeID
 
 	// check if rangeID column and rangeID field in shard column matches, if not we need to pick the larger
 	// rangeID.
@@ -115,13 +125,17 @@ func (sh *nosqlShardStore) GetShard(
 		}
 	} else {
 		// return the actual rangeID
-		shardInfo.RangeID = rangeID
+		shardRow.RangeID = rangeID
 		//
 		// If shardInfoRangeID = rangeID, no corruption, so no action needed.
 		//
 		// If shardInfoRangeID < rangeID, we also don't need to do anything here as createShardInfo will ignore
 		// shardInfoRangeID and return rangeID instead. Later when updating the shard, CAS can still succeed
 		// as the value from rangeID columns is returned, shardInfoRangeID will also be updated to the correct value.
+	}
+	shardInfo, err := sh.shardsRowToShardInfo(storeShard, shardRow)
+	if err != nil {
+		return nil, err
 	}
 
 	return &persistence.InternalGetShardResponse{ShardInfo: shardInfo}, nil
@@ -161,7 +175,11 @@ func (sh *nosqlShardStore) UpdateShard(
 	if err != nil {
 		return err
 	}
-	err = storeShard.db.UpdateShard(ctx, request.ShardInfo, request.PreviousRangeID)
+	shardRow, err := sh.shardInfoToShardsRow(request.ShardInfo)
+	if err != nil {
+		return err
+	}
+	err = storeShard.db.UpdateShard(ctx, shardRow, request.PreviousRangeID)
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
 		if ok {
@@ -175,4 +193,137 @@ func (sh *nosqlShardStore) UpdateShard(
 	}
 
 	return nil
+}
+
+func (sh *nosqlShardStore) shardInfoToShardsRow(s *persistence.InternalShardInfo) (*nosqlplugin.ShardRow, error) {
+	var markerData []byte
+	markerEncoding := string(constants.EncodingTypeEmpty)
+	if s.PendingFailoverMarkers != nil {
+		markerData = s.PendingFailoverMarkers.Data
+		markerEncoding = string(s.PendingFailoverMarkers.Encoding)
+	}
+
+	var transferPQSData []byte
+	transferPQSEncoding := string(constants.EncodingTypeEmpty)
+	if s.TransferProcessingQueueStates != nil {
+		transferPQSData = s.TransferProcessingQueueStates.Data
+		transferPQSEncoding = string(s.TransferProcessingQueueStates.Encoding)
+	}
+
+	var timerPQSData []byte
+	timerPQSEncoding := string(constants.EncodingTypeEmpty)
+	if s.TimerProcessingQueueStates != nil {
+		timerPQSData = s.TimerProcessingQueueStates.Data
+		timerPQSEncoding = string(s.TimerProcessingQueueStates.Encoding)
+	}
+
+	shardInfo := &serialization.ShardInfo{
+		StolenSinceRenew:                      int32(s.StolenSinceRenew),
+		UpdatedAt:                             s.UpdatedAt,
+		ReplicationAckLevel:                   s.ReplicationAckLevel,
+		TransferAckLevel:                      s.TransferAckLevel,
+		TimerAckLevel:                         s.TimerAckLevel,
+		ClusterTransferAckLevel:               s.ClusterTransferAckLevel,
+		ClusterTimerAckLevel:                  s.ClusterTimerAckLevel,
+		TransferProcessingQueueStates:         transferPQSData,
+		TransferProcessingQueueStatesEncoding: transferPQSEncoding,
+		TimerProcessingQueueStates:            timerPQSData,
+		TimerProcessingQueueStatesEncoding:    timerPQSEncoding,
+		DomainNotificationVersion:             s.DomainNotificationVersion,
+		Owner:                                 s.Owner,
+		ClusterReplicationLevel:               s.ClusterReplicationLevel,
+		ReplicationDlqAckLevel:                s.ReplicationDLQAckLevel,
+		PendingFailoverMarkers:                markerData,
+		PendingFailoverMarkersEncoding:        markerEncoding,
+	}
+
+	blob, err := sh.parser.ShardInfoToBlob(shardInfo)
+	if err != nil {
+		return nil, err
+	}
+	return &nosqlplugin.ShardRow{
+		InternalShardInfo: s,
+		Data:              blob.Data,
+		DataEncoding:      string(blob.Encoding),
+	}, nil
+}
+
+func (sh *nosqlShardStore) shardsRowToShardInfo(storeShard *nosqlStore, shardRow *nosqlplugin.ShardRow) (*persistence.InternalShardInfo, error) {
+	if !storeShard.dc.ReadNoSQLShardFromDataBlob() {
+		return shardRow.InternalShardInfo, nil
+	}
+	if len(shardRow.Data) == 0 {
+		sh.GetLogger().Warn("Shard info data blob is empty, falling back to typed fields")
+		return shardRow.InternalShardInfo, nil
+	}
+	shardInfo, err := sh.parser.ShardInfoFromBlob(shardRow.Data, shardRow.DataEncoding)
+	if err != nil {
+		sh.GetLogger().Error("Failed to decode shard info from data blob, falling back to typed fields", tag.Error(err))
+		return shardRow.InternalShardInfo, nil
+	}
+	if len(shardInfo.ClusterTransferAckLevel) == 0 {
+		shardInfo.ClusterTransferAckLevel = map[string]int64{
+			sh.currentClusterName: shardInfo.GetTransferAckLevel(),
+		}
+	}
+
+	timerAckLevel := make(map[string]time.Time, len(shardInfo.ClusterTimerAckLevel))
+	for k, v := range shardInfo.ClusterTimerAckLevel {
+		timerAckLevel[k] = v
+	}
+
+	if len(timerAckLevel) == 0 {
+		timerAckLevel = map[string]time.Time{
+			sh.currentClusterName: shardInfo.GetTimerAckLevel(),
+		}
+	}
+
+	if shardInfo.ClusterReplicationLevel == nil {
+		shardInfo.ClusterReplicationLevel = make(map[string]int64)
+	}
+	if shardInfo.ReplicationDlqAckLevel == nil {
+		shardInfo.ReplicationDlqAckLevel = make(map[string]int64)
+	}
+
+	var transferPQS *persistence.DataBlob
+	if shardInfo.GetTransferProcessingQueueStates() != nil {
+		transferPQS = &persistence.DataBlob{
+			Encoding: constants.EncodingType(shardInfo.GetTransferProcessingQueueStatesEncoding()),
+			Data:     shardInfo.GetTransferProcessingQueueStates(),
+		}
+	}
+
+	var timerPQS *persistence.DataBlob
+	if shardInfo.GetTimerProcessingQueueStates() != nil {
+		timerPQS = &persistence.DataBlob{
+			Encoding: constants.EncodingType(shardInfo.GetTimerProcessingQueueStatesEncoding()),
+			Data:     shardInfo.GetTimerProcessingQueueStates(),
+		}
+	}
+
+	var pendingFailoverMarkers *persistence.DataBlob
+	if shardInfo.GetPendingFailoverMarkers() != nil {
+		pendingFailoverMarkers = &persistence.DataBlob{
+			Encoding: constants.EncodingType(shardInfo.GetPendingFailoverMarkersEncoding()),
+			Data:     shardInfo.GetPendingFailoverMarkers(),
+		}
+	}
+	return &persistence.InternalShardInfo{
+		ShardID:                       int(shardRow.ShardID),
+		RangeID:                       shardRow.RangeID,
+		Owner:                         shardInfo.GetOwner(),
+		StolenSinceRenew:              int(shardInfo.GetStolenSinceRenew()),
+		UpdatedAt:                     shardInfo.GetUpdatedAt(),
+		ReplicationAckLevel:           shardInfo.GetReplicationAckLevel(),
+		TransferAckLevel:              shardInfo.GetTransferAckLevel(),
+		TimerAckLevel:                 shardInfo.GetTimerAckLevel(),
+		ClusterTransferAckLevel:       shardInfo.ClusterTransferAckLevel,
+		ClusterTimerAckLevel:          timerAckLevel,
+		TransferProcessingQueueStates: transferPQS,
+		TimerProcessingQueueStates:    timerPQS,
+		DomainNotificationVersion:     shardInfo.GetDomainNotificationVersion(),
+		ClusterReplicationLevel:       shardInfo.ClusterReplicationLevel,
+		ReplicationDLQAckLevel:        shardInfo.ReplicationDlqAckLevel,
+		PendingFailoverMarkers:        pendingFailoverMarkers,
+	}, nil
 }

--- a/common/persistence/nosql/nosql_shard_store_test.go
+++ b/common/persistence/nosql/nosql_shard_store_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/persistence/serialization"
@@ -211,6 +212,7 @@ func TestGetShard(t *testing.T) {
 					Data:              []byte("shard-info"),
 					DataEncoding:      "base64",
 				}, nil).Times(1)
+				storeShardMock.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).Times(1)
 				mockParser.EXPECT().ShardInfoFromBlob(gomock.Any(), gomock.Any()).Return(&serialization.ShardInfo{
 					Owner:               "test-owner",
 					StolenSinceRenew:    1,
@@ -294,6 +296,7 @@ func TestGetShard(t *testing.T) {
 					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(false),
 				}}, nil).Times(2)
 				storeShardMock.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
+				storeShardMock.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).Times(1)
 				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), &nosqlplugin.ShardRow{
 					InternalShardInfo: testFixtureInternalShardInfo(),
 					Data:              []byte("shard-info"),

--- a/common/persistence/nosql/nosql_shard_store_test.go
+++ b/common/persistence/nosql/nosql_shard_store_test.go
@@ -31,9 +31,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
+	"github.com/uber/cadence/common/persistence/serialization"
 )
 
 func testFixtureInternalShardInfo() *persistence.InternalShardInfo {
@@ -79,32 +81,42 @@ func testFixtureInternalShardInfo() *persistence.InternalShardInfo {
 	}
 }
 
-func setUpMocksForShardStore(t *testing.T) (*nosqlShardStore, *nosqlplugin.MockDB, *MockshardedNosqlStore, *gomock.Controller) {
+func setUpMocksForShardStore(t *testing.T) (*nosqlShardStore, *nosqlplugin.MockDB, *MockshardedNosqlStore, *serialization.MockParser, *gomock.Controller) {
 	ctrl := gomock.NewController(t)
 	dbMock := nosqlplugin.NewMockDB(ctrl)
 	storeShardMock := NewMockshardedNosqlStore(ctrl)
+	mockParser := serialization.NewMockParser(ctrl)
 
 	shardStore := &nosqlShardStore{
 		shardedNosqlStore:  storeShardMock,
 		currentClusterName: "test-cluster",
+		parser:             mockParser,
 	}
 
-	return shardStore, dbMock, storeShardMock, ctrl
+	return shardStore, dbMock, storeShardMock, mockParser, ctrl
 }
 
 func TestCreateShard(t *testing.T) {
 	testCases := []struct {
 		name          string
-		setupMock     func(*nosqlplugin.MockDB, *MockshardedNosqlStore)
+		setupMock     func(*nosqlplugin.MockDB, *MockshardedNosqlStore, *serialization.MockParser)
 		request       *persistence.InternalCreateShardRequest
 		expectError   bool
 		expectedError string
 	}{
 		{
 			name: "success",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
-				dbMock.EXPECT().InsertShard(gomock.Any(), testFixtureInternalShardInfo()).Return(nil).Times(1)
+				mockParser.EXPECT().ShardInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Encoding: "base64",
+					Data:     []byte("shard-info"),
+				}, nil).Times(1)
+				dbMock.EXPECT().InsertShard(gomock.Any(), &nosqlplugin.ShardRow{
+					InternalShardInfo: testFixtureInternalShardInfo(),
+					Data:              []byte("shard-info"),
+					DataEncoding:      "base64",
+				}).Return(nil).Times(1)
 			},
 			request: &persistence.InternalCreateShardRequest{
 				ShardInfo: testFixtureInternalShardInfo(),
@@ -113,8 +125,12 @@ func TestCreateShard(t *testing.T) {
 		},
 		{
 			name: "shard already exists error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
+				mockParser.EXPECT().ShardInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Encoding: "base64",
+					Data:     []byte("shard-info"),
+				}, nil).Times(1)
 				dbMock.EXPECT().InsertShard(gomock.Any(), gomock.Any()).Return(&nosqlplugin.ShardOperationConditionFailure{
 					RangeID: 200,
 					Details: "rangeID mismatch",
@@ -131,8 +147,12 @@ func TestCreateShard(t *testing.T) {
 		},
 		{
 			name: "generic db error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
+				mockParser.EXPECT().ShardInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Encoding: "base64",
+					Data:     []byte("shard-info"),
+				}, nil).Times(1)
 				dbMock.EXPECT().InsertShard(gomock.Any(), gomock.Any()).Return(errors.New("db error")).Times(1)
 				dbMock.EXPECT().IsNotFoundError(gomock.Any()).Return(true).Times(1)
 			},
@@ -150,11 +170,11 @@ func TestCreateShard(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup mocks for each test case individually
-			shardStore, dbMock, storeShardMock, ctrl := setUpMocksForShardStore(t)
+			shardStore, dbMock, storeShardMock, mockParser, ctrl := setUpMocksForShardStore(t)
 			defer ctrl.Finish()
 
 			// Setup test-specific mock behavior
-			tc.setupMock(dbMock, storeShardMock)
+			tc.setupMock(dbMock, storeShardMock, mockParser)
 
 			// Execute the method under test
 			err := shardStore.CreateShard(context.Background(), tc.request)
@@ -173,7 +193,7 @@ func TestCreateShard(t *testing.T) {
 func TestGetShard(t *testing.T) {
 	testCases := []struct {
 		name          string
-		setupMock     func(*nosqlplugin.MockDB, *MockshardedNosqlStore)
+		setupMock     func(*nosqlplugin.MockDB, *MockshardedNosqlStore, *serialization.MockParser)
 		request       *persistence.InternalGetShardRequest
 		expectError   bool
 		expected      *persistence.InternalGetShardResponse
@@ -181,22 +201,104 @@ func TestGetShard(t *testing.T) {
 	}{
 		{
 			name: "success - no update",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
-				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(101), testFixtureInternalShardInfo(), nil).Times(1)
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
+					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(true),
+				}}, nil).Times(1)
+				shardInfo := testFixtureInternalShardInfo()
+				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(101), &nosqlplugin.ShardRow{
+					InternalShardInfo: shardInfo,
+					Data:              []byte("shard-info"),
+					DataEncoding:      "base64",
+				}, nil).Times(1)
+				mockParser.EXPECT().ShardInfoFromBlob(gomock.Any(), gomock.Any()).Return(&serialization.ShardInfo{
+					Owner:               "test-owner",
+					StolenSinceRenew:    1,
+					UpdatedAt:           time.Unix(100000, 0),
+					ReplicationAckLevel: 100,
+					TransferAckLevel:    50,
+					TimerAckLevel:       time.Unix(100000, 0),
+					ClusterTransferAckLevel: map[string]int64{
+						"cluster-1": 60,
+						"cluster-2": 70,
+					},
+					ClusterTimerAckLevel: map[string]time.Time{
+						"cluster-1": time.Unix(100000, 0),
+						"cluster-2": time.Unix(100000, 0),
+					},
+					TransferProcessingQueueStates:         []byte("transfer-processing-states"),
+					TransferProcessingQueueStatesEncoding: "base64",
+					TimerProcessingQueueStates:            []byte("timer-processing-states"),
+					TimerProcessingQueueStatesEncoding:    "base64",
+					ClusterReplicationLevel: map[string]int64{
+						"cluster-1": 200,
+						"cluster-2": 250,
+					},
+					DomainNotificationVersion:      102,
+					PendingFailoverMarkers:         []byte("pending-failover-markers"),
+					PendingFailoverMarkersEncoding: "base64",
+					ReplicationDlqAckLevel: map[string]int64{
+						"cluster-1": 10,
+						"cluster-2": 15,
+					},
+				}, nil).Times(1)
 			},
 			request:     &persistence.InternalGetShardRequest{ShardID: 1},
 			expectError: false,
 			expected: &persistence.InternalGetShardResponse{
-				ShardInfo: testFixtureInternalShardInfo(),
+				ShardInfo: &persistence.InternalShardInfo{
+					ShardID:             1,
+					RangeID:             101,
+					Owner:               "test-owner",
+					StolenSinceRenew:    1,
+					UpdatedAt:           time.Unix(100000, 0),
+					ReplicationAckLevel: 100,
+					TransferAckLevel:    50,
+					TimerAckLevel:       time.Unix(100000, 0),
+					ClusterTransferAckLevel: map[string]int64{
+						"cluster-1": 60,
+						"cluster-2": 70,
+					},
+					ClusterTimerAckLevel: map[string]time.Time{
+						"cluster-1": time.Unix(100000, 0),
+						"cluster-2": time.Unix(100000, 0),
+					},
+					TransferProcessingQueueStates: &persistence.DataBlob{
+						Encoding: "base64",
+						Data:     []byte("transfer-processing-states"),
+					},
+					TimerProcessingQueueStates: &persistence.DataBlob{
+						Encoding: "base64",
+						Data:     []byte("timer-processing-states"),
+					},
+					ClusterReplicationLevel: map[string]int64{
+						"cluster-1": 200,
+						"cluster-2": 250,
+					},
+					DomainNotificationVersion: 102,
+					PendingFailoverMarkers: &persistence.DataBlob{
+						Encoding: "base64",
+						Data:     []byte("pending-failover-markers"),
+					},
+					ReplicationDLQAckLevel: map[string]int64{
+						"cluster-1": 10,
+						"cluster-2": 15,
+					},
+				},
 			},
 		},
 		{
 			name: "success - fix shard",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(2)
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
+					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(false),
+				}}, nil).Times(2)
 				storeShardMock.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
-				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), testFixtureInternalShardInfo(), nil).Times(1)
+				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), &nosqlplugin.ShardRow{
+					InternalShardInfo: testFixtureInternalShardInfo(),
+					Data:              []byte("shard-info"),
+					DataEncoding:      "base64",
+				}, nil).Times(1)
 				dbMock.EXPECT().UpdateRangeID(gomock.Any(), 1, int64(101), int64(100)).Return(nil).Times(1)
 			},
 			request:     &persistence.InternalGetShardRequest{ShardID: 1},
@@ -207,10 +309,16 @@ func TestGetShard(t *testing.T) {
 		},
 		{
 			name: "error fixing shard - shard ownership lost error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(2)
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
+					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(false),
+				}}, nil).Times(2)
 				storeShardMock.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
-				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), testFixtureInternalShardInfo(), nil).Times(1)
+				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), &nosqlplugin.ShardRow{
+					InternalShardInfo: testFixtureInternalShardInfo(),
+					Data:              []byte("shard-info"),
+					DataEncoding:      "base64",
+				}, nil).Times(1)
 				dbMock.EXPECT().UpdateRangeID(gomock.Any(), 1, int64(101), int64(100)).Return(&nosqlplugin.ShardOperationConditionFailure{
 					RangeID: 200,
 					Details: "rangeID mismatch",
@@ -222,10 +330,16 @@ func TestGetShard(t *testing.T) {
 		},
 		{
 			name: "error fixing shard - generic db error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(2)
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
+					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(false),
+				}}, nil).Times(2)
 				storeShardMock.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
-				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), testFixtureInternalShardInfo(), nil).Times(1)
+				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), &nosqlplugin.ShardRow{
+					InternalShardInfo: testFixtureInternalShardInfo(),
+					Data:              []byte("shard-info"),
+					DataEncoding:      "base64",
+				}, nil).Times(1)
 				dbMock.EXPECT().UpdateRangeID(gomock.Any(), 1, int64(101), int64(100)).Return(errors.New("db error")).Times(1)
 				dbMock.EXPECT().IsNotFoundError(gomock.Any()).Return(true).Times(1)
 			},
@@ -235,7 +349,7 @@ func TestGetShard(t *testing.T) {
 		},
 		{
 			name: "shard not found error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
 				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(0), nil, errors.New("not found")).Times(1)
 				dbMock.EXPECT().IsNotFoundError(errors.New("not found")).Return(true).Times(1)
@@ -246,7 +360,7 @@ func TestGetShard(t *testing.T) {
 		},
 		{
 			name: "generic db error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
 				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(0), nil, errors.New("db error")).Times(1)
 				dbMock.EXPECT().IsNotFoundError(gomock.Any()).Return(false).Times(1)
@@ -261,11 +375,11 @@ func TestGetShard(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup mocks for each test case individually
-			shardStore, dbMock, storeShardMock, ctrl := setUpMocksForShardStore(t)
+			shardStore, dbMock, storeShardMock, mockParser, ctrl := setUpMocksForShardStore(t)
 			defer ctrl.Finish()
 
 			// Setup test-specific mock behavior
-			tc.setupMock(dbMock, storeShardMock)
+			tc.setupMock(dbMock, storeShardMock, mockParser)
 
 			// Execute the method under test
 			resp, err := shardStore.GetShard(context.Background(), tc.request)
@@ -285,16 +399,24 @@ func TestGetShard(t *testing.T) {
 func TestUpdateShard(t *testing.T) {
 	testCases := []struct {
 		name          string
-		setupMock     func(*nosqlplugin.MockDB, *MockshardedNosqlStore)
+		setupMock     func(*nosqlplugin.MockDB, *MockshardedNosqlStore, *serialization.MockParser)
 		request       *persistence.InternalUpdateShardRequest
 		expectError   bool
 		expectedError string
 	}{
 		{
 			name: "success",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
-				dbMock.EXPECT().UpdateShard(gomock.Any(), testFixtureInternalShardInfo(), int64(100)).Return(nil).Times(1)
+				mockParser.EXPECT().ShardInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Encoding: "base64",
+					Data:     []byte("shard-info"),
+				}, nil).Times(1)
+				dbMock.EXPECT().UpdateShard(gomock.Any(), &nosqlplugin.ShardRow{
+					InternalShardInfo: testFixtureInternalShardInfo(),
+					Data:              []byte("shard-info"),
+					DataEncoding:      "base64",
+				}, int64(100)).Return(nil).Times(1)
 			},
 			request: &persistence.InternalUpdateShardRequest{
 				ShardInfo:       testFixtureInternalShardInfo(),
@@ -304,8 +426,12 @@ func TestUpdateShard(t *testing.T) {
 		},
 		{
 			name: "shard ownership lost error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
+				mockParser.EXPECT().ShardInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Encoding: "base64",
+					Data:     []byte("shard-info"),
+				}, nil).Times(1)
 				dbMock.EXPECT().UpdateShard(gomock.Any(), gomock.Any(), int64(100)).Return(&nosqlplugin.ShardOperationConditionFailure{
 					RangeID: 200,
 					Details: "rangeID mismatch",
@@ -323,9 +449,13 @@ func TestUpdateShard(t *testing.T) {
 		},
 		{
 			name: "generic db error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
 				dbMock.EXPECT().UpdateShard(gomock.Any(), gomock.Any(), int64(100)).Return(errors.New("db error")).Times(1)
+				mockParser.EXPECT().ShardInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Encoding: "base64",
+					Data:     []byte("shard-info"),
+				}, nil).Times(1)
 				dbMock.EXPECT().IsNotFoundError(gomock.Any()).Return(true).Times(1)
 			},
 			request: &persistence.InternalUpdateShardRequest{
@@ -343,11 +473,11 @@ func TestUpdateShard(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup mocks for each test case individually
-			shardStore, dbMock, storeShardMock, ctrl := setUpMocksForShardStore(t)
+			shardStore, dbMock, storeShardMock, mockParser, ctrl := setUpMocksForShardStore(t)
 			defer ctrl.Finish()
 
 			// Setup test-specific mock behavior
-			tc.setupMock(dbMock, storeShardMock)
+			tc.setupMock(dbMock, storeShardMock, mockParser)
 
 			// Execute the method under test
 			err := shardStore.UpdateShard(context.Background(), tc.request)
@@ -366,7 +496,7 @@ func TestUpdateShard(t *testing.T) {
 func TestUpdateRangeID(t *testing.T) {
 	testCases := []struct {
 		name            string
-		setupMock       func(*nosqlplugin.MockDB, *MockshardedNosqlStore)
+		setupMock       func(*nosqlplugin.MockDB, *MockshardedNosqlStore, *serialization.MockParser)
 		shardID         int
 		rangeID         int64
 		previousRangeID int64
@@ -375,7 +505,7 @@ func TestUpdateRangeID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
 				dbMock.EXPECT().UpdateRangeID(gomock.Any(), 1, int64(100), int64(99)).Return(nil).Times(1)
 			},
@@ -386,7 +516,7 @@ func TestUpdateRangeID(t *testing.T) {
 		},
 		{
 			name: "shard ownership lost error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
 				dbMock.EXPECT().UpdateRangeID(gomock.Any(), 1, int64(100), int64(99)).Return(&nosqlplugin.ShardOperationConditionFailure{
 					RangeID: 200,
@@ -401,7 +531,7 @@ func TestUpdateRangeID(t *testing.T) {
 		},
 		{
 			name: "generic db error",
-			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore) {
+			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
 				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock}, nil).Times(1)
 				dbMock.EXPECT().UpdateRangeID(gomock.Any(), 1, int64(100), int64(99)).Return(errors.New("db error")).Times(1)
 				dbMock.EXPECT().IsNotFoundError(gomock.Any()).Return(true).Times(1)
@@ -417,11 +547,11 @@ func TestUpdateRangeID(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup mocks for each test case individually
-			shardStore, dbMock, storeShardMock, ctrl := setUpMocksForShardStore(t)
+			shardStore, dbMock, storeShardMock, mockParser, ctrl := setUpMocksForShardStore(t)
 			defer ctrl.Finish()
 
 			// Setup test-specific mock behavior
-			tc.setupMock(dbMock, storeShardMock)
+			tc.setupMock(dbMock, storeShardMock, mockParser)
 
 			// Execute the method under test
 			err := shardStore.updateRangeID(context.Background(), tc.shardID, tc.rangeID, tc.previousRangeID)

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/types"
@@ -52,9 +53,10 @@ const (
 func newNoSQLTaskStore(
 	cfg config.ShardedNoSQL,
 	logger log.Logger,
+	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.TaskStore, error) {
-	s, err := newShardedNosqlStore(cfg, logger, dc)
+	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_task_store_test.go
+++ b/common/persistence/nosql/nosql_task_store_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/types"
@@ -51,7 +52,7 @@ func TestNewNoSQLStore(t *testing.T) {
 	registerCassandraMock(t)
 	cfg := getValidShardedNoSQLConfig()
 
-	store, err := newNoSQLTaskStore(cfg, log.NewNoop(), nil)
+	store, err := newNoSQLTaskStore(cfg, log.NewNoop(), metrics.NewNoopMetricsClient(), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 }

--- a/common/persistence/nosql/nosql_visibility_store.go
+++ b/common/persistence/nosql/nosql_visibility_store.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/types"
@@ -48,9 +49,10 @@ func newNoSQLVisibilityStore(
 	listClosedOrderingByCloseTime bool,
 	cfg config.ShardedNoSQL,
 	logger log.Logger,
+	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.VisibilityStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_visibility_store_test.go
+++ b/common/persistence/nosql/nosql_visibility_store_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/types"
@@ -50,7 +51,7 @@ const (
 func TestNewNoSQLVisibilityStore(t *testing.T) {
 	cfg := getValidShardedNoSQLConfig()
 
-	store, err := newNoSQLVisibilityStore(false, cfg, log.NewNoop(), nil)
+	store, err := newNoSQLVisibilityStore(false, cfg, log.NewNoop(), metrics.NewNoopMetricsClient(), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard_cql.go
@@ -45,10 +45,10 @@ const (
 		`}`
 
 	templateCreateShardQuery = `INSERT INTO executions (` +
-		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, shard, range_id) ` +
-		`VALUES(?, ?, ?, ?, ?, ?, ?, ` + templateShardType + `, ?) IF NOT EXISTS`
+		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, shard, data, data_encoding, range_id) ` +
+		`VALUES(?, ?, ?, ?, ?, ?, ?, ` + templateShardType + `, ?, ?, ?) IF NOT EXISTS`
 
-	templateGetShardQuery = `SELECT shard, range_id ` +
+	templateGetShardQuery = `SELECT shard, data, data_encoding, range_id ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
@@ -59,7 +59,7 @@ const (
 		`and task_id = ?`
 
 	templateUpdateShardQuery = `UPDATE executions ` +
-		`SET shard = ` + templateShardType + `, range_id = ? ` +
+		`SET shard = ` + templateShardType + `, data = ?, data_encoding = ?, range_id = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
 		`and domain_id = ? ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
@@ -63,13 +63,14 @@ func TestInsertShard(t *testing.T) {
 				`INSERT INTO executions (` +
 					`shard_id, type, domain_id, workflow_id, run_id, ` +
 					`visibility_ts, task_id, ` +
-					`shard, ` +
+					`shard, data, data_encoding, ` +
 					`range_id` +
 					`) ` +
 					`VALUES(` +
 					`15, 0, 10000000-1000-f000-f000-000000000000, 20000000-1000-f000-f000-000000000000, 30000000-1000-f000-f000-000000000000, ` +
 					`946684800000, -11, ` +
 					`{shard_id: 15, owner: owner, range_id: 1000, stolen_since_renew: 0, updated_at: 1712080800000, replication_ack_level: 2000, transfer_ack_level: 3000, timer_ack_level: 2024-04-02T17:00:00Z, cluster_transfer_ack_level: map[cluster2:4000], cluster_timer_ack_level: map[cluster2:2024-04-02 16:00:00 +0000 UTC], transfer_processing_queue_states: [116 114 97 110 115 102 101 114 113 117 101 117 101], transfer_processing_queue_states_encoding: thriftrw, timer_processing_queue_states: [116 105 109 101 114 113 117 101 117 101], timer_processing_queue_states_encoding: thriftrw, domain_notification_version: 3, cluster_replication_level: map[cluster2:5000], replication_dlq_ack_level: map[cluster2:10], pending_failover_markers: [102 97 105 108 111 118 101 114 109 97 114 107 101 114 115], pending_failover_markers_encoding: thriftrw }, ` +
+					`[115 104 97 114 100 100 97 116 97], thriftrw, ` +
 					`1000` +
 					`) IF NOT EXISTS`,
 			},
@@ -143,7 +144,7 @@ func TestSelectShard(t *testing.T) {
 		queryMockFn   func(query *gocql.MockQuery)
 		wantQueries   []string
 		wantRangeID   int64
-		wantShardInfo *persistence.InternalShardInfo
+		wantShardInfo *nosqlplugin.ShardRow
 		wantErr       bool
 	}{
 		{
@@ -155,29 +156,35 @@ func TestSelectShard(t *testing.T) {
 				query.EXPECT().MapScan(gomock.Any()).DoAndReturn(func(m map[string]interface{}) error {
 					m["range_id"] = int64(1000)
 					m["shard"] = testdata.NewShardMap(ts)
+					m["data"] = []byte("sharddata")
+					m["data_encoding"] = "thriftrw"
 					return nil
 				}).Times(1)
 			},
 			wantRangeID: int64(1000),
-			wantShardInfo: &persistence.InternalShardInfo{
-				ShardID:                       15,
-				Owner:                         "owner",
-				RangeID:                       1000,
-				UpdatedAt:                     ts,
-				ReplicationAckLevel:           2000,
-				ReplicationDLQAckLevel:        map[string]int64{"cluster2": 5},
-				TransferAckLevel:              3000,
-				TimerAckLevel:                 ts.Add(-1 * time.Hour),
-				ClusterTransferAckLevel:       map[string]int64{"cluster1": 3000},
-				ClusterTimerAckLevel:          map[string]time.Time{"cluster1": ts.Add(-1 * time.Hour)},
-				TransferProcessingQueueStates: &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("transferqueue")},
-				TimerProcessingQueueStates:    &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("timerqueue")},
-				ClusterReplicationLevel:       map[string]int64{"cluster2": 1500},
-				DomainNotificationVersion:     3,
-				PendingFailoverMarkers:        &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("failovermarkers")},
+			wantShardInfo: &nosqlplugin.ShardRow{
+				InternalShardInfo: &persistence.InternalShardInfo{
+					ShardID:                       15,
+					Owner:                         "owner",
+					RangeID:                       1000,
+					UpdatedAt:                     ts,
+					ReplicationAckLevel:           2000,
+					ReplicationDLQAckLevel:        map[string]int64{"cluster2": 5},
+					TransferAckLevel:              3000,
+					TimerAckLevel:                 ts.Add(-1 * time.Hour),
+					ClusterTransferAckLevel:       map[string]int64{"cluster1": 3000},
+					ClusterTimerAckLevel:          map[string]time.Time{"cluster1": ts.Add(-1 * time.Hour)},
+					TransferProcessingQueueStates: &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("transferqueue")},
+					TimerProcessingQueueStates:    &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("timerqueue")},
+					ClusterReplicationLevel:       map[string]int64{"cluster2": 1500},
+					DomainNotificationVersion:     3,
+					PendingFailoverMarkers:        &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("failovermarkers")},
+				},
+				Data:         []byte("sharddata"),
+				DataEncoding: "thriftrw",
 			},
 			wantQueries: []string{
-				`SELECT shard, range_id FROM executions WHERE ` +
+				`SELECT shard, data, data_encoding, range_id FROM executions WHERE ` +
 					`shard_id = 15 and type = 0 and ` +
 					`domain_id = 10000000-1000-f000-f000-000000000000 and ` +
 					`workflow_id = 20000000-1000-f000-f000-000000000000 and ` +
@@ -205,25 +212,27 @@ func TestSelectShard(t *testing.T) {
 				}).Times(1)
 			},
 			wantRangeID: int64(1000),
-			wantShardInfo: &persistence.InternalShardInfo{
-				ShardID:                       15,
-				Owner:                         "owner",
-				RangeID:                       1000,
-				UpdatedAt:                     ts,
-				ReplicationAckLevel:           2000,
-				ReplicationDLQAckLevel:        map[string]int64{}, // this was reset to empty map
-				TransferAckLevel:              3000,
-				TimerAckLevel:                 ts.Add(-1 * time.Hour),
-				ClusterTransferAckLevel:       map[string]int64{"cluster1": 3000},
-				ClusterTimerAckLevel:          map[string]time.Time{"cluster1": ts.Add(-1 * time.Hour)},
-				TransferProcessingQueueStates: &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("transferqueue")},
-				TimerProcessingQueueStates:    &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("timerqueue")},
-				ClusterReplicationLevel:       map[string]int64{}, // this was reset to empty map
-				DomainNotificationVersion:     3,
-				PendingFailoverMarkers:        &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("failovermarkers")},
+			wantShardInfo: &nosqlplugin.ShardRow{
+				InternalShardInfo: &persistence.InternalShardInfo{
+					ShardID:                       15,
+					Owner:                         "owner",
+					RangeID:                       1000,
+					UpdatedAt:                     ts,
+					ReplicationAckLevel:           2000,
+					ReplicationDLQAckLevel:        map[string]int64{}, // this was reset to empty map
+					TransferAckLevel:              3000,
+					TimerAckLevel:                 ts.Add(-1 * time.Hour),
+					ClusterTransferAckLevel:       map[string]int64{"cluster1": 3000},
+					ClusterTimerAckLevel:          map[string]time.Time{"cluster1": ts.Add(-1 * time.Hour)},
+					TransferProcessingQueueStates: &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("transferqueue")},
+					TimerProcessingQueueStates:    &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("timerqueue")},
+					ClusterReplicationLevel:       map[string]int64{}, // this was reset to empty map
+					DomainNotificationVersion:     3,
+					PendingFailoverMarkers:        &persistence.DataBlob{Encoding: "thriftrw", Data: []uint8("failovermarkers")},
+				},
 			},
 			wantQueries: []string{
-				`SELECT shard, range_id FROM executions WHERE ` +
+				`SELECT shard, data, data_encoding, range_id FROM executions WHERE ` +
 					`shard_id = 15 and type = 0 and ` +
 					`domain_id = 10000000-1000-f000-f000-000000000000 and ` +
 					`workflow_id = 20000000-1000-f000-f000-000000000000 and ` +
@@ -422,6 +431,8 @@ func TestUpdateShard(t *testing.T) {
 					`pending_failover_markers: [102 97 105 108 111 118 101 114 109 97 114 107 101 114 115], ` +
 					`pending_failover_markers_encoding: thriftrw ` +
 					`}, ` +
+					`data = [115 104 97 114 100 100 97 116 97], ` +
+					`data_encoding = thriftrw, ` +
 					`range_id = 1000 ` +
 					`WHERE ` +
 					`shard_id = 15 and ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/testdata/shard.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/testdata/shard.go
@@ -31,21 +31,25 @@ import (
 
 func NewShardRow(ts time.Time) *nosqlplugin.ShardRow {
 	return &nosqlplugin.ShardRow{
-		ShardID:                       15,
-		Owner:                         "owner",
-		RangeID:                       1000,
-		ReplicationAckLevel:           2000,
-		TransferAckLevel:              3000,
-		TimerAckLevel:                 ts.Add(-time.Hour),
-		ClusterTransferAckLevel:       map[string]int64{"cluster2": 4000},
-		ClusterTimerAckLevel:          map[string]time.Time{"cluster2": ts.Add(-2 * time.Hour)},
-		DomainNotificationVersion:     3,
-		ClusterReplicationLevel:       map[string]int64{"cluster2": 5000},
-		ReplicationDLQAckLevel:        map[string]int64{"cluster2": 10},
-		PendingFailoverMarkers:        &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("failovermarkers")},
-		TransferProcessingQueueStates: &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("transferqueue")},
-		TimerProcessingQueueStates:    &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("timerqueue")},
-		CurrentTimestamp:              ts,
+		InternalShardInfo: &persistence.InternalShardInfo{
+			ShardID:                       15,
+			Owner:                         "owner",
+			RangeID:                       1000,
+			ReplicationAckLevel:           2000,
+			TransferAckLevel:              3000,
+			TimerAckLevel:                 ts.Add(-time.Hour),
+			ClusterTransferAckLevel:       map[string]int64{"cluster2": 4000},
+			ClusterTimerAckLevel:          map[string]time.Time{"cluster2": ts.Add(-2 * time.Hour)},
+			DomainNotificationVersion:     3,
+			ClusterReplicationLevel:       map[string]int64{"cluster2": 5000},
+			ReplicationDLQAckLevel:        map[string]int64{"cluster2": 10},
+			PendingFailoverMarkers:        &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("failovermarkers")},
+			TransferProcessingQueueStates: &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("transferqueue")},
+			TimerProcessingQueueStates:    &persistence.DataBlob{Encoding: "thriftrw", Data: []byte("timerqueue")},
+			CurrentTimestamp:              ts,
+		},
+		Data:         []byte("sharddata"),
+		DataEncoding: "thriftrw",
 	}
 }
 

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -212,7 +212,11 @@ type (
 
 	// ShardRow is the same as persistence.InternalShardInfo
 	// Separate them later when there is a need.
-	ShardRow = persistence.InternalShardInfo
+	ShardRow struct {
+		*persistence.InternalShardInfo
+		Data         []byte
+		DataEncoding string
+	}
 
 	// ConflictedShardRow contains the partial information about a shard returned when a conditional write fails
 	ConflictedShardRow struct {

--- a/common/persistence/nosql/sharded_nosql_store_mock.go
+++ b/common/persistence/nosql/sharded_nosql_store_mock.go
@@ -37,6 +37,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	log "github.com/uber/cadence/common/log"
+	metrics "github.com/uber/cadence/common/metrics"
 )
 
 // MockshardedNosqlStore is a mock of shardedNosqlStore interface.
@@ -101,6 +102,20 @@ func (m *MockshardedNosqlStore) GetLogger() log.Logger {
 func (mr *MockshardedNosqlStoreMockRecorder) GetLogger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockshardedNosqlStore)(nil).GetLogger))
+}
+
+// GetMetricsClient mocks base method.
+func (m *MockshardedNosqlStore) GetMetricsClient() metrics.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetricsClient")
+	ret0, _ := ret[0].(metrics.Client)
+	return ret0
+}
+
+// GetMetricsClient indicates an expected call of GetMetricsClient.
+func (mr *MockshardedNosqlStoreMockRecorder) GetMetricsClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsClient", reflect.TypeOf((*MockshardedNosqlStore)(nil).GetMetricsClient))
 }
 
 // GetName mocks base method.

--- a/common/persistence/nosql/sharded_nosql_store_test.go
+++ b/common/persistence/nosql/sharded_nosql_store_test.go
@@ -30,6 +30,7 @@ import (
 
 	. "github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
 
@@ -152,7 +153,7 @@ func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForHistoryShard() {
 func (s *shardedNosqlStoreTestSuite) newShardedStoreForTest() *shardedNosqlStoreImpl {
 	cfg := getValidShardedNoSQLConfig()
 	logger := log.NewNoop()
-	storeInterface, err := newShardedNosqlStore(cfg, logger, nil)
+	storeInterface, err := newShardedNosqlStore(cfg, logger, metrics.NewNoopMetricsClient(), nil)
 	s.NoError(err)
 	s.Equal("shardedNosql", storeInterface.GetName())
 	s.Equal(logger, storeInterface.GetLogger())

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -156,6 +156,7 @@ func NewTestBaseWithNoSQL(t *testing.T, options *TestBaseOptions) *TestBase {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := TestBaseParams{
 		DefaultTestCluster:    testCluster,

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -156,7 +156,7 @@ func NewTestBaseWithNoSQL(t *testing.T, options *TestBaseOptions) *TestBase {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 	}
 	params := TestBaseParams{
 		DefaultTestCluster:    testCluster,

--- a/common/persistence/sql/sql_shard_store.go
+++ b/common/persistence/sql/sql_shard_store.go
@@ -136,6 +136,13 @@ func (m *sqlShardStore) GetShard(
 		}
 	}
 
+	var pendingFailoverMarkers *persistence.DataBlob
+	if shardInfo.GetPendingFailoverMarkers() != nil {
+		pendingFailoverMarkers = &persistence.DataBlob{
+			Encoding: constants.EncodingType(shardInfo.GetPendingFailoverMarkersEncoding()),
+			Data:     shardInfo.GetPendingFailoverMarkers(),
+		}
+	}
 	resp := &persistence.InternalGetShardResponse{ShardInfo: &persistence.InternalShardInfo{
 		ShardID:                       int(row.ShardID),
 		RangeID:                       row.RangeID,
@@ -152,6 +159,7 @@ func (m *sqlShardStore) GetShard(
 		DomainNotificationVersion:     shardInfo.GetDomainNotificationVersion(),
 		ClusterReplicationLevel:       shardInfo.ClusterReplicationLevel,
 		ReplicationDLQAckLevel:        shardInfo.ReplicationDlqAckLevel,
+		PendingFailoverMarkers:        pendingFailoverMarkers,
 	}}
 
 	return resp, nil

--- a/common/persistence/sql/sql_shard_store_test.go
+++ b/common/persistence/sql/sql_shard_store_test.go
@@ -71,6 +71,12 @@ func TestGetShard(t *testing.T) {
 					TimerProcessingQueueStates:            []byte(`timer`),
 					TimerProcessingQueueStatesEncoding:    "timer",
 					DomainNotificationVersion:             99,
+					PendingFailoverMarkers:                []byte(`markers`),
+					PendingFailoverMarkersEncoding:        "markers",
+					ReplicationDlqAckLevel:                map[string]int64{"active": 10},
+					ClusterReplicationLevel:               map[string]int64{"active": 1002},
+					ClusterTimerAckLevel:                  map[string]time.Time{"active": time.Unix(2, 1)},
+					ClusterTransferAckLevel:               map[string]int64{"active": 1002},
 				}, nil)
 			},
 			want: &persistence.InternalGetShardResponse{
@@ -94,8 +100,12 @@ func TestGetShard(t *testing.T) {
 						Data:     []byte(`timer`),
 					},
 					DomainNotificationVersion: 99,
-					ClusterReplicationLevel:   map[string]int64{},
-					ReplicationDLQAckLevel:    map[string]int64{},
+					ClusterReplicationLevel:   map[string]int64{"active": 1002},
+					ReplicationDLQAckLevel:    map[string]int64{"active": 10},
+					PendingFailoverMarkers: &persistence.DataBlob{
+						Encoding: constants.EncodingType("markers"),
+						Data:     []byte(`markers`),
+					},
 				},
 			},
 			wantErr: false,

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -703,7 +703,7 @@ func createConfigStoreOrDefault(
 		FetchTimeout:        dc.GetDurationProperty(dynamicproperties.IsolationGroupStateFetchTimeout)(),
 		UpdateTimeout:       dc.GetDurationProperty(dynamicproperties.IsolationGroupStateUpdateTimeout)(),
 	}
-	cfgStoreClient, err := configstore.NewConfigStoreClient(cscConfig, &params.PersistenceConfig, params.Logger, persistence.GlobalIsolationGroupConfig)
+	cfgStoreClient, err := configstore.NewConfigStoreClient(cscConfig, &params.PersistenceConfig, params.Logger, params.MetricsClient, persistence.GlobalIsolationGroupConfig)
 	if err != nil {
 		// not possible to create the client under some persistence configurations, so this is expected
 		params.Logger.Warn("not instantiating Isolation group config store, this feature will not be enabled", tag.Error(err))

--- a/host/async_wf_test.go
+++ b/host/async_wf_test.go
@@ -98,6 +98,7 @@ func (s *AsyncWFIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/async_wf_test.go
+++ b/host/async_wf_test.go
@@ -98,7 +98,7 @@ func (s *AsyncWFIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -48,7 +48,6 @@ var (
 		dynamicproperties.EnableConsistentQueryByDomain:                 true,
 		dynamicproperties.MinRetentionDays:                              0,
 		dynamicproperties.WorkflowDeletionJitterRange:                   1,
-		dynamicproperties.ReadNoSQLShardFromDataBlob:                    true,
 	}
 )
 

--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -48,6 +48,7 @@ var (
 		dynamicproperties.EnableConsistentQueryByDomain:                 true,
 		dynamicproperties.MinRetentionDays:                              0,
 		dynamicproperties.WorkflowDeletionJitterRange:                   1,
+		dynamicproperties.ReadNoSQLShardFromDataBlob:                    true,
 	}
 )
 

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -114,6 +114,7 @@ func (s *IntegrationBase) setupSuite() {
 			EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 			EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 			ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
+			ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 		}
 		params := pt.TestBaseParams{
 			DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -114,7 +114,7 @@ func (s *IntegrationBase) setupSuite() {
 			EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 			EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 			ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-			ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
+			ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		}
 		params := pt.TestBaseParams{
 			DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -102,6 +102,7 @@ func (s *NDCIntegrationTestSuite) SetupSuite() {
 		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.defaultTestCluster,

--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -102,7 +102,7 @@ func (s *NDCIntegrationTestSuite) SetupSuite() {
 		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.defaultTestCluster,

--- a/host/persistence/cassandra/cassandra_persistence_test.go
+++ b/host/persistence/cassandra/cassandra_persistence_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/testflags"
@@ -58,6 +59,15 @@ func TestCassandraShardPersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.ShardPersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(t, &persistencetests.TestBaseOptions{})
+	s.Setup()
+	suite.Run(t, s)
+}
+
+func TestCassandraShardMigrationPersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
+	s := new(persistencetests.ShardPersistenceSuite)
+	s.TestBase = public.NewTestBaseWithPublicCassandra(t, &persistencetests.TestBaseOptions{})
+	s.TestBase.DynamicConfiguration.ReadNoSQLShardFromDataBlob = dynamicproperties.GetBoolPropertyFn(true)
 	s.Setup()
 	suite.Run(t, s)
 }

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -113,7 +113,7 @@ func (s *PinotIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -113,6 +113,7 @@ func (s *PinotIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/workflowidratelimit_test.go
+++ b/host/workflowidratelimit_test.go
@@ -76,6 +76,7 @@ func (s *WorkflowIDRateLimitIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/workflowidratelimit_test.go
+++ b/host/workflowidratelimit_test.go
@@ -76,7 +76,7 @@ func (s *WorkflowIDRateLimitIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/workflowsidinternalratelimit_test.go
+++ b/host/workflowsidinternalratelimit_test.go
@@ -79,6 +79,7 @@ func (s *WorkflowIDInternalRateLimitIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Serialized shard data into a blob and store it into data column in Cassandra
- Introduce a feature flag to control where to read data from
- Fix a bug in GetShard method for SQL implementation

<!-- Tell your future self why have you made these changes -->
**Why?**
To migrate shard data from Cassandra typed column to serialized blob column so that we don't need to update our schema when introducing new field to shard data. This is a preparation work for history queue revamp.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests and integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
