### PR TITLE
Refactor history task key

### DIFF
--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -723,7 +723,7 @@ func (d *nosqlExecutionStore) getImmediateHistoryTasks(
 ) (*persistence.GetHistoryTasksResponse, error) {
 	switch request.TaskCategory.ID() {
 	case persistence.HistoryTaskCategoryIDTransfer:
-		tasks, nextPageToken, err := d.db.SelectTransferTasksOrderByTaskID(ctx, d.shardID, request.PageSize, request.NextPageToken, request.InclusiveMinTaskKey.TaskID, request.ExclusiveMaxTaskKey.TaskID)
+		tasks, nextPageToken, err := d.db.SelectTransferTasksOrderByTaskID(ctx, d.shardID, request.PageSize, request.NextPageToken, request.InclusiveMinTaskKey.GetTaskID(), request.ExclusiveMaxTaskKey.GetTaskID())
 		if err != nil {
 			return nil, convertCommonErrors(d.db, "GetImmediateHistoryTasks", err)
 		}
@@ -749,7 +749,7 @@ func (d *nosqlExecutionStore) getImmediateHistoryTasks(
 			NextPageToken: nextPageToken,
 		}, nil
 	case persistence.HistoryTaskCategoryIDReplication:
-		tasks, nextPageToken, err := d.db.SelectReplicationTasksOrderByTaskID(ctx, d.shardID, request.PageSize, request.NextPageToken, request.InclusiveMinTaskKey.TaskID, request.ExclusiveMaxTaskKey.TaskID)
+		tasks, nextPageToken, err := d.db.SelectReplicationTasksOrderByTaskID(ctx, d.shardID, request.PageSize, request.NextPageToken, request.InclusiveMinTaskKey.GetTaskID(), request.ExclusiveMaxTaskKey.GetTaskID())
 		if err != nil {
 			return nil, convertCommonErrors(d.db, "GetImmediateHistoryTasks", err)
 		}
@@ -785,7 +785,7 @@ func (d *nosqlExecutionStore) getScheduledHistoryTasks(
 ) (*persistence.GetHistoryTasksResponse, error) {
 	switch request.TaskCategory.ID() {
 	case persistence.HistoryTaskCategoryIDTimer:
-		timers, nextPageToken, err := d.db.SelectTimerTasksOrderByVisibilityTime(ctx, d.shardID, request.PageSize, request.NextPageToken, request.InclusiveMinTaskKey.ScheduledTime, request.ExclusiveMaxTaskKey.ScheduledTime)
+		timers, nextPageToken, err := d.db.SelectTimerTasksOrderByVisibilityTime(ctx, d.shardID, request.PageSize, request.NextPageToken, request.InclusiveMinTaskKey.GetScheduledTime(), request.ExclusiveMaxTaskKey.GetScheduledTime())
 		if err != nil {
 			return nil, convertCommonErrors(d.db, "GetScheduledHistoryTasks", err)
 		}
@@ -836,7 +836,7 @@ func (d *nosqlExecutionStore) completeScheduledHistoryTask(
 ) error {
 	switch request.TaskCategory.ID() {
 	case persistence.HistoryTaskCategoryIDTimer:
-		err := d.db.DeleteTimerTask(ctx, d.shardID, request.TaskKey.TaskID, request.TaskKey.ScheduledTime)
+		err := d.db.DeleteTimerTask(ctx, d.shardID, request.TaskKey.GetTaskID(), request.TaskKey.GetScheduledTime())
 		if err != nil {
 			return convertCommonErrors(d.db, "CompleteScheduledHistoryTask", err)
 		}
@@ -852,13 +852,13 @@ func (d *nosqlExecutionStore) completeImmediateHistoryTask(
 ) error {
 	switch request.TaskCategory.ID() {
 	case persistence.HistoryTaskCategoryIDTransfer:
-		err := d.db.DeleteTransferTask(ctx, d.shardID, request.TaskKey.TaskID)
+		err := d.db.DeleteTransferTask(ctx, d.shardID, request.TaskKey.GetTaskID())
 		if err != nil {
 			return convertCommonErrors(d.db, "CompleteImmediateHistoryTask", err)
 		}
 		return nil
 	case persistence.HistoryTaskCategoryIDReplication:
-		err := d.db.DeleteReplicationTask(ctx, d.shardID, request.TaskKey.TaskID)
+		err := d.db.DeleteReplicationTask(ctx, d.shardID, request.TaskKey.GetTaskID())
 		if err != nil {
 			return convertCommonErrors(d.db, "CompleteImmediateHistoryTask", err)
 		}
@@ -888,7 +888,7 @@ func (d *nosqlExecutionStore) rangeCompleteScheduledHistoryTask(
 ) (*persistence.RangeCompleteHistoryTaskResponse, error) {
 	switch request.TaskCategory.ID() {
 	case persistence.HistoryTaskCategoryIDTimer:
-		err := d.db.RangeDeleteTimerTasks(ctx, d.shardID, request.InclusiveMinTaskKey.ScheduledTime, request.ExclusiveMaxTaskKey.ScheduledTime)
+		err := d.db.RangeDeleteTimerTasks(ctx, d.shardID, request.InclusiveMinTaskKey.GetScheduledTime(), request.ExclusiveMaxTaskKey.GetScheduledTime())
 		if err != nil {
 			return nil, convertCommonErrors(d.db, "RangeCompleteTimerTask", err)
 		}
@@ -904,12 +904,12 @@ func (d *nosqlExecutionStore) rangeCompleteImmediateHistoryTask(
 ) (*persistence.RangeCompleteHistoryTaskResponse, error) {
 	switch request.TaskCategory.ID() {
 	case persistence.HistoryTaskCategoryIDTransfer:
-		err := d.db.RangeDeleteTransferTasks(ctx, d.shardID, request.InclusiveMinTaskKey.TaskID, request.ExclusiveMaxTaskKey.TaskID)
+		err := d.db.RangeDeleteTransferTasks(ctx, d.shardID, request.InclusiveMinTaskKey.GetTaskID(), request.ExclusiveMaxTaskKey.GetTaskID())
 		if err != nil {
 			return nil, convertCommonErrors(d.db, "RangeCompleteTransferTask", err)
 		}
 	case persistence.HistoryTaskCategoryIDReplication:
-		err := d.db.RangeDeleteReplicationTasks(ctx, d.shardID, request.ExclusiveMaxTaskKey.TaskID)
+		err := d.db.RangeDeleteReplicationTasks(ctx, d.shardID, request.ExclusiveMaxTaskKey.GetTaskID())
 		if err != nil {
 			return nil, convertCommonErrors(d.db, "RangeCompleteReplicationTask", err)
 		}

--- a/common/persistence/nosql/nosql_execution_store_test.go
+++ b/common/persistence/nosql/nosql_execution_store_test.go
@@ -1294,8 +1294,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "success - scheduled timer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0)},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute)},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute), 0),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().RangeDeleteTimerTasks(ctx, shardID, time.Unix(0, 0), time.Unix(0, 0).Add(time.Minute)).Return(nil)
@@ -1306,8 +1306,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "success - immediate transfer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().RangeDeleteTransferTasks(ctx, shardID, int64(100), int64(200)).Return(nil)
@@ -1318,8 +1318,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "success - immediate replication task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100}, // this is ignored by replication task
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100), // this is ignored by replication task
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().RangeDeleteReplicationTasks(ctx, shardID, int64(200)).Return(nil)
@@ -1338,8 +1338,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "database error on timer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0)},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute)},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute), 0),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().RangeDeleteTimerTasks(ctx, shardID, time.Unix(0, 0), time.Unix(0, 0).Add(time.Minute)).Return(errors.New("db error"))
@@ -1351,8 +1351,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "database error on transfer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().RangeDeleteTransferTasks(ctx, shardID, int64(100), int64(200)).Return(errors.New("db error"))
@@ -1364,8 +1364,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "database error on replication task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().RangeDeleteReplicationTasks(ctx, shardID, int64(200)).Return(errors.New("db error"))
@@ -1411,8 +1411,8 @@ func TestGetHistoryTasks(t *testing.T) {
 			name: "success - get immediate transfer tasks",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            10,
 				NextPageToken:       []byte("next-page-token"),
 			},
@@ -1456,8 +1456,8 @@ func TestGetHistoryTasks(t *testing.T) {
 			name: "success - get immediate transfer tasks from data blob",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            10,
 				NextPageToken:       []byte("next-page-token"),
 			},
@@ -1506,8 +1506,8 @@ func TestGetHistoryTasks(t *testing.T) {
 			name: "success - get scheduled timer tasks",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0)},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute)},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute), 0),
 				PageSize:            10,
 				NextPageToken:       []byte("next-page-token"),
 			},
@@ -1549,8 +1549,8 @@ func TestGetHistoryTasks(t *testing.T) {
 			name: "success - get scheduled timer tasks from data blob",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0)},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute)},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute), 0),
 				PageSize:            10,
 				NextPageToken:       []byte("next-page-token"),
 			},
