### PR TITLE
[sharddistributor][leaderelection] Add leader election into sharddistributor service

### DIFF
--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -331,3 +331,23 @@ steps:
       - docker-compose#v3.0.0:
           run: integration-test-async-wf
           config: docker/buildkite/docker-compose.yml
+
+  - label: ":golang: integration test with etcd"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                  - |-
+                    # ensure that we are not rebuilding binaries and not regenerating code
+                    make .just-build
+                    make integration_tests_etcd
+      - docker-compose#v3.0.0:
+          run: integration-test-with-etcd
+          config: docker/buildkite/docker-compose.yml

--- a/Makefile
+++ b/Makefile
@@ -681,6 +681,19 @@ cover_integration_profile:
 	$Q time go test $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
 	$Q cat $(BUILD)/$(INTEG_TEST_DIR)/coverage.out | grep -v "^mode: \w\+" >> $(INTEG_COVER_FILE)
 
+integration_tests_etcd:
+	$Q mkdir -p $(BUILD)
+	$Q mkdir -p $(COVER_ROOT)
+	$Q echo "mode: atomic" > $(INTEG_COVER_FILE)
+
+	$Q echo "Running integration tests with etcd"
+	$Q mkdir -p $(BUILD)/$(INTEG_TEST_DIR)
+	$Q (ETCD_TEST_DIRS=$$(find . -name "*_test.go" -exec grep -l "testflags.RequireEtcd" {} \; | xargs -n1 dirname | sort | uniq); \
+		echo "Found etcd test directories:"; \
+		echo "$$ETCD_TEST_DIRS"; \
+		ETCD=1 ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-}" time go test $$ETCD_TEST_DIRS $(TEST_ARG) $(TEST_TAG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1)
+	$Q cat $(BUILD)/$(INTEG_TEST_DIR)/coverage.out | grep -v "^mode: \w\+" >> $(INTEG_COVER_FILE)
+
 cover_ndc_profile:
 	$Q mkdir -p $(BUILD)
 	$Q mkdir -p $(COVER_ROOT)

--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -35,11 +35,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/uber/cadence/common/client"
-	"github.com/uber/cadence/common/clock/clockfx"
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
-	"github.com/uber/cadence/common/metrics/metricsfx"
 	"github.com/uber/cadence/common/service"
 
 	_ "go.uber.org/automaxprocs" // defines automaxpocs for dockerized usage.
