### PR TITLE
Add cache count and cache full metrics to base cache for enhanced monitoring

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -343,6 +343,9 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 			// replace the value
 			existing := entry.value
 			if allowUpdate {
+				if c.isCacheFull() {
+					c.metricsScope.IncCounter(metrics.BaseCacheFullCounter)
+				}
 				for c.isCacheFull() {
 					// Find the oldest unpinned item to evict
 					oldest := c.byAccess.Back()
@@ -400,6 +403,9 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 		}
 		c.byKey[key] = c.byAccess.PushFront(entry)
 		c.updateSizeOnAdd(key, valueSize)
+		if c.isCacheFull() {
+			c.metricsScope.IncCounter(metrics.BaseCacheFullCounter)
+		}
 		for c.isCacheFull() {
 			// Find the oldest unpinned item to evict
 			oldest := c.byAccess.Back()
@@ -421,7 +427,9 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 	} else {
 		c.byKey[key] = c.byAccess.PushFront(entry)
 		c.updateSizeOnAdd(key, valueSize)
-
+		if c.isCacheFull() {
+			c.metricsScope.IncCounter(metrics.BaseCacheFullCounter)
+		}
 		for c.isCacheFull() {
 			// Find the oldest unpinned item to evict
 			oldest := c.byAccess.Back()

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -488,5 +488,6 @@ func (c *lru) updateSizeOnDelete(key interface{}) {
 func (c *lru) emitSizeOnUpdate() {
 	c.metricsScope.UpdateGauge(metrics.BaseCacheByteSize, float64(c.currSize))
 	c.metricsScope.UpdateGauge(metrics.BaseCacheByteSizeLimitGauge, float64(c.maxSize()))
-
+	c.metricsScope.UpdateGauge(metrics.BaseCacheCount, float64(len(c.byKey)))
+	c.metricsScope.UpdateGauge(metrics.BaseCacheCountLimitGauge, float64(c.maxCount))
 }

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2320,6 +2320,8 @@ const (
 	BaseCacheByteSizeLimitGauge
 	BaseCacheHit
 	BaseCacheMiss
+	BaseCacheCount
+	BaseCacheCountLimitGauge
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -3064,6 +3066,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		BaseCacheByteSizeLimitGauge: {metricName: "cache_byte_size_limit", metricType: Gauge},
 		BaseCacheHit:                {metricName: "cache_hit", metricType: Counter},
 		BaseCacheMiss:               {metricName: "cache_miss", metricType: Counter},
+		BaseCacheCount:              {metricName: "cache_count", metricType: Counter},
+		BaseCacheCountLimitGauge:    {metricName: "cache_count_limit", metricType: Gauge},
 	},
 	History: {
 		TaskRequests:             {metricName: "task_requests", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2322,6 +2322,7 @@ const (
 	BaseCacheMiss
 	BaseCacheCount
 	BaseCacheCountLimitGauge
+	BaseCacheFullCounter
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -3068,6 +3069,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		BaseCacheMiss:               {metricName: "cache_miss", metricType: Counter},
 		BaseCacheCount:              {metricName: "cache_count", metricType: Counter},
 		BaseCacheCountLimitGauge:    {metricName: "cache_count_limit", metricType: Gauge},
+		BaseCacheFullCounter:        {metricName: "cache_full", metricType: Counter},
 	},
 	History: {
 		TaskRequests:             {metricName: "task_requests", metricType: Counter},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added `cache count` and `cache full` metrics to the base cache implementation.

<!-- Tell your future self why have you made these changes -->
**Why?**
During evaluation of the new cache rollout, we identified gaps in metrics reporting where these key cache metrics were not consistently available across all usages. Adding them to the base cache ensures comprehensive monitoring.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
tested in dev environment

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
only adding new metrics, no functional logic change.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