@@ -1596,8 +1596,8 @@ func TestGetHistoryTasks(t *testing.T) {
 			name: "success - get immediate replication tasks",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            10,
 				NextPageToken:       []byte("next-page-token"),
 			},
@@ -1646,8 +1646,8 @@ func TestGetHistoryTasks(t *testing.T) {
 			name: "success - get immediate replication tasks from data blob",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            10,
 				NextPageToken:       []byte("next-page-token"),
 			},
@@ -1779,7 +1779,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "success - complete scheduled timer task",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTimer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 1, ScheduledTime: time.Unix(10, 10)},
+				TaskKey:      persistence.NewHistoryTaskKey(time.Unix(10, 10), 1),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().DeleteTimerTask(ctx, shardID, int64(1), time.Unix(10, 10)).Return(nil)
@@ -1790,7 +1790,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "success - complete immediate transfer task",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTransfer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 2},
+				TaskKey:      persistence.NewImmediateTaskKey(2),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().DeleteTransferTask(ctx, shardID, int64(2)).Return(nil)
@@ -1801,7 +1801,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "success - complete immediate replication task",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryReplication,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 3},
+				TaskKey:      persistence.NewImmediateTaskKey(3),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().DeleteReplicationTask(ctx, shardID, int64(3)).Return(nil)
@@ -1820,7 +1820,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "delete timer task error",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTimer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 1, ScheduledTime: time.Unix(10, 10)},
+				TaskKey:      persistence.NewHistoryTaskKey(time.Unix(10, 10), 1),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().DeleteTimerTask(ctx, shardID, int64(1), time.Unix(10, 10)).Return(errors.New("db error"))
@@ -1832,7 +1832,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "delete transfer task error",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTransfer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 2},
+				TaskKey:      persistence.NewImmediateTaskKey(2),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().DeleteTransferTask(ctx, shardID, int64(2)).Return(errors.New("db error"))
@@ -1844,7 +1844,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "delete replication task error",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryReplication,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 3},
+				TaskKey:      persistence.NewImmediateTaskKey(3),
 			},
 			setupMock: func(mockDB *nosqlplugin.MockDB) {
 				mockDB.EXPECT().DeleteReplicationTask(ctx, shardID, int64(3)).Return(errors.New("db error"))

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1443,15 +1443,11 @@ func (s *TestBase) GetTransferTasks(ctx context.Context, batchSize int, getAll b
 Loop:
 	for {
 		response, err := s.ExecutionManager.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
-			TaskCategory: persistence.HistoryTaskCategoryTransfer,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				TaskID: 0,
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				TaskID: math.MaxInt64,
-			},
-			PageSize:      batchSize,
-			NextPageToken: token,
+			TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+			InclusiveMinTaskKey: persistence.NewImmediateTaskKey(0),
+			ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(math.MaxInt64),
+			PageSize:            batchSize,
+			NextPageToken:       token,
 		})
 		if err != nil {
 			return nil, err
@@ -1480,15 +1476,11 @@ func (s *TestBase) GetReplicationTasks(ctx context.Context, batchSize int, getAl
 Loop:
 	for {
 		response, err := s.ExecutionManager.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
-			TaskCategory: persistence.HistoryTaskCategoryReplication,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				TaskID: 0,
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				TaskID: math.MaxInt64,
-			},
-			PageSize:      batchSize,
-			NextPageToken: token,
+			TaskCategory:        persistence.HistoryTaskCategoryReplication,
+			InclusiveMinTaskKey: persistence.NewImmediateTaskKey(0),
+			ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(math.MaxInt64),
+			PageSize:            batchSize,
+			NextPageToken:       token,
 		})
 		if err != nil {
 			return nil, err
@@ -1508,11 +1500,9 @@ Loop:
 func (s *TestBase) RangeCompleteReplicationTask(ctx context.Context, exclusiveEndTaskID int64) error {
 	for {
 		resp, err := s.ExecutionManager.RangeCompleteHistoryTask(ctx, &persistence.RangeCompleteHistoryTaskRequest{
-			TaskCategory: persistence.HistoryTaskCategoryReplication,
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				TaskID: exclusiveEndTaskID,
-			},
-			PageSize: 1,
+			TaskCategory:        persistence.HistoryTaskCategoryReplication,
+			ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(exclusiveEndTaskID),
+			PageSize:            1,
 		})
 		if err != nil {
 			return err
@@ -1613,9 +1603,7 @@ func (s *TestBase) CompleteTransferTask(ctx context.Context, taskID int64) error
 
 	return s.ExecutionManager.CompleteHistoryTask(ctx, &persistence.CompleteHistoryTaskRequest{
 		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-		TaskKey: persistence.HistoryTaskKey{
-			TaskID: taskID,
-		},
+		TaskKey:      persistence.NewImmediateTaskKey(taskID),
 	})
 }
 
@@ -1623,14 +1611,10 @@ func (s *TestBase) CompleteTransferTask(ctx context.Context, taskID int64) error
 func (s *TestBase) RangeCompleteTransferTask(ctx context.Context, inclusiveBeginTaskID int64, exclusiveEndTaskID int64) error {
 	for {
 		resp, err := s.ExecutionManager.RangeCompleteHistoryTask(ctx, &persistence.RangeCompleteHistoryTaskRequest{
-			TaskCategory: persistence.HistoryTaskCategoryTransfer,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				TaskID: inclusiveBeginTaskID,
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				TaskID: exclusiveEndTaskID,
-			},
-			PageSize: 1,
+			TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+			InclusiveMinTaskKey: persistence.NewImmediateTaskKey(inclusiveBeginTaskID),
+			ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(exclusiveEndTaskID),
+			PageSize:            1,
 		})
 		if err != nil {
 			return err
@@ -1657,9 +1641,7 @@ func (s *TestBase) CompleteReplicationTask(ctx context.Context, taskID int64) er
 
 	return s.ExecutionManager.CompleteHistoryTask(ctx, &persistence.CompleteHistoryTaskRequest{
 		TaskCategory: persistence.HistoryTaskCategoryReplication,
-		TaskKey: persistence.HistoryTaskKey{
-			TaskID: taskID,
-		},
+		TaskKey:      persistence.NewImmediateTaskKey(taskID),
 	})
 }
 
@@ -1671,15 +1653,11 @@ func (s *TestBase) GetTimerIndexTasks(ctx context.Context, batchSize int, getAll
 Loop:
 	for {
 		response, err := s.ExecutionManager.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
-			TaskCategory: persistence.HistoryTaskCategoryTimer,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: time.Time{},
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: time.Unix(0, math.MaxInt64),
-			},
-			PageSize:      batchSize,
-			NextPageToken: token,
+			TaskCategory:        persistence.HistoryTaskCategoryTimer,
+			InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+			ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, math.MaxInt64), 0),
+			PageSize:            batchSize,
+			NextPageToken:       token,
 		})
 		if err != nil {
 			return nil, err
@@ -1699,10 +1677,7 @@ Loop:
 func (s *TestBase) CompleteTimerTask(ctx context.Context, ts time.Time, taskID int64) error {
 	return s.ExecutionManager.CompleteHistoryTask(ctx, &persistence.CompleteHistoryTaskRequest{
 		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		TaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: ts,
-			TaskID:        taskID,
-		},
+		TaskKey:      persistence.NewHistoryTaskKey(ts, taskID),
 	})
 }
 
