### PR TITLE
Fix not enough columns to scan issue for InsertInitialQueueMetadataRe…

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/queue.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue.go
@@ -176,7 +176,7 @@ func (db *cdb) InsertQueueMetadata(ctx context.Context, row nosqlplugin.QueueMet
 	// NOTE: Must pass nils to be compatible with ScyllaDB's LWT behavior
 	// "Scylla always returns the old version of the row, regardless of whether the condition is true or not."
 	// See also https://docs.scylladb.com/kb/lwt-differences/
-	_, err := query.ScanCAS(nil, nil, nil)
+	_, err := query.ScanCAS(nil, nil, nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (db *cdb) UpdateQueueMetadataCas(
 	// NOTE: Must pass nils to be compatible with ScyllaDB's LWT behavior
 	// "Scylla always returns the old version of the row, regardless of whether the condition is true or not."
 	// See also https://docs.scylladb.com/kb/lwt-differences/
-	applied, err := query.ScanCAS(nil, nil, nil, nil)
+	applied, err := query.ScanCAS(nil, nil, nil, nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* scan 5 instead of 3

<!-- Tell your future self why have you made these changes -->
**Why?**

new schema have 6 columns
```
CREATE TABLE queue_metadata (
  queue_type        int,
  cluster_ack_level map<text, bigint>,
  version           bigint,
  created_time      timestamp,            #new 
  last_updated_time timestamp,        #new 
PRIMARY KEY (queue_type)
)  WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
   };
```


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
