### PR TITLE
Generalize domain failover callback registration

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -80,6 +80,8 @@ type (
 	// it is guaranteed that  CallbackFn pair will be both called or non will be called
 	CallbackFn func(updatedDomains []*DomainCacheEntry)
 
+	// CatchUpFn is a function to execute PrepareCallbackFn and/or CallbackFn during domain callback registration,
+	// allowing the caller to catch up with the latest domain changes
 	CatchUpFn func(domainCache DomainCache, prepareCallback PrepareCallbackFn, callback CallbackFn)
 
 	// DomainCache is used the cache domain information and configuration to avoid making too many calls to cassandra.

--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -80,6 +80,8 @@ type (
 	// it is guaranteed that  CallbackFn pair will be both called or non will be called
 	CallbackFn func(updatedDomains []*DomainCacheEntry)
 
+	CatchUpFn func(domainCache DomainCache, prepareCallback PrepareCallbackFn, callback CallbackFn)
+
 	// DomainCache is used the cache domain information and configuration to avoid making too many calls to cassandra.
 	// This cache is mainly used by frontend for resolving domain names to domain uuids which are used throughout the
 	// system.  Each domain entry is kept in the cache for one hour but also has an expiry of 10 seconds.  This results
@@ -87,8 +89,8 @@ type (
 	// requests using the stale entry from cache upto an hour
 	DomainCache interface {
 		common.Daemon
-		RegisterDomainChangeCallback(shard int, initialNotificationVersion int64, prepareCallback PrepareCallbackFn, callback CallbackFn)
-		UnregisterDomainChangeCallback(shard int)
+		RegisterDomainChangeCallback(id string, catchUpFn CatchUpFn, prepareCallback PrepareCallbackFn, callback CallbackFn)
+		UnregisterDomainChangeCallback(id string)
 		GetDomain(name string) (*DomainCacheEntry, error)
 		GetDomainByID(id string) (*DomainCacheEntry, error)
 		GetDomainID(name string) (string, error)
@@ -117,8 +119,8 @@ type (
 		lastCallbackEmitTime time.Time
 
 		callbackLock     sync.Mutex
-		prepareCallbacks map[int]PrepareCallbackFn
-		callbacks        map[int]CallbackFn
+		prepareCallbacks map[string]PrepareCallbackFn
+		callbacks        map[string]CallbackFn
 
 		throttleRetry *backoff.ThrottleRetry
 	}
@@ -178,8 +180,8 @@ func NewDomainCache(
 		timeSource:       clock.NewRealTimeSource(),
 		scope:            metricsClient.Scope(metrics.DomainCacheScope),
 		logger:           logger,
-		prepareCallbacks: make(map[int]PrepareCallbackFn),
-		callbacks:        make(map[int]CallbackFn),
+		prepareCallbacks: make(map[string]PrepareCallbackFn),
+		callbacks:        make(map[string]CallbackFn),
 		throttleRetry:    throttleRetry,
 	}
 	cache.cacheNameToID.Store(newDomainCache())
@@ -317,49 +319,31 @@ func (c *DefaultDomainCache) GetAllDomain() map[string]*DomainCacheEntry {
 // make sure the callback function will not call domain cache again in case of dead lock
 // afterCallback will be invoked when NOT holding the domain cache lock.
 func (c *DefaultDomainCache) RegisterDomainChangeCallback(
-	shard int,
-	initialNotificationVersion int64,
+	id string,
+	catchUpFn CatchUpFn,
 	prepareCallback PrepareCallbackFn,
 	callback CallbackFn,
 ) {
 
 	c.callbackLock.Lock()
-	c.prepareCallbacks[shard] = prepareCallback
-	c.callbacks[shard] = callback
+	c.prepareCallbacks[id] = prepareCallback
+	c.callbacks[id] = callback
 	c.callbackLock.Unlock()
 
-	// this section is trying to make the shard catch up with domain changes
-	domains := DomainCacheEntries{}
-	for _, domain := range c.GetAllDomain() {
-		domains = append(domains, domain)
-	}
-	// we mush notify the change in a ordered fashion
-	// since history shard have to update the shard info
-	// with domain change version.
-	sort.Sort(domains)
+	catchUpFn(c, prepareCallback, callback)
 
-	var updatedEntries []*DomainCacheEntry
-	for _, domain := range domains {
-		if domain.notificationVersion >= initialNotificationVersion {
-			updatedEntries = append(updatedEntries, domain)
-		}
-	}
-	if len(updatedEntries) > 0 {
-		prepareCallback()
-		callback(updatedEntries)
-	}
 }
 
 // UnregisterDomainChangeCallback delete a domain failover callback
 func (c *DefaultDomainCache) UnregisterDomainChangeCallback(
-	shard int,
+	id string,
 ) {
 
 	c.callbackLock.Lock()
 	defer c.callbackLock.Unlock()
 
-	delete(c.prepareCallbacks, shard)
-	delete(c.callbacks, shard)
+	delete(c.prepareCallbacks, id)
+	delete(c.callbacks, id)
 }
 
 // GetDomain retrieves the information from the cache if it exists, otherwise retrieves the information from metadata

--- a/common/cache/domainCacheNoOp.go
+++ b/common/cache/domainCacheNoOp.go
@@ -30,15 +30,15 @@ func (c *noOpDomainCache) GetAllDomain() map[string]*DomainCacheEntry {
 }
 
 func (c *noOpDomainCache) RegisterDomainChangeCallback(
-	shard int,
-	initialNotificationVersion int64,
+	id string,
+	catchUpFn CatchUpFn,
 	prepareCallback PrepareCallbackFn,
 	callback CallbackFn,
 ) {
 }
 
 func (c *noOpDomainCache) UnregisterDomainChangeCallback(
-	shard int,
+	id string,
 ) {
 }
 

--- a/common/cache/domainCache_mock.go
+++ b/common/cache/domainCache_mock.go
@@ -151,15 +151,15 @@ func (mr *MockDomainCacheMockRecorder) GetDomainName(id any) *gomock.Call {
 }
 
 // RegisterDomainChangeCallback mocks base method.
-func (m *MockDomainCache) RegisterDomainChangeCallback(shard int, initialNotificationVersion int64, prepareCallback PrepareCallbackFn, callback CallbackFn) {
+func (m *MockDomainCache) RegisterDomainChangeCallback(id string, catchUpFn CatchUpFn, prepareCallback PrepareCallbackFn, callback CallbackFn) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterDomainChangeCallback", shard, initialNotificationVersion, prepareCallback, callback)
+	m.ctrl.Call(m, "RegisterDomainChangeCallback", id, catchUpFn, prepareCallback, callback)
 }
 
 // RegisterDomainChangeCallback indicates an expected call of RegisterDomainChangeCallback.
-func (mr *MockDomainCacheMockRecorder) RegisterDomainChangeCallback(shard, initialNotificationVersion, prepareCallback, callback any) *gomock.Call {
+func (mr *MockDomainCacheMockRecorder) RegisterDomainChangeCallback(id, catchUpFn, prepareCallback, callback any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDomainChangeCallback", reflect.TypeOf((*MockDomainCache)(nil).RegisterDomainChangeCallback), shard, initialNotificationVersion, prepareCallback, callback)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDomainChangeCallback", reflect.TypeOf((*MockDomainCache)(nil).RegisterDomainChangeCallback), id, catchUpFn, prepareCallback, callback)
 }
 
 // Start mocks base method.
@@ -187,13 +187,13 @@ func (mr *MockDomainCacheMockRecorder) Stop() *gomock.Call {
 }
 
 // UnregisterDomainChangeCallback mocks base method.
-func (m *MockDomainCache) UnregisterDomainChangeCallback(shard int) {
+func (m *MockDomainCache) UnregisterDomainChangeCallback(id string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UnregisterDomainChangeCallback", shard)
+	m.ctrl.Call(m, "UnregisterDomainChangeCallback", id)
 }
 
 // UnregisterDomainChangeCallback indicates an expected call of UnregisterDomainChangeCallback.
-func (mr *MockDomainCacheMockRecorder) UnregisterDomainChangeCallback(shard any) *gomock.Call {
+func (mr *MockDomainCacheMockRecorder) UnregisterDomainChangeCallback(id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterDomainChangeCallback", reflect.TypeOf((*MockDomainCache)(nil).UnregisterDomainChangeCallback), shard)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterDomainChangeCallback", reflect.TypeOf((*MockDomainCache)(nil).UnregisterDomainChangeCallback), id)
 }

--- a/common/cache/domainCache_test.go
+++ b/common/cache/domainCache_test.go
@@ -395,82 +395,26 @@ func Test_IsActiveIn(t *testing.T) {
 }
 
 func (s *domainCacheSuite) TestRegisterCallback_CatchUp() {
-	domainNotificationVersion := int64(0)
-	domainRecord1 := &persistence.GetDomainResponse{
-		Info: &persistence.DomainInfo{ID: uuid.New(), Name: "some random domain name", Data: make(map[string]string)},
-		Config: &persistence.DomainConfig{
-			Retention: 1,
-			BadBinaries: types.BadBinaries{
-				Binaries: map[string]*types.BadBinaryInfo{},
-			}},
-		ReplicationConfig: &persistence.DomainReplicationConfig{
-			ActiveClusterName: cluster.TestCurrentClusterName,
-			Clusters: []*persistence.ClusterReplicationConfig{
-				{ClusterName: cluster.TestCurrentClusterName},
-				{ClusterName: cluster.TestAlternativeClusterName},
-			},
-		},
-		ConfigVersion:               10,
-		FailoverVersion:             11,
-		FailoverNotificationVersion: 0,
-		NotificationVersion:         domainNotificationVersion,
-	}
-	entry1 := s.buildEntryFromRecord(domainRecord1)
-	domainNotificationVersion++
-
-	domainRecord2 := &persistence.GetDomainResponse{
-		Info: &persistence.DomainInfo{ID: uuid.New(), Name: "another random domain name", Data: make(map[string]string)},
-		Config: &persistence.DomainConfig{
-			Retention: 2,
-			BadBinaries: types.BadBinaries{
-				Binaries: map[string]*types.BadBinaryInfo{},
-			}},
-		ReplicationConfig: &persistence.DomainReplicationConfig{
-			ActiveClusterName: cluster.TestAlternativeClusterName,
-			Clusters: []*persistence.ClusterReplicationConfig{
-				{ClusterName: cluster.TestCurrentClusterName},
-				{ClusterName: cluster.TestAlternativeClusterName},
-			},
-		},
-		ConfigVersion:               20,
-		FailoverVersion:             21,
-		FailoverNotificationVersion: 0,
-		NotificationVersion:         domainNotificationVersion,
-	}
-	entry2 := s.buildEntryFromRecord(domainRecord2)
-	domainNotificationVersion++
-
-	s.metadataMgr.On("GetMetadata", mock.Anything).Return(&persistence.GetMetadataResponse{NotificationVersion: domainNotificationVersion}, nil).Once()
-	s.metadataMgr.On("ListDomains", mock.Anything, &persistence.ListDomainsRequest{
-		PageSize:      domainCacheRefreshPageSize,
-		NextPageToken: nil,
-	}).Return(&persistence.ListDomainsResponse{
-		Domains:       []*persistence.GetDomainResponse{domainRecord1, domainRecord2},
-		NextPageToken: nil,
-	}, nil).Once()
-
-	// load domains
-	s.Nil(s.domainCache.refreshDomains())
-
 	prepareCallbacckInvoked := false
+	callBackInvoked := false
 	entriesNotification := []*DomainCacheEntry{}
-	// we are not testing catching up, so make this really large
-	currentDomainNotificationVersion := int64(0)
+
 	s.domainCache.RegisterDomainChangeCallback(
-		0,
-		currentDomainNotificationVersion,
+		"0",
+		func(_ DomainCache, prepareCallback PrepareCallbackFn, callback CallbackFn) {
+			prepareCallback()
+			callback(entriesNotification)
+		},
 		func() {
 			prepareCallbacckInvoked = true
 		},
 		func(nextDomains []*DomainCacheEntry) {
-			s.Equal(2, len(nextDomains))
-			entriesNotification = nextDomains
+			callBackInvoked = true
 		},
 	)
 
-	// the order matters here, should be ordered by notification version
 	s.True(prepareCallbacckInvoked)
-	s.Equal([]*DomainCacheEntry{entry1, entry2}, entriesNotification)
+	s.True(callBackInvoked)
 }
 
 func (s *domainCacheSuite) TestUpdateCache_TriggerCallBack() {
@@ -567,11 +511,9 @@ func (s *domainCacheSuite) TestUpdateCache_TriggerCallBack() {
 
 	prepareCallbacckInvoked := false
 	entriesNew := []*DomainCacheEntry{}
-	// we are not testing catching up, so make this really large
-	currentDomainNotificationVersion := int64(9999999)
 	s.domainCache.RegisterDomainChangeCallback(
-		0,
-		currentDomainNotificationVersion,
+		"0",
+		func(domainCache DomainCache, prepareCallback PrepareCallbackFn, callback CallbackFn) {},
 		func() {
 			prepareCallbacckInvoked = true
 		},
@@ -743,14 +685,14 @@ func (s *domainCacheSuite) TestStart_Error() {
 }
 
 func (s *domainCacheSuite) TestUnregisterDomainChangeCallback() {
-	s.domainCache.prepareCallbacks = map[int]PrepareCallbackFn{
-		1: func() {},
+	s.domainCache.prepareCallbacks = map[string]PrepareCallbackFn{
+		"1": func() {},
 	}
-	s.domainCache.callbacks = map[int]CallbackFn{
-		1: func([]*DomainCacheEntry) {},
+	s.domainCache.callbacks = map[string]CallbackFn{
+		"1": func([]*DomainCacheEntry) {},
 	}
 
-	s.domainCache.UnregisterDomainChangeCallback(1)
+	s.domainCache.UnregisterDomainChangeCallback("1")
 	s.Empty(s.domainCache.prepareCallbacks)
 	s.Empty(s.domainCache.callbacks)
 }

--- a/common/cache/domainCache_test.go
+++ b/common/cache/domainCache_test.go
@@ -395,7 +395,7 @@ func Test_IsActiveIn(t *testing.T) {
 }
 
 func (s *domainCacheSuite) TestRegisterCallback_CatchUp() {
-	prepareCallbacckInvoked := false
+	prepareCallbackInvoked := false
 	callBackInvoked := false
 	entriesNotification := []*DomainCacheEntry{}
 
@@ -406,14 +406,14 @@ func (s *domainCacheSuite) TestRegisterCallback_CatchUp() {
 			callback(entriesNotification)
 		},
 		func() {
-			prepareCallbacckInvoked = true
+			prepareCallbackInvoked = true
 		},
 		func(nextDomains []*DomainCacheEntry) {
 			callBackInvoked = true
 		},
 	)
 
-	s.True(prepareCallbacckInvoked)
+	s.True(prepareCallbackInvoked)
 	s.True(callBackInvoked)
 }
 
@@ -509,19 +509,19 @@ func (s *domainCacheSuite) TestUpdateCache_TriggerCallBack() {
 	entry1New := s.buildEntryFromRecord(domainRecord1New)
 	domainNotificationVersion++
 
-	prepareCallbacckInvoked := false
+	prepareCallbackInvoked := false
 	entriesNew := []*DomainCacheEntry{}
 	s.domainCache.RegisterDomainChangeCallback(
 		"0",
 		func(domainCache DomainCache, prepareCallback PrepareCallbackFn, callback CallbackFn) {},
 		func() {
-			prepareCallbacckInvoked = true
+			prepareCallbackInvoked = true
 		},
 		func(nextDomains []*DomainCacheEntry) {
 			entriesNew = nextDomains
 		},
 	)
-	s.False(prepareCallbacckInvoked)
+	s.False(prepareCallbackInvoked)
 	s.Empty(entriesNew)
 
 	s.metadataMgr.On("GetMetadata", mock.Anything).Return(&persistence.GetMetadataResponse{NotificationVersion: domainNotificationVersion}, nil).Once()
@@ -540,7 +540,7 @@ func (s *domainCacheSuite) TestUpdateCache_TriggerCallBack() {
 	// the record 1 got updated later, thus a higher notification version.
 	// making sure notifying from lower to higher version helps the shard to keep track the
 	// domain change events
-	s.True(prepareCallbacckInvoked)
+	s.True(prepareCallbackInvoked)
 	s.Equal([]*DomainCacheEntry{entry2New, entry1New}, entriesNew)
 }
 

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -24,7 +24,7 @@ package engineimpl
 import (
 	"context"
 	"errors"
-	"strconv"
+	"fmt"
 	"time"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
@@ -398,7 +398,7 @@ func (e *historyEngineImpl) Stop() {
 	e.failoverMarkerNotifier.Stop()
 
 	// unset the failover callback
-	e.shard.GetDomainCache().UnregisterDomainChangeCallback(strconv.Itoa(e.shard.GetShardID()))
+	e.shard.GetDomainCache().UnregisterDomainChangeCallback(createShardNameFromShardID(e.shard.GetShardID()))
 }
 
 // ScheduleDecisionTask schedules a decision if no outstanding decision found
@@ -487,4 +487,8 @@ func getScheduleID(activityID string, mutableState execution.MutableState) (int6
 
 func (e *historyEngineImpl) getActiveDomainByID(id string) (*cache.DomainCacheEntry, error) {
 	return cache.GetActiveDomainByID(e.shard.GetDomainCache(), e.clusterMetadata.GetCurrentClusterName(), id)
+}
+
+func createShardNameFromShardID(shardID int) string {
+	return fmt.Sprintf("history-engine-%d", shardID)
 }

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -24,6 +24,7 @@ package engineimpl
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
@@ -397,7 +398,7 @@ func (e *historyEngineImpl) Stop() {
 	e.failoverMarkerNotifier.Stop()
 
 	// unset the failover callback
-	e.shard.GetDomainCache().UnregisterDomainChangeCallback(e.shard.GetShardID())
+	e.shard.GetDomainCache().UnregisterDomainChangeCallback(strconv.Itoa(e.shard.GetShardID()))
 }
 
 // ScheduleDecisionTask schedules a decision if no outstanding decision found

--- a/service/history/engine/engineimpl/history_engine_test.go
+++ b/service/history/engine/engineimpl/history_engine_test.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -5545,4 +5546,10 @@ func TestRecordChildExecutionCompleted(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_createShardNameFromShardID(t *testing.T) {
+	shardID := 1
+	shardName := createShardNameFromShardID(shardID)
+	assert.Equal(t, fmt.Sprintf("history-engine-%d", shardID), shardName)
 }

--- a/service/history/engine/engineimpl/register_domain_failover_callback.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback.go
@@ -23,9 +23,6 @@ package engineimpl
 
 import (
 	"context"
-	"sort"
-	"strconv"
-
 	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/constants"
@@ -33,6 +30,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	hcommon "github.com/uber/cadence/service/history/common"
+	"sort"
 )
 
 func (e *historyEngineImpl) registerDomainFailoverCallback() {
@@ -83,7 +81,7 @@ func (e *historyEngineImpl) registerDomainFailoverCallback() {
 
 	// first set the failover callback
 	e.shard.GetDomainCache().RegisterDomainChangeCallback(
-		strconv.Itoa(e.shard.GetShardID()),
+		createShardNameFromShardID(e.shard.GetShardID()),
 		catchUpFn,
 		e.lockTaskProcessingForDomainUpdate,
 		e.domainChangeCB,

--- a/service/history/engine/engineimpl/register_domain_failover_callback.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback.go
@@ -23,6 +23,8 @@ package engineimpl
 
 import (
 	"context"
+	"sort"
+
 	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/constants"
@@ -30,7 +32,6 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	hcommon "github.com/uber/cadence/service/history/common"
-	"sort"
 )
 
 func (e *historyEngineImpl) registerDomainFailoverCallback() {

--- a/service/history/engine/engineimpl/register_domain_failover_callback.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback.go
@@ -23,6 +23,8 @@ package engineimpl
 
 import (
 	"context"
+	"sort"
+	"strconv"
 
 	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
@@ -54,10 +56,35 @@ func (e *historyEngineImpl) registerDomainFailoverCallback() {
 	//		failover min / max task levels calculated & updated to shard (using shard lock) -> failover start
 	// above 2 guarantees that failover start is after persistence of the task.
 
+	initialNotificationVersion := e.shard.GetDomainNotificationVersion()
+
+	catchUpFn := func(domainCache cache.DomainCache, prepareCallback cache.PrepareCallbackFn, callback cache.CallbackFn) {
+		// this section is trying to make the shard catch up with domain changes
+		domains := cache.DomainCacheEntries{}
+		for _, domain := range domainCache.GetAllDomain() {
+			domains = append(domains, domain)
+		}
+		// we must notify the change in an ordered fashion
+		// since history shard has to update the shard info
+		// with the domain change version.
+		sort.Sort(domains)
+
+		var updatedEntries []*cache.DomainCacheEntry
+		for _, domain := range domains {
+			if domain.GetNotificationVersion() >= initialNotificationVersion {
+				updatedEntries = append(updatedEntries, domain)
+			}
+		}
+		if len(updatedEntries) > 0 {
+			prepareCallback()
+			callback(updatedEntries)
+		}
+	}
+
 	// first set the failover callback
 	e.shard.GetDomainCache().RegisterDomainChangeCallback(
-		e.shard.GetShardID(),
-		e.shard.GetDomainNotificationVersion(),
+		strconv.Itoa(e.shard.GetShardID()),
+		catchUpFn,
 		e.lockTaskProcessingForDomainUpdate,
 		e.domainChangeCB,
 	)

--- a/service/history/engine/engineimpl/register_domain_failover_callback_test.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback_test.go
@@ -23,6 +23,7 @@
 package engineimpl
 
 import (
+	"github.com/uber/cadence/common/activecluster"
 	"testing"
 	"time"
 
@@ -677,3 +678,227 @@ func TestDomainLocking(t *testing.T) {
 	he.lockTaskProcessingForDomainUpdate()
 	he.unlockProcessingForDomainUpdate()
 }
+
+func TestHistoryEngine_registerDomainFailoverCallback_ClosureBehavior(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockShard := shard.NewMockContext(ctrl)
+	mockDomainCache := cache.NewMockDomainCache(ctrl)
+	mockActiveClusterManager := activecluster.NewMockManager(ctrl)
+
+	// Define the initial shard notification version
+	initialShardVersion := int64(5)
+	mockShard.EXPECT().GetDomainNotificationVersion().Return(initialShardVersion)
+	mockShard.EXPECT().GetShardID().Return(456).Times(2)
+	mockShard.EXPECT().GetDomainCache().Return(mockDomainCache)
+
+	// Capture the registered catchUpFn
+	var registeredCatchUpFn func(cache.DomainCache, cache.PrepareCallbackFn, cache.CallbackFn)
+	mockDomainCache.EXPECT().RegisterDomainChangeCallback(
+		createShardNameFromShardID(456), // id of the callback
+		gomock.Any(),                    // catchUpFn
+		gomock.Any(),                    // lockTaskProcessingForDomainUpdate
+		gomock.Any(),                    // domainChangeCB
+	).Do(func(_ string, catchUpFn, _, _ interface{}) {
+		if fn, ok := catchUpFn.(cache.CatchUpFn); ok {
+			registeredCatchUpFn = fn
+		} else {
+			t.Fatalf("Failed to convert catchUpFn to cache.CatchUpFn: got type %T", catchUpFn)
+		}
+	}).Times(1)
+
+	mockShard.EXPECT().GetActiveClusterManager().Return(mockActiveClusterManager).Times(1)
+	mockActiveClusterManager.EXPECT().RegisterChangeCallback(456, gomock.Any()).Times(1)
+
+	cluster := cluster.NewMetadata(
+		config.ClusterGroupMetadata{
+			FailoverVersionIncrement: 10,
+			PrimaryClusterName:       "cluster0",
+			CurrentClusterName:       "cluster0",
+			ClusterGroup: map[string]config.ClusterInformation{
+				"cluster0": config.ClusterInformation{
+					Enabled:                true,
+					InitialFailoverVersion: 1,
+				},
+				"cluster1": config.ClusterInformation{
+					Enabled:                true,
+					InitialFailoverVersion: 0,
+				},
+				"cluster2": config.ClusterInformation{
+					Enabled:                true,
+					InitialFailoverVersion: 2,
+				},
+			},
+		},
+		func(string) bool { return false },
+		metrics.NewNoopMetricsClient(),
+		log.NewNoop(),
+	)
+
+	// Create the history engine instance
+	engine := &historyEngineImpl{
+		shard:              mockShard,
+		logger:             log.NewNoop(),
+		clusterMetadata:    cluster,    // Or a specific mock if needed
+		currentClusterName: "cluster0", // Or a specific value
+		metricsClient:      metrics.NewNoopMetricsClient(),
+	}
+
+	// Call the method under test to register the callback
+	engine.registerDomainFailoverCallback()
+
+	// --- Test the behavior of the registered catchUpFn ---
+
+	t.Run("catchUpFn - No updated domains", func(t *testing.T) {
+		mockDomainCache.EXPECT().GetAllDomain().Return(map[string]*cache.DomainCacheEntry{
+			"uuid-domain1": cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: "uuid-domain1", Name: "domain1"},
+				nil,
+				true,
+				&persistence.DomainReplicationConfig{ActiveClusterName: "A"},
+				0,
+				nil,
+				0,
+				0,
+				1,
+			),
+			"uuid-domain2": cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: "uuid-domain2", Name: "domain2"},
+				nil,
+				true,
+				&persistence.DomainReplicationConfig{ActiveClusterName: "A"},
+				0,
+				nil,
+				0,
+				0,
+				4,
+			),
+		})
+
+		prepareCalled := false
+		callbackCalled := false
+		prepare := func() { prepareCalled = true }
+		callback := func([]*cache.DomainCacheEntry) { callbackCalled = true }
+
+		if registeredCatchUpFn != nil {
+			registeredCatchUpFn(mockDomainCache, prepare, callback)
+			assert.False(t, prepareCalled, "prepareCallback should not be called")
+			assert.False(t, callbackCalled, "callback should not be called")
+		} else {
+			assert.Fail(t, "catchUpFn was not registered")
+		}
+	})
+
+	t.Run("catchUpFn - Some updated domains", func(t *testing.T) {
+		mockDomainCache.EXPECT().GetAllDomain().Return(map[string]*cache.DomainCacheEntry{
+			"uuid-domain1": cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: "uuid-domain1", Name: "domain1"},
+				nil,
+				true,
+				&persistence.DomainReplicationConfig{ActiveClusterName: "A"},
+				0,
+				nil,
+				0,
+				0,
+				7,
+			),
+			"uuid-domain2": cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: "uuid-domain2", Name: "domain2"},
+				nil,
+				true,
+				&persistence.DomainReplicationConfig{ActiveClusterName: "A"},
+				0,
+				nil,
+				0,
+				0,
+				4,
+			),
+		})
+
+		prepareCalled := false
+		callbackCalled := false
+		var actualUpdatedEntries []*cache.DomainCacheEntry
+		prepare := func() { prepareCalled = true }
+		callback := func(entries []*cache.DomainCacheEntry) {
+			callbackCalled = true
+			actualUpdatedEntries = entries
+		}
+
+		if registeredCatchUpFn != nil {
+			registeredCatchUpFn(mockDomainCache, prepare, callback)
+			assert.True(t, prepareCalled, "prepareCallback should be called")
+			assert.True(t, callbackCalled, "callback should be called")
+			assert.Len(t, actualUpdatedEntries, 1, "should have one updated entry")
+			assert.Equal(t, int64(7), actualUpdatedEntries[0].GetNotificationVersion())
+		} else {
+			assert.Fail(t, "catchUpFn was not registered")
+		}
+	})
+
+	t.Run("catchUpFn - All domains should be updated", func(t *testing.T) {
+		mockDomainCache.EXPECT().GetAllDomain().Return(map[string]*cache.DomainCacheEntry{
+			"uuid-domain1": cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: "uuid-domain1", Name: "domain1"},
+				nil,
+				true,
+				&persistence.DomainReplicationConfig{ActiveClusterName: "A"},
+				0,
+				nil,
+				0,
+				0,
+				7,
+			),
+			"uuid-domain2": cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: "uuid-domain2", Name: "domain2"},
+				nil,
+				true,
+				&persistence.DomainReplicationConfig{ActiveClusterName: "A"},
+				0,
+				nil,
+				0,
+				0,
+				5,
+			),
+		})
+
+		prepareCalled := false
+		callbackCalled := false
+		var actualUpdatedEntries []*cache.DomainCacheEntry
+		prepare := func() { prepareCalled = true }
+		callback := func(entries []*cache.DomainCacheEntry) {
+			callbackCalled = true
+			actualUpdatedEntries = entries
+		}
+
+		if registeredCatchUpFn != nil {
+			registeredCatchUpFn(mockDomainCache, prepare, callback)
+			assert.True(t, prepareCalled, "prepareCallback should be called")
+			assert.True(t, callbackCalled, "callback should be called")
+			assert.Len(t, actualUpdatedEntries, 2, "should have two updated entries")
+			assert.Equal(t, int64(5), actualUpdatedEntries[0].GetNotificationVersion())
+			assert.Equal(t, int64(7), actualUpdatedEntries[1].GetNotificationVersion())
+		} else {
+			assert.Fail(t, "catchUpFn was not registered")
+		}
+	})
+
+	t.Run("catchUpFn - Empty domain cache", func(t *testing.T) {
+		mockDomainCache.EXPECT().GetAllDomain().Return(map[string]*cache.DomainCacheEntry{})
+
+		prepareCalled := false
+		callbackCalled := false
+		prepare := func() { prepareCalled = true }
+		callback := func([]*cache.DomainCacheEntry) { callbackCalled = true }
+
+		if registeredCatchUpFn != nil {
+			registeredCatchUpFn(mockDomainCache, prepare, callback)
+			assert.False(t, prepareCalled, "prepareCallback should not be called")
+			assert.False(t, callbackCalled, "callback should not be called")
+		} else {
+			assert.Fail(t, "catchUpFn was not registered")
+		}
+	})
+}
+
+// Helper function to create

--- a/service/history/engine/engineimpl/register_domain_failover_callback_test.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback_test.go
@@ -136,7 +136,7 @@ func TestGenerateFailoverTasksForDomainCallback(t *testing.T) {
 		"non-graceful failover domain update. This should generate no tasks as there's no failover taking place": {
 			domainUpdates:              failoverUpdateT2,
 			currentNotificationVersion: 2,
-			expectedRes: []*persistence.FailoverMarkerTask{
+			expectedRes:                []*persistence.FailoverMarkerTask{
 				// no failoverMarker tasks are created for non-graceful failovers, they just occur immediately
 			},
 		},

--- a/service/history/engine/engineimpl/register_domain_failover_callback_test.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback_test.go
@@ -23,7 +23,6 @@
 package engineimpl
 
 import (
-	"github.com/uber/cadence/common/activecluster"
 	"testing"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"

--- a/service/history/engine/engineimpl/register_domain_failover_callback_test.go
+++ b/service/history/engine/engineimpl/register_domain_failover_callback_test.go
@@ -136,7 +136,7 @@ func TestGenerateFailoverTasksForDomainCallback(t *testing.T) {
 		"non-graceful failover domain update. This should generate no tasks as there's no failover taking place": {
 			domainUpdates:              failoverUpdateT2,
 			currentNotificationVersion: 2,
-			expectedRes:                []*persistence.FailoverMarkerTask{
+			expectedRes: []*persistence.FailoverMarkerTask{
 				// no failoverMarker tasks are created for non-graceful failovers, they just occur immediately
 			},
 		},
@@ -900,5 +900,3 @@ func TestHistoryEngine_registerDomainFailoverCallback_ClosureBehavior(t *testing
 		}
 	})
 }
-
-// Helper function to create


### PR DESCRIPTION
**What changed?**
Generalized the RegisterDomainChangeCallback to allow its usage by other services. Previously, it was tightly coupled with the history service.

**Why?**
This change is being done to allow the RegisterDomainChangeCallback to be used by the matching service or other services that need to use it.

**How did you test it?**
Unit tests and tested locally

**Potential risks**
Potential failover issues if the existing behavior is altered due to the refactor.

**Release notes**

**Documentation Changes**