@@ -1710,14 +1685,10 @@ func (s *TestBase) CompleteTimerTask(ctx context.Context, ts time.Time, taskID i
 func (s *TestBase) RangeCompleteTimerTask(ctx context.Context, inclusiveBeginTimestamp time.Time, exclusiveEndTimestamp time.Time) error {
 	for {
 		resp, err := s.ExecutionManager.RangeCompleteHistoryTask(ctx, &persistence.RangeCompleteHistoryTaskRequest{
-			TaskCategory: persistence.HistoryTaskCategoryTimer,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: inclusiveBeginTimestamp,
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: exclusiveEndTimestamp,
-			},
-			PageSize: 1,
+			TaskCategory:        persistence.HistoryTaskCategoryTimer,
+			InclusiveMinTaskKey: persistence.NewHistoryTaskKey(inclusiveBeginTimestamp, 0),
+			ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(exclusiveEndTimestamp, 0),
+			PageSize:            1,
 		})
 
 		if err != nil {

--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -2614,8 +2614,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "success - scheduled timer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0)},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute)},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute), 0),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2632,8 +2632,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "success - immediate transfer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2650,8 +2650,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "success - immediate replication task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100}, // this is ignored by replication task
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100), // this is ignored by replication task
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2675,8 +2675,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "database error on timer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0)},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute)},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute), 0),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2694,8 +2694,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "database error on transfer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2713,8 +2713,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "database error on replication task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2731,8 +2731,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "sql result error on timer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0)},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute)},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute), 0),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2750,8 +2750,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "sql result error on transfer task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2769,8 +2769,8 @@ func TestRangeCompleteHistoryTask(t *testing.T) {
 			name: "sql result error on replication task",
 			request: &persistence.RangeCompleteHistoryTaskRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            1000,
 			},
 			setupMock: func(mockDB *sqlplugin.MockDB) {
@@ -2822,8 +2822,8 @@ func TestGetHistoryTasks_SQL(t *testing.T) {
 			name: "success - get immediate transfer tasks",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTransfer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            10,
 				NextPageToken:       serializePageToken(101),
 			},
@@ -2860,8 +2860,8 @@ func TestGetHistoryTasks_SQL(t *testing.T) {
 			name: "success - get scheduled timer tasks",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryTimer,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).UTC()},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{ScheduledTime: time.Unix(0, 0).Add(time.Minute).UTC()},
