### PR TITLE
Refactor ndc history resender to handle multiple remote clusters

### DIFF
--- a/common/ndc/history_resender_mock.go
+++ b/common/ndc/history_resender_mock.go
@@ -40,15 +40,15 @@ func (m *MockHistoryResender) EXPECT() *MockHistoryResenderMockRecorder {
 }
 
 // SendSingleWorkflowHistory mocks base method.
-func (m *MockHistoryResender) SendSingleWorkflowHistory(domainID, workflowID, runID string, startEventID, startEventVersion, endEventID, endEventVersion *int64) error {
+func (m *MockHistoryResender) SendSingleWorkflowHistory(remoteCluster, domainID, workflowID, runID string, startEventID, startEventVersion, endEventID, endEventVersion *int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendSingleWorkflowHistory", domainID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
+	ret := m.ctrl.Call(m, "SendSingleWorkflowHistory", remoteCluster, domainID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendSingleWorkflowHistory indicates an expected call of SendSingleWorkflowHistory.
-func (mr *MockHistoryResenderMockRecorder) SendSingleWorkflowHistory(domainID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion any) *gomock.Call {
+func (mr *MockHistoryResenderMockRecorder) SendSingleWorkflowHistory(remoteCluster, domainID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSingleWorkflowHistory", reflect.TypeOf((*MockHistoryResender)(nil).SendSingleWorkflowHistory), domainID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSingleWorkflowHistory", reflect.TypeOf((*MockHistoryResender)(nil).SendSingleWorkflowHistory), remoteCluster, domainID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
 }

--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -1293,13 +1293,9 @@ func (adh *adminHandlerImpl) ResendReplicationTasks(
 	if request == nil {
 		return adh.error(validate.ErrRequestNotSet, scope)
 	}
-	remoteAdminClient, err := adh.GetRemoteAdminClient(request.GetRemoteCluster())
-	if err != nil {
-		return adh.error(&types.BadRequestError{Message: err.Error()}, scope)
-	}
 	resender := ndc.NewHistoryResender(
 		adh.GetDomainCache(),
-		remoteAdminClient,
+		adh.GetClientBean(),
 		func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 			return adh.GetHistoryClient().ReplicateEventsV2(ctx, request)
 		},
@@ -1308,6 +1304,7 @@ func (adh *adminHandlerImpl) ResendReplicationTasks(
 		adh.GetLogger(),
 	)
 	return resender.SendSingleWorkflowHistory(
+		request.GetRemoteCluster(),
 		request.DomainID,
 		request.GetWorkflowID(),
 		request.GetRunID(),

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -255,27 +255,17 @@ func NewEngineWithShardContext(
 		return historyRetryableClient.ReplicateEventsV2(ctx, request)
 	}
 	for _, replicationTaskFetcher := range replicationTaskFetchers.GetFetchers() {
-		// TODO: refactor ndc resender to use client.Bean and dynamically get the client
 		sourceCluster := replicationTaskFetcher.GetSourceCluster()
-		// Intentionally use the raw client to create its own retry policy
-		adminClient, err := shard.GetService().GetClientBean().GetRemoteAdminClient(sourceCluster)
-		if err != nil {
-			logger.Fatal("Failed to get remote admin client for cluster", tag.Error(err))
-		}
-		adminRetryableClient := retryable.NewAdminClient(
-			adminClient,
-			common.CreateReplicationServiceBusyRetryPolicy(),
-			common.IsServiceBusyError,
-		)
 		historyResender := cndc.NewHistoryResender(
 			shard.GetDomainCache(),
-			adminRetryableClient,
+			shard.GetService().GetClientBean(),
 			resendFunc,
 			nil,
 			openExecutionCheck,
 			shard.GetLogger().WithTags(tag.ComponentReplicatorQueue, tag.ActiveClusterName(sourceCluster)),
 		)
 		replicationTaskExecutor := replication.NewTaskExecutor(
+			sourceCluster,
 			shard,
 			shard.GetDomainCache(),
 			historyResender,

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -108,14 +108,9 @@ func NewTimerQueueProcessor(
 	standbyQueueProcessors := make(map[string]*timerQueueProcessorBase)
 	standbyQueueTimerGates := make(map[string]clock.EventTimerGate)
 	for clusterName := range shard.GetClusterMetadata().GetRemoteClusterInfo() {
-		// TODO: refactor ndc resender to use client.Bean and dynamically get the client
-		remoteAdminClient, err := shard.GetService().GetClientBean().GetRemoteAdminClient(clusterName)
-		if err != nil {
-			logger.Fatal("Failed to get remote admin client for cluster", tag.Error(err))
-		}
 		historyResender := ndc.NewHistoryResender(
 			shard.GetDomainCache(),
-			remoteAdminClient,
+			shard.GetService().GetClientBean(),
 			func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 				return shard.GetEngine().ReplicateEventsV2(ctx, request)
 			},

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -117,14 +117,9 @@ func NewTransferQueueProcessor(
 
 	standbyQueueProcessors := make(map[string]*transferQueueProcessorBase)
 	for clusterName := range shard.GetClusterMetadata().GetRemoteClusterInfo() {
-		// TODO: refactor ndc resender to use client.Bean and dynamically get the client
-		remoteAdminClient, err := shard.GetService().GetClientBean().GetRemoteAdminClient(clusterName)
-		if err != nil {
-			logger.Fatal("Failed to get remote admin client for cluster", tag.Error(err))
-		}
 		historyResender := ndc.NewHistoryResender(
 			shard.GetDomainCache(),
-			remoteAdminClient,
+			shard.GetService().GetClientBean(),
 			func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 				return shard.GetEngine().ReplicateEventsV2(ctx, request)
 			},

--- a/service/history/replication/task_executor_test.go
+++ b/service/history/replication/task_executor_test.go
@@ -51,6 +51,7 @@ type (
 		*require.Assertions
 		controller *gomock.Controller
 
+		sourceCluster      string
 		mockShard          *shard.TestContext
 		mockEngine         *engine.MockEngine
 		historyClient      *historyClient.MockClient
@@ -94,6 +95,7 @@ func (s *taskExecutorSuite) SetupTest() {
 		s.config,
 	)
 
+	s.sourceCluster = "source-cluster"
 	s.mockDomainCache = s.mockShard.Resource.DomainCache
 	s.mockClientBean = s.mockShard.Resource.ClientBean
 	s.adminClient = s.mockShard.Resource.RemoteAdminClient
@@ -103,6 +105,7 @@ func (s *taskExecutorSuite) SetupTest() {
 	s.historyClient = s.mockShard.Resource.HistoryClient
 
 	s.taskHandler = NewTaskExecutor(
+		s.sourceCluster,
 		s.mockShard,
 		s.mockDomainCache,
 		s.nDCHistoryResender,
@@ -217,6 +220,7 @@ func (s *taskExecutorSuite) TestProcessTask_SyncActivityReplicationTask_SameShar
 		EndEventVersion:   common.Ptr(int64(102)),
 	}).Times(1)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.sourceCluster,
 		"test-domain-id",
 		"test-wf-id",
 		"test-run-id",
@@ -258,6 +262,7 @@ func (s *taskExecutorSuite) TestProcessTask_SyncActivityReplicationTask_SameShar
 		EndEventVersion:   common.Ptr(int64(102)),
 	}).Times(1)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.sourceCluster,
 		"test-domain-id",
 		"test-wf-id",
 		"test-run-id",
@@ -299,6 +304,7 @@ func (s *taskExecutorSuite) TestProcessTask_SyncActivityReplicationTask_SameShar
 	}
 	s.mockEngine.EXPECT().SyncActivity(gomock.Any(), request).Return(retryErr).Times(1)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.sourceCluster,
 		"test-domain-id",
 		"test-wf-id",
 		"test-run-id",
@@ -368,6 +374,7 @@ func (s *taskExecutorSuite) TestProcessTask_HistoryV2ReplicationTask_SameShardID
 	}
 	s.mockEngine.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(retryErr).Times(1)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.sourceCluster,
 		"test-domain-id",
 		"test-wf-id",
 		"test-run-id",
@@ -412,6 +419,7 @@ func (s *taskExecutorSuite) TestProcessTask_HistoryV2ReplicationTask_SameShardID
 	}
 	s.mockEngine.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(retryErr).Times(1)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.sourceCluster,
 		"test-domain-id",
 		"test-wf-id",
 		"test-run-id",
@@ -455,6 +463,7 @@ func (s *taskExecutorSuite) TestProcessTask_HistoryV2ReplicationTask_SameShardID
 	}
 	s.mockEngine.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(retryErr).Times(1)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.sourceCluster,
 		"test-domain-id",
 		"test-wf-id",
 		"test-run-id",

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -503,6 +503,7 @@ func (t *timerStandbyTaskExecutor) fetchHistoryFromRemote(
 		// note history resender doesn't take in a context parameter, there's a separate dynamicconfig for
 		// controlling the timeout for resending history.
 		err = t.historyResender.SendSingleWorkflowHistory(
+			t.clusterName,
 			taskInfo.GetDomainID(),
 			taskInfo.GetWorkflowID(),
 			taskInfo.GetRunID(),

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -179,6 +179,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		timerTask.GetDomainID(),
 		timerTask.GetWorkflowID(),
 		timerTask.GetRunID(),
@@ -296,6 +297,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		timerTask.GetDomainID(),
 		timerTask.GetWorkflowID(),
 		timerTask.GetRunID(),
@@ -520,6 +522,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		timerTask.GetDomainID(),
 		timerTask.GetWorkflowID(),
 		timerTask.GetRunID(),
@@ -624,6 +627,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pending(
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		timerTask.GetDomainID(),
 		timerTask.GetWorkflowID(),
 		timerTask.GetRunID(),
@@ -699,6 +703,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.timeSource.Now().Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		timerTask.GetDomainID(),
 		timerTask.GetWorkflowID(),
 		timerTask.GetRunID(),

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -655,6 +655,7 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 		// note history resender doesn't take in a context parameter, there's a separate dynamicconfig for
 		// controlling the timeout for resending history.
 		err = t.historyResender.SendSingleWorkflowHistory(
+			t.clusterName,
 			taskInfo.GetDomainID(),
 			taskInfo.GetWorkflowID(),
 			taskInfo.GetRunID(),

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -532,6 +532,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Pending() 
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		transferTask.GetDomainID(),
 		transferTask.GetWorkflowID(),
 		transferTask.GetRunID(),
@@ -643,6 +644,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Pending() 
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		transferTask.GetDomainID(),
 		transferTask.GetWorkflowID(),
 		transferTask.GetRunID(),
@@ -753,6 +755,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Pendin
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		transferTask.GetDomainID(),
 		transferTask.GetWorkflowID(),
 		transferTask.GetRunID(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This picks a commit from Temporal https://github.com/temporalio/temporal/pull/2866

<!-- Tell your future self why have you made these changes -->
**Why?**
To prepare for history queuev2

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
As a side effect, this removes the retry of history re-replication, so history re-replication may be affected due to lack of retry.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
