### PR TITLE
[domain deprecation]Integrate domain deprecation workflow with CLI

### DIFF
--- a/service/worker/domaindeprecation/activities.go
+++ b/service/worker/domaindeprecation/activities.go
@@ -32,7 +32,7 @@ import (
 )
 
 // DisableArchivalActivity disables archival for the domain
-func (w *domainDeprecator) DisableArchivalActivity(ctx context.Context, params DomainActivityParams) error {
+func (w *domainDeprecator) DisableArchivalActivity(ctx context.Context, params DomainDeprecationParams) error {
 	client := w.clientBean.GetFrontendClient()
 	disabled := types.ArchivalStatusDisabled
 
@@ -59,7 +59,7 @@ func (w *domainDeprecator) DisableArchivalActivity(ctx context.Context, params D
 		Name:                     params.DomainName,
 		HistoryArchivalStatus:    &disabled,
 		VisibilityArchivalStatus: &disabled,
-		SecurityToken:            w.cfg.AdminOperationToken(),
+		SecurityToken:            params.SecurityToken,
 	}
 	updateResp, err := client.UpdateDomain(ctx, updateRequest)
 	if err != nil {
@@ -76,12 +76,12 @@ func (w *domainDeprecator) DisableArchivalActivity(ctx context.Context, params D
 }
 
 // DeprecateDomainActivity deprecates the domain
-func (w *domainDeprecator) DeprecateDomainActivity(ctx context.Context, params DomainActivityParams) error {
+func (w *domainDeprecator) DeprecateDomainActivity(ctx context.Context, params DomainDeprecationParams) error {
 	client := w.clientBean.GetFrontendClient()
 
 	err := client.DeprecateDomain(ctx, &types.DeprecateDomainRequest{
 		Name:          params.DomainName,
-		SecurityToken: w.cfg.AdminOperationToken(),
+		SecurityToken: params.SecurityToken,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to deprecate domain: %v", err)

--- a/service/worker/domaindeprecation/entities.go
+++ b/service/worker/domaindeprecation/entities.go
@@ -22,6 +22,11 @@
 
 package domaindeprecation
 
+type DomainDeprecationParams struct {
+	DomainName    string `json:"domain_name"`
+	SecurityToken string `json:"security_token"`
+}
+
 // DomainActivityParams contains the domain name parameter used by domain-related activities.
 type DomainActivityParams struct {
 	DomainName string `json:"domain_name"`

--- a/service/worker/domaindeprecation/module.go
+++ b/service/worker/domaindeprecation/module.go
@@ -107,8 +107,8 @@ func (w *domainDeprecator) Start() error {
 		MaxConcurrentActivityTaskPollers: 10,
 		MaxConcurrentDecisionTaskPollers: 10,
 	}
-	newWorker := worker.New(w.svcClient, constants.SystemLocalDomainName, domainDeprecationTaskListName, workerOpts)
-	newWorker.RegisterWorkflowWithOptions(w.DomainDeprecationWorkflow, workflow.RegisterOptions{Name: domainDeprecationWorkflowTypeName})
+	newWorker := worker.New(w.svcClient, constants.SystemLocalDomainName, DomainDeprecationTaskListName, workerOpts)
+	newWorker.RegisterWorkflowWithOptions(w.DomainDeprecationWorkflow, workflow.RegisterOptions{Name: DomainDeprecationWorkflowTypeName})
 	newWorker.RegisterActivityWithOptions(w.DisableArchivalActivity, activity.RegisterOptions{Name: disableArchivalActivity, EnableAutoHeartbeat: true})
 	newWorker.RegisterActivityWithOptions(w.DeprecateDomainActivity, activity.RegisterOptions{Name: deprecateDomainActivity, EnableAutoHeartbeat: true})
 	w.worker = newWorker

--- a/service/worker/domaindeprecation/workflow_test.go
+++ b/service/worker/domaindeprecation/workflow_test.go
@@ -76,7 +76,7 @@ func (s *domainDeprecationWorkflowTestSuite) SetupTest() {
 		mockResource.Finish(s.T())
 	})
 
-	s.workflowEnv.RegisterWorkflowWithOptions(s.deprecator.DomainDeprecationWorkflow, workflow.RegisterOptions{Name: domainDeprecationWorkflowTypeName})
+	s.workflowEnv.RegisterWorkflowWithOptions(s.deprecator.DomainDeprecationWorkflow, workflow.RegisterOptions{Name: DomainDeprecationWorkflowTypeName})
 	s.workflowEnv.RegisterActivityWithOptions(s.deprecator.DisableArchivalActivity, activity.RegisterOptions{Name: disableArchivalActivity})
 	s.workflowEnv.RegisterActivityWithOptions(s.deprecator.DeprecateDomainActivity, activity.RegisterOptions{Name: deprecateDomainActivity})
 }
@@ -93,7 +93,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Success() {
 			SuccessCount: 10,
 			ErrorCount:   0,
 		}, nil).Once()
-	s.workflowEnv.ExecuteWorkflow(domainDeprecationWorkflowTypeName, testDomain)
+	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, testDomain)
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.NoError(s.workflowEnv.GetWorkflowError())
 }
@@ -101,7 +101,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Success() {
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Disable_Archival_Error() {
 	mockErr := errors.New("error")
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultActivityParams).Return(mockErr)
-	s.workflowEnv.ExecuteWorkflow(domainDeprecationWorkflowTypeName, testDomain)
+	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, testDomain)
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.Error(s.workflowEnv.GetWorkflowError())
 	s.ErrorContains(s.workflowEnv.GetWorkflowError(), mockErr.Error())
@@ -111,7 +111,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Deprecate_Domain_Error
 	mockErr := errors.New("error")
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultActivityParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultActivityParams).Return(mockErr)
-	s.workflowEnv.ExecuteWorkflow(domainDeprecationWorkflowTypeName, testDomain)
+	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, testDomain)
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.Error(s.workflowEnv.GetWorkflowError())
 	s.ErrorContains(s.workflowEnv.GetWorkflowError(), mockErr.Error())
@@ -124,7 +124,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_BatchTerminate_ChildWo
 	s.workflowEnv.OnWorkflow(batcher.BatchWorkflow, mock.Anything, mock.Anything).Return(
 		batcher.HeartBeatDetails{}, mockErr)
 
-	s.workflowEnv.ExecuteWorkflow(domainDeprecationWorkflowTypeName, testDomain)
+	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, testDomain)
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.Error(s.workflowEnv.GetWorkflowError())
 	s.ErrorContains(s.workflowEnv.GetWorkflowError(), mockErr.Error())