+				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).UTC(), 0),
+				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 0).Add(time.Minute).UTC(), 0),
 				PageSize:            1,
 				NextPageToken: func() []byte {
 					ti := &timerTaskPageToken{TaskID: 10, Timestamp: time.Unix(0, 1).UTC()}
@@ -2921,8 +2921,8 @@ func TestGetHistoryTasks_SQL(t *testing.T) {
 			name: "success - get immediate replication tasks",
 			request: &persistence.GetHistoryTasksRequest{
 				TaskCategory:        persistence.HistoryTaskCategoryReplication,
-				InclusiveMinTaskKey: persistence.HistoryTaskKey{TaskID: 100},
-				ExclusiveMaxTaskKey: persistence.HistoryTaskKey{TaskID: 200},
+				InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+				ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
 				PageSize:            10,
 				NextPageToken:       serializePageToken(101),
 			},
@@ -3040,7 +3040,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "success - complete scheduled timer task",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTimer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 1, ScheduledTime: time.Unix(10, 10)},
+				TaskKey:      persistence.NewHistoryTaskKey(time.Unix(10, 10), 1),
 			},
 			setupMock: func(mockDB any) {
 				mock := mockDB.(*sqlplugin.MockDB)
@@ -3056,7 +3056,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "success - complete immediate transfer task",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTransfer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 2},
+				TaskKey:      persistence.NewImmediateTaskKey(2),
 			},
 			setupMock: func(mockDB any) {
 				mock := mockDB.(*sqlplugin.MockDB)
@@ -3071,7 +3071,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "success - complete immediate replication task",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryReplication,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 3},
+				TaskKey:      persistence.NewImmediateTaskKey(3),
 			},
 			setupMock: func(mockDB any) {
 				mock := mockDB.(*sqlplugin.MockDB)
@@ -3094,7 +3094,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "delete timer task error",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTimer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 1, ScheduledTime: time.Unix(10, 10)},
+				TaskKey:      persistence.NewHistoryTaskKey(time.Unix(10, 10), 1),
 			},
 			setupMock: func(mockDB any) {
 				mock := mockDB.(*sqlplugin.MockDB)
@@ -3111,7 +3111,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "delete transfer task error",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryTransfer,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 2},
+				TaskKey:      persistence.NewImmediateTaskKey(2),
 			},
 			setupMock: func(mockDB any) {
 				mock := mockDB.(*sqlplugin.MockDB)
@@ -3127,7 +3127,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			name: "delete replication task error",
 			request: &persistence.CompleteHistoryTaskRequest{
 				TaskCategory: persistence.HistoryTaskCategoryReplication,
-				TaskKey:      persistence.HistoryTaskKey{TaskID: 3},
+				TaskKey:      persistence.NewImmediateTaskKey(3),
 			},
 			setupMock: func(mockDB any) {
 				mock := mockDB.(*sqlplugin.MockDB)

--- a/common/persistence/tasks.go
+++ b/common/persistence/tasks.go
@@ -51,8 +51,8 @@ type Task interface {
 
 type (
 	HistoryTaskKey struct {
-		ScheduledTime time.Time
-		TaskID        int64
+		scheduledTime time.Time
+		taskID        int64
 	}
 
 	WorkflowIdentifier struct {
@@ -254,7 +254,31 @@ var (
 	_ Task = (*HistoryReplicationTask)(nil)
 	_ Task = (*SyncActivityTask)(nil)
 	_ Task = (*FailoverMarkerTask)(nil)
+
+	immediateTaskKeyScheduleTime = time.Unix(0, 0).UTC()
 )
+
+func NewImmediateTaskKey(taskID int64) HistoryTaskKey {
+	return HistoryTaskKey{
+		scheduledTime: immediateTaskKeyScheduleTime,
+		taskID:        taskID,
+	}
+}
+
+func NewHistoryTaskKey(scheduledTime time.Time, taskID int64) HistoryTaskKey {
+	return HistoryTaskKey{
+		scheduledTime: scheduledTime,
+		taskID:        taskID,
+	}
+}
+
+func (a HistoryTaskKey) GetTaskID() int64 {
+	return a.taskID
+}
+
+func (a HistoryTaskKey) GetScheduledTime() time.Time {
+	return a.scheduledTime
+}
 
 func (a *WorkflowIdentifier) GetDomainID() string {
 	return a.DomainID

--- a/common/reconciliation/fetcher/timer.go
+++ b/common/reconciliation/fetcher/timer.go
@@ -50,14 +50,10 @@ func getUserTimers(
 ) pagination.FetchFn {
 	return func(ctx context.Context, token pagination.PageToken) (pagination.Page, error) {
 		req := &persistence.GetHistoryTasksRequest{
-			TaskCategory: persistence.HistoryTaskCategoryTimer,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: minTimestamp,
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: maxTimestamp,
-			},
-			PageSize: pageSize,
+			TaskCategory:        persistence.HistoryTaskCategoryTimer,
+			InclusiveMinTaskKey: persistence.NewHistoryTaskKey(minTimestamp, 0),
+			ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxTimestamp, 0),
+			PageSize:            pageSize,
 		}
 		if token != nil {
 			req.NextPageToken = token.([]byte)

--- a/common/reconciliation/fetcher/timer_test.go
+++ b/common/reconciliation/fetcher/timer_test.go
@@ -90,15 +90,11 @@ func TestGetUserTimers(t *testing.T) {
 
 				mockRetryer.EXPECT().
 					GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
-						TaskCategory: persistence.HistoryTaskCategoryTimer,
-						InclusiveMinTaskKey: persistence.HistoryTaskKey{
-							ScheduledTime: minTimestamp,
-						},
-						ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-							ScheduledTime: maxTimestamp,
-						},
-						PageSize:      pageSize,
-						NextPageToken: nil,
+						TaskCategory:        persistence.HistoryTaskCategoryTimer,
+						InclusiveMinTaskKey: persistence.NewHistoryTaskKey(minTimestamp, 0),
+						ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxTimestamp, 0),
+						PageSize:            pageSize,
+						NextPageToken:       nil,
 					}).
 					Return(&persistence.GetHistoryTasksResponse{
 						Tasks:         timerTasks,
@@ -131,15 +127,11 @@ func TestGetUserTimers(t *testing.T) {
 
 				mockRetryer.EXPECT().
 					GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
-						TaskCategory: persistence.HistoryTaskCategoryTimer,
-						InclusiveMinTaskKey: persistence.HistoryTaskKey{
-							ScheduledTime: minTimestamp,
-						},
-						ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-							ScheduledTime: maxTimestamp,
-						},
-						PageSize:      pageSize,
-						NextPageToken: nonNilToken,
+						TaskCategory:        persistence.HistoryTaskCategoryTimer,
+						InclusiveMinTaskKey: persistence.NewHistoryTaskKey(minTimestamp, 0),
+						ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxTimestamp, 0),
+						PageSize:            pageSize,
+						NextPageToken:       nonNilToken,
 					}).
 					Return(&persistence.GetHistoryTasksResponse{
 						Tasks:         nil,
@@ -174,15 +166,11 @@ func TestGetUserTimers(t *testing.T) {
 
 				mockRetryer.EXPECT().
 					GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
-						TaskCategory: persistence.HistoryTaskCategoryTimer,
-						InclusiveMinTaskKey: persistence.HistoryTaskKey{
-							ScheduledTime: minTimestamp,
-						},
-						ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-							ScheduledTime: maxTimestamp,
-						},
-						PageSize:      pageSize,
-						NextPageToken: nil,
+						TaskCategory:        persistence.HistoryTaskCategoryTimer,
+						InclusiveMinTaskKey: persistence.NewHistoryTaskKey(minTimestamp, 0),
+						ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxTimestamp, 0),
+						PageSize:            pageSize,
+						NextPageToken:       nil,
 					}).
 					Return(&persistence.GetHistoryTasksResponse{
 						Tasks:         []persistence.Task{invalidTimer},

--- a/common/reconciliation/invariant/timer_invalid.go
+++ b/common/reconciliation/invariant/timer_invalid.go
@@ -144,10 +144,10 @@ func (h *TimerInvalid) Fix(
 
 	req := persistence.CompleteHistoryTaskRequest{
 		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		TaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: timer.VisibilityTimestamp,
-			TaskID:        timer.TaskID,
-		},
+		TaskKey: persistence.NewHistoryTaskKey(
+			timer.VisibilityTimestamp,
+			timer.TaskID,
+		),
 	}
 
 	if err := h.pr.CompleteHistoryTask(ctx, &req); err != nil {

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -753,24 +753,17 @@ func (h *handlerImpl) RemoveTask(
 	case commonconstants.TaskTypeTransfer:
 		return executionMgr.CompleteHistoryTask(ctx, &persistence.CompleteHistoryTaskRequest{
 			TaskCategory: persistence.HistoryTaskCategoryTransfer,
-			TaskKey: persistence.HistoryTaskKey{
-				TaskID: request.GetTaskID(),
-			},
+			TaskKey:      persistence.NewImmediateTaskKey(request.GetTaskID()),
 		})
 	case commonconstants.TaskTypeTimer:
 		return executionMgr.CompleteHistoryTask(ctx, &persistence.CompleteHistoryTaskRequest{
 			TaskCategory: persistence.HistoryTaskCategoryTimer,
-			TaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: time.Unix(0, request.GetVisibilityTimestamp()),
-				TaskID:        request.GetTaskID(),
-			},
+			TaskKey:      persistence.NewHistoryTaskKey(time.Unix(0, request.GetVisibilityTimestamp()), request.GetTaskID()),
 		})
 	case commonconstants.TaskTypeReplication:
 		return executionMgr.CompleteHistoryTask(ctx, &persistence.CompleteHistoryTaskRequest{
 			TaskCategory: persistence.HistoryTaskCategoryReplication,
-			TaskKey: persistence.HistoryTaskKey{
-				TaskID: request.GetTaskID(),
-			},
+			TaskKey:      persistence.NewImmediateTaskKey(request.GetTaskID()),
 		})
 	default:
 		return constants.ErrInvalidTaskType

--- a/service/history/handler/handler_test.go
+++ b/service/history/handler/handler_test.go
@@ -1218,9 +1218,7 @@ func (s *handlerSuite) TestRemoveTask() {
 			mockFn: func() {
 				s.mockResource.ExecutionMgr.On("CompleteHistoryTask", mock.Anything, &persistence.CompleteHistoryTaskRequest{
 					TaskCategory: persistence.HistoryTaskCategoryTransfer,
-					TaskKey: persistence.HistoryTaskKey{
-						TaskID: int64(1),
-					},
+					TaskKey:      persistence.NewImmediateTaskKey(1),
 				}).Return(nil).Once()
 			},
 		},
@@ -1235,10 +1233,7 @@ func (s *handlerSuite) TestRemoveTask() {
 			mockFn: func() {
 				s.mockResource.ExecutionMgr.On("CompleteHistoryTask", mock.Anything, &persistence.CompleteHistoryTaskRequest{
 					TaskCategory: persistence.HistoryTaskCategoryTimer,
-					TaskKey: persistence.HistoryTaskKey{
-						ScheduledTime: time.Unix(0, int64(now.UnixNano())),
-						TaskID:        int64(1),
-					},
+					TaskKey:      persistence.NewHistoryTaskKey(time.Unix(0, int64(now.UnixNano())), 1),
 				}).Return(nil).Once()
 			},
 		},
@@ -1252,9 +1247,7 @@ func (s *handlerSuite) TestRemoveTask() {
 			mockFn: func() {
 				s.mockResource.ExecutionMgr.On("CompleteHistoryTask", mock.Anything, &persistence.CompleteHistoryTaskRequest{
 					TaskCategory: persistence.HistoryTaskCategoryReplication,
-					TaskKey: persistence.HistoryTaskKey{
-						TaskID: int64(1),
-					},
+					TaskKey:      persistence.NewImmediateTaskKey(1),
 				}).Return(nil).Once()
 			},
 		},

--- a/service/history/queue/timer_queue_active_processor.go
+++ b/service/history/queue/timer_queue_active_processor.go
@@ -60,13 +60,11 @@ func newTimerQueueActiveProcessor(
 	}
 
 	updateMaxReadLevel := func() task.Key {
-		return newTimerTaskKey(shard.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, clusterName).ScheduledTime, 0)
+		return newTimerTaskKey(shard.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, clusterName).GetScheduledTime(), 0)
 	}
 
 	updateClusterAckLevel := func(ackLevel task.Key) error {
-		return shard.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryTimer, clusterName, persistence.HistoryTaskKey{
-			ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
-		})
+		return shard.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryTimer, clusterName, persistence.NewHistoryTaskKey(ackLevel.(timerTaskKey).visibilityTimestamp, 0))
 	}
 
 	updateProcessingQueueStates := func(states []ProcessingQueueState) error {

--- a/service/history/queue/timer_queue_failover_processor.go
+++ b/service/history/queue/timer_queue_failover_processor.go
@@ -81,17 +81,11 @@ func newTimerQueueFailoverProcessor(
 			persistence.HistoryTaskCategoryTimer,
 			failoverUUID,
 			persistence.FailoverLevel{
-				StartTime: failoverStartTime,
-				MinLevel: persistence.HistoryTaskKey{
-					ScheduledTime: minLevel,
-				},
-				CurrentLevel: persistence.HistoryTaskKey{
-					ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
-				},
-				MaxLevel: persistence.HistoryTaskKey{
-					ScheduledTime: maxLevel,
-				},
-				DomainIDs: domainIDs,
+				StartTime:    failoverStartTime,
+				MinLevel:     persistence.NewHistoryTaskKey(minLevel, 0),
+				CurrentLevel: persistence.NewHistoryTaskKey(ackLevel.(timerTaskKey).visibilityTimestamp, 0),
+				MaxLevel:     persistence.NewHistoryTaskKey(maxLevel, 0),
+				DomainIDs:    domainIDs,
 			},
 		)
 	}

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -512,15 +512,11 @@ func (t *timerQueueProcessorBase) readLookAheadTask(lookAheadStartLevel task.Key
 
 func (t *timerQueueProcessorBase) getTimerTasks(readLevel, maxReadLevel task.Key, nextPageToken []byte, batchSize int) (*persistence.GetHistoryTasksResponse, error) {
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      batchSize,
-		NextPageToken: nextPageToken,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            batchSize,
+		NextPageToken:       nextPageToken,
 	}
 	var err error
 	var response *persistence.GetHistoryTasksResponse

--- a/service/history/queue/timer_queue_processor_base_test.go
+++ b/service/history/queue/timer_queue_processor_base_test.go
@@ -120,15 +120,11 @@ func (s *timerQueueProcessorBaseSuite) TestGetTimerTasks_More() {
 	batchSize := 10
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      batchSize,
-		NextPageToken: []byte("some random input next page token"),
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            batchSize,
+		NextPageToken:       []byte("some random input next page token"),
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -167,15 +163,11 @@ func (s *timerQueueProcessorBaseSuite) TestGetTimerTasks_NoMore() {
 	batchSize := 10
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      batchSize,
-		NextPageToken: nil,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            batchSize,
+		NextPageToken:       nil,
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -214,15 +206,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadLookAheadTask() {
 	maxReadLevel := newTimerTaskKey(shardMaxReadLevel.Add(10*time.Second), 0)
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      1,
-		NextPageToken: nil,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            1,
+		NextPageToken:       nil,
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -259,27 +247,19 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_NoNext
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: []byte("some random input next page token"),
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       []byte("some random input next page token"),
 	}
 
 	lookAheadRequest := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      1,
-		NextPageToken: nil,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            1,
+		NextPageToken:       nil,
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -319,15 +299,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_HasNex
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: []byte("some random input next page token"),
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       []byte("some random input next page token"),
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -366,15 +342,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_NoNex
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: []byte("some random input next page token"),
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       []byte("some random input next page token"),
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -422,15 +394,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_HasNe
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: []byte("some random input next page token"),
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       []byte("some random input next page token"),
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -478,27 +446,19 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_LookAheadFailed_No
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: readLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: []byte("some random input next page token"),
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(readLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       []byte("some random input next page token"),
 	}
 
 	lookAheadRequest := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      1,
-		NextPageToken: nil,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(maxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            1,
+		NextPageToken:       nil,
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -659,15 +619,11 @@ func (s *timerQueueProcessorBaseSuite) TestProcessBatch_HasNextPage() {
 	}
 
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: shardMaxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: nil,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(ackLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(shardMaxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       nil,
 	}
 
 	response := &persistence.GetHistoryTasksResponse{
@@ -758,15 +714,11 @@ func (s *timerQueueProcessorBaseSuite) TestProcessBatch_NoNextPage_HasLookAhead(
 
 	requestNextPageToken := []byte("some random input next page token")
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: shardMaxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: requestNextPageToken,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(ackLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(shardMaxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       requestNextPageToken,
 	}
 
 	lookAheadTaskTimestamp := now.Add(50 * time.Millisecond)
@@ -858,27 +810,19 @@ func (s *timerQueueProcessorBaseSuite) TestProcessBatch_NoNextPage_NoLookAhead()
 
 	requestNextPageToken := []byte("some random input next page token")
 	request := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: shardMaxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      s.mockShard.GetConfig().TimerTaskBatchSize(),
-		NextPageToken: requestNextPageToken,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(ackLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(shardMaxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            s.mockShard.GetConfig().TimerTaskBatchSize(),
+		NextPageToken:       requestNextPageToken,
 	}
 
 	lookAheadRequest := &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTimer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: shardMaxReadLevel.(timerTaskKey).visibilityTimestamp,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			ScheduledTime: maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp,
-		},
-		PageSize:      1,
-		NextPageToken: nil,
+		TaskCategory:        persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(shardMaxReadLevel.(timerTaskKey).visibilityTimestamp, 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp, 0),
+		PageSize:            1,
+		NextPageToken:       nil,
 	}
 
 	response := &persistence.GetHistoryTasksResponse{

--- a/service/history/queue/timer_queue_standby_processor.go
+++ b/service/history/queue/timer_queue_standby_processor.go
@@ -78,13 +78,11 @@ func newTimerQueueStandbyProcessor(
 	}
 
 	updateMaxReadLevel := func() task.Key {
-		return newTimerTaskKey(shard.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, clusterName).ScheduledTime, 0)
+		return newTimerTaskKey(shard.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, clusterName).GetScheduledTime(), 0)
 	}
 
 	updateClusterAckLevel := func(ackLevel task.Key) error {
-		return shard.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryTimer, clusterName, persistence.HistoryTaskKey{
-			ScheduledTime: ackLevel.(timerTaskKey).visibilityTimestamp,
-		})
+		return shard.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryTimer, clusterName, persistence.NewHistoryTaskKey(ackLevel.(timerTaskKey).visibilityTimestamp, 0))
 	}
 
 	updateProcessingQueueStates := func(states []ProcessingQueueState) error {

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -529,14 +529,10 @@ func (t *transferQueueProcessorBase) readTasks(
 	op := func() error {
 		var err error
 		response, err = t.shard.GetExecutionManager().GetHistoryTasks(context.Background(), &persistence.GetHistoryTasksRequest{
-			TaskCategory: persistence.HistoryTaskCategoryTransfer,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				TaskID: readLevel.(transferTaskKey).taskID + 1,
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				TaskID: maxReadLevel.(transferTaskKey).taskID + 1,
-			},
-			PageSize: t.options.BatchSize(),
+			TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+			InclusiveMinTaskKey: persistence.NewImmediateTaskKey(readLevel.(transferTaskKey).taskID + 1),
+			ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxReadLevel.(transferTaskKey).taskID + 1),
+			PageSize:            t.options.BatchSize(),
 		})
 		return err
 	}

--- a/service/history/queue/transfer_queue_processor_base_test.go
+++ b/service/history/queue/transfer_queue_processor_base_test.go
@@ -139,14 +139,10 @@ func (s *transferQueueProcessorBaseSuite) TestProcessQueueCollections_NoNextPage
 	}
 	mockExecutionManager := s.mockShard.Resource.ExecutionMgr
 	mockExecutionManager.On("GetHistoryTasks", mock.Anything, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			TaskID: ackLevel.(transferTaskKey).taskID + 1,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: maxLevel.(transferTaskKey).taskID + 1,
-		},
-		PageSize: s.mockShard.GetConfig().TransferTaskBatchSize(),
+		TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+		InclusiveMinTaskKey: persistence.NewImmediateTaskKey(ackLevel.(transferTaskKey).taskID + 1),
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxLevel.(transferTaskKey).taskID + 1),
+		PageSize:            s.mockShard.GetConfig().TransferTaskBatchSize(),
 	}).Return(&persistence.GetHistoryTasksResponse{
 		Tasks:         taskInfos,
 		NextPageToken: nil,
@@ -220,14 +216,10 @@ func (s *transferQueueProcessorBaseSuite) TestProcessQueueCollections_NoNextPage
 	}
 	mockExecutionManager := s.mockShard.Resource.ExecutionMgr
 	mockExecutionManager.On("GetHistoryTasks", mock.Anything, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			TaskID: ackLevel.(transferTaskKey).taskID + 1,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: shardMaxLevel.(transferTaskKey).taskID + 1,
-		},
-		PageSize: s.mockShard.GetConfig().TransferTaskBatchSize(),
+		TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+		InclusiveMinTaskKey: persistence.NewImmediateTaskKey(ackLevel.(transferTaskKey).taskID + 1),
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(shardMaxLevel.(transferTaskKey).taskID + 1),
+		PageSize:            s.mockShard.GetConfig().TransferTaskBatchSize(),
 	}).Return(&persistence.GetHistoryTasksResponse{
 		Tasks:         taskInfos,
 		NextPageToken: nil,
@@ -311,14 +303,10 @@ func (s *transferQueueProcessorBaseSuite) TestProcessQueueCollections_WithNextPa
 	}
 	mockExecutionManager := s.mockShard.Resource.ExecutionMgr
 	mockExecutionManager.On("GetHistoryTasks", mock.Anything, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			TaskID: ackLevel.(transferTaskKey).taskID + 1,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: maxLevel.(transferTaskKey).taskID + 1,
-		},
-		PageSize: s.mockShard.GetConfig().TransferTaskBatchSize(),
+		TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+		InclusiveMinTaskKey: persistence.NewImmediateTaskKey(ackLevel.(transferTaskKey).taskID + 1),
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxLevel.(transferTaskKey).taskID + 1),
+		PageSize:            s.mockShard.GetConfig().TransferTaskBatchSize(),
 	}).Return(&persistence.GetHistoryTasksResponse{
 		Tasks:         taskInfos,
 		NextPageToken: []byte{1, 2, 3},
@@ -375,14 +363,10 @@ func (s *transferQueueProcessorBaseSuite) TestProcessQueueCollections_WithNextPa
 	}
 	mockExecutionManager := s.mockShard.Resource.ExecutionMgr
 	mockExecutionManager.On("GetHistoryTasks", mock.Anything, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			TaskID: ackLevel.(transferTaskKey).taskID + 1,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: maxLevel.(transferTaskKey).taskID + 1,
-		},
-		PageSize: s.mockShard.GetConfig().TransferTaskBatchSize(),
+		TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+		InclusiveMinTaskKey: persistence.NewImmediateTaskKey(ackLevel.(transferTaskKey).taskID + 1),
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxLevel.(transferTaskKey).taskID + 1),
+		PageSize:            s.mockShard.GetConfig().TransferTaskBatchSize(),
 	}).Return(&persistence.GetHistoryTasksResponse{
 		Tasks:         taskInfos,
 		NextPageToken: []byte{1, 2, 3},
@@ -441,14 +425,10 @@ func (s *transferQueueProcessorBaseSuite) TestReadTasks_NoNextPage() {
 		NextPageToken: nil,
 	}
 	mockExecutionManager.On("GetHistoryTasks", mock.Anything, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			TaskID: readLevel.(transferTaskKey).taskID + 1,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: maxReadLevel.(transferTaskKey).taskID + 1,
-		},
-		PageSize: s.mockShard.GetConfig().TransferTaskBatchSize(),
+		TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+		InclusiveMinTaskKey: persistence.NewImmediateTaskKey(readLevel.(transferTaskKey).taskID + 1),
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxReadLevel.(transferTaskKey).taskID + 1),
+		PageSize:            s.mockShard.GetConfig().TransferTaskBatchSize(),
 	}).Return(getTransferTaskResponse, nil).Once()
 
 	processorBase := s.newTestTransferQueueProcessorBase(
@@ -475,14 +455,10 @@ func (s *transferQueueProcessorBaseSuite) TestReadTasks_WithNextPage() {
 		NextPageToken: []byte{1, 2, 3},
 	}
 	mockExecutionManager.On("GetHistoryTasks", mock.Anything, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			TaskID: readLevel.(transferTaskKey).taskID + 1,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: maxReadLevel.(transferTaskKey).taskID + 1,
-		},
-		PageSize: s.mockShard.GetConfig().TransferTaskBatchSize(),
+		TaskCategory:        persistence.HistoryTaskCategoryTransfer,
+		InclusiveMinTaskKey: persistence.NewImmediateTaskKey(readLevel.(transferTaskKey).taskID + 1),
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxReadLevel.(transferTaskKey).taskID + 1),
+		PageSize:            s.mockShard.GetConfig().TransferTaskBatchSize(),
 	}).Return(getTransferTaskResponse, nil).Once()
 
 	processorBase := s.newTestTransferQueueProcessorBase(

--- a/service/history/queue/transfer_queue_processor_test.go
+++ b/service/history/queue/transfer_queue_processor_test.go
@@ -928,14 +928,14 @@ func Test_loadTransferProcessingQueueStates(t *testing.T) {
 			enableLoadQueueStates: true,
 			clusterName:           constants.TestClusterMetadata.GetCurrentClusterName(),
 			taskID: func(testContext *shard.TestContext) int64 {
-				return testContext.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryTransfer, constants.TestClusterMetadata.GetCurrentClusterName()).TaskID
+				return testContext.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryTransfer, constants.TestClusterMetadata.GetCurrentClusterName()).GetTaskID()
 			},
 		},
 		"load queue states false": {
 			enableLoadQueueStates: false,
 			clusterName:           "standby",
 			taskID: func(testContext *shard.TestContext) int64 {
-				return testContext.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryTransfer, "standby").TaskID
+				return testContext.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryTransfer, "standby").GetTaskID()
 			},
 		},
 	}

