### PR TITLE
Removed deprecated mock clock and replaced with the new timeSource

### DIFF
--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -340,6 +340,7 @@ func NewEngineWithShardContext(
 			shard.GetMetricsClient(),
 			replicationTaskFetcher,
 			replicationTaskExecutor,
+			shard.GetTimeSource(),
 		)
 		replicationTaskProcessors = append(replicationTaskProcessors, replicationTaskProcessor)
 	}

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -114,6 +115,7 @@ func NewTaskProcessor(
 	metricsClient metrics.Client,
 	taskFetcher TaskFetcher,
 	taskExecutor TaskExecutor,
+	clock clock.TimeSource,
 ) TaskProcessor {
 	shardID := shard.GetShardID()
 	sourceCluster := taskFetcher.GetSourceCluster()
@@ -130,7 +132,7 @@ func NewTaskProcessor(
 	noTaskBackoffPolicy := backoff.NewExponentialRetryPolicy(config.ReplicationTaskProcessorNoTaskRetryWait(shardID))
 	noTaskBackoffPolicy.SetBackoffCoefficient(1)
 	noTaskBackoffPolicy.SetExpirationInterval(backoff.NoInterval)
-	noTaskRetrier := backoff.NewRetrier(noTaskBackoffPolicy, backoff.SystemClock)
+	noTaskRetrier := backoff.NewRetrier(noTaskBackoffPolicy, clock)
 	return &taskProcessorImpl{
 		currentCluster:         shard.GetClusterMetadata().GetCurrentClusterName(),
 		sourceCluster:          sourceCluster,

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
@@ -76,6 +77,7 @@ type (
 		taskFetcher        *fakeTaskFetcher
 		taskExecutor       *MockTaskExecutor
 		taskProcessor      *taskProcessorImpl
+		clock              clock.MockedTimeSource
 	}
 )
 
@@ -131,6 +133,7 @@ func (s *taskProcessorSuite) SetupTest() {
 	s.mockFrontendClient = s.mockShard.Resource.RemoteFrontendClient
 	s.adminClient = s.mockShard.Resource.RemoteAdminClient
 	s.executionManager = s.mockShard.Resource.ExecutionMgr
+	s.clock = clock.NewMockedTimeSource()
 
 	s.mockEngine = engine.NewMockEngine(s.controller)
 	s.config = config.NewForTest()
@@ -153,6 +156,7 @@ func (s *taskProcessorSuite) SetupTest() {
 		metricsClient,
 		s.taskFetcher,
 		s.taskExecutor,
+		s.clock,
 	).(*taskProcessorImpl)
 }
 
@@ -646,6 +650,7 @@ func TestProcessorLoop_TaskExecuteFailed_ShardChangeErr(t *testing.T) {
 		metricsClient,
 		taskFetcher,
 		taskExecutor,
+		clock.NewMockedTimeSource(),
 	).(*taskProcessorImpl)
 
 	// start the process loop


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed global system clock and it's implementations, exchaged with the TimeSource system


<!-- Tell your future self why have you made these changes -->
**Why?**
The TimeSource is much more robust and reliable, additionally we only want on of these wrappers in the code base


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran the unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
