### PR TITLE
Reduce repetitive warn and error logging in base lru cache

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -68,6 +68,8 @@ type (
 		timeSource   clock.TimeSource
 		logger       log.Logger
 		metricsScope metrics.Scope
+		warnOnce     sync.Once
+		errorOnce    sync.Once
 	}
 
 	iteratorImpl struct {
@@ -174,6 +176,8 @@ func New(opts *Options) Cache {
 		logger:        opts.Logger,
 		isSizeBased:   opts.IsSizeBased,
 		metricsScope:  opts.MetricsScope,
+		warnOnce:      sync.Once{},
+		errorOnce:     sync.Once{},
 	}
 
 	if cache.logger == nil {
@@ -326,7 +330,9 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 	defer c.mut.Unlock()
 
 	if !ok {
-		c.logger.Warn(fmt.Sprintf("Cache is strictly count-based because value %T does not implement sizable", value))
+		c.warnOnce.Do(func() {
+			c.logger.Warn(fmt.Sprintf("Cache is strictly count-based because value %T does not implement sizable", value))
+		})
 	} else {
 		valueSize = sizeableValue.ByteSize()
 	}
@@ -474,7 +480,9 @@ func (c *lru) isCacheFull() bool {
 		if c.maxSize() == 0 {
 			// we don't want to stop caching if maxSize is misconfigured to 0, we will use cacheDefaultSizeLimit instead
 			// BUT we need to warn users for this config
-			c.logger.Error(fmt.Sprintf("Cache size is misconfigured to 0 for value type %T, please fix config", c.byKey[0].Value.(*entryImpl).value))
+			c.errorOnce.Do(func() {
+				c.logger.Error(fmt.Sprintf("Cache size is misconfigured to 0 for value type %T, please fix config", c.byKey[0].Value.(*entryImpl).value))
+			})
 			return c.currSize > uint64(cacheDefaultSizeLimit) || count > cacheCountLimit
 		}
 		return c.currSize > uint64(c.maxSize()) || count > cacheCountLimit

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -176,8 +176,6 @@ func New(opts *Options) Cache {
 		logger:        opts.Logger,
 		isSizeBased:   opts.IsSizeBased,
 		metricsScope:  opts.MetricsScope,
-		warnOnce:      sync.Once{},
-		errorOnce:     sync.Once{},
 	}
 
 	if cache.logger == nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Reduce repetitive warn and error logging in base lru cache

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently warning logging in base lru cache is spamming the logging system, we want to reduce the times we log it to at most once.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested in local dev environment.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