--- a/service/history/replication/metrics_emitter.go
+++ b/service/history/replication/metrics_emitter.go
@@ -161,7 +161,7 @@ func (m *MetricsEmitterImpl) emitMetrics() {
 
 func (m *MetricsEmitterImpl) determineReplicationLatency(remoteClusterName string) (time.Duration, error) {
 	logger := m.logger.WithTags(tag.RemoteCluster(remoteClusterName))
-	lastReadTaskID := m.shardData.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, remoteClusterName).TaskID
+	lastReadTaskID := m.shardData.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, remoteClusterName).GetTaskID()
 
 	tasks, _, err := m.reader.Read(m.ctx, lastReadTaskID, lastReadTaskID+1, 1)
 	if err != nil {

--- a/service/history/replication/metrics_emitter_test.go
+++ b/service/history/replication/metrics_emitter_test.go
@@ -83,17 +83,13 @@ func TestMetricsEmitter(t *testing.T) {
 	assert.Equal(t, time.Hour, latency)
 
 	// Move replication level up for cluster2 and our latency shortens
-	testShardData.clusterReplicationLevel[cluster2] = persistence.HistoryTaskKey{
-		TaskID: 2,
-	}
+	testShardData.clusterReplicationLevel[cluster2] = persistence.NewImmediateTaskKey(2)
 	latency, err = metricsEmitter.determineReplicationLatency(cluster2)
 	assert.NoError(t, err)
 	assert.Equal(t, time.Minute, latency)
 
 	// Move replication level up for cluster2 and we no longer have latency
-	testShardData.clusterReplicationLevel[cluster2] = persistence.HistoryTaskKey{
-		TaskID: 3,
-	}
+	testShardData.clusterReplicationLevel[cluster2] = persistence.NewImmediateTaskKey(3)
 	latency, err = metricsEmitter.determineReplicationLatency(cluster2)
 	assert.NoError(t, err)
 	assert.Equal(t, time.Duration(0), latency)
@@ -115,9 +111,7 @@ func newTestShardData(timeSource clock.TimeSource, metadata cluster.Metadata) te
 	remotes := metadata.GetRemoteClusterInfo()
 	clusterReplicationLevels := make(map[string]persistence.HistoryTaskKey, len(remotes))
 	for remote := range remotes {
-		clusterReplicationLevels[remote] = persistence.HistoryTaskKey{
-			TaskID: 1,
-		}
+		clusterReplicationLevels[remote] = persistence.NewImmediateTaskKey(1)
 	}
 	return testShardData{
 		logger:                  log.NewNoop(),

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -125,8 +125,8 @@ type getTasksResult struct {
 func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, lastReadTaskID int64) (*getTasksResult, error) {
 	var (
 		oldestUnprocessedTaskTimestamp = t.timeSource.Now().UnixNano()
-		oldestUnprocessedTaskID        = t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).TaskID
-		previousReadTaskID             = t.ackLevels.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).TaskID
+		oldestUnprocessedTaskID        = t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()
+		previousReadTaskID             = t.ackLevels.GetQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()
 	)
 
 	if lastReadTaskID == constants.EmptyMessageID {
@@ -139,7 +139,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 	batchSize := t.dynamicTaskBatchSizer.value()
 	t.scope.UpdateGauge(metrics.ReplicationTasksBatchSize, float64(batchSize))
 
-	taskInfos, hasMore, err := t.reader.Read(ctx, lastReadTaskID, t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).TaskID, batchSize)
+	taskInfos, hasMore, err := t.reader.Read(ctx, lastReadTaskID, t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID(), batchSize)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 		oldestUnprocessedTaskTimestamp = taskInfos[0].GetVisibilityTimestamp().UnixNano()
 	}
 
-	t.scope.RecordTimer(metrics.ReplicationTasksLagRaw, time.Duration(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).TaskID-oldestUnprocessedTaskID))
+	t.scope.RecordTimer(metrics.ReplicationTasksLagRaw, time.Duration(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()-oldestUnprocessedTaskID))
 	t.scope.RecordHistogramDuration(metrics.ReplicationTasksDelay, time.Duration(oldestUnprocessedTaskTimestamp-t.timeSource.Now().UnixNano()))
 
 	// hydrate the tasks
