### PR TITLE
Fix Parent workflow is not notified of child workflow completion issue

### DIFF
--- a/service/history/engine/engineimpl/history_engine_test.go
+++ b/service/history/engine/engineimpl/history_engine_test.go
@@ -5443,41 +5443,15 @@ func TestRecordChildExecutionCompleted(t *testing.T) {
 					WorkflowID: "wid1",
 					RunID:      "312b2440-2859-4e50-a59f-d92a300a072d",
 				},
-				StartedID: 11,
 			},
 			mockSetup: func(ms *execution.MockMutableState) {
 				ms.EXPECT().IsWorkflowExecutionRunning().Return(true)
 				ms.EXPECT().GetChildExecutionInfo(int64(10)).Return(&persistence.ChildExecutionInfo{StartedID: commonconstants.EmptyEventID}, true)
-				ms.EXPECT().GetNextEventID().Return(int64(11)).Times(2)
+				ms.EXPECT().GetNextEventID().Return(int64(11)).Times(1)
 			},
 			wantErr: true,
 			assertErr: func(t *testing.T, err error) {
 				assert.Equal(t, workflow.ErrStaleState, err)
-			},
-		},
-		{
-			name: "pending child execution not started",
-			request: &types.RecordChildExecutionCompletedRequest{
-				DomainUUID:  "58f7998e-9c00-4827-bbd3-6a891b3ca0ca",
-				InitiatedID: 10,
-				WorkflowExecution: &types.WorkflowExecution{
-					WorkflowID: "wid",
-					RunID:      "4353ddce-ca34-4c78-9785-dc0b83af4bbc",
-				},
-				CompletedExecution: &types.WorkflowExecution{
-					WorkflowID: "wid1",
-					RunID:      "312b2440-2859-4e50-a59f-d92a300a072d",
-				},
-				StartedID: 11,
-			},
-			mockSetup: func(ms *execution.MockMutableState) {
-				ms.EXPECT().IsWorkflowExecutionRunning().Return(true)
-				ms.EXPECT().GetChildExecutionInfo(int64(10)).Return(&persistence.ChildExecutionInfo{StartedID: commonconstants.EmptyEventID}, true)
-				ms.EXPECT().GetNextEventID().Return(int64(12)).Times(1)
-			},
-			wantErr: true,
-			assertErr: func(t *testing.T, err error) {
-				assert.Equal(t, &types.EntityNotExistsError{Message: "Pending child execution not started."}, err)
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update RecordChildWorkflowComplete endpoint to always return staleness error if child workflow is initiated but not started.

<!-- Tell your future self why have you made these changes -->
**Why?**
When child workflow is complete, a transfer task is generated to notify parent workflow for completion, but if there is a shard movement for parent workflow, the child workflow may notify a history host with stale data, and if the endpoint returns a non-retryable EntityNotExistsError, the transfer task will be dropped and the parent workflow will never receive the notification.

Previously, we introduce staleness check, but the child workflow doesn't know the start event ID in parent workflow, so we're unable to do staleness check if the pending child workflow info exists in parent's mutable state but is not started. In this case, we just assume that the workflow has stale data and return a retryable error so that the transfer task won't be dropped. On the next attempt, if the request is sent to the correct host with non-stale data, it will either hit EntityNotExistsError branch because it's already marked as complete in parent workflow or add child workflow completion event to parent workflow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The record child workflow complete transfer tasks may keep retrying. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