--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pborman/uuid"
 	"github.com/urfave/cli/v2"
 
 	"github.com/uber/cadence/client/admin"
@@ -38,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/domain"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/domaindeprecation"
 	"github.com/uber/cadence/tools/common/commoncli"
 	"github.com/uber/cadence/tools/common/flag"
 )
@@ -300,48 +302,56 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) error {
 func (d *domainCLIImpl) DeprecateDomain(c *cli.Context) error {
 	domainName, err := getRequiredOption(c, FlagDomain)
 	if err != nil {
-		return commoncli.Problem("Required flag not found: ", err)
+		return commoncli.Problem("Required flag not provided: ", err)
 	}
-	securityToken := c.String(FlagSecurityToken)
-	force := c.Bool(FlagForce)
+
+	securityToken, err := getRequiredOption(c, FlagSecurityToken)
+	if err != nil {
+		return commoncli.Problem("Required flag not provided: ", err)
+	}
 
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
 		return commoncli.Problem("Error in creating context: ", err)
 	}
-	if !force {
-		wfc, err := getWorkflowClient(c)
-		if err != nil {
-			return err
-		}
-		// check if there is any workflow in this domain, if exists, do not deprecate
-		wfs, _, err := listClosedWorkflow(wfc, 1, 0, time.Now().UnixNano(), domainName, "", "", workflowStatusNotSet, c)(nil)
-		if err != nil {
-			return commoncli.Problem("Operation DeprecateDomain failed: fail to list closed workflows: ", err)
-		}
-		if len(wfs) > 0 {
-			return commoncli.Problem("Operation DeprecateDomain failed.", errors.New("workflow history not cleared in this domain"))
-		}
-		wfs, _, err = listOpenWorkflow(wfc, 1, 0, time.Now().UnixNano(), domainName, "", "", c)(nil)
-		if err != nil {
-			return commoncli.Problem("Operation DeprecateDomain failed: fail to list open workflows: ", err)
-		}
-		if len(wfs) > 0 {
-			return commoncli.Problem("Operation DeprecateDomain failed.", errors.New("workflow still running in this domain"))
-		}
-	}
-	err = d.deprecateDomain(ctx, &types.DeprecateDomainRequest{
-		Name:          domainName,
-		SecurityToken: securityToken,
-	})
+
+	frontendClient, err := getDeps(c).ServerFrontendClient(c)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
-			return commoncli.Problem("Operation DeprecateDomain failed.", err)
-		}
-		return commoncli.Problem(fmt.Sprintf("Domain %s does not exist.", domainName), err)
+		return err
 	}
-	fmt.Printf("Domain %s successfully deprecated.\n", domainName)
+
+	params := domaindeprecation.DomainDeprecationParams{
+		DomainName:    domainName,
+		SecurityToken: securityToken,
+	}
+	input, err := json.Marshal(params)
+	if err != nil {
+		return commoncli.Problem("Failed to encode domain deprecation parameters", err)
+	}
+
+	workflowID := uuid.NewRandom().String()
+	startRequest := &types.StartWorkflowExecutionRequest{
+		Domain:     constants.SystemLocalDomainName,
+		WorkflowID: fmt.Sprintf("domain-deprecation-%s-%s", domainName, workflowID),
+		WorkflowType: &types.WorkflowType{
+			Name: domaindeprecation.DomainDeprecationWorkflowTypeName,
+		},
+		TaskList: &types.TaskList{
+			Name: domaindeprecation.DomainDeprecationTaskListName,
+		},
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(int32(24 * 30 * 60 * 60)), // 30 days
+		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(5 * 60),                   // 5 minutes
+		RequestID:                           uuid.New(),
+		Input:                               input,
+	}
+
+	resp, err := frontendClient.StartWorkflowExecution(ctx, startRequest)
+	if err != nil {
+		return commoncli.Problem("Failed to start domain deprecation workflow", err)
+	}
+
+	fmt.Printf("Domain deprecation workflow started. Workflow ID: %s, Run ID: %s\n", startRequest.WorkflowID, resp.GetRunID())
 	return nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR connects the domain deprecation workflow to the CLI's deprecate domain command. When a user runs `cadence domain deprecate`, the CLI will now:

1. Require a security token flag for authentication
2. Start the domain deprecation workflow
3. Return the workflow ID and run ID to the user
4. The workflow will then:
   - Disable archival
   - Deprecate the domain
   - Terminate open workflows
   - Validate no workflows remain
   - Retry termination if needed

The force flag has been removed since the domain is now deprecated early in the process, before workflow termination and cleanup. This ensures a more controlled deprecation sequence where the domain is marked as deprecated first, followed by proper cleanup of workflows.

<!-- Tell your future self why have you made these changes -->
**Why?**
The goal is to provide a safe and automated way to deprecate domains, ensuring all workflows are properly terminated and validated before the deprecation is considered complete.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests & local testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