@@ -191,7 +191,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 		return nil, err
 	}
 
-	t.scope.RecordTimer(metrics.ReplicationTasksLag, time.Duration(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).TaskID-msgs.LastRetrievedMessageID))
+	t.scope.RecordTimer(metrics.ReplicationTasksLag, time.Duration(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()-msgs.LastRetrievedMessageID))
 	t.scope.RecordTimer(metrics.ReplicationTasksReturned, time.Duration(len(msgs.ReplicationTasks)))
 	t.scope.RecordTimer(metrics.ReplicationTasksReturnedDiff, time.Duration(len(taskInfos)-len(msgs.ReplicationTasks)))
 
@@ -215,9 +215,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 
 // ackLevel updates the ack level for the given cluster
 func (t *TaskAckManager) ackLevel(pollingCluster string, lastReadTaskID int64) {
-	if err := t.ackLevels.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, pollingCluster, persistence.HistoryTaskKey{
-		TaskID: lastReadTaskID,
-	}); err != nil {
+	if err := t.ackLevels.UpdateQueueClusterAckLevel(persistence.HistoryTaskCategoryReplication, pollingCluster, persistence.NewImmediateTaskKey(lastReadTaskID)); err != nil {
 		t.logger.Error("error updating replication level for shard", tag.Error(err), tag.OperationFailed)
 	}
 

--- a/service/history/replication/task_ack_manager_test.go
+++ b/service/history/replication/task_ack_manager_test.go
@@ -127,7 +127,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - no replication tasks",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
 			reader:         fakeTaskReader{},
@@ -147,7 +147,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - continues on recoverable error",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -172,7 +172,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - stops at non recoverable error",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -197,7 +197,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - stops at second task, batch size is 2",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -222,7 +222,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - stops at a message exceeded max response size",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -253,7 +253,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "main flow - fail at a message exceeded max response size",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains: fakeDomainCache{testDomainID: testDomain},
 			reader:  fakeTaskReader{&testTask11, &testTask12, &testTask13, &testTask14},
@@ -277,7 +277,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "skips tasks for domains non belonging to polling cluster",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
 			reader:         fakeTaskReader{&testTask11},
@@ -297,7 +297,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "uses remote ack level for first fetch (empty task ID)",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 12}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(12)},
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
 			reader:         fakeTaskReader{&testTask11, &testTask12},
