### PR TITLE
 Unify methods for creating history tasks

### DIFF
--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -128,7 +128,7 @@ func newTimerQueueProcessorBase(
 	t := &timerQueueProcessorBase{
 		processorBase: processorBase,
 		taskInitializer: func(taskInfo persistence.Task) task.Task {
-			return task.NewTimerTask(
+			return task.NewHistoryTask(
 				shard,
 				taskInfo,
 				queueType,

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -117,7 +117,7 @@ func newTransferQueueProcessorBase(
 	transferQueueProcessorBase := &transferQueueProcessorBase{
 		processorBase: processorBase,
 		taskInitializer: func(taskInfo persistence.Task) task.Task {
-			return task.NewTransferTask(
+			return task.NewHistoryTask(
 				shard,
 				taskInfo,
 				queueType,

--- a/service/history/queue/transfer_queue_processor_test.go
+++ b/service/history/queue/transfer_queue_processor_test.go
@@ -498,9 +498,6 @@ func Test_transferQueueActiveProcessor_taskFilter(t *testing.T) {
 	}{
 		"noop - domain not registered": {
 			mockSetup: func(testContext *shard.TestContext) {
-				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainName(constants.TestDomainID).
-					Return(constants.TestDomainName, nil).Times(1)
-
 				cacheEntry := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{Status: persistence.DomainStatusDeprecated}, nil, true, nil, 1, nil, 0, 0, 0)
 
 				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainByID(constants.TestDomainID).
@@ -623,9 +620,6 @@ func Test_transferQueueStandbyProcessor_taskFilter(t *testing.T) {
 	}{
 		"noop - domain not registered": {
 			mockSetup: func(testContext *shard.TestContext) {
-				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainName(constants.TestDomainID).
-					Return(constants.TestDomainName, nil).Times(1)
-
 				cacheEntry := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{Status: persistence.DomainStatusDeprecated}, nil, true, nil, 1, nil, 0, 0, 0)
 
 				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainByID(constants.TestDomainID).
@@ -674,9 +668,6 @@ func Test_transferQueueStandbyProcessor_taskFilter(t *testing.T) {
 		},
 		"error - TransferTaskTypeCloseExecution or TransferTaskTypeRecordWorkflowClosed - cannot find domain - retry": {
 			mockSetup: func(testContext *shard.TestContext) {
-				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainName(constants.TestDomainID).
-					Return(constants.TestDomainName, nil).Times(1)
-
 				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainByID(constants.TestDomainID).
 					Return(nil, assert.AnError).Times(2)
 			},
@@ -689,9 +680,6 @@ func Test_transferQueueStandbyProcessor_taskFilter(t *testing.T) {
 		},
 		"noop - TransferTaskTypeCloseExecution or TransferTaskTypeRecordWorkflowClosed - EntityNotExistsError": {
 			mockSetup: func(testContext *shard.TestContext) {
-				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainName(constants.TestDomainID).
-					Return(constants.TestDomainName, nil).Times(1)
-
 				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainByID(constants.TestDomainID).
 					Return(nil, &types.EntityNotExistsError{Message: "domain doesn't exist"}).Times(2)
 			},
@@ -704,9 +692,6 @@ func Test_transferQueueStandbyProcessor_taskFilter(t *testing.T) {
 		},
 		"taskFilter success": {
 			mockSetup: func(testContext *shard.TestContext) {
-				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainName(constants.TestDomainID).
-					Return(constants.TestDomainName, nil).Times(1)
-
 				cacheEntry := cache.NewDomainCacheEntryForTest(
 					&persistence.DomainInfo{Status: persistence.DomainStatusRegistered},
 					nil,
@@ -810,9 +795,6 @@ func Test_transferQueueFailoverProcessor_taskFilter(t *testing.T) {
 	}{
 		"noop - domain not registered": {
 			mockSetup: func(testContext *shard.TestContext) {
-				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainName(constants.TestDomainID).
-					Return(constants.TestDomainName, nil).Times(1)
-
 				cacheEntry := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{Status: persistence.DomainStatusDeprecated}, nil, true, nil, 1, nil, 0, 0, 0)
 
 				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainByID(constants.TestDomainID).
@@ -827,9 +809,6 @@ func Test_transferQueueFailoverProcessor_taskFilter(t *testing.T) {
 		},
 		"taskFilter success": {
 			mockSetup: func(testContext *shard.TestContext) {
-				testContext.GetDomainCache().(*cache.MockDomainCache).EXPECT().GetDomainName(constants.TestDomainID).
-					Return(constants.TestDomainName, nil).Times(1)
-
 				cacheEntry := cache.NewDomainCacheEntryForTest(
 					&persistence.DomainInfo{Status: persistence.DomainStatusRegistered},
 					nil,

--- a/service/history/queue/transfer_queue_validator_test.go
+++ b/service/history/queue/transfer_queue_validator_test.go
@@ -170,7 +170,7 @@ func (s *transferQueueValidatorSuite) TestAckTasks_NoTaskLost() {
 
 	loadedTasks := make(map[task.Key]task.Task, len(pendingTasks))
 	for _, pendingTask := range pendingTasks[:len(pendingTasks)-1] {
-		loadedTasks[newTransferTaskKey(pendingTask.GetTaskID())] = task.NewTransferTask(
+		loadedTasks[newTransferTaskKey(pendingTask.GetTaskID())] = task.NewHistoryTask(
 			s.mockShard,
 			&persistence.DecisionTask{
 				TaskData: persistence.TaskData{
@@ -203,7 +203,7 @@ func (s *transferQueueValidatorSuite) TestAckTasks_TaskLost() {
 
 	loadedTasks := make(map[task.Key]task.Task, len(pendingTasks))
 	for _, pendingTask := range pendingTasks[1:] {
-		loadedTasks[newTransferTaskKey(pendingTask.GetTaskID())] = task.NewTransferTask(
+		loadedTasks[newTransferTaskKey(pendingTask.GetTaskID())] = task.NewHistoryTask(
 			s.mockShard,
 			&persistence.DecisionTask{
 				TaskData: persistence.TaskData{

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -59,7 +59,7 @@ type (
 
 	// Executor contains the execution logic for Task
 	Executor interface {
-		Execute(task Task, shouldProcessTask bool) error
+		Execute(task Task) error
 		Stop()
 	}
 

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -25,6 +25,7 @@ package task
 import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/future"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/task"
 	"github.com/uber/cadence/common/types"
@@ -59,7 +60,7 @@ type (
 
 	// Executor contains the execution logic for Task
 	Executor interface {
-		Execute(task Task) error
+		Execute(task Task) (metrics.Scope, error)
 		Stop()
 	}
 

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -16,6 +16,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	future "github.com/uber/cadence/common/future"
+	metrics "github.com/uber/cadence/common/metrics"
 	persistence "github.com/uber/cadence/common/persistence"
 	task "github.com/uber/cadence/common/task"
 	types "github.com/uber/cadence/common/types"
@@ -928,11 +929,12 @@ func (m *MockExecutor) EXPECT() *MockExecutorMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockExecutor) Execute(task Task) error {
+func (m *MockExecutor) Execute(task Task) (metrics.Scope, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", task)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(metrics.Scope)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -928,17 +928,17 @@ func (m *MockExecutor) EXPECT() *MockExecutorMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockExecutor) Execute(task Task, shouldProcessTask bool) error {
+func (m *MockExecutor) Execute(task Task) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", task, shouldProcessTask)
+	ret := m.ctrl.Call(m, "Execute", task)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockExecutorMockRecorder) Execute(task, shouldProcessTask any) *gomock.Call {
+func (mr *MockExecutorMockRecorder) Execute(task any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockExecutor)(nil).Execute), task, shouldProcessTask)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockExecutor)(nil).Execute), task)
 }
 
 // Stop mocks base method.

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -76,7 +76,6 @@ type (
 		submitTime         time.Time
 		logger             log.Logger
 		eventLogger        eventLogger
-		scopeIdx           int
 		scope              metrics.Scope // initialized when processing task to make the initialization parallel
 		taskExecutor       Executor
 		taskProcessor      Processor
@@ -90,8 +89,7 @@ type (
 	}
 )
 
-// NewTimerTask creates a new timer task
-func NewTimerTask(
+func NewHistoryTask(
 	shard shard.Context,
 	taskInfo persistence.Task,
 	queueType QueueType,
@@ -102,58 +100,6 @@ func NewTimerTask(
 	redispatchFn func(task Task),
 	criticalRetryCount dynamicproperties.IntPropertyFn,
 ) Task {
-	return newTask(
-		shard,
-		taskInfo,
-		queueType,
-		GetTimerTaskMetricScope(taskInfo.GetTaskType(), queueType == QueueTypeActiveTimer),
-		logger,
-		taskFilter,
-		taskExecutor,
-		taskProcessor,
-		criticalRetryCount,
-		redispatchFn,
-	)
-}
-
-// NewTransferTask creates a new transfer task
-func NewTransferTask(
-	shard shard.Context,
-	taskInfo persistence.Task,
-	queueType QueueType,
-	logger log.Logger,
-	taskFilter Filter,
-	taskExecutor Executor,
-	taskProcessor Processor,
-	redispatchFn func(task Task),
-	criticalRetryCount dynamicproperties.IntPropertyFn,
-) Task {
-	return newTask(
-		shard,
-		taskInfo,
-		queueType,
-		GetTransferTaskMetricsScope(taskInfo.GetTaskType(), queueType == QueueTypeActiveTransfer),
-		logger,
-		taskFilter,
-		taskExecutor,
-		taskProcessor,
-		criticalRetryCount,
-		redispatchFn,
-	)
-}
-
-func newTask(
-	shard shard.Context,
-	taskInfo persistence.Task,
-	queueType QueueType,
-	scopeIdx int,
-	logger log.Logger,
-	taskFilter Filter,
-	taskExecutor Executor,
-	taskProcessor Processor,
-	criticalRetryCount dynamicproperties.IntPropertyFn,
-	redispatchFn func(task Task),
-) *taskImpl {
 	timeSource := shard.GetTimeSource()
 	var eventLogger eventLogger
 	if shard.GetConfig().EnableDebugMode &&
@@ -169,8 +115,7 @@ func newTask(
 		state:              ctask.TaskStatePending,
 		priority:           noPriority,
 		queueType:          queueType,
-		scopeIdx:           scopeIdx,
-		scope:              nil,
+		scope:              metrics.NoopScope(metrics.History),
 		logger:             logger,
 		eventLogger:        eventLogger,
 		attempt:            0,
@@ -185,14 +130,6 @@ func newTask(
 }
 
 func (t *taskImpl) Execute() error {
-	// TODO: after mergering active and standby queue,
-	// the task should be smart enough to tell if it should be
-	// processed as active or standby and use the corresponding
-	// task executor.
-	if t.scope == nil {
-		t.scope = getOrCreateDomainTaggedScope(t.shard, t.scopeIdx, t.GetDomainID(), t.logger)
-	}
-
 	var err error
 	t.shouldProcessTask, err = t.taskFilter(t.Task)
 	if err != nil {
@@ -210,7 +147,8 @@ func (t *taskImpl) Execute() error {
 		t.scope.IncCounter(metrics.TaskRequestsPerDomain)
 		t.scope.RecordTimer(metrics.TaskProcessingLatencyPerDomain, time.Since(executionStartTime))
 	}()
-	return t.taskExecutor.Execute(t)
+	t.scope, err = t.taskExecutor.Execute(t)
+	return err
 }
 
 func (t *taskImpl) HandleErr(err error) (retErr error) {

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -110,7 +110,7 @@ func (s *taskSuite) TestExecute_ExecutionErr() {
 	}, nil)
 
 	executionErr := errors.New("some random error")
-	s.mockTaskExecutor.EXPECT().Execute(task, true).Return(executionErr).Times(1)
+	s.mockTaskExecutor.EXPECT().Execute(task).Return(executionErr).Times(1)
 
 	err := task.Execute()
 	s.Equal(executionErr, err)
@@ -121,7 +121,7 @@ func (s *taskSuite) TestExecute_Success() {
 		return true, nil
 	}, nil)
 
-	s.mockTaskExecutor.EXPECT().Execute(task, true).Return(nil).Times(1)
+	s.mockTaskExecutor.EXPECT().Execute(task).Return(nil).Times(1)
 
 	err := task.Execute()
 	s.NoError(err)

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -36,6 +36,7 @@ import (
 	cadence_errors "github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	t "github.com/uber/cadence/common/task"
 	"github.com/uber/cadence/common/types"
@@ -110,7 +111,7 @@ func (s *taskSuite) TestExecute_ExecutionErr() {
 	}, nil)
 
 	executionErr := errors.New("some random error")
-	s.mockTaskExecutor.EXPECT().Execute(task).Return(executionErr).Times(1)
+	s.mockTaskExecutor.EXPECT().Execute(task).Return(metrics.NoopScope(metrics.History), executionErr).Times(1)
 
 	err := task.Execute()
 	s.Equal(executionErr, err)
@@ -121,7 +122,7 @@ func (s *taskSuite) TestExecute_Success() {
 		return true, nil
 	}, nil)
 
-	s.mockTaskExecutor.EXPECT().Execute(task).Return(nil).Times(1)
+	s.mockTaskExecutor.EXPECT().Execute(task).Return(metrics.NoopScope(metrics.History), nil).Times(1)
 
 	err := task.Execute()
 	s.NoError(err)
@@ -346,18 +347,17 @@ func (s *taskSuite) newTestTask(
 			// noop
 		}
 	}
-	taskBase := newTask(
+	taskBase := NewHistoryTask(
 		s.mockShard,
 		s.mockTaskInfo,
 		QueueTypeActiveTransfer,
-		0,
 		s.logger,
 		taskFilter,
 		s.mockTaskExecutor,
 		s.mockTaskProcessor,
-		s.maxRetryCount,
 		redispatchFn,
-	)
+		s.maxRetryCount,
+	).(*taskImpl)
 	taskBase.scope = s.mockShard.GetMetricsClient().Scope(0)
 	return taskBase
 }

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -76,13 +76,7 @@ func NewTimerActiveTaskExecutor(
 	}
 }
 
-func (t *timerActiveTaskExecutor) Execute(
-	task Task,
-	shouldProcessTask bool,
-) error {
-	if !shouldProcessTask {
-		return nil
-	}
+func (t *timerActiveTaskExecutor) Execute(task Task) error {
 	switch timerTask := task.GetInfo().(type) {
 	case *persistence.UserTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -76,38 +76,39 @@ func NewTimerActiveTaskExecutor(
 	}
 }
 
-func (t *timerActiveTaskExecutor) Execute(task Task) error {
+func (t *timerActiveTaskExecutor) Execute(task Task) (metrics.Scope, error) {
+	scope := getOrCreateDomainTaggedScope(t.shard, GetTimerTaskMetricScope(task.GetTaskType(), true), task.GetDomainID(), t.logger)
 	switch timerTask := task.GetInfo().(type) {
 	case *persistence.UserTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeUserTimerTimeoutTask(ctx, timerTask)
+		return scope, t.executeUserTimerTimeoutTask(ctx, timerTask)
 	case *persistence.ActivityTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeActivityTimeoutTask(ctx, timerTask)
+		return scope, t.executeActivityTimeoutTask(ctx, timerTask)
 	case *persistence.DecisionTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeDecisionTimeoutTask(ctx, timerTask)
+		return scope, t.executeDecisionTimeoutTask(ctx, timerTask)
 	case *persistence.WorkflowTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeWorkflowTimeoutTask(ctx, timerTask)
+		return scope, t.executeWorkflowTimeoutTask(ctx, timerTask)
 	case *persistence.ActivityRetryTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeActivityRetryTimerTask(ctx, timerTask)
+		return scope, t.executeActivityRetryTimerTask(ctx, timerTask)
 	case *persistence.WorkflowBackoffTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeWorkflowBackoffTimerTask(ctx, timerTask)
+		return scope, t.executeWorkflowBackoffTimerTask(ctx, timerTask)
 	case *persistence.DeleteHistoryEventTask:
 		ctx, cancel := context.WithTimeout(t.ctx, time.Duration(t.config.DeleteHistoryEventContextTimeout())*time.Second)
 		defer cancel()
-		return t.executeDeleteHistoryEventTask(ctx, timerTask)
+		return scope, t.executeDeleteHistoryEventTask(ctx, timerTask)
 	default:
-		return errUnknownTimerTask
+		return scope, errUnknownTimerTask
 	}
 }
 

--- a/service/history/task/timer_active_task_executor_test.go
+++ b/service/history/task/timer_active_task_executor_test.go
@@ -175,7 +175,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Fire() {
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	_, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetUserTimerInfo(timerID)
@@ -207,7 +207,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Noop() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -280,7 +280,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Resurrected()
 
 	s.timerActiveTaskExecutor.config.ResurrectionCheckMinDelay = dynamicproperties.GetDurationPropertyFnFilteredByDomain(timerTimeout2 - timerTimeout1)
 	s.timeSource.Advance(timerTimeout2)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -318,7 +318,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	_, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetActivityInfo(scheduledEvent.ID)
@@ -362,7 +362,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -409,7 +409,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	activityInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetActivityInfo(scheduledEvent.ID)
@@ -461,7 +461,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	activityInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetActivityInfo(scheduledEvent.ID)
@@ -518,7 +518,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_No
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -567,7 +567,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_Heartbeat_Noop
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -672,7 +672,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_Resurrected() 
 
 	s.timerActiveTaskExecutor.config.ResurrectionCheckMinDelay = dynamicproperties.GetDurationPropertyFnFilteredByDomain(timerTimeout2 - timerTimeout1)
 	s.timeSource.Advance(timerTimeout2)
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -709,7 +709,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionScheduleToStartTimeout_Normal
 			len(req.UpdateWorkflowMutation.TasksByCategory[persistence.HistoryTaskCategoryTimer]) == 1 // another schedule to start timer
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -749,7 +749,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionScheduleToStartTimeout_Transi
 			len(req.UpdateWorkflowMutation.TasksByCategory[persistence.HistoryTaskCategoryTimer]) == 0 // since the max attempt is 1 at the beginning of the test
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -795,7 +795,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionScheduleToStartTimeout_Sticky
 			len(req.UpdateWorkflowMutation.TasksByCategory[persistence.HistoryTaskCategoryTimer]) == 1 // schedule to start timer
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -828,7 +828,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionStartToCloseTimeout_Fire() {
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	decisionInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetPendingDecision()
@@ -865,7 +865,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionStartToCloseTimeout_Noop() {
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -896,7 +896,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Fire() {
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	decisionInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetPendingDecision()
@@ -929,7 +929,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Noop() {
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -994,7 +994,7 @@ func (s *timerActiveTaskExecutorSuite) TestActivityRetryTimer_Fire() {
 		},
 	).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -1046,7 +1046,7 @@ func (s *timerActiveTaskExecutorSuite) TestActivityRetryTimer_Noop() {
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -1074,7 +1074,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_Fire() {
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	running := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).IsWorkflowExecutionRunning()
@@ -1115,7 +1115,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_ContinueAsNew_Retry()
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Times(2)
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	state, closeStatus := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetWorkflowStateCloseStatus()
@@ -1152,7 +1152,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_ContinueAsNew_Cron() 
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Times(2)
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask)
+	_, err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	state, closeStatus := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetWorkflowStateCloseStatus()
@@ -1174,7 +1174,7 @@ func (s *timerActiveTaskExecutorSuite) getMutableStateFromCache(
 func (s *timerActiveTaskExecutorSuite) newTimerTaskFromInfo(
 	task persistence.Task,
 ) Task {
-	return NewTimerTask(s.mockShard, task, QueueTypeActiveTimer, s.logger, nil, nil, nil, nil, nil)
+	return NewHistoryTask(s.mockShard, task, QueueTypeActiveTimer, s.logger, nil, nil, nil, nil, nil)
 }
 
 func (s *timerActiveTaskExecutorSuite) TestActiveTaskTimeout() {

--- a/service/history/task/timer_active_task_executor_test.go
+++ b/service/history/task/timer_active_task_executor_test.go
@@ -175,7 +175,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Fire() {
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	_, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetUserTimerInfo(timerID)
@@ -207,7 +207,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Noop() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -280,7 +280,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Resurrected()
 
 	s.timerActiveTaskExecutor.config.ResurrectionCheckMinDelay = dynamicproperties.GetDurationPropertyFnFilteredByDomain(timerTimeout2 - timerTimeout1)
 	s.timeSource.Advance(timerTimeout2)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -318,7 +318,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	_, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetActivityInfo(scheduledEvent.ID)
@@ -362,7 +362,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -409,7 +409,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	activityInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetActivityInfo(scheduledEvent.ID)
@@ -461,7 +461,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	activityInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetActivityInfo(scheduledEvent.ID)
@@ -518,7 +518,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_No
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.timeSource.Advance(2 * timerTimeout)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -567,7 +567,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_Heartbeat_Noop
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -672,7 +672,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_Resurrected() 
 
 	s.timerActiveTaskExecutor.config.ResurrectionCheckMinDelay = dynamicproperties.GetDurationPropertyFnFilteredByDomain(timerTimeout2 - timerTimeout1)
 	s.timeSource.Advance(timerTimeout2)
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -709,7 +709,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionScheduleToStartTimeout_Normal
 			len(req.UpdateWorkflowMutation.TasksByCategory[persistence.HistoryTaskCategoryTimer]) == 1 // another schedule to start timer
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -749,7 +749,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionScheduleToStartTimeout_Transi
 			len(req.UpdateWorkflowMutation.TasksByCategory[persistence.HistoryTaskCategoryTimer]) == 0 // since the max attempt is 1 at the beginning of the test
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -795,7 +795,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionScheduleToStartTimeout_Sticky
 			len(req.UpdateWorkflowMutation.TasksByCategory[persistence.HistoryTaskCategoryTimer]) == 1 // schedule to start timer
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -828,7 +828,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionStartToCloseTimeout_Fire() {
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	decisionInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetPendingDecision()
@@ -865,7 +865,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionStartToCloseTimeout_Noop() {
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -896,7 +896,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Fire() {
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	decisionInfo, ok := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetPendingDecision()
@@ -929,7 +929,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Noop() {
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -994,7 +994,7 @@ func (s *timerActiveTaskExecutorSuite) TestActivityRetryTimer_Fire() {
 		},
 	).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -1046,7 +1046,7 @@ func (s *timerActiveTaskExecutorSuite) TestActivityRetryTimer_Noop() {
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 }
 
@@ -1074,7 +1074,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_Fire() {
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	running := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).IsWorkflowExecutionRunning()
@@ -1115,7 +1115,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_ContinueAsNew_Retry()
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Times(2)
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	state, closeStatus := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetWorkflowStateCloseStatus()
@@ -1152,7 +1152,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_ContinueAsNew_Cron() 
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Times(2)
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.timerActiveTaskExecutor.Execute(timerTask, true)
+	err = s.timerActiveTaskExecutor.Execute(timerTask)
 	s.NoError(err)
 
 	state, closeStatus := s.getMutableStateFromCache(s.domainID, workflowExecution.GetWorkflowID(), workflowExecution.GetRunID()).GetWorkflowStateCloseStatus()
@@ -1189,5 +1189,5 @@ func (s *timerActiveTaskExecutorSuite) TestActiveTaskTimeout() {
 			TaskID:  int64(100),
 		},
 	})
-	s.timerActiveTaskExecutor.Execute(deleteHistoryEventTask, true)
+	s.timerActiveTaskExecutor.Execute(deleteHistoryEventTask)
 }

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -77,14 +77,7 @@ func NewTimerStandbyTaskExecutor(
 	}
 }
 
-func (t *timerStandbyTaskExecutor) Execute(
-	task Task,
-	shouldProcessTask bool,
-) error {
-	if !shouldProcessTask {
-		return nil
-	}
-
+func (t *timerStandbyTaskExecutor) Execute(task Task) error {
 	switch timerTask := task.GetInfo().(type) {
 	case *persistence.UserTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -77,39 +77,40 @@ func NewTimerStandbyTaskExecutor(
 	}
 }
 
-func (t *timerStandbyTaskExecutor) Execute(task Task) error {
+func (t *timerStandbyTaskExecutor) Execute(task Task) (metrics.Scope, error) {
+	scope := getOrCreateDomainTaggedScope(t.shard, GetTimerTaskMetricScope(task.GetTaskType(), false), task.GetDomainID(), t.logger)
 	switch timerTask := task.GetInfo().(type) {
 	case *persistence.UserTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeUserTimerTimeoutTask(ctx, timerTask)
+		return scope, t.executeUserTimerTimeoutTask(ctx, timerTask)
 	case *persistence.ActivityTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeActivityTimeoutTask(ctx, timerTask)
+		return scope, t.executeActivityTimeoutTask(ctx, timerTask)
 	case *persistence.DecisionTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeDecisionTimeoutTask(ctx, timerTask)
+		return scope, t.executeDecisionTimeoutTask(ctx, timerTask)
 	case *persistence.WorkflowTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeWorkflowTimeoutTask(ctx, timerTask)
+		return scope, t.executeWorkflowTimeoutTask(ctx, timerTask)
 	case *persistence.ActivityRetryTimerTask:
 		// retry backoff timer should not get created on passive cluster
 		// TODO: add error logs
-		return nil
+		return scope, nil
 	case *persistence.WorkflowBackoffTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return t.executeWorkflowBackoffTimerTask(ctx, timerTask)
+		return scope, t.executeWorkflowBackoffTimerTask(ctx, timerTask)
 	case *persistence.DeleteHistoryEventTask:
 		// special timeout for delete history event
 		deleteHistoryEventContext, deleteHistoryEventCancel := context.WithTimeout(t.ctx, time.Duration(t.config.DeleteHistoryEventContextTimeout())*time.Second)
 		defer deleteHistoryEventCancel()
-		return t.executeDeleteHistoryEventTask(deleteHistoryEventContext, timerTask)
+		return scope, t.executeDeleteHistoryEventTask(deleteHistoryEventContext, timerTask)
 	default:
-		return errUnknownTimerTask
+		return scope, errUnknownTimerTask
 	}
 }
 

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -174,7 +174,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -188,11 +188,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 		nil,
 	).Return(nil).Times(1)
 
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -221,7 +221,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -254,7 +254,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Multiple() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -291,7 +291,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -304,11 +304,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -349,7 +349,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -390,7 +390,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Heartbeat_Noo
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -482,7 +482,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple_CanU
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -515,7 +515,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -528,11 +528,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -561,7 +561,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_ScheduleToSta
 	})
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err := s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err := s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(nil, err)
 }
 
@@ -590,7 +590,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -619,7 +619,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pending(
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().Add(s.fetchHistoryDuration))
@@ -632,11 +632,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pending(
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -665,7 +665,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Success(
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -694,7 +694,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -707,11 +707,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -740,7 +740,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -763,14 +763,14 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessRetryTimeout() {
 	})
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask)
+	_, err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
 func (s *timerStandbyTaskExecutorSuite) newTimerTaskFromInfo(
 	task persistence.Task,
 ) Task {
-	return NewTimerTask(s.mockShard, task, QueueTypeStandbyTimer, s.logger, nil, nil, nil, nil, nil)
+	return NewHistoryTask(s.mockShard, task, QueueTypeStandbyTimer, s.logger, nil, nil, nil, nil, nil)
 }
 
 func (s *timerStandbyTaskExecutorSuite) TestTransferTaskTimeout() {

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -174,7 +174,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -188,11 +188,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 		nil,
 	).Return(nil).Times(1)
 
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -221,7 +221,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -254,7 +254,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Multiple() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -291,7 +291,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -304,11 +304,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -349,7 +349,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -390,7 +390,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Heartbeat_Noo
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -482,7 +482,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple_CanU
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -515,7 +515,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -528,11 +528,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -561,7 +561,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_ScheduleToSta
 	})
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err := s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err := s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(nil, err)
 }
 
@@ -590,7 +590,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -619,7 +619,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pending(
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().Add(s.fetchHistoryDuration))
@@ -632,11 +632,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pending(
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -665,7 +665,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Success(
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -694,7 +694,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
@@ -707,11 +707,11 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.discardDuration))
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -740,7 +740,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -763,7 +763,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessRetryTimeout() {
 	})
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now())
-	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
+	err = s.timerStandbyTaskExecutor.Execute(timerTask)
 	s.Nil(err)
 }
 
@@ -785,5 +785,5 @@ func (s *timerStandbyTaskExecutorSuite) TestTransferTaskTimeout() {
 			TaskID:  int64(100),
 		},
 	})
-	s.timerStandbyTaskExecutor.Execute(deleteHistoryEventTask, true)
+	s.timerStandbyTaskExecutor.Execute(deleteHistoryEventTask)
 }

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -110,14 +110,7 @@ func NewTransferActiveTaskExecutor(
 	}
 }
 
-func (t *transferActiveTaskExecutor) Execute(
-	task Task,
-	shouldProcessTask bool,
-) error {
-	if !shouldProcessTask {
-		return nil
-	}
-
+func (t *transferActiveTaskExecutor) Execute(task Task) error {
 	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
 	defer cancel()
 

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -110,35 +110,36 @@ func NewTransferActiveTaskExecutor(
 	}
 }
 
-func (t *transferActiveTaskExecutor) Execute(task Task) error {
+func (t *transferActiveTaskExecutor) Execute(task Task) (metrics.Scope, error) {
+	scope := getOrCreateDomainTaggedScope(t.shard, GetTransferTaskMetricsScope(task.GetTaskType(), true), task.GetDomainID(), t.logger)
 	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
 	defer cancel()
 
 	switch transferTask := task.GetInfo().(type) {
 	case *persistence.ActivityTask:
-		return t.processActivityTask(ctx, transferTask)
+		return scope, t.processActivityTask(ctx, transferTask)
 	case *persistence.DecisionTask:
-		return t.processDecisionTask(ctx, transferTask)
+		return scope, t.processDecisionTask(ctx, transferTask)
 	case *persistence.CloseExecutionTask:
-		return t.processCloseExecution(ctx, transferTask)
+		return scope, t.processCloseExecution(ctx, transferTask)
 	case *persistence.RecordWorkflowClosedTask:
-		return t.processRecordWorkflowClosed(ctx, transferTask)
+		return scope, t.processRecordWorkflowClosed(ctx, transferTask)
 	case *persistence.RecordChildExecutionCompletedTask:
-		return t.processRecordChildExecutionCompleted(ctx, transferTask)
+		return scope, t.processRecordChildExecutionCompleted(ctx, transferTask)
 	case *persistence.CancelExecutionTask:
-		return t.processCancelExecution(ctx, transferTask)
+		return scope, t.processCancelExecution(ctx, transferTask)
 	case *persistence.SignalExecutionTask:
-		return t.processSignalExecution(ctx, transferTask)
+		return scope, t.processSignalExecution(ctx, transferTask)
 	case *persistence.StartChildExecutionTask:
-		return t.processStartChildExecution(ctx, transferTask)
+		return scope, t.processStartChildExecution(ctx, transferTask)
 	case *persistence.RecordWorkflowStartedTask:
-		return t.processRecordWorkflowStarted(ctx, transferTask)
+		return scope, t.processRecordWorkflowStarted(ctx, transferTask)
 	case *persistence.ResetWorkflowTask:
-		return t.processResetWorkflow(ctx, transferTask)
+		return scope, t.processResetWorkflow(ctx, transferTask)
 	case *persistence.UpsertWorkflowSearchAttributesTask:
-		return t.processUpsertWorkflowSearchAttributes(ctx, transferTask)
+		return scope, t.processUpsertWorkflowSearchAttributes(ctx, transferTask)
 	default:
-		return errUnknownTransferTask
+		return scope, errUnknownTransferTask
 	}
 }
 

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -191,14 +191,6 @@ func (s *transferActiveTaskExecutorSuite) TearDownTest() {
 	s.mockParentClosePolicyClient.AssertExpectations(s.T())
 }
 
-func (s *transferActiveTaskExecutorSuite) TestExecute_ShouldNotProcessTask() {
-	transferTask := s.newTransferTaskFromInfo(&persistence.ActivityTask{})
-
-	err := s.transferActiveTaskExecutor.Execute(transferTask, false)
-
-	s.NoError(err)
-}
-
 func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Success() {
 
 	workflowExecution, mutableState, decisionCompletionID, err := test.SetupWorkflowWithCompletedDecision(s.T(), s.mockShard, s.domainID)
@@ -234,7 +226,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTask, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -292,23 +284,23 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Ratelimits() {
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 }
@@ -351,7 +343,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Duplication() 
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -382,7 +374,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_FirstDecision(
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -414,7 +406,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_NonFirstDecisi
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -464,23 +456,23 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_Ratelimits() {
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 }
@@ -518,7 +510,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_Sticky_NonFirs
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -555,7 +547,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_DecisionNotSti
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -582,7 +574,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_Duplication() 
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -631,7 +623,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_StickyWorkerUn
 		s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), gomock.Eq(&modifiedRequest)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1),
 	)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.NoError(err)
 }
 
@@ -718,7 +710,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessCloseExecutionWithParent(
 
 	setupMockFn(mutableState, workflowExecution, parentExecution)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	if failRecordChild {
 		s.Equal(&types.DomainNotActiveError{}, err)
 	} else {
@@ -767,7 +759,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent() {
 		}
 	}
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -912,7 +904,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessCloseExecutionNoParentHasFe
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 	setupMockFn()
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 }
 
@@ -984,7 +976,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent_Has
 		},
 	)).Return(nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1028,7 +1020,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent_Has
 	s.mockVisibilityMgr.On("RecordWorkflowExecutionClosed", mock.Anything, mock.Anything).Return(nil).Once()
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1152,7 +1144,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessCancelExecutionWithError(
 
 	setupMockFn(mutableState, workflowExecution, targetExecution, event, transferTask, rci)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 }
 
@@ -1200,7 +1192,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCancelExecution_WorkflowCan
 	}
 	setupMockFn(mutableState, workflowExecution, workflowExecution, event, transferTask, rci)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.NoError(err)
 }
 
@@ -1355,7 +1347,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessSignalExecution_WorkflowSig
 
 	setupMockFn(mutableState, workflowExecution, workflowExecution, event, transferTask, signalInfo)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.NoError(err)
 }
 
@@ -1425,7 +1417,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessSignalExecutionWithErrorAnd
 
 	setupMockFn(mutableState, workflowExecution, targetExecution, event, transferTask, signalInfo)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 
 	assert.Equal(s.T(), len(expectedLogs), observedLogs.Len(), "expected %v logs, but got %v logs", len(expectedLogs), observedLogs.Len())
@@ -1720,7 +1712,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessStartChildExecutionWithErro
 
 	setupMockFn(mutableState, workflowExecution, childExecution, event, transferTask, ci)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 }
 
@@ -1765,7 +1757,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTask()
 			false),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1818,7 +1810,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskWi
 			true),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1853,7 +1845,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 			false),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1895,7 +1887,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 			true),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1919,7 +1911,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessResetWorkflow_ResetPointNil
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1947,7 +1939,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessResetWorkflow_WorkflowNotRu
 	s.mockExecutionMgr.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{DomainID: s.domainID, WorkflowID: workflowExecution.GetWorkflowID(), DomainName: s.domainName}).
 		Return(&persistence.GetCurrentExecutionResponse{RunID: "runID"}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -2043,7 +2035,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessResetWorkflowWithError(same
 		nil,
 		false).Return(resetError).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
+	err = s.transferActiveTaskExecutor.Execute(transferTask)
 
 	if returnErr != nil {
 		s.Equal(returnErr, err)

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -226,7 +226,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTask, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -284,23 +284,23 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Ratelimits() {
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 }
@@ -343,7 +343,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Duplication() 
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -374,7 +374,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_FirstDecision(
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -406,7 +406,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_NonFirstDecisi
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -456,23 +456,23 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_Ratelimits() {
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(rateLimitedTransferTask)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 
 	// RPS still below allowed value so the task can be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 
 	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(false).Times(1)
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 }
@@ -510,7 +510,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_Sticky_NonFirs
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -547,7 +547,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_DecisionNotSti
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -574,7 +574,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_Duplication() 
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -623,7 +623,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessDecisionTask_StickyWorkerUn
 		s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), gomock.Eq(&modifiedRequest)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1),
 	)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.NoError(err)
 }
 
@@ -710,7 +710,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessCloseExecutionWithParent(
 
 	setupMockFn(mutableState, workflowExecution, parentExecution)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	if failRecordChild {
 		s.Equal(&types.DomainNotActiveError{}, err)
 	} else {
@@ -759,7 +759,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent() {
 		}
 	}
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -904,7 +904,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessCloseExecutionNoParentHasFe
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 	setupMockFn()
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 }
 
@@ -976,7 +976,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent_Has
 		},
 	)).Return(nil).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1020,7 +1020,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent_Has
 	s.mockVisibilityMgr.On("RecordWorkflowExecutionClosed", mock.Anything, mock.Anything).Return(nil).Once()
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1144,7 +1144,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessCancelExecutionWithError(
 
 	setupMockFn(mutableState, workflowExecution, targetExecution, event, transferTask, rci)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 }
 
@@ -1192,7 +1192,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCancelExecution_WorkflowCan
 	}
 	setupMockFn(mutableState, workflowExecution, workflowExecution, event, transferTask, rci)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.NoError(err)
 }
 
@@ -1347,7 +1347,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessSignalExecution_WorkflowSig
 
 	setupMockFn(mutableState, workflowExecution, workflowExecution, event, transferTask, signalInfo)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.NoError(err)
 }
 
@@ -1417,7 +1417,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessSignalExecutionWithErrorAnd
 
 	setupMockFn(mutableState, workflowExecution, targetExecution, event, transferTask, signalInfo)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 
 	assert.Equal(s.T(), len(expectedLogs), observedLogs.Len(), "expected %v logs, but got %v logs", len(expectedLogs), observedLogs.Len())
@@ -1712,7 +1712,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessStartChildExecutionWithErro
 
 	setupMockFn(mutableState, workflowExecution, childExecution, event, transferTask, ci)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Equal(expectedErr, err)
 }
 
@@ -1757,7 +1757,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTask()
 			false),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1810,7 +1810,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskWi
 			true),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1845,7 +1845,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 			false),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1887,7 +1887,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 			true),
 	).Once().Return(nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1911,7 +1911,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessResetWorkflow_ResetPointNil
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1939,7 +1939,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessResetWorkflow_WorkflowNotRu
 	s.mockExecutionMgr.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{DomainID: s.domainID, WorkflowID: workflowExecution.GetWorkflowID(), DomainName: s.domainName}).
 		Return(&persistence.GetCurrentExecutionResponse{RunID: "runID"}, nil)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -2035,7 +2035,7 @@ func (s *transferActiveTaskExecutorSuite) testProcessResetWorkflowWithError(same
 		nil,
 		false).Return(resetError).Times(1)
 
-	err = s.transferActiveTaskExecutor.Execute(transferTask)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 
 	if returnErr != nil {
 		s.Equal(returnErr, err)
@@ -2062,7 +2062,7 @@ func (s *transferActiveTaskExecutorSuite) TestCopySearchAttributes() {
 func (s *transferActiveTaskExecutorSuite) newTransferTaskFromInfo(
 	task persistence.Task,
 ) Task {
-	return NewTransferTask(s.mockShard, task, QueueTypeActiveTransfer, s.logger, nil, nil, nil, nil, nil)
+	return NewHistoryTask(s.mockShard, task, QueueTypeActiveTransfer, s.logger, nil, nil, nil, nil, nil)
 }
 
 func createAddActivityTaskRequest(

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -70,14 +70,7 @@ func NewTransferStandbyTaskExecutor(
 	}
 }
 
-func (t *transferStandbyTaskExecutor) Execute(
-	task Task,
-	shouldProcessTask bool,
-) error {
-	if !shouldProcessTask {
-		return nil
-	}
-
+func (t *transferStandbyTaskExecutor) Execute(task Task) error {
 	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
 	defer cancel()
 

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -70,42 +70,43 @@ func NewTransferStandbyTaskExecutor(
 	}
 }
 
-func (t *transferStandbyTaskExecutor) Execute(task Task) error {
+func (t *transferStandbyTaskExecutor) Execute(task Task) (metrics.Scope, error) {
+	scope := getOrCreateDomainTaggedScope(t.shard, GetTransferTaskMetricsScope(task.GetTaskType(), false), task.GetDomainID(), t.logger)
 	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
 	defer cancel()
 
 	switch transferTask := task.GetInfo().(type) {
 	case *persistence.ActivityTask:
-		return t.processActivityTask(ctx, transferTask)
+		return scope, t.processActivityTask(ctx, transferTask)
 	case *persistence.DecisionTask:
-		return t.processDecisionTask(ctx, transferTask)
+		return scope, t.processDecisionTask(ctx, transferTask)
 	case *persistence.CloseExecutionTask:
-		return t.processCloseExecution(ctx, transferTask)
+		return scope, t.processCloseExecution(ctx, transferTask)
 	case *persistence.RecordWorkflowClosedTask:
-		return t.processCloseExecution(ctx, &persistence.CloseExecutionTask{
+		return scope, t.processCloseExecution(ctx, &persistence.CloseExecutionTask{
 			WorkflowIdentifier: transferTask.WorkflowIdentifier,
 			TaskData:           transferTask.TaskData,
 		})
 	case *persistence.RecordChildExecutionCompletedTask:
 		// no action needed for standby
 		// check the comment in t.processCloseExecution()
-		return nil
+		return scope, nil
 	case *persistence.CancelExecutionTask:
-		return t.processCancelExecution(ctx, transferTask)
+		return scope, t.processCancelExecution(ctx, transferTask)
 	case *persistence.SignalExecutionTask:
-		return t.processSignalExecution(ctx, transferTask)
+		return scope, t.processSignalExecution(ctx, transferTask)
 	case *persistence.StartChildExecutionTask:
-		return t.processStartChildExecution(ctx, transferTask)
+		return scope, t.processStartChildExecution(ctx, transferTask)
 	case *persistence.RecordWorkflowStartedTask:
-		return t.processRecordWorkflowStarted(ctx, transferTask)
+		return scope, t.processRecordWorkflowStarted(ctx, transferTask)
 	case *persistence.ResetWorkflowTask:
 		// no reset needed for standby
 		// TODO: add error logs
-		return nil
+		return scope, nil
 	case *persistence.UpsertWorkflowSearchAttributesTask:
-		return t.processUpsertWorkflowSearchAttributes(ctx, transferTask)
+		return scope, t.processUpsertWorkflowSearchAttributes(ctx, transferTask)
 	default:
-		return errUnknownTransferTask
+		return scope, errUnknownTransferTask
 	}
 }
 

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -202,7 +202,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 }
 
@@ -242,7 +242,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending_PushT
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTask, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -283,7 +283,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -315,7 +315,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 }
 
@@ -349,7 +349,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Pending_PushT
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -384,7 +384,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Success_First
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -419,7 +419,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Success_NonFi
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -450,7 +450,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCloseExecution() {
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -481,7 +481,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowClosedTask()
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -527,7 +527,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Pending() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
@@ -540,11 +540,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Pending() 
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -591,7 +591,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Success() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -638,7 +638,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Pending() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
@@ -651,11 +651,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Pending() 
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -704,7 +704,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Success() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -748,7 +748,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Pendin
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
@@ -761,11 +761,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Pendin
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -813,7 +813,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Succes
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -861,7 +861,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -918,7 +918,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskW
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -956,7 +956,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1003,7 +1003,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
+	err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -202,7 +202,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 }
 
@@ -242,7 +242,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending_PushT
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTask, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -283,7 +283,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Success() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -315,7 +315,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Pending() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 }
 
@@ -349,7 +349,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Pending_PushT
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(&types.AddDecisionTaskResponse{}, nil).Times(1)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -384,7 +384,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Success_First
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -419,7 +419,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Success_NonFi
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -450,7 +450,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCloseExecution() {
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -481,7 +481,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowClosedTask()
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -527,7 +527,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Pending() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
@@ -540,11 +540,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Pending() 
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -591,7 +591,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Success() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -638,7 +638,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Pending() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
@@ -651,11 +651,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Pending() 
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -704,7 +704,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Success() 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -748,7 +748,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Pendin
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
@@ -761,11 +761,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Pendin
 		nil,
 		nil,
 	).Return(nil).Times(1)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Equal(ErrTaskDiscarded, err)
 }
 
@@ -813,7 +813,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Succes
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -861,7 +861,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -918,7 +918,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskW
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -956,7 +956,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
@@ -1003,12 +1003,12 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
-	err = s.transferStandbyTaskExecutor.Execute(transferTask)
+	_, err = s.transferStandbyTaskExecutor.Execute(transferTask)
 	s.Nil(err)
 }
 
 func (s *transferStandbyTaskExecutorSuite) newTransferTaskFromInfo(
 	task persistence.Task,
 ) Task {
-	return NewTransferTask(s.mockShard, task, QueueTypeStandbyTransfer, s.logger, nil, nil, nil, nil, nil)
+	return NewHistoryTask(s.mockShard, task, QueueTypeStandbyTransfer, s.logger, nil, nil, nil, nil, nil)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor the code to unify the methods for creating history tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a preparation work for history queue revamp. By unifying the methods for creating history tasks, it makes it easier for us to introduce new history tasks and simplify the code for history queuev2.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Task processing may be stuck

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