@@ -138,11 +134,7 @@ func BuildCLI(releaseVersion string, gitRevision string) *cli.App {
 					func(serviceName string) fxAppInterface {
 						return fx.New(
 							fx.Module(serviceName,
-								config.Module,
-								dynamicconfigfx.Module,
-								logfx.Module,
-								metricsfx.Module,
-								clockfx.Module,
+								_commonModule,
 								fx.Provide(
 									func() appContext {
 										return appCtx
@@ -158,7 +150,6 @@ func BuildCLI(releaseVersion string, gitRevision string) *cli.App {
 	}
 
 	return app
-
 }
 
 func runServices(services []string, appBuilder func(serviceName string) fxAppInterface) error {

--- a/cmd/server/cadence/config/development.yaml
+++ b/cmd/server/cadence/config/development.yaml
@@ -1,0 +1,65 @@
+leaderElection:
+  leaderStore:
+    storageParams:
+      endpoints:
+      - ${ETCD_ENDPOINTS:"localhost:2379"}
+  election:
+    leaderPeriod: 30s
+    maxRandomDelay: 5s
+    failedElectionCooldown: 30s
+  namespaces:
+    - name: cadence-matching-dev
+      type: ephemeral
+      mode: shadow
+  process:
+    period: 2s
+
+persistence:
+  defaultStore: cass-default
+  visibilityStore: cass-visibility
+  numHistoryShards: 4
+  datastores:
+    cass-default:
+      nosql:
+        pluginName: "cassandra"
+        hosts: "127.0.0.1"
+        keyspace: "cadence"
+        connectTimeout: 2s # defaults to 2s if not defined
+        timeout: 5s # defaults to 10s if not defined
+        consistency: LOCAL_QUORUM # default value
+        serialConsistency: LOCAL_SERIAL # default value
+    cass-visibility:
+      nosql:
+        pluginName: "cassandra"
+        hosts: "127.0.0.1"
+        keyspace: "cadence_visibility"
+services:
+  shard-distributor:
+    rpc:
+      port: 7941
+      grpcPort: 7943
+      bindOnLocalHost: true
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7942
+
+ringpop:
+  name: cadence
+  bootstrapMode: hosts
+  bootstrapHosts: [ "127.0.0.1:7941"]
+  maxJoinDuration: 30s
+
+clusterGroupMetadata:
+  failoverVersionIncrement: 10
+  primaryClusterName: "cluster0"
+  currentClusterName: "cluster0"
+  clusterGroup:
+    cluster0:
+      enabled: true
+      initialFailoverVersion: 0
+      newInitialFailoverVersion: 1 # migrating to this new failover version
+      rpcAddress: "localhost:7833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -29,18 +29,32 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock/clockfx"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/logfx"
 	"github.com/uber/cadence/common/membership/membershipfx"
+	"github.com/uber/cadence/common/metrics/metricsfx"
 	"github.com/uber/cadence/common/peerprovider/ringpopprovider/ringpopfx"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/common/rpc/rpcfx"
 	"github.com/uber/cadence/common/service"
+	shardDistributorCfg "github.com/uber/cadence/service/sharddistributor/config"
+	"github.com/uber/cadence/service/sharddistributor/leader/leaderstore"
+	_ "github.com/uber/cadence/service/sharddistributor/leader/leaderstore/etcd"
 	"github.com/uber/cadence/service/sharddistributor/sharddistributorfx"
 	"github.com/uber/cadence/tools/cassandra"
 	"github.com/uber/cadence/tools/sql"
 )
+
+var _commonModule = fx.Options(
+	config.Module,
+	dynamicconfigfx.Module,
+	logfx.Module,
+	metricsfx.Module,
+	clockfx.Module)
 
 // Module provides a cadence server initialization with root components.
 // AppParams allows to provide optional/overrides for implementation specific dependencies.
@@ -51,6 +65,11 @@ func Module(serviceName string) fx.Option {
 				Name:     serviceName,
 				FullName: service.FullName(serviceName),
 			}),
+			fx.Provide(func(cfg config.Config) shardDistributorCfg.LeaderElection {
+				return shardDistributorCfg.GetLeaderElectionFromExternal(cfg.LeaderElection)
+			}),
+			leaderstore.StoreModule("etcd"),
+
 			rpcfx.Module,
 			// PeerProvider could be overriden e.g. with a DNS based internal solution.
 			ringpopfx.Module,

--- a/cmd/server/cadence/fx_test.go
+++ b/cmd/server/cadence/fx_test.go
@@ -29,16 +29,11 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
-	"github.com/uber/cadence/common/log/logfx"
-	"github.com/uber/cadence/common/metrics/metricsfx"
+	"github.com/uber/cadence/common/service"
 )
 
 func TestFxDependencies(t *testing.T) {
-	err := fx.ValidateApp(config.Module,
-		logfx.Module,
-		metricsfx.Module,
-		dynamicconfigfx.Module,
+	err := fx.ValidateApp(_commonModule,
 		fx.Supply(appContext{
 			CfgContext: config.Context{
 				Environment: "",
@@ -48,5 +43,19 @@ func TestFxDependencies(t *testing.T) {
 			RootDir:   "",
 		}),
 		Module(""))
+	require.NoError(t, err)
+}
+
+func TestFxDependenciesForShardDistributor(t *testing.T) {
+	err := fx.ValidateApp(_commonModule,
+		fx.Supply(appContext{
+			CfgContext: config.Context{
+				Environment: "",
+				Zone:        "",
+			},
+			ConfigDir: "",
+			RootDir:   "",
+		}),
+		Module(service.ShortName(service.ShardDistributor)))
 	require.NoError(t, err)
 }

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -89,6 +89,9 @@ type (
 		// Shard distributor is used to distribute shards across multiple cadence service instances
 		// Note: This is not recommended for use, it's still experimental
 		ShardDistributorClient ShardDistributorClient `yaml:"shardDistributorClient"`
+
+		// LeaderElection is a config for the shard distributor leader election component that allows to run a single process per region and manage shard namespaces.
+		LeaderElection LeaderElection `yaml:"leaderElection"`
 	}
 
 	// Membership holds peer provider configuration.
@@ -617,6 +620,36 @@ type (
 	AsyncWorkflowQueueProvider struct {
 		Type   string    `yaml:"type"`
 		Config *YamlNode `yaml:"config"`
+	}
+
+	// LeaderElection is a configuration for leader election running.
+	// This configuration should be in sync with sharddistributor.
+	LeaderElection struct {
+		Store      LeaderStore   `yaml:"leaderStore"`
+		Election   Election      `yaml:"election"`
+		Namespaces []Namespace   `yaml:"namespaces"`
+		Process    LeaderProcess `yaml:"process"`
+	}
+
+	// LeaderStore provides a config for leader election.
+	LeaderStore struct {
+		StorageParams *YamlNode `yaml:"storageParams"`
+	}
+
+	Namespace struct {
+		Name string `yaml:"name"`
+		Type string `yaml:"type"`
+		Mode string `yaml:"mode"`
+	}
+
+	Election struct {
+		LeaderPeriod           time.Duration `yaml:"leaderPeriod"`           // Time to hold leadership before resigning
+		MaxRandomDelay         time.Duration `yaml:"maxRandomDelay"`         // Maximum random delay before campaigning
+		FailedElectionCooldown time.Duration `yaml:"failedElectionCooldown"` // wait between election attempts with unhandled errors
+	}
+
+	LeaderProcess struct {
+		Period time.Duration `yaml:"period"`
 	}
 )
 

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -78,6 +78,17 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: cadence
 
+  etcd:
+    image: bitnami/etcd:3.5.21
+    restart: always
+    networks:
+      services-network:
+        aliases:
+          - etcd
+    environment:
+      ALLOW_NONE_AUTHENTICATION: yes
+      ETCD_ADVERTISE_CLIENT_URLS: http://etcd:2379
+
   unit-test:
     build:
       context: ../../
@@ -302,6 +313,27 @@ services:
       services-network:
         aliases:
           - integration-test-async-wf
+
+  integration-test-with-etcd:
+    build:
+      context: ../../
+      dockerfile: ./docker/buildkite/Dockerfile
+    environment:
+      - "ETCD=1"
+      - "ETCD_ENDPOINTS=http://etcd:2379"
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+    depends_on:
+      etcd:
+        condition: service_healthy
+    volumes:
+      - ../../:/cadence
+    networks:
+      services-network:
+        aliases:
+          - integration-test-with-etcd
 
   coverage-report:
     build:

--- a/service/sharddistributor/config/config.go
+++ b/service/sharddistributor/config/config.go
@@ -25,6 +25,7 @@ package config
 import (
 	"time"
 
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 )
@@ -41,16 +42,8 @@ type (
 	}
 
 	StaticConfig struct {
-		// ETCD provides is the configuration for ETCD storage that is required for usage of Shard distributor
-		ETCD ETCD `yaml:"etcd"`
 		// LeaderElection is the configuration for leader election mechanism that is used by Shard distributor to handle shard distribution per namespace.
 		LeaderElection LeaderElection `yaml:"leaderElection"`
-	}
-
-	// ETCD provides configuration for ETCD that is used inside shard distributor service.
-	ETCD struct {
-		Endpoints   []string      `yaml:"endpoints"`
-		DialTimeout time.Duration `yaml:"dialTimeout"`
 	}
 
 	// LeaderElection is a configuration for leader election running.
@@ -63,9 +56,7 @@ type (
 
 	// LeaderStore provides a config for leader election.
 	LeaderStore struct {
-		ETCD   ETCD          `yaml:"etcd"`
-		Prefix string        `yaml:"prefix"`
-		TTL    time.Duration `yaml:"ttl"`
+		StorageParams *config.YamlNode `yaml:"storageParams"`
 	}
 
 	Namespace struct {
@@ -92,5 +83,21 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string) *Config {
 		PersistenceGlobalMaxQPS: dc.GetIntProperty(dynamicproperties.ShardManagerPersistenceGlobalMaxQPS),
 		ThrottledLogRPS:         dc.GetIntProperty(dynamicproperties.ShardManagerThrottledLogRPS),
 		HostName:                hostName,
+	}
+}
+
+// GetLeaderElectionFromExternal converts other configs to an internal one.
+func GetLeaderElectionFromExternal(in config.LeaderElection) LeaderElection {
+
+	namespaces := make([]Namespace, 0, len(in.Namespaces))
+	for _, namespace := range in.Namespaces {
+		namespaces = append(namespaces, Namespace(namespace))
+	}
+
+	return LeaderElection{
+		Store:      LeaderStore(in.Store),
+		Election:   Election(in.Election),
+		Namespaces: namespaces,
+		Process:    LeaderProcess(in.Process),
 	}
 }

--- a/service/sharddistributor/leader/leaderstore/etcd/etcdstore.go
+++ b/service/sharddistributor/leader/leaderstore/etcd/etcdstore.go
@@ -9,12 +9,12 @@ import (
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.uber.org/fx"
 
-	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/service/sharddistributor/config"
 	"github.com/uber/cadence/service/sharddistributor/leader/leaderstore"
 )
 
 func init() {
-	leaderstore.RegisterStore("etcd", fx.Options(fx.Provide(NewStore)))
+	leaderstore.RegisterStore("etcd", fx.Provide(NewStore))
 }
 
 type LeaderStore struct {
@@ -27,7 +27,7 @@ type StoreParams struct {
 
 	// Client could be provided externally.
 	Client    *clientv3.Client `optional:"true"`
-	Cfg       *config.YamlNode `name:"leaderStoreConfig"`
+	Cfg       config.LeaderElection
 	Lifecycle fx.Lifecycle
 }
 
@@ -43,7 +43,7 @@ func NewStore(p StoreParams) (leaderstore.Store, error) {
 	var err error
 
 	var out etcdCfg
-	if err := p.Cfg.Decode(&out); err != nil {
+	if err := p.Cfg.Store.StorageParams.Decode(&out); err != nil {
 		return nil, fmt.Errorf("bad config: %w", err)
 	}
 

--- a/service/sharddistributor/leader/leaderstore/etcd/etcdstore_test.go
+++ b/service/sharddistributor/leader/leaderstore/etcd/etcdstore_test.go
@@ -37,6 +37,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/uber/cadence/common/config"
+	shardDistributorCfg "github.com/uber/cadence/service/sharddistributor/config"
 	"github.com/uber/cadence/service/sharddistributor/leader/leaderstore"
 	"github.com/uber/cadence/testflags"
 )
@@ -251,7 +252,7 @@ func setupETCDCluster(t *testing.T) *testCluster {
 
 	// Create store
 	storeParams := StoreParams{
-		Cfg:       createConfig(t, testConfig),
+		Cfg:       shardDistributorCfg.LeaderElection{Store: shardDistributorCfg.LeaderStore{StorageParams: createConfig(t, testConfig)}},
 		Lifecycle: fxtest.NewLifecycle(t),
 	}
 

--- a/service/sharddistributor/leader/leaderstore/store.go
+++ b/service/sharddistributor/leader/leaderstore/store.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"go.uber.org/fx"
-
-	"github.com/uber/cadence/common/config"
 )
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination=leaderstore_mock.go Store,Election
@@ -44,18 +42,10 @@ func RegisterStore(name string, factory StoreImpl) {
 
 // StoreModule returns registered a leader store fx.Option from the configuration.
 // This can introduce extra dependency requirements to the fx application.
-func StoreModule(name string, cfg *config.YamlNode) (fx.Option, error) {
+func StoreModule(name string) fx.Option {
 	factory, ok := storeRegistry[name]
 	if !ok {
-		return nil, fmt.Errorf("no leader store registered with name %s", name)
+		panic(fmt.Sprintf("no leader store registered with name %s", name))
 	}
-	return fx.Options(
-		fx.Provide(func() configBuilder { return configBuilder{Cfg: cfg} }),
-		factory), nil
-}
-
-type configBuilder struct {
-	fx.Out
-
-	Cfg *config.YamlNode `name:"leaderStoreConfig"`
+	return factory
 }

--- a/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
+++ b/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
@@ -26,6 +26,13 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/uber/cadence/service/sharddistributor"
+	"github.com/uber/cadence/service/sharddistributor/leader/election"
+	"github.com/uber/cadence/service/sharddistributor/leader/namespace"
+	"github.com/uber/cadence/service/sharddistributor/leader/process"
 )
 
-var Module = fx.Module("sharddistributor", fx.Provide(sharddistributor.FXService), fx.Invoke(func(*sharddistributor.Service) {}))
+var Module = fx.Module("sharddistributor",
+	namespace.Module,
+	election.Module,
+	process.Module,
+	fx.Provide(sharddistributor.FXService), fx.Invoke(func(*sharddistributor.Service) {}))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added leader election into sharddistributor fx application.
Also, added integration tests that test etcd related components on ci and locally.
The component is optional, so it should not affect start of other services.

<!-- Tell your future self why have you made these changes -->
**Why?**
Leader election will be running as a part of shard distrbutor service.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration tests on local machine and cadence-server start

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