@@ -317,7 +317,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "failed to read replication tasks - return error",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			reader:         (fakeTaskReader)(nil),
 			pollingCluster: testClusterA,
@@ -330,7 +330,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "failed to get domain - stops",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 			},
 			domains:        fakeDomainCache{},
 			reader:         fakeTaskReader{&testTask11},
@@ -349,7 +349,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			name: "failed to update ack level - no error, return response anyway",
 			ackLevels: &fakeAckLevelStore{
 				readLevel: 200,
-				remote:    map[string]persistence.HistoryTaskKey{testClusterA: {TaskID: 2}},
+				remote:    map[string]persistence.HistoryTaskKey{testClusterA: persistence.NewImmediateTaskKey(2)},
 				updateErr: errors.New("error update ack level"),
 			},
 			domains:        fakeDomainCache{testDomainID: testDomain},
@@ -392,7 +392,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			}
 
 			if tt.expectAckLevel != 0 {
-				assert.Equal(t, tt.expectAckLevel, tt.ackLevels.remote[tt.pollingCluster].TaskID)
+				assert.Equal(t, tt.expectAckLevel, tt.ackLevels.remote[tt.pollingCluster].GetTaskID())
 			}
 		})
 	}
@@ -405,9 +405,7 @@ type fakeAckLevelStore struct {
 }
 
 func (s *fakeAckLevelStore) UpdateIfNeededAndGetQueueMaxReadLevel(category persistence.HistoryTaskCategory, cluster string) persistence.HistoryTaskKey {
-	return persistence.HistoryTaskKey{
-		TaskID: s.readLevel,
-	}
+	return persistence.NewImmediateTaskKey(s.readLevel)
 }
 func (s *fakeAckLevelStore) GetQueueClusterAckLevel(category persistence.HistoryTaskCategory, cluster string) persistence.HistoryTaskKey {
 	return s.remote[cluster]

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -542,11 +542,9 @@ func (s *taskProcessorSuite) TestCleanupReplicationTaskLoop() {
 	req := &persistence.RangeCompleteHistoryTaskRequest{
 		// this is min ack level of remote clusters. there's only one remote cluster in this test "standby".
 		// its replication ack level is set to 350 in SetupTest(), and since the max key is exclusive, set the task id to 351
-		TaskCategory: persistence.HistoryTaskCategoryReplication,
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: 351,
-		},
-		PageSize: 50, // this comes from test config
+		TaskCategory:        persistence.HistoryTaskCategoryReplication,
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(351),
+		PageSize:            50, // this comes from test config
 	}
 	s.executionManager.On("RangeCompleteHistoryTask", mock.Anything, req).Return(&persistence.RangeCompleteHistoryTaskResponse{
 		TasksCompleted: 50, // if this number equals to page size the loop continues

--- a/service/history/replication/task_reader.go
+++ b/service/history/replication/task_reader.go
@@ -51,14 +51,10 @@ func (r *TaskReader) Read(ctx context.Context, readLevel int64, maxReadLevel int
 	}
 
 	response, err := r.executionManager.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryReplication,
-		InclusiveMinTaskKey: persistence.HistoryTaskKey{
-			TaskID: readLevel + 1,
-		},
-		ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-			TaskID: maxReadLevel + 1,
-		},
-		PageSize: batchSize,
+		TaskCategory:        persistence.HistoryTaskCategoryReplication,
+		InclusiveMinTaskKey: persistence.NewImmediateTaskKey(readLevel + 1),
+		ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxReadLevel + 1),
+		PageSize:            batchSize,
 	})
 	if err != nil {
 		return nil, false, err

--- a/service/history/replication/task_reader_test.go
+++ b/service/history/replication/task_reader_test.go
@@ -62,14 +62,10 @@ func TestTaskReader(t *testing.T) {
 			maxReadLevel: 100,
 			prepareExecutions: func(m *persistence.MockExecutionManager) {
 				m.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
-					TaskCategory: persistence.HistoryTaskCategoryReplication,
-					InclusiveMinTaskKey: persistence.HistoryTaskKey{
-						TaskID: 51,
-					},
-					ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-						TaskID: 101,
-					},
-					PageSize: testBatchSize,
+					TaskCategory:        persistence.HistoryTaskCategoryReplication,
+					InclusiveMinTaskKey: persistence.NewImmediateTaskKey(51),
+					ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(101),
+					PageSize:            testBatchSize,
 				}).Return(&persistence.GetHistoryTasksResponse{Tasks: testReplicationTasks}, nil)
 			},
 			expectResponse: testReplicationTasks,

