### PR TITLE
Added retries on creating the cassandra client.

### DIFF
--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -21,10 +21,12 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/tools/common/schema"
@@ -111,26 +113,36 @@ const (
 
 var _ schema.SchemaClient = (*CqlClientImpl)(nil)
 
-// NewCQLClient returns a new instance of CQLClient
 func NewCQLClient(cfg *CQLClientConfig, expectedConsistency gocql.Consistency) (CqlClient, error) {
-	var err error
+	retrier := createClientCreationRetrier()
+	cassClient := gocql.GetRegisteredClient()
+	return NewCQLClientWithRetry(cfg, expectedConsistency, cassClient, retrier)
+}
 
+// NewCQLClient returns a new instance of CQLClient
+func NewCQLClientWithRetry(cfg *CQLClientConfig, expectedConsistency gocql.Consistency, cassClient gocql.Client, retrier *backoff.ThrottleRetry) (CqlClient, error) {
 	cqlClient := new(CqlClientImpl)
 	cqlClient.cfg = cfg
 	cqlClient.nReplicas = cfg.NumReplicas
-	cqlClient.session, err = gocql.GetRegisteredClient().CreateSession(gocql.ClusterConfig{
-		Hosts:                 cfg.Hosts,
-		Port:                  cfg.Port,
-		User:                  cfg.User,
-		Password:              cfg.Password,
-		AllowedAuthenticators: cfg.AllowedAuthenticators,
-		Keyspace:              cfg.Keyspace,
-		TLS:                   cfg.TLS,
-		Timeout:               time.Duration(cfg.Timeout) * time.Second,
-		ConnectTimeout:        time.Duration(cfg.ConnectTimeout) * time.Second,
-		ProtoVersion:          cfg.ProtoVersion,
-		Consistency:           expectedConsistency,
-	})
+
+	op := func() error {
+		var err error
+		cqlClient.session, err = cassClient.CreateSession(gocql.ClusterConfig{
+			Hosts:                 cfg.Hosts,
+			Port:                  cfg.Port,
+			User:                  cfg.User,
+			Password:              cfg.Password,
+			AllowedAuthenticators: cfg.AllowedAuthenticators,
+			Keyspace:              cfg.Keyspace,
+			TLS:                   cfg.TLS,
+			Timeout:               time.Duration(cfg.Timeout) * time.Second,
+			ConnectTimeout:        time.Duration(cfg.ConnectTimeout) * time.Second,
+			ProtoVersion:          cfg.ProtoVersion,
+			Consistency:           expectedConsistency,
+		})
+		return err
+	}
+	err := retrier.Do(context.Background(), op)
 	if err != nil {
 		return nil, err
 	}
@@ -289,4 +301,16 @@ func (client *CqlClientImpl) DropAllTablesTypes() error {
 		return err
 	}
 	return nil
+}
+
+func createClientCreationRetrier() *backoff.ThrottleRetry {
+	policy := backoff.NewExponentialRetryPolicy(time.Second)
+	policy.SetMaximumInterval(10 * time.Second)
+	policy.SetMaximumAttempts(3)
+
+	retrier := backoff.NewThrottleRetry(
+		backoff.WithRetryPolicy(policy),
+		backoff.WithRetryableError(func(err error) bool { return true }),
+	)
+	return retrier
 }

--- a/tools/cassandra/cqlclient_test.go
+++ b/tools/cassandra/cqlclient_test.go
@@ -1,0 +1,132 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cassandra
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+)
+
+func TestNewCQLClientWithRetry(t *testing.T) {
+	mockClient, mockSession, mockClock := setUpMocks(t)
+	cfg := configuration()
+	expectedCfg := expectedConfig()
+
+	// Fail the first two times, then succeed.
+	mockClient.EXPECT().CreateSession(expectedCfg).Return(mockSession, assert.AnError)
+	mockClient.EXPECT().CreateSession(expectedCfg).Return(mockSession, assert.AnError)
+	mockClient.EXPECT().CreateSession(expectedCfg).Return(mockSession, nil)
+
+	go func() {
+		// First retry happens after 1 second
+		mockClock.BlockUntil(1)
+		mockClock.Advance(1 * time.Second)
+		// Second retry happens after 2 seconds
+		mockClock.BlockUntil(1)
+		mockClock.Advance(2 * time.Second)
+	}()
+
+	testRetrier := createClientCreationRetrier()
+	backoff.WithClock(mockClock)(testRetrier)
+
+	cqlClient, err := NewCQLClientWithRetry(cfg, gocql.One, mockClient, testRetrier)
+	assert.NoError(t, err)
+
+	cqlClientImpl, ok := cqlClient.(*CqlClientImpl)
+	require.True(t, ok)
+
+	assert.Equal(t, 333, cqlClientImpl.nReplicas)
+	assert.Equal(t, cfg, cqlClientImpl.cfg)
+	assert.Equal(t, mockSession, cqlClientImpl.session)
+}
+
+func TestNewCQLClientWithRetry_Fail(t *testing.T) {
+	mockClient, mockSession, mockClock := setUpMocks(t)
+	cfg := configuration()
+	expectedCfg := expectedConfig()
+
+	mockClient.EXPECT().CreateSession(expectedCfg).Return(mockSession, assert.AnError).AnyTimes()
+
+	go func() {
+		// Wait until someone sleeps, then advance the clock more than the backoff would be.
+		for {
+			mockClock.BlockUntil(1)
+			mockClock.Advance(1 * time.Hour)
+		}
+	}()
+
+	testRetrier := createClientCreationRetrier()
+	backoff.WithClock(mockClock)(testRetrier)
+
+	_, err := NewCQLClientWithRetry(cfg, gocql.One, mockClient, testRetrier)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func setUpMocks(t *testing.T) (*gocql.MockClient, *gocql.MockSession, clock.MockedTimeSource) {
+	ctrl := gomock.NewController(t)
+	mockClient := gocql.NewMockClient(ctrl)
+	mockSession := gocql.NewMockSession(ctrl)
+	mockClock := clock.NewMockedTimeSource()
+	return mockClient, mockSession, mockClock
+}
+
+func configuration() *CQLClientConfig {
+	return &CQLClientConfig{
+		Hosts:                 "testHost",
+		Port:                  1234,
+		User:                  "testUser",
+		Password:              "testPassword",
+		AllowedAuthenticators: []string{"testAuthenticator"},
+		Keyspace:              "testKeyspace",
+		Timeout:               111,
+		ConnectTimeout:        222,
+		NumReplicas:           333,
+		ProtoVersion:          444,
+		TLS:                   &config.TLS{Enabled: true},
+	}
+}
+
+func expectedConfig() gocql.ClusterConfig {
+	return gocql.ClusterConfig{
+		Hosts:                 "testHost",
+		Port:                  1234,
+		User:                  "testUser",
+		Password:              "testPassword",
+		AllowedAuthenticators: []string{"testAuthenticator"},
+		Keyspace:              "testKeyspace",
+		TLS:                   &config.TLS{Enabled: true},
+		Timeout:               111 * time.Second,
+		ConnectTimeout:        222 * time.Second,
+		ProtoVersion:          444,
+		Consistency:           gocql.One,
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now do 3 attempts to create the client, with exponential backoff using a retry policy.

Also removed deprecated mock clock and replaced with the new timeSource

<!-- Tell your future self why have you made these changes -->
**Why?**
We sometimes see trancient failures on creating the client, currently this causes the whole server to crash during startup, this adds a few retries before giving up


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
