### PR TITLE
Fix TestReplicationTaskFetcherSuite/TestLifecycle unit test

### DIFF
--- a/service/history/replication/task_fetcher_test.go
+++ b/service/history/replication/task_fetcher_test.go
@@ -227,6 +227,7 @@ func (s *taskFetcherSuite) TestLifecycle() {
 
 	// process the existing replication requests and return service busy error
 	s.Equal(0, fetchAndDistributeTasksFnCall)
+	mockTimeSource.BlockUntil(1)
 	mockTimeSource.Advance(s.config.ReplicationTaskFetcherAggregationInterval())
 	_, open = <-fetchAndDistributeTasksSyncChan[0] // block until fetchAndDistributeTasksFn is called
 	s.False(open)
@@ -238,18 +239,21 @@ func (s *taskFetcherSuite) TestLifecycle() {
 	s.False(open)
 
 	// process the existing replication requests and return non-service busy error
+	mockTimeSource.BlockUntil(1)
 	mockTimeSource.Advance(s.config.ReplicationTaskFetcherServiceBusyWait())
 	_, open = <-fetchAndDistributeTasksSyncChan[1] // block until fetchAndDistributeTasksFn is called
 	s.False(open)
 	s.Equal(2, fetchAndDistributeTasksFnCall)
 
 	// process the existing replication requests and return success
+	mockTimeSource.BlockUntil(1)
 	mockTimeSource.Advance(s.config.ReplicationTaskFetcherErrorRetryWait())
 	_, open = <-fetchAndDistributeTasksSyncChan[2] // block until fetchAndDistributeTasksFn is called
 	s.False(open)
 	s.Equal(3, fetchAndDistributeTasksFnCall)
 
 	// process empty requests and return success
+	mockTimeSource.BlockUntil(1)
 	mockTimeSource.Advance(s.config.ReplicationTaskFetcherAggregationInterval())
 	_, open = <-fetchAndDistributeTasksSyncChan[3] // block until fetchAndDistributeTasksFn is called
 	s.False(open)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix TestReplicationTaskFetcherSuite/TestLifecycle unit test

<!-- Tell your future self why have you made these changes -->
**Why?**
There was a race condition between timer reset and timer advance in the unit test. If timer is advanced before reset, the test will be stuck.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally by running the tests 10k times.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