--- a/tools/cli/admin_timers.go
+++ b/tools/cli/admin_timers.go
@@ -265,15 +265,11 @@ func (cl *dbLoadCloser) Load() ([]*persistence.TimerTaskInfo, error) {
 	for isFirstIteration || len(token) != 0 {
 		isFirstIteration = false
 		req := persistence.GetHistoryTasksRequest{
-			TaskCategory: persistence.HistoryTaskCategoryTimer,
-			InclusiveMinTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: st,
-			},
-			ExclusiveMaxTaskKey: persistence.HistoryTaskKey{
-				ScheduledTime: et,
-			},
-			PageSize:      batchSize,
-			NextPageToken: token,
+			TaskCategory:        persistence.HistoryTaskCategoryTimer,
+			InclusiveMinTaskKey: persistence.NewHistoryTaskKey(st, 0),
+			ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(et, 0),
+			PageSize:            batchSize,
+			NextPageToken:       token,
 		}
 
 		resp := &persistence.GetHistoryTasksResponse{}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
A large but simple refactoring for history task key type:
- We must use provided methods to create new history task key
- History task key is now immutable
- Set scheduled time to unix 0 timestamp for immediate task key

<!-- Tell your future self why have you made these changes -->
**Why?**
This is to prevent misuse of history task key. Especially for immediate task key, when we store the key into database, we convert the timestamp to unix nanoseconds. To unify the logic of type conversion for immediate task key and scheduled task key, we set the scheduled time of immediate keys to unix 0 timestamp to avoid handling zero timestamp in golang.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
