### PR TITLE
Add a new parameter of context.Context to the Operation in retryer & inject retryCount to retryable operations

### DIFF
--- a/client/templates/retry.tmpl
+++ b/client/templates/retry.tmpl
@@ -32,7 +32,7 @@ func New{{$Decorator}}(client {{.Interface.Type}}, policy backoff.RetryPolicy, i
     {{$resultsLength := len ($method.Results)}}
     {{if eq $resultsLength 1}}
         func (c *{{$decorator}}) {{$method.Declaration}} {
-            op := func() error {
+            op := func(ctx context.Context) error {
                 return c.client.{{$method.Call}}
             }
             return c.throttleRetry.Do(ctx, op)
@@ -40,7 +40,7 @@ func New{{$Decorator}}(client {{.Interface.Type}}, policy backoff.RetryPolicy, i
     {{else}}
         func (c *{{$decorator}}) {{$method.Declaration}} {
             var resp {{ (index $method.Results 0).Type }}
-            op := func() error {
+            op := func(ctx context.Context) error {
                 var err error
                 resp, err = c.client.{{$method.Call}}
                 return err

--- a/client/wrappers/retryable/admin_generated.go
+++ b/client/wrappers/retryable/admin_generated.go
@@ -32,14 +32,14 @@ func NewAdminClient(client admin.Client, policy backoff.RetryPolicy, isRetryable
 }
 
 func (c *adminClient) AddSearchAttribute(ctx context.Context, ap1 *types.AddSearchAttributeRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.AddSearchAttribute(ctx, ap1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *adminClient) CloseShard(ctx context.Context, cp1 *types.CloseShardRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.CloseShard(ctx, cp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -47,7 +47,7 @@ func (c *adminClient) CloseShard(ctx context.Context, cp1 *types.CloseShardReque
 
 func (c *adminClient) CountDLQMessages(ctx context.Context, cp1 *types.CountDLQMessagesRequest, p1 ...yarpc.CallOption) (cp2 *types.CountDLQMessagesResponse, err error) {
 	var resp *types.CountDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CountDLQMessages(ctx, cp1, p1...)
 		return err
@@ -58,7 +58,7 @@ func (c *adminClient) CountDLQMessages(ctx context.Context, cp1 *types.CountDLQM
 
 func (c *adminClient) DeleteWorkflow(ctx context.Context, ap1 *types.AdminDeleteWorkflowRequest, p1 ...yarpc.CallOption) (ap2 *types.AdminDeleteWorkflowResponse, err error) {
 	var resp *types.AdminDeleteWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DeleteWorkflow(ctx, ap1, p1...)
 		return err
@@ -69,7 +69,7 @@ func (c *adminClient) DeleteWorkflow(ctx context.Context, ap1 *types.AdminDelete
 
 func (c *adminClient) DescribeCluster(ctx context.Context, p1 ...yarpc.CallOption) (dp1 *types.DescribeClusterResponse, err error) {
 	var resp *types.DescribeClusterResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeCluster(ctx, p1...)
 		return err
@@ -80,7 +80,7 @@ func (c *adminClient) DescribeCluster(ctx context.Context, p1 ...yarpc.CallOptio
 
 func (c *adminClient) DescribeHistoryHost(ctx context.Context, dp1 *types.DescribeHistoryHostRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeHistoryHostResponse, err error) {
 	var resp *types.DescribeHistoryHostResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeHistoryHost(ctx, dp1, p1...)
 		return err
@@ -91,7 +91,7 @@ func (c *adminClient) DescribeHistoryHost(ctx context.Context, dp1 *types.Descri
 
 func (c *adminClient) DescribeQueue(ctx context.Context, dp1 *types.DescribeQueueRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeQueueResponse, err error) {
 	var resp *types.DescribeQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeQueue(ctx, dp1, p1...)
 		return err
@@ -102,7 +102,7 @@ func (c *adminClient) DescribeQueue(ctx context.Context, dp1 *types.DescribeQueu
 
 func (c *adminClient) DescribeShardDistribution(ctx context.Context, dp1 *types.DescribeShardDistributionRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeShardDistributionResponse, err error) {
 	var resp *types.DescribeShardDistributionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeShardDistribution(ctx, dp1, p1...)
 		return err
@@ -113,7 +113,7 @@ func (c *adminClient) DescribeShardDistribution(ctx context.Context, dp1 *types.
 
 func (c *adminClient) DescribeWorkflowExecution(ctx context.Context, ap1 *types.AdminDescribeWorkflowExecutionRequest, p1 ...yarpc.CallOption) (ap2 *types.AdminDescribeWorkflowExecutionResponse, err error) {
 	var resp *types.AdminDescribeWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeWorkflowExecution(ctx, ap1, p1...)
 		return err
@@ -124,7 +124,7 @@ func (c *adminClient) DescribeWorkflowExecution(ctx context.Context, ap1 *types.
 
 func (c *adminClient) GetDLQReplicationMessages(ctx context.Context, gp1 *types.GetDLQReplicationMessagesRequest, p1 ...yarpc.CallOption) (gp2 *types.GetDLQReplicationMessagesResponse, err error) {
 	var resp *types.GetDLQReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDLQReplicationMessages(ctx, gp1, p1...)
 		return err
@@ -135,7 +135,7 @@ func (c *adminClient) GetDLQReplicationMessages(ctx context.Context, gp1 *types.
 
 func (c *adminClient) GetDomainAsyncWorkflowConfiguraton(ctx context.Context, request *types.GetDomainAsyncWorkflowConfiguratonRequest, opts ...yarpc.CallOption) (gp1 *types.GetDomainAsyncWorkflowConfiguratonResponse, err error) {
 	var resp *types.GetDomainAsyncWorkflowConfiguratonResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDomainAsyncWorkflowConfiguraton(ctx, request, opts...)
 		return err
@@ -146,7 +146,7 @@ func (c *adminClient) GetDomainAsyncWorkflowConfiguraton(ctx context.Context, re
 
 func (c *adminClient) GetDomainIsolationGroups(ctx context.Context, request *types.GetDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (gp1 *types.GetDomainIsolationGroupsResponse, err error) {
 	var resp *types.GetDomainIsolationGroupsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDomainIsolationGroups(ctx, request, opts...)
 		return err
@@ -157,7 +157,7 @@ func (c *adminClient) GetDomainIsolationGroups(ctx context.Context, request *typ
 
 func (c *adminClient) GetDomainReplicationMessages(ctx context.Context, gp1 *types.GetDomainReplicationMessagesRequest, p1 ...yarpc.CallOption) (gp2 *types.GetDomainReplicationMessagesResponse, err error) {
 	var resp *types.GetDomainReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDomainReplicationMessages(ctx, gp1, p1...)
 		return err
@@ -168,7 +168,7 @@ func (c *adminClient) GetDomainReplicationMessages(ctx context.Context, gp1 *typ
 
 func (c *adminClient) GetDynamicConfig(ctx context.Context, gp1 *types.GetDynamicConfigRequest, p1 ...yarpc.CallOption) (gp2 *types.GetDynamicConfigResponse, err error) {
 	var resp *types.GetDynamicConfigResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDynamicConfig(ctx, gp1, p1...)
 		return err
@@ -179,7 +179,7 @@ func (c *adminClient) GetDynamicConfig(ctx context.Context, gp1 *types.GetDynami
 
 func (c *adminClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (gp1 *types.GetGlobalIsolationGroupsResponse, err error) {
 	var resp *types.GetGlobalIsolationGroupsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetGlobalIsolationGroups(ctx, request, opts...)
 		return err
@@ -190,7 +190,7 @@ func (c *adminClient) GetGlobalIsolationGroups(ctx context.Context, request *typ
 
 func (c *adminClient) GetReplicationMessages(ctx context.Context, gp1 *types.GetReplicationMessagesRequest, p1 ...yarpc.CallOption) (gp2 *types.GetReplicationMessagesResponse, err error) {
 	var resp *types.GetReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetReplicationMessages(ctx, gp1, p1...)
 		return err
@@ -201,7 +201,7 @@ func (c *adminClient) GetReplicationMessages(ctx context.Context, gp1 *types.Get
 
 func (c *adminClient) GetWorkflowExecutionRawHistoryV2(ctx context.Context, gp1 *types.GetWorkflowExecutionRawHistoryV2Request, p1 ...yarpc.CallOption) (gp2 *types.GetWorkflowExecutionRawHistoryV2Response, err error) {
 	var resp *types.GetWorkflowExecutionRawHistoryV2Response
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetWorkflowExecutionRawHistoryV2(ctx, gp1, p1...)
 		return err
@@ -212,7 +212,7 @@ func (c *adminClient) GetWorkflowExecutionRawHistoryV2(ctx context.Context, gp1 
 
 func (c *adminClient) ListDynamicConfig(ctx context.Context, lp1 *types.ListDynamicConfigRequest, p1 ...yarpc.CallOption) (lp2 *types.ListDynamicConfigResponse, err error) {
 	var resp *types.ListDynamicConfigResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListDynamicConfig(ctx, lp1, p1...)
 		return err
@@ -223,7 +223,7 @@ func (c *adminClient) ListDynamicConfig(ctx context.Context, lp1 *types.ListDyna
 
 func (c *adminClient) MaintainCorruptWorkflow(ctx context.Context, ap1 *types.AdminMaintainWorkflowRequest, p1 ...yarpc.CallOption) (ap2 *types.AdminMaintainWorkflowResponse, err error) {
 	var resp *types.AdminMaintainWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.MaintainCorruptWorkflow(ctx, ap1, p1...)
 		return err
@@ -234,7 +234,7 @@ func (c *adminClient) MaintainCorruptWorkflow(ctx context.Context, ap1 *types.Ad
 
 func (c *adminClient) MergeDLQMessages(ctx context.Context, mp1 *types.MergeDLQMessagesRequest, p1 ...yarpc.CallOption) (mp2 *types.MergeDLQMessagesResponse, err error) {
 	var resp *types.MergeDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.MergeDLQMessages(ctx, mp1, p1...)
 		return err
@@ -244,7 +244,7 @@ func (c *adminClient) MergeDLQMessages(ctx context.Context, mp1 *types.MergeDLQM
 }
 
 func (c *adminClient) PurgeDLQMessages(ctx context.Context, pp1 *types.PurgeDLQMessagesRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.PurgeDLQMessages(ctx, pp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -252,7 +252,7 @@ func (c *adminClient) PurgeDLQMessages(ctx context.Context, pp1 *types.PurgeDLQM
 
 func (c *adminClient) ReadDLQMessages(ctx context.Context, rp1 *types.ReadDLQMessagesRequest, p1 ...yarpc.CallOption) (rp2 *types.ReadDLQMessagesResponse, err error) {
 	var resp *types.ReadDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ReadDLQMessages(ctx, rp1, p1...)
 		return err
@@ -262,42 +262,42 @@ func (c *adminClient) ReadDLQMessages(ctx context.Context, rp1 *types.ReadDLQMes
 }
 
 func (c *adminClient) ReapplyEvents(ctx context.Context, rp1 *types.ReapplyEventsRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.ReapplyEvents(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *adminClient) RefreshWorkflowTasks(ctx context.Context, rp1 *types.RefreshWorkflowTasksRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RefreshWorkflowTasks(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *adminClient) RemoveTask(ctx context.Context, rp1 *types.RemoveTaskRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RemoveTask(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *adminClient) ResendReplicationTasks(ctx context.Context, rp1 *types.ResendReplicationTasksRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.ResendReplicationTasks(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *adminClient) ResetQueue(ctx context.Context, rp1 *types.ResetQueueRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.ResetQueue(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *adminClient) RestoreDynamicConfig(ctx context.Context, rp1 *types.RestoreDynamicConfigRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RestoreDynamicConfig(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -305,7 +305,7 @@ func (c *adminClient) RestoreDynamicConfig(ctx context.Context, rp1 *types.Resto
 
 func (c *adminClient) UpdateDomainAsyncWorkflowConfiguraton(ctx context.Context, request *types.UpdateDomainAsyncWorkflowConfiguratonRequest, opts ...yarpc.CallOption) (up1 *types.UpdateDomainAsyncWorkflowConfiguratonResponse, err error) {
 	var resp *types.UpdateDomainAsyncWorkflowConfiguratonResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateDomainAsyncWorkflowConfiguraton(ctx, request, opts...)
 		return err
@@ -316,7 +316,7 @@ func (c *adminClient) UpdateDomainAsyncWorkflowConfiguraton(ctx context.Context,
 
 func (c *adminClient) UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (up1 *types.UpdateDomainIsolationGroupsResponse, err error) {
 	var resp *types.UpdateDomainIsolationGroupsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateDomainIsolationGroups(ctx, request, opts...)
 		return err
@@ -326,7 +326,7 @@ func (c *adminClient) UpdateDomainIsolationGroups(ctx context.Context, request *
 }
 
 func (c *adminClient) UpdateDynamicConfig(ctx context.Context, up1 *types.UpdateDynamicConfigRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.UpdateDynamicConfig(ctx, up1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -334,7 +334,7 @@ func (c *adminClient) UpdateDynamicConfig(ctx context.Context, up1 *types.Update
 
 func (c *adminClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (up1 *types.UpdateGlobalIsolationGroupsResponse, err error) {
 	var resp *types.UpdateGlobalIsolationGroupsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
 		return err
@@ -345,7 +345,7 @@ func (c *adminClient) UpdateGlobalIsolationGroups(ctx context.Context, request *
 
 func (c *adminClient) UpdateTaskListPartitionConfig(ctx context.Context, request *types.UpdateTaskListPartitionConfigRequest, opts ...yarpc.CallOption) (up1 *types.UpdateTaskListPartitionConfigResponse, err error) {
 	var resp *types.UpdateTaskListPartitionConfigResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateTaskListPartitionConfig(ctx, request, opts...)
 		return err

--- a/client/wrappers/retryable/frontend_generated.go
+++ b/client/wrappers/retryable/frontend_generated.go
@@ -33,7 +33,7 @@ func NewFrontendClient(client frontend.Client, policy backoff.RetryPolicy, isRet
 
 func (c *frontendClient) CountWorkflowExecutions(ctx context.Context, cp1 *types.CountWorkflowExecutionsRequest, p1 ...yarpc.CallOption) (cp2 *types.CountWorkflowExecutionsResponse, err error) {
 	var resp *types.CountWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CountWorkflowExecutions(ctx, cp1, p1...)
 		return err
@@ -43,14 +43,14 @@ func (c *frontendClient) CountWorkflowExecutions(ctx context.Context, cp1 *types
 }
 
 func (c *frontendClient) DeleteDomain(ctx context.Context, dp1 *types.DeleteDomainRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.DeleteDomain(ctx, dp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) DeprecateDomain(ctx context.Context, dp1 *types.DeprecateDomainRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.DeprecateDomain(ctx, dp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -58,7 +58,7 @@ func (c *frontendClient) DeprecateDomain(ctx context.Context, dp1 *types.Depreca
 
 func (c *frontendClient) DescribeDomain(ctx context.Context, dp1 *types.DescribeDomainRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeDomainResponse, err error) {
 	var resp *types.DescribeDomainResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeDomain(ctx, dp1, p1...)
 		return err
@@ -69,7 +69,7 @@ func (c *frontendClient) DescribeDomain(ctx context.Context, dp1 *types.Describe
 
 func (c *frontendClient) DescribeTaskList(ctx context.Context, dp1 *types.DescribeTaskListRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeTaskListResponse, err error) {
 	var resp *types.DescribeTaskListResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeTaskList(ctx, dp1, p1...)
 		return err
@@ -80,7 +80,7 @@ func (c *frontendClient) DescribeTaskList(ctx context.Context, dp1 *types.Descri
 
 func (c *frontendClient) DescribeWorkflowExecution(ctx context.Context, dp1 *types.DescribeWorkflowExecutionRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeWorkflowExecutionResponse, err error) {
 	var resp *types.DescribeWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeWorkflowExecution(ctx, dp1, p1...)
 		return err
@@ -91,7 +91,7 @@ func (c *frontendClient) DescribeWorkflowExecution(ctx context.Context, dp1 *typ
 
 func (c *frontendClient) DiagnoseWorkflowExecution(ctx context.Context, dp1 *types.DiagnoseWorkflowExecutionRequest, p1 ...yarpc.CallOption) (dp2 *types.DiagnoseWorkflowExecutionResponse, err error) {
 	var resp *types.DiagnoseWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DiagnoseWorkflowExecution(ctx, dp1, p1...)
 		return err
@@ -102,7 +102,7 @@ func (c *frontendClient) DiagnoseWorkflowExecution(ctx context.Context, dp1 *typ
 
 func (c *frontendClient) GetClusterInfo(ctx context.Context, p1 ...yarpc.CallOption) (cp1 *types.ClusterInfo, err error) {
 	var resp *types.ClusterInfo
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetClusterInfo(ctx, p1...)
 		return err
@@ -113,7 +113,7 @@ func (c *frontendClient) GetClusterInfo(ctx context.Context, p1 ...yarpc.CallOpt
 
 func (c *frontendClient) GetSearchAttributes(ctx context.Context, p1 ...yarpc.CallOption) (gp1 *types.GetSearchAttributesResponse, err error) {
 	var resp *types.GetSearchAttributesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetSearchAttributes(ctx, p1...)
 		return err
@@ -124,7 +124,7 @@ func (c *frontendClient) GetSearchAttributes(ctx context.Context, p1 ...yarpc.Ca
 
 func (c *frontendClient) GetTaskListsByDomain(ctx context.Context, gp1 *types.GetTaskListsByDomainRequest, p1 ...yarpc.CallOption) (gp2 *types.GetTaskListsByDomainResponse, err error) {
 	var resp *types.GetTaskListsByDomainResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetTaskListsByDomain(ctx, gp1, p1...)
 		return err
@@ -135,7 +135,7 @@ func (c *frontendClient) GetTaskListsByDomain(ctx context.Context, gp1 *types.Ge
 
 func (c *frontendClient) GetWorkflowExecutionHistory(ctx context.Context, gp1 *types.GetWorkflowExecutionHistoryRequest, p1 ...yarpc.CallOption) (gp2 *types.GetWorkflowExecutionHistoryResponse, err error) {
 	var resp *types.GetWorkflowExecutionHistoryResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetWorkflowExecutionHistory(ctx, gp1, p1...)
 		return err
@@ -146,7 +146,7 @@ func (c *frontendClient) GetWorkflowExecutionHistory(ctx context.Context, gp1 *t
 
 func (c *frontendClient) ListArchivedWorkflowExecutions(ctx context.Context, lp1 *types.ListArchivedWorkflowExecutionsRequest, p1 ...yarpc.CallOption) (lp2 *types.ListArchivedWorkflowExecutionsResponse, err error) {
 	var resp *types.ListArchivedWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListArchivedWorkflowExecutions(ctx, lp1, p1...)
 		return err
@@ -157,7 +157,7 @@ func (c *frontendClient) ListArchivedWorkflowExecutions(ctx context.Context, lp1
 
 func (c *frontendClient) ListClosedWorkflowExecutions(ctx context.Context, lp1 *types.ListClosedWorkflowExecutionsRequest, p1 ...yarpc.CallOption) (lp2 *types.ListClosedWorkflowExecutionsResponse, err error) {
 	var resp *types.ListClosedWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListClosedWorkflowExecutions(ctx, lp1, p1...)
 		return err
@@ -168,7 +168,7 @@ func (c *frontendClient) ListClosedWorkflowExecutions(ctx context.Context, lp1 *
 
 func (c *frontendClient) ListDomains(ctx context.Context, lp1 *types.ListDomainsRequest, p1 ...yarpc.CallOption) (lp2 *types.ListDomainsResponse, err error) {
 	var resp *types.ListDomainsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListDomains(ctx, lp1, p1...)
 		return err
@@ -179,7 +179,7 @@ func (c *frontendClient) ListDomains(ctx context.Context, lp1 *types.ListDomains
 
 func (c *frontendClient) ListOpenWorkflowExecutions(ctx context.Context, lp1 *types.ListOpenWorkflowExecutionsRequest, p1 ...yarpc.CallOption) (lp2 *types.ListOpenWorkflowExecutionsResponse, err error) {
 	var resp *types.ListOpenWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListOpenWorkflowExecutions(ctx, lp1, p1...)
 		return err
@@ -190,7 +190,7 @@ func (c *frontendClient) ListOpenWorkflowExecutions(ctx context.Context, lp1 *ty
 
 func (c *frontendClient) ListTaskListPartitions(ctx context.Context, lp1 *types.ListTaskListPartitionsRequest, p1 ...yarpc.CallOption) (lp2 *types.ListTaskListPartitionsResponse, err error) {
 	var resp *types.ListTaskListPartitionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListTaskListPartitions(ctx, lp1, p1...)
 		return err
@@ -201,7 +201,7 @@ func (c *frontendClient) ListTaskListPartitions(ctx context.Context, lp1 *types.
 
 func (c *frontendClient) ListWorkflowExecutions(ctx context.Context, lp1 *types.ListWorkflowExecutionsRequest, p1 ...yarpc.CallOption) (lp2 *types.ListWorkflowExecutionsResponse, err error) {
 	var resp *types.ListWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListWorkflowExecutions(ctx, lp1, p1...)
 		return err
@@ -212,7 +212,7 @@ func (c *frontendClient) ListWorkflowExecutions(ctx context.Context, lp1 *types.
 
 func (c *frontendClient) PollForActivityTask(ctx context.Context, pp1 *types.PollForActivityTaskRequest, p1 ...yarpc.CallOption) (pp2 *types.PollForActivityTaskResponse, err error) {
 	var resp *types.PollForActivityTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollForActivityTask(ctx, pp1, p1...)
 		return err
@@ -223,7 +223,7 @@ func (c *frontendClient) PollForActivityTask(ctx context.Context, pp1 *types.Pol
 
 func (c *frontendClient) PollForDecisionTask(ctx context.Context, pp1 *types.PollForDecisionTaskRequest, p1 ...yarpc.CallOption) (pp2 *types.PollForDecisionTaskResponse, err error) {
 	var resp *types.PollForDecisionTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollForDecisionTask(ctx, pp1, p1...)
 		return err
@@ -234,7 +234,7 @@ func (c *frontendClient) PollForDecisionTask(ctx context.Context, pp1 *types.Pol
 
 func (c *frontendClient) QueryWorkflow(ctx context.Context, qp1 *types.QueryWorkflowRequest, p1 ...yarpc.CallOption) (qp2 *types.QueryWorkflowResponse, err error) {
 	var resp *types.QueryWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.QueryWorkflow(ctx, qp1, p1...)
 		return err
@@ -245,7 +245,7 @@ func (c *frontendClient) QueryWorkflow(ctx context.Context, qp1 *types.QueryWork
 
 func (c *frontendClient) RecordActivityTaskHeartbeat(ctx context.Context, rp1 *types.RecordActivityTaskHeartbeatRequest, p1 ...yarpc.CallOption) (rp2 *types.RecordActivityTaskHeartbeatResponse, err error) {
 	var resp *types.RecordActivityTaskHeartbeatResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskHeartbeat(ctx, rp1, p1...)
 		return err
@@ -256,7 +256,7 @@ func (c *frontendClient) RecordActivityTaskHeartbeat(ctx context.Context, rp1 *t
 
 func (c *frontendClient) RecordActivityTaskHeartbeatByID(ctx context.Context, rp1 *types.RecordActivityTaskHeartbeatByIDRequest, p1 ...yarpc.CallOption) (rp2 *types.RecordActivityTaskHeartbeatResponse, err error) {
 	var resp *types.RecordActivityTaskHeartbeatResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskHeartbeatByID(ctx, rp1, p1...)
 		return err
@@ -266,21 +266,21 @@ func (c *frontendClient) RecordActivityTaskHeartbeatByID(ctx context.Context, rp
 }
 
 func (c *frontendClient) RefreshWorkflowTasks(ctx context.Context, rp1 *types.RefreshWorkflowTasksRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RefreshWorkflowTasks(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RegisterDomain(ctx context.Context, rp1 *types.RegisterDomainRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RegisterDomain(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RequestCancelWorkflowExecution(ctx context.Context, rp1 *types.RequestCancelWorkflowExecutionRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RequestCancelWorkflowExecution(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -288,7 +288,7 @@ func (c *frontendClient) RequestCancelWorkflowExecution(ctx context.Context, rp1
 
 func (c *frontendClient) ResetStickyTaskList(ctx context.Context, rp1 *types.ResetStickyTaskListRequest, p1 ...yarpc.CallOption) (rp2 *types.ResetStickyTaskListResponse, err error) {
 	var resp *types.ResetStickyTaskListResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetStickyTaskList(ctx, rp1, p1...)
 		return err
@@ -299,7 +299,7 @@ func (c *frontendClient) ResetStickyTaskList(ctx context.Context, rp1 *types.Res
 
 func (c *frontendClient) ResetWorkflowExecution(ctx context.Context, rp1 *types.ResetWorkflowExecutionRequest, p1 ...yarpc.CallOption) (rp2 *types.ResetWorkflowExecutionResponse, err error) {
 	var resp *types.ResetWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetWorkflowExecution(ctx, rp1, p1...)
 		return err
@@ -309,42 +309,42 @@ func (c *frontendClient) ResetWorkflowExecution(ctx context.Context, rp1 *types.
 }
 
 func (c *frontendClient) RespondActivityTaskCanceled(ctx context.Context, rp1 *types.RespondActivityTaskCanceledRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskCanceled(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RespondActivityTaskCanceledByID(ctx context.Context, rp1 *types.RespondActivityTaskCanceledByIDRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskCanceledByID(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RespondActivityTaskCompleted(ctx context.Context, rp1 *types.RespondActivityTaskCompletedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskCompleted(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RespondActivityTaskCompletedByID(ctx context.Context, rp1 *types.RespondActivityTaskCompletedByIDRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskCompletedByID(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RespondActivityTaskFailed(ctx context.Context, rp1 *types.RespondActivityTaskFailedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskFailed(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RespondActivityTaskFailedByID(ctx context.Context, rp1 *types.RespondActivityTaskFailedByIDRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskFailedByID(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -352,7 +352,7 @@ func (c *frontendClient) RespondActivityTaskFailedByID(ctx context.Context, rp1 
 
 func (c *frontendClient) RespondDecisionTaskCompleted(ctx context.Context, rp1 *types.RespondDecisionTaskCompletedRequest, p1 ...yarpc.CallOption) (rp2 *types.RespondDecisionTaskCompletedResponse, err error) {
 	var resp *types.RespondDecisionTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondDecisionTaskCompleted(ctx, rp1, p1...)
 		return err
@@ -362,14 +362,14 @@ func (c *frontendClient) RespondDecisionTaskCompleted(ctx context.Context, rp1 *
 }
 
 func (c *frontendClient) RespondDecisionTaskFailed(ctx context.Context, rp1 *types.RespondDecisionTaskFailedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondDecisionTaskFailed(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *frontendClient) RespondQueryTaskCompleted(ctx context.Context, rp1 *types.RespondQueryTaskCompletedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondQueryTaskCompleted(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -377,7 +377,7 @@ func (c *frontendClient) RespondQueryTaskCompleted(ctx context.Context, rp1 *typ
 
 func (c *frontendClient) RestartWorkflowExecution(ctx context.Context, rp1 *types.RestartWorkflowExecutionRequest, p1 ...yarpc.CallOption) (rp2 *types.RestartWorkflowExecutionResponse, err error) {
 	var resp *types.RestartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RestartWorkflowExecution(ctx, rp1, p1...)
 		return err
@@ -388,7 +388,7 @@ func (c *frontendClient) RestartWorkflowExecution(ctx context.Context, rp1 *type
 
 func (c *frontendClient) ScanWorkflowExecutions(ctx context.Context, lp1 *types.ListWorkflowExecutionsRequest, p1 ...yarpc.CallOption) (lp2 *types.ListWorkflowExecutionsResponse, err error) {
 	var resp *types.ListWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ScanWorkflowExecutions(ctx, lp1, p1...)
 		return err
@@ -399,7 +399,7 @@ func (c *frontendClient) ScanWorkflowExecutions(ctx context.Context, lp1 *types.
 
 func (c *frontendClient) SignalWithStartWorkflowExecution(ctx context.Context, sp1 *types.SignalWithStartWorkflowExecutionRequest, p1 ...yarpc.CallOption) (sp2 *types.StartWorkflowExecutionResponse, err error) {
 	var resp *types.StartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SignalWithStartWorkflowExecution(ctx, sp1, p1...)
 		return err
@@ -410,7 +410,7 @@ func (c *frontendClient) SignalWithStartWorkflowExecution(ctx context.Context, s
 
 func (c *frontendClient) SignalWithStartWorkflowExecutionAsync(ctx context.Context, sp1 *types.SignalWithStartWorkflowExecutionAsyncRequest, p1 ...yarpc.CallOption) (sp2 *types.SignalWithStartWorkflowExecutionAsyncResponse, err error) {
 	var resp *types.SignalWithStartWorkflowExecutionAsyncResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SignalWithStartWorkflowExecutionAsync(ctx, sp1, p1...)
 		return err
@@ -420,7 +420,7 @@ func (c *frontendClient) SignalWithStartWorkflowExecutionAsync(ctx context.Conte
 }
 
 func (c *frontendClient) SignalWorkflowExecution(ctx context.Context, sp1 *types.SignalWorkflowExecutionRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.SignalWorkflowExecution(ctx, sp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -428,7 +428,7 @@ func (c *frontendClient) SignalWorkflowExecution(ctx context.Context, sp1 *types
 
 func (c *frontendClient) StartWorkflowExecution(ctx context.Context, sp1 *types.StartWorkflowExecutionRequest, p1 ...yarpc.CallOption) (sp2 *types.StartWorkflowExecutionResponse, err error) {
 	var resp *types.StartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.StartWorkflowExecution(ctx, sp1, p1...)
 		return err
@@ -439,7 +439,7 @@ func (c *frontendClient) StartWorkflowExecution(ctx context.Context, sp1 *types.
 
 func (c *frontendClient) StartWorkflowExecutionAsync(ctx context.Context, sp1 *types.StartWorkflowExecutionAsyncRequest, p1 ...yarpc.CallOption) (sp2 *types.StartWorkflowExecutionAsyncResponse, err error) {
 	var resp *types.StartWorkflowExecutionAsyncResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.StartWorkflowExecutionAsync(ctx, sp1, p1...)
 		return err
@@ -449,7 +449,7 @@ func (c *frontendClient) StartWorkflowExecutionAsync(ctx context.Context, sp1 *t
 }
 
 func (c *frontendClient) TerminateWorkflowExecution(ctx context.Context, tp1 *types.TerminateWorkflowExecutionRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.TerminateWorkflowExecution(ctx, tp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -457,7 +457,7 @@ func (c *frontendClient) TerminateWorkflowExecution(ctx context.Context, tp1 *ty
 
 func (c *frontendClient) UpdateDomain(ctx context.Context, up1 *types.UpdateDomainRequest, p1 ...yarpc.CallOption) (up2 *types.UpdateDomainResponse, err error) {
 	var resp *types.UpdateDomainResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateDomain(ctx, up1, p1...)
 		return err

--- a/client/wrappers/retryable/history_generated.go
+++ b/client/wrappers/retryable/history_generated.go
@@ -32,7 +32,7 @@ func NewHistoryClient(client history.Client, policy backoff.RetryPolicy, isRetry
 }
 
 func (c *historyClient) CloseShard(ctx context.Context, cp1 *types.CloseShardRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.CloseShard(ctx, cp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -40,7 +40,7 @@ func (c *historyClient) CloseShard(ctx context.Context, cp1 *types.CloseShardReq
 
 func (c *historyClient) CountDLQMessages(ctx context.Context, cp1 *types.CountDLQMessagesRequest, p1 ...yarpc.CallOption) (hp1 *types.HistoryCountDLQMessagesResponse, err error) {
 	var resp *types.HistoryCountDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CountDLQMessages(ctx, cp1, p1...)
 		return err
@@ -51,7 +51,7 @@ func (c *historyClient) CountDLQMessages(ctx context.Context, cp1 *types.CountDL
 
 func (c *historyClient) DescribeHistoryHost(ctx context.Context, dp1 *types.DescribeHistoryHostRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeHistoryHostResponse, err error) {
 	var resp *types.DescribeHistoryHostResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeHistoryHost(ctx, dp1, p1...)
 		return err
@@ -62,7 +62,7 @@ func (c *historyClient) DescribeHistoryHost(ctx context.Context, dp1 *types.Desc
 
 func (c *historyClient) DescribeMutableState(ctx context.Context, dp1 *types.DescribeMutableStateRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeMutableStateResponse, err error) {
 	var resp *types.DescribeMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeMutableState(ctx, dp1, p1...)
 		return err
@@ -73,7 +73,7 @@ func (c *historyClient) DescribeMutableState(ctx context.Context, dp1 *types.Des
 
 func (c *historyClient) DescribeQueue(ctx context.Context, dp1 *types.DescribeQueueRequest, p1 ...yarpc.CallOption) (dp2 *types.DescribeQueueResponse, err error) {
 	var resp *types.DescribeQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeQueue(ctx, dp1, p1...)
 		return err
@@ -84,7 +84,7 @@ func (c *historyClient) DescribeQueue(ctx context.Context, dp1 *types.DescribeQu
 
 func (c *historyClient) DescribeWorkflowExecution(ctx context.Context, hp1 *types.HistoryDescribeWorkflowExecutionRequest, p1 ...yarpc.CallOption) (dp1 *types.DescribeWorkflowExecutionResponse, err error) {
 	var resp *types.DescribeWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeWorkflowExecution(ctx, hp1, p1...)
 		return err
@@ -95,7 +95,7 @@ func (c *historyClient) DescribeWorkflowExecution(ctx context.Context, hp1 *type
 
 func (c *historyClient) GetCrossClusterTasks(ctx context.Context, gp1 *types.GetCrossClusterTasksRequest, p1 ...yarpc.CallOption) (gp2 *types.GetCrossClusterTasksResponse, err error) {
 	var resp *types.GetCrossClusterTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetCrossClusterTasks(ctx, gp1, p1...)
 		return err
@@ -106,7 +106,7 @@ func (c *historyClient) GetCrossClusterTasks(ctx context.Context, gp1 *types.Get
 
 func (c *historyClient) GetDLQReplicationMessages(ctx context.Context, gp1 *types.GetDLQReplicationMessagesRequest, p1 ...yarpc.CallOption) (gp2 *types.GetDLQReplicationMessagesResponse, err error) {
 	var resp *types.GetDLQReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDLQReplicationMessages(ctx, gp1, p1...)
 		return err
@@ -117,7 +117,7 @@ func (c *historyClient) GetDLQReplicationMessages(ctx context.Context, gp1 *type
 
 func (c *historyClient) GetFailoverInfo(ctx context.Context, gp1 *types.GetFailoverInfoRequest, p1 ...yarpc.CallOption) (gp2 *types.GetFailoverInfoResponse, err error) {
 	var resp *types.GetFailoverInfoResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetFailoverInfo(ctx, gp1, p1...)
 		return err
@@ -128,7 +128,7 @@ func (c *historyClient) GetFailoverInfo(ctx context.Context, gp1 *types.GetFailo
 
 func (c *historyClient) GetMutableState(ctx context.Context, gp1 *types.GetMutableStateRequest, p1 ...yarpc.CallOption) (gp2 *types.GetMutableStateResponse, err error) {
 	var resp *types.GetMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetMutableState(ctx, gp1, p1...)
 		return err
@@ -139,7 +139,7 @@ func (c *historyClient) GetMutableState(ctx context.Context, gp1 *types.GetMutab
 
 func (c *historyClient) GetReplicationMessages(ctx context.Context, gp1 *types.GetReplicationMessagesRequest, p1 ...yarpc.CallOption) (gp2 *types.GetReplicationMessagesResponse, err error) {
 	var resp *types.GetReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetReplicationMessages(ctx, gp1, p1...)
 		return err
@@ -150,7 +150,7 @@ func (c *historyClient) GetReplicationMessages(ctx context.Context, gp1 *types.G
 
 func (c *historyClient) MergeDLQMessages(ctx context.Context, mp1 *types.MergeDLQMessagesRequest, p1 ...yarpc.CallOption) (mp2 *types.MergeDLQMessagesResponse, err error) {
 	var resp *types.MergeDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.MergeDLQMessages(ctx, mp1, p1...)
 		return err
@@ -160,7 +160,7 @@ func (c *historyClient) MergeDLQMessages(ctx context.Context, mp1 *types.MergeDL
 }
 
 func (c *historyClient) NotifyFailoverMarkers(ctx context.Context, np1 *types.NotifyFailoverMarkersRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.NotifyFailoverMarkers(ctx, np1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -168,7 +168,7 @@ func (c *historyClient) NotifyFailoverMarkers(ctx context.Context, np1 *types.No
 
 func (c *historyClient) PollMutableState(ctx context.Context, pp1 *types.PollMutableStateRequest, p1 ...yarpc.CallOption) (pp2 *types.PollMutableStateResponse, err error) {
 	var resp *types.PollMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollMutableState(ctx, pp1, p1...)
 		return err
@@ -178,7 +178,7 @@ func (c *historyClient) PollMutableState(ctx context.Context, pp1 *types.PollMut
 }
 
 func (c *historyClient) PurgeDLQMessages(ctx context.Context, pp1 *types.PurgeDLQMessagesRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.PurgeDLQMessages(ctx, pp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -186,7 +186,7 @@ func (c *historyClient) PurgeDLQMessages(ctx context.Context, pp1 *types.PurgeDL
 
 func (c *historyClient) QueryWorkflow(ctx context.Context, hp1 *types.HistoryQueryWorkflowRequest, p1 ...yarpc.CallOption) (hp2 *types.HistoryQueryWorkflowResponse, err error) {
 	var resp *types.HistoryQueryWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.QueryWorkflow(ctx, hp1, p1...)
 		return err
@@ -197,7 +197,7 @@ func (c *historyClient) QueryWorkflow(ctx context.Context, hp1 *types.HistoryQue
 
 func (c *historyClient) RatelimitUpdate(ctx context.Context, request *types.RatelimitUpdateRequest, opts ...yarpc.CallOption) (rp1 *types.RatelimitUpdateResponse, err error) {
 	var resp *types.RatelimitUpdateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RatelimitUpdate(ctx, request, opts...)
 		return err
@@ -208,7 +208,7 @@ func (c *historyClient) RatelimitUpdate(ctx context.Context, request *types.Rate
 
 func (c *historyClient) ReadDLQMessages(ctx context.Context, rp1 *types.ReadDLQMessagesRequest, p1 ...yarpc.CallOption) (rp2 *types.ReadDLQMessagesResponse, err error) {
 	var resp *types.ReadDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ReadDLQMessages(ctx, rp1, p1...)
 		return err
@@ -218,7 +218,7 @@ func (c *historyClient) ReadDLQMessages(ctx context.Context, rp1 *types.ReadDLQM
 }
 
 func (c *historyClient) ReapplyEvents(ctx context.Context, hp1 *types.HistoryReapplyEventsRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.ReapplyEvents(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -226,7 +226,7 @@ func (c *historyClient) ReapplyEvents(ctx context.Context, hp1 *types.HistoryRea
 
 func (c *historyClient) RecordActivityTaskHeartbeat(ctx context.Context, hp1 *types.HistoryRecordActivityTaskHeartbeatRequest, p1 ...yarpc.CallOption) (rp1 *types.RecordActivityTaskHeartbeatResponse, err error) {
 	var resp *types.RecordActivityTaskHeartbeatResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskHeartbeat(ctx, hp1, p1...)
 		return err
@@ -237,7 +237,7 @@ func (c *historyClient) RecordActivityTaskHeartbeat(ctx context.Context, hp1 *ty
 
 func (c *historyClient) RecordActivityTaskStarted(ctx context.Context, rp1 *types.RecordActivityTaskStartedRequest, p1 ...yarpc.CallOption) (rp2 *types.RecordActivityTaskStartedResponse, err error) {
 	var resp *types.RecordActivityTaskStartedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskStarted(ctx, rp1, p1...)
 		return err
@@ -247,7 +247,7 @@ func (c *historyClient) RecordActivityTaskStarted(ctx context.Context, rp1 *type
 }
 
 func (c *historyClient) RecordChildExecutionCompleted(ctx context.Context, rp1 *types.RecordChildExecutionCompletedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RecordChildExecutionCompleted(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -255,7 +255,7 @@ func (c *historyClient) RecordChildExecutionCompleted(ctx context.Context, rp1 *
 
 func (c *historyClient) RecordDecisionTaskStarted(ctx context.Context, rp1 *types.RecordDecisionTaskStartedRequest, p1 ...yarpc.CallOption) (rp2 *types.RecordDecisionTaskStartedResponse, err error) {
 	var resp *types.RecordDecisionTaskStartedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordDecisionTaskStarted(ctx, rp1, p1...)
 		return err
@@ -265,42 +265,42 @@ func (c *historyClient) RecordDecisionTaskStarted(ctx context.Context, rp1 *type
 }
 
 func (c *historyClient) RefreshWorkflowTasks(ctx context.Context, hp1 *types.HistoryRefreshWorkflowTasksRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RefreshWorkflowTasks(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) RemoveSignalMutableState(ctx context.Context, rp1 *types.RemoveSignalMutableStateRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RemoveSignalMutableState(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) RemoveTask(ctx context.Context, rp1 *types.RemoveTaskRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RemoveTask(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) ReplicateEventsV2(ctx context.Context, rp1 *types.ReplicateEventsV2Request, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.ReplicateEventsV2(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) RequestCancelWorkflowExecution(ctx context.Context, hp1 *types.HistoryRequestCancelWorkflowExecutionRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RequestCancelWorkflowExecution(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) ResetQueue(ctx context.Context, rp1 *types.ResetQueueRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.ResetQueue(ctx, rp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -308,7 +308,7 @@ func (c *historyClient) ResetQueue(ctx context.Context, rp1 *types.ResetQueueReq
 
 func (c *historyClient) ResetStickyTaskList(ctx context.Context, hp1 *types.HistoryResetStickyTaskListRequest, p1 ...yarpc.CallOption) (hp2 *types.HistoryResetStickyTaskListResponse, err error) {
 	var resp *types.HistoryResetStickyTaskListResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetStickyTaskList(ctx, hp1, p1...)
 		return err
@@ -319,7 +319,7 @@ func (c *historyClient) ResetStickyTaskList(ctx context.Context, hp1 *types.Hist
 
 func (c *historyClient) ResetWorkflowExecution(ctx context.Context, hp1 *types.HistoryResetWorkflowExecutionRequest, p1 ...yarpc.CallOption) (rp1 *types.ResetWorkflowExecutionResponse, err error) {
 	var resp *types.ResetWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetWorkflowExecution(ctx, hp1, p1...)
 		return err
@@ -329,21 +329,21 @@ func (c *historyClient) ResetWorkflowExecution(ctx context.Context, hp1 *types.H
 }
 
 func (c *historyClient) RespondActivityTaskCanceled(ctx context.Context, hp1 *types.HistoryRespondActivityTaskCanceledRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskCanceled(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) RespondActivityTaskCompleted(ctx context.Context, hp1 *types.HistoryRespondActivityTaskCompletedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskCompleted(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) RespondActivityTaskFailed(ctx context.Context, hp1 *types.HistoryRespondActivityTaskFailedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondActivityTaskFailed(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -351,7 +351,7 @@ func (c *historyClient) RespondActivityTaskFailed(ctx context.Context, hp1 *type
 
 func (c *historyClient) RespondCrossClusterTasksCompleted(ctx context.Context, rp1 *types.RespondCrossClusterTasksCompletedRequest, p1 ...yarpc.CallOption) (rp2 *types.RespondCrossClusterTasksCompletedResponse, err error) {
 	var resp *types.RespondCrossClusterTasksCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondCrossClusterTasksCompleted(ctx, rp1, p1...)
 		return err
@@ -362,7 +362,7 @@ func (c *historyClient) RespondCrossClusterTasksCompleted(ctx context.Context, r
 
 func (c *historyClient) RespondDecisionTaskCompleted(ctx context.Context, hp1 *types.HistoryRespondDecisionTaskCompletedRequest, p1 ...yarpc.CallOption) (hp2 *types.HistoryRespondDecisionTaskCompletedResponse, err error) {
 	var resp *types.HistoryRespondDecisionTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondDecisionTaskCompleted(ctx, hp1, p1...)
 		return err
@@ -372,14 +372,14 @@ func (c *historyClient) RespondDecisionTaskCompleted(ctx context.Context, hp1 *t
 }
 
 func (c *historyClient) RespondDecisionTaskFailed(ctx context.Context, hp1 *types.HistoryRespondDecisionTaskFailedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondDecisionTaskFailed(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) ScheduleDecisionTask(ctx context.Context, sp1 *types.ScheduleDecisionTaskRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.ScheduleDecisionTask(ctx, sp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -387,7 +387,7 @@ func (c *historyClient) ScheduleDecisionTask(ctx context.Context, sp1 *types.Sch
 
 func (c *historyClient) SignalWithStartWorkflowExecution(ctx context.Context, hp1 *types.HistorySignalWithStartWorkflowExecutionRequest, p1 ...yarpc.CallOption) (sp1 *types.StartWorkflowExecutionResponse, err error) {
 	var resp *types.StartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SignalWithStartWorkflowExecution(ctx, hp1, p1...)
 		return err
@@ -397,7 +397,7 @@ func (c *historyClient) SignalWithStartWorkflowExecution(ctx context.Context, hp
 }
 
 func (c *historyClient) SignalWorkflowExecution(ctx context.Context, hp1 *types.HistorySignalWorkflowExecutionRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.SignalWorkflowExecution(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -405,7 +405,7 @@ func (c *historyClient) SignalWorkflowExecution(ctx context.Context, hp1 *types.
 
 func (c *historyClient) StartWorkflowExecution(ctx context.Context, hp1 *types.HistoryStartWorkflowExecutionRequest, p1 ...yarpc.CallOption) (sp1 *types.StartWorkflowExecutionResponse, err error) {
 	var resp *types.StartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.StartWorkflowExecution(ctx, hp1, p1...)
 		return err
@@ -415,21 +415,21 @@ func (c *historyClient) StartWorkflowExecution(ctx context.Context, hp1 *types.H
 }
 
 func (c *historyClient) SyncActivity(ctx context.Context, sp1 *types.SyncActivityRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.SyncActivity(ctx, sp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) SyncShardStatus(ctx context.Context, sp1 *types.SyncShardStatusRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.SyncShardStatus(ctx, sp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
 }
 
 func (c *historyClient) TerminateWorkflowExecution(ctx context.Context, hp1 *types.HistoryTerminateWorkflowExecutionRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.TerminateWorkflowExecution(ctx, hp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)

--- a/client/wrappers/retryable/matching_generated.go
+++ b/client/wrappers/retryable/matching_generated.go
@@ -33,7 +33,7 @@ func NewMatchingClient(client matching.Client, policy backoff.RetryPolicy, isRet
 
 func (c *matchingClient) AddActivityTask(ctx context.Context, ap1 *types.AddActivityTaskRequest, p1 ...yarpc.CallOption) (ap2 *types.AddActivityTaskResponse, err error) {
 	var resp *types.AddActivityTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.AddActivityTask(ctx, ap1, p1...)
 		return err
@@ -44,7 +44,7 @@ func (c *matchingClient) AddActivityTask(ctx context.Context, ap1 *types.AddActi
 
 func (c *matchingClient) AddDecisionTask(ctx context.Context, ap1 *types.AddDecisionTaskRequest, p1 ...yarpc.CallOption) (ap2 *types.AddDecisionTaskResponse, err error) {
 	var resp *types.AddDecisionTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.AddDecisionTask(ctx, ap1, p1...)
 		return err
@@ -54,7 +54,7 @@ func (c *matchingClient) AddDecisionTask(ctx context.Context, ap1 *types.AddDeci
 }
 
 func (c *matchingClient) CancelOutstandingPoll(ctx context.Context, cp1 *types.CancelOutstandingPollRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.CancelOutstandingPoll(ctx, cp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -62,7 +62,7 @@ func (c *matchingClient) CancelOutstandingPoll(ctx context.Context, cp1 *types.C
 
 func (c *matchingClient) DescribeTaskList(ctx context.Context, mp1 *types.MatchingDescribeTaskListRequest, p1 ...yarpc.CallOption) (dp1 *types.DescribeTaskListResponse, err error) {
 	var resp *types.DescribeTaskListResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeTaskList(ctx, mp1, p1...)
 		return err
@@ -73,7 +73,7 @@ func (c *matchingClient) DescribeTaskList(ctx context.Context, mp1 *types.Matchi
 
 func (c *matchingClient) GetTaskListsByDomain(ctx context.Context, gp1 *types.GetTaskListsByDomainRequest, p1 ...yarpc.CallOption) (gp2 *types.GetTaskListsByDomainResponse, err error) {
 	var resp *types.GetTaskListsByDomainResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetTaskListsByDomain(ctx, gp1, p1...)
 		return err
@@ -84,7 +84,7 @@ func (c *matchingClient) GetTaskListsByDomain(ctx context.Context, gp1 *types.Ge
 
 func (c *matchingClient) ListTaskListPartitions(ctx context.Context, mp1 *types.MatchingListTaskListPartitionsRequest, p1 ...yarpc.CallOption) (lp1 *types.ListTaskListPartitionsResponse, err error) {
 	var resp *types.ListTaskListPartitionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListTaskListPartitions(ctx, mp1, p1...)
 		return err
@@ -95,7 +95,7 @@ func (c *matchingClient) ListTaskListPartitions(ctx context.Context, mp1 *types.
 
 func (c *matchingClient) PollForActivityTask(ctx context.Context, mp1 *types.MatchingPollForActivityTaskRequest, p1 ...yarpc.CallOption) (mp2 *types.MatchingPollForActivityTaskResponse, err error) {
 	var resp *types.MatchingPollForActivityTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollForActivityTask(ctx, mp1, p1...)
 		return err
@@ -106,7 +106,7 @@ func (c *matchingClient) PollForActivityTask(ctx context.Context, mp1 *types.Mat
 
 func (c *matchingClient) PollForDecisionTask(ctx context.Context, mp1 *types.MatchingPollForDecisionTaskRequest, p1 ...yarpc.CallOption) (mp2 *types.MatchingPollForDecisionTaskResponse, err error) {
 	var resp *types.MatchingPollForDecisionTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollForDecisionTask(ctx, mp1, p1...)
 		return err
@@ -117,7 +117,7 @@ func (c *matchingClient) PollForDecisionTask(ctx context.Context, mp1 *types.Mat
 
 func (c *matchingClient) QueryWorkflow(ctx context.Context, mp1 *types.MatchingQueryWorkflowRequest, p1 ...yarpc.CallOption) (mp2 *types.MatchingQueryWorkflowResponse, err error) {
 	var resp *types.MatchingQueryWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.QueryWorkflow(ctx, mp1, p1...)
 		return err
@@ -128,7 +128,7 @@ func (c *matchingClient) QueryWorkflow(ctx context.Context, mp1 *types.MatchingQ
 
 func (c *matchingClient) RefreshTaskListPartitionConfig(ctx context.Context, mp1 *types.MatchingRefreshTaskListPartitionConfigRequest, p1 ...yarpc.CallOption) (mp2 *types.MatchingRefreshTaskListPartitionConfigResponse, err error) {
 	var resp *types.MatchingRefreshTaskListPartitionConfigResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RefreshTaskListPartitionConfig(ctx, mp1, p1...)
 		return err
@@ -138,7 +138,7 @@ func (c *matchingClient) RefreshTaskListPartitionConfig(ctx context.Context, mp1
 }
 
 func (c *matchingClient) RespondQueryTaskCompleted(ctx context.Context, mp1 *types.MatchingRespondQueryTaskCompletedRequest, p1 ...yarpc.CallOption) (err error) {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return c.client.RespondQueryTaskCompleted(ctx, mp1, p1...)
 	}
 	return c.throttleRetry.Do(ctx, op)
@@ -146,7 +146,7 @@ func (c *matchingClient) RespondQueryTaskCompleted(ctx context.Context, mp1 *typ
 
 func (c *matchingClient) UpdateTaskListPartitionConfig(ctx context.Context, mp1 *types.MatchingUpdateTaskListPartitionConfigRequest, p1 ...yarpc.CallOption) (mp2 *types.MatchingUpdateTaskListPartitionConfigResponse, err error) {
 	var resp *types.MatchingUpdateTaskListPartitionConfigResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateTaskListPartitionConfig(ctx, mp1, p1...)
 		return err

--- a/client/wrappers/retryable/sharddistributor_generated.go
+++ b/client/wrappers/retryable/sharddistributor_generated.go
@@ -33,7 +33,7 @@ func NewShardDistributorClient(client sharddistributor.Client, policy backoff.Re
 
 func (c *sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.GetShardOwnerRequest, p1 ...yarpc.CallOption) (gp2 *types.GetShardOwnerResponse, err error) {
 	var resp *types.GetShardOwnerResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetShardOwner(ctx, gp1, p1...)
 		return err

--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -292,7 +292,7 @@ func (h *historyArchiver) ValidateURI(URI archiver.URI) error {
 
 func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIterator) (*archiver.HistoryBlob, error) {
 	historyBlob, err := historyIterator.Next()
-	op := func() error {
+	op := func(ctx context.Context) error {
 		historyBlob, err = historyIterator.Next()
 		return err
 	}

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -312,7 +312,7 @@ func (h *historyArchiver) validateURI(URI archiver.URI) (err error) {
 
 func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIterator) (*archiver.HistoryBlob, error) {
 	historyBlob, err := historyIterator.Next()
-	op := func() error {
+	op := func(ctx context.Context) error {
 		historyBlob, err = historyIterator.Next()
 		return err
 	}

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -356,7 +356,7 @@ func (h *historyArchiver) ValidateURI(URI archiver.URI) error {
 
 func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIterator) (*archiver.HistoryBlob, error) {
 	historyBlob, err := historyIterator.Next()
-	op := func() error {
+	op := func(ctx context.Context) error {
 		historyBlob, err = historyIterator.Next()
 		return err
 	}

--- a/common/asyncworkflow/queue/consumer/default_consumer.go
+++ b/common/asyncworkflow/queue/consumer/default_consumer.go
@@ -198,7 +198,7 @@ func (c *DefaultConsumer) processRequest(logger log.Logger, request *sqlblobs.As
 
 		var resp *types.StartWorkflowExecutionResponse
 		op := func(ctx1 context.Context) error {
-			ctx, cancel := context.WithTimeout(c.ctx, c.startWFTimeout)
+			ctx, cancel := context.WithTimeout(ctx1, c.startWFTimeout)
 			defer cancel()
 			resp, err = c.frontendClient.StartWorkflowExecution(ctx, startWFReq, yarpcCallOpts...)
 
@@ -228,7 +228,7 @@ func (c *DefaultConsumer) processRequest(logger log.Logger, request *sqlblobs.As
 		scope := c.scope.Tagged(metrics.DomainTag(startWFReq.GetDomain()))
 		var resp *types.StartWorkflowExecutionResponse
 		op := func(ctx1 context.Context) error {
-			ctx, cancel := context.WithTimeout(c.ctx, c.startWFTimeout)
+			ctx, cancel := context.WithTimeout(ctx1, c.startWFTimeout)
 			defer cancel()
 			resp, err = c.frontendClient.SignalWithStartWorkflowExecution(ctx, startWFReq, yarpcCallOpts...)
 

--- a/common/asyncworkflow/queue/consumer/default_consumer.go
+++ b/common/asyncworkflow/queue/consumer/default_consumer.go
@@ -197,7 +197,7 @@ func (c *DefaultConsumer) processRequest(logger log.Logger, request *sqlblobs.As
 		scope := scope.Tagged(metrics.DomainTag(startWFReq.GetDomain()))
 
 		var resp *types.StartWorkflowExecutionResponse
-		op := func() error {
+		op := func(ctx1 context.Context) error {
 			ctx, cancel := context.WithTimeout(c.ctx, c.startWFTimeout)
 			defer cancel()
 			resp, err = c.frontendClient.StartWorkflowExecution(ctx, startWFReq, yarpcCallOpts...)
@@ -227,7 +227,7 @@ func (c *DefaultConsumer) processRequest(logger log.Logger, request *sqlblobs.As
 		yarpcCallOpts := getYARPCOptions(request.GetHeader())
 		scope := c.scope.Tagged(metrics.DomainTag(startWFReq.GetDomain()))
 		var resp *types.StartWorkflowExecutionResponse
-		op := func() error {
+		op := func(ctx1 context.Context) error {
 			ctx, cancel := context.WithTimeout(c.ctx, c.startWFTimeout)
 			defer cancel()
 			resp, err = c.frontendClient.SignalWithStartWorkflowExecution(ctx, startWFReq, yarpcCallOpts...)
@@ -255,7 +255,7 @@ func (c *DefaultConsumer) processRequest(logger log.Logger, request *sqlblobs.As
 	return nil
 }
 
-func callFrontendWithRetries(ctx context.Context, op func() error) error {
+func callFrontendWithRetries(ctx context.Context, op func(ctx context.Context) error) error {
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(common.CreateFrontendServiceRetryPolicy()),
 		backoff.WithRetryableError(common.IsServiceTransientError),

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -49,7 +49,7 @@ func (s *RetrySuite) SetupTest() {
 
 func (s *RetrySuite) TestRetrySuccess() {
 	i := 0
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 
 		if i == 5 {
@@ -75,7 +75,7 @@ func (s *RetrySuite) TestRetrySuccess() {
 
 func (s *RetrySuite) TestRetryFailed() {
 	i := 0
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 
 		if i == 7 {
@@ -102,7 +102,7 @@ func (s *RetrySuite) TestRetryFailedReturnPreviousError() {
 	i := 0
 
 	the5thError := fmt.Errorf("this is the error of the 5th attempt(4th retry attempt)")
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 		if i == 5 {
 			return the5thError
@@ -133,7 +133,7 @@ func (s *RetrySuite) TestRetryFailedReturnPreviousError() {
 
 func (s *RetrySuite) TestIsRetryableSuccess() {
 	i := 0
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 
 		if i == 5 {
@@ -167,7 +167,7 @@ func (s *RetrySuite) TestIsRetryableSuccess() {
 
 func (s *RetrySuite) TestIsRetryableFailure() {
 	i := 0
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 
 		if i == 5 {
@@ -193,7 +193,7 @@ func (s *RetrySuite) TestIsRetryableFailure() {
 
 func (s *RetrySuite) TestRetryExpired() {
 	i := 0
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 		time.Sleep(time.Second)
 		return &someError{}
@@ -217,7 +217,7 @@ func (s *RetrySuite) TestRetryExpired() {
 func (s *RetrySuite) TestRetryExpiredReturnPreviousError() {
 	i := 0
 	prevErr := fmt.Errorf("previousError")
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 		if i == 1 {
 			return prevErr
@@ -244,7 +244,7 @@ func (s *RetrySuite) TestRetryExpiredReturnPreviousError() {
 func (s *RetrySuite) TestRetryThrottled() {
 	i := 0
 	throttleErr := fmt.Errorf("throttled")
-	op := func() error {
+	op := func(ctx context.Context) error {
 		i++
 		if i == 1 {
 			return throttleErr

--- a/common/blobstore/retryable_client.go
+++ b/common/blobstore/retryable_client.go
@@ -49,7 +49,7 @@ func NewRetryableClient(client Client, policy backoff.RetryPolicy) Client {
 func (c *retryableClient) Put(ctx context.Context, req *PutRequest) (*PutResponse, error) {
 	var resp *PutResponse
 	var err error
-	op := func() error {
+	op := func(ctx context.Context) error {
 		resp, err = c.client.Put(ctx, req)
 		return err
 	}
@@ -63,7 +63,7 @@ func (c *retryableClient) Put(ctx context.Context, req *PutRequest) (*PutRespons
 func (c *retryableClient) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
 	var resp *GetResponse
 	var err error
-	op := func() error {
+	op := func(ctx context.Context) error {
 		resp, err = c.client.Get(ctx, req)
 		return err
 	}
@@ -77,7 +77,7 @@ func (c *retryableClient) Get(ctx context.Context, req *GetRequest) (*GetRespons
 func (c *retryableClient) Exists(ctx context.Context, req *ExistsRequest) (*ExistsResponse, error) {
 	var resp *ExistsResponse
 	var err error
-	op := func() error {
+	op := func(ctx context.Context) error {
 		resp, err = c.client.Exists(ctx, req)
 		return err
 	}
@@ -91,7 +91,7 @@ func (c *retryableClient) Exists(ctx context.Context, req *ExistsRequest) (*Exis
 func (c *retryableClient) Delete(ctx context.Context, req *DeleteRequest) (*DeleteResponse, error) {
 	var resp *DeleteResponse
 	var err error
-	op := func() error {
+	op := func(ctx context.Context) error {
 		resp, err = c.client.Delete(ctx, req)
 		return err
 	}

--- a/common/cache/domainCache_test.go
+++ b/common/cache/domainCache_test.go
@@ -21,6 +21,7 @@
 package cache
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -903,8 +904,9 @@ func (s *domainCacheSuite) Test_refreshDomainsLocked_IntervalTooShort() {
 	s.domainCache.timeSource = mockedTimeSource
 
 	s.domainCache.lastRefreshTime = mockedTimeSource.Now()
+	ctx := context.Background()
 
-	err := s.domainCache.refreshDomainsLocked()
+	err := s.domainCache.refreshDomainsLocked(ctx)
 	s.NoError(err)
 }
 

--- a/common/domain/failover_watcher.go
+++ b/common/domain/failover_watcher.go
@@ -207,8 +207,8 @@ func CleanPendingActiveState(
 			FailoverEndTime:             nil,
 			NotificationVersion:         metadata.NotificationVersion,
 		}
-		op := func() error {
-			return domainManager.UpdateDomain(context.Background(), updateReq)
+		op := func(ctx context.Context) error {
+			return domainManager.UpdateDomain(ctx, updateReq)
 		}
 		throttleRetry := backoff.NewThrottleRetry(
 			backoff.WithRetryPolicy(policy),

--- a/common/messaging/kafka/consumer_impl.go
+++ b/common/messaging/kafka/consumer_impl.go
@@ -192,10 +192,10 @@ func (h *consumerHandlerImpl) completeMessage(message *messageImpl, isAck bool) 
 	defer h.RUnlock()
 
 	if !isAck {
-		op := func() error {
+		op := func(ctx context.Context) error {
 			// NOTE: current KafkaProducer is not taking use the this context, because saramaProducer doesn't support it
 			// https://github.com/Shopify/sarama/issues/1849
-			ctx, cancel := context.WithTimeout(context.Background(), dlqPublishTimeout)
+			ctx, cancel := context.WithTimeout(ctx, dlqPublishTimeout)
 			err := h.dlqProducer.Publish(ctx, message.saramaMsg)
 			cancel()
 			return err

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -758,8 +758,9 @@ type (
 
 	// ListConcreteExecutionsRequest is request to ListConcreteExecutions
 	ListConcreteExecutionsRequest struct {
-		PageSize  int
-		PageToken []byte
+		PageSize   int
+		PageToken  []byte
+		RetryCount int
 	}
 
 	// ListConcreteExecutionsResponse is response to ListConcreteExecutions

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -758,9 +758,8 @@ type (
 
 	// ListConcreteExecutionsRequest is request to ListConcreteExecutions
 	ListConcreteExecutionsRequest struct {
-		PageSize   int
-		PageToken  []byte
-		RetryCount int
+		PageSize  int
+		PageToken []byte
 	}
 
 	// ListConcreteExecutionsResponse is response to ListConcreteExecutions

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -755,8 +755,8 @@ func (s *HistoryV2PersistenceSuite) deleteHistoryBranch(ctx context.Context, bra
 		}
 
 		domainName := s.DomainManager.GetName()
-		op := func(ctx1 context.Context) error {
-			err := s.HistoryV2Mgr.DeleteHistoryBranch(ctx1, &p.DeleteHistoryBranchRequest{
+		op := func(ctx context.Context) error {
+			err := s.HistoryV2Mgr.DeleteHistoryBranch(ctx, &p.DeleteHistoryBranchRequest{
 				BranchToken: branchToken,
 				ShardID:     common.IntPtr(s.ShardInfo.ShardID),
 				DomainName:  domainName,
@@ -875,9 +875,9 @@ func (s *HistoryV2PersistenceSuite) append(ctx context.Context, branch []byte, e
 
 	var resp *p.AppendHistoryNodesResponse
 	domainName := s.DomainManager.GetName()
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		var err error
-		resp, err = s.HistoryV2Mgr.AppendHistoryNodes(ctx1, &p.AppendHistoryNodesRequest{
+		resp, err = s.HistoryV2Mgr.AppendHistoryNodes(ctx, &p.AppendHistoryNodesRequest{
 			IsNewBranch:   isNewBranch,
 			Info:          branchInfo,
 			BranchToken:   branch,
@@ -903,9 +903,9 @@ func (s *HistoryV2PersistenceSuite) fork(ctx context.Context, forkBranch []byte,
 
 	bi := []byte{}
 	domainName := s.DomainManager.GetName()
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		var err error
-		resp, err := s.HistoryV2Mgr.ForkHistoryBranch(ctx1, &p.ForkHistoryBranchRequest{
+		resp, err := s.HistoryV2Mgr.ForkHistoryBranch(ctx, &p.ForkHistoryBranchRequest{
 			ForkBranchToken: forkBranch,
 			ForkNodeID:      forkNodeID,
 			Info:            testForkRunID,

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -755,8 +755,8 @@ func (s *HistoryV2PersistenceSuite) deleteHistoryBranch(ctx context.Context, bra
 		}
 
 		domainName := s.DomainManager.GetName()
-		op := func() error {
-			err := s.HistoryV2Mgr.DeleteHistoryBranch(ctx, &p.DeleteHistoryBranchRequest{
+		op := func(ctx1 context.Context) error {
+			err := s.HistoryV2Mgr.DeleteHistoryBranch(ctx1, &p.DeleteHistoryBranchRequest{
 				BranchToken: branchToken,
 				ShardID:     common.IntPtr(s.ShardInfo.ShardID),
 				DomainName:  domainName,
@@ -875,9 +875,9 @@ func (s *HistoryV2PersistenceSuite) append(ctx context.Context, branch []byte, e
 
 	var resp *p.AppendHistoryNodesResponse
 	domainName := s.DomainManager.GetName()
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		var err error
-		resp, err = s.HistoryV2Mgr.AppendHistoryNodes(ctx, &p.AppendHistoryNodesRequest{
+		resp, err = s.HistoryV2Mgr.AppendHistoryNodes(ctx1, &p.AppendHistoryNodesRequest{
 			IsNewBranch:   isNewBranch,
 			Info:          branchInfo,
 			BranchToken:   branch,
@@ -903,9 +903,9 @@ func (s *HistoryV2PersistenceSuite) fork(ctx context.Context, forkBranch []byte,
 
 	bi := []byte{}
 	domainName := s.DomainManager.GetName()
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		var err error
-		resp, err := s.HistoryV2Mgr.ForkHistoryBranch(ctx, &p.ForkHistoryBranchRequest{
+		resp, err := s.HistoryV2Mgr.ForkHistoryBranch(ctx1, &p.ForkHistoryBranchRequest{
 			ForkBranchToken: forkBranch,
 			ForkNodeID:      forkNodeID,
 			Info:            testForkRunID,

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1936,8 +1936,8 @@ func (s *TestBase) Publish(
 			return persistence.IsTransientError(e) || isMessageIDConflictError(e)
 		}),
 	)
-	return throttleRetry.Do(ctx, func() error {
-		return s.DomainReplicationQueueMgr.EnqueueMessage(ctx, messagePayload)
+	return throttleRetry.Do(ctx, func(ctx1 context.Context) error {
+		return s.DomainReplicationQueueMgr.EnqueueMessage(ctx1, messagePayload)
 	})
 }
 
@@ -1989,8 +1989,8 @@ func (s *TestBase) PublishToDomainDLQ(
 			return persistence.IsTransientError(e) || isMessageIDConflictError(e)
 		}),
 	)
-	return throttleRetry.Do(ctx, func() error {
-		return s.DomainReplicationQueueMgr.EnqueueMessageToDLQ(ctx, messagePayload)
+	return throttleRetry.Do(ctx, func(ctx1 context.Context) error {
+		return s.DomainReplicationQueueMgr.EnqueueMessageToDLQ(ctx1, messagePayload)
 	})
 }
 

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1936,8 +1936,8 @@ func (s *TestBase) Publish(
 			return persistence.IsTransientError(e) || isMessageIDConflictError(e)
 		}),
 	)
-	return throttleRetry.Do(ctx, func(ctx1 context.Context) error {
-		return s.DomainReplicationQueueMgr.EnqueueMessage(ctx1, messagePayload)
+	return throttleRetry.Do(ctx, func(ctx context.Context) error {
+		return s.DomainReplicationQueueMgr.EnqueueMessage(ctx, messagePayload)
 	})
 }
 
@@ -1989,8 +1989,8 @@ func (s *TestBase) PublishToDomainDLQ(
 			return persistence.IsTransientError(e) || isMessageIDConflictError(e)
 		}),
 	)
-	return throttleRetry.Do(ctx, func(ctx1 context.Context) error {
-		return s.DomainReplicationQueueMgr.EnqueueMessageToDLQ(ctx1, messagePayload)
+	return throttleRetry.Do(ctx, func(ctx context.Context) error {
+		return s.DomainReplicationQueueMgr.EnqueueMessageToDLQ(ctx, messagePayload)
 	})
 }
 

--- a/common/persistence/retryer.go
+++ b/common/persistence/retryer.go
@@ -75,7 +75,7 @@ func (pr *persistenceRetryer) ListConcreteExecutions(
 	req *ListConcreteExecutionsRequest,
 ) (*ListConcreteExecutionsResponse, error) {
 	var resp *ListConcreteExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = pr.execManager.ListConcreteExecutions(ctx, req)
 		return err
@@ -93,7 +93,7 @@ func (pr *persistenceRetryer) GetWorkflowExecution(
 	req *GetWorkflowExecutionRequest,
 ) (*GetWorkflowExecutionResponse, error) {
 	var resp *GetWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = pr.execManager.GetWorkflowExecution(ctx, req)
 		return err
@@ -111,7 +111,7 @@ func (pr *persistenceRetryer) GetCurrentExecution(
 	req *GetCurrentExecutionRequest,
 ) (*GetCurrentExecutionResponse, error) {
 	var resp *GetCurrentExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = pr.execManager.GetCurrentExecution(ctx, req)
 		return err
@@ -129,7 +129,7 @@ func (pr *persistenceRetryer) ListCurrentExecutions(
 	req *ListCurrentExecutionsRequest,
 ) (*ListCurrentExecutionsResponse, error) {
 	var resp *ListCurrentExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = pr.execManager.ListCurrentExecutions(ctx, req)
 		return err
@@ -147,7 +147,7 @@ func (pr *persistenceRetryer) IsWorkflowExecutionExists(
 	req *IsWorkflowExecutionExistsRequest,
 ) (*IsWorkflowExecutionExistsResponse, error) {
 	var resp *IsWorkflowExecutionExistsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = pr.execManager.IsWorkflowExecutionExists(ctx, req)
 		return err
@@ -165,7 +165,7 @@ func (pr *persistenceRetryer) ReadHistoryBranch(
 	req *ReadHistoryBranchRequest,
 ) (*ReadHistoryBranchResponse, error) {
 	var resp *ReadHistoryBranchResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = pr.historyManager.ReadHistoryBranch(ctx, req)
 		return err
@@ -182,7 +182,7 @@ func (pr *persistenceRetryer) DeleteWorkflowExecution(
 	ctx context.Context,
 	req *DeleteWorkflowExecutionRequest,
 ) error {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return pr.execManager.DeleteWorkflowExecution(ctx, req)
 	}
 	return pr.throttleRetry.Do(ctx, op)
@@ -193,7 +193,7 @@ func (pr *persistenceRetryer) DeleteCurrentWorkflowExecution(
 	ctx context.Context,
 	req *DeleteCurrentWorkflowExecutionRequest,
 ) error {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return pr.execManager.DeleteCurrentWorkflowExecution(ctx, req)
 	}
 	return pr.throttleRetry.Do(ctx, op)
@@ -210,7 +210,7 @@ func (pr *persistenceRetryer) GetHistoryTasks(
 	req *GetHistoryTasksRequest,
 ) (*GetHistoryTasksResponse, error) {
 	var resp *GetHistoryTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = pr.execManager.GetHistoryTasks(ctx, req)
 		return err
@@ -228,7 +228,7 @@ func (pr *persistenceRetryer) CompleteHistoryTask(
 	ctx context.Context,
 	request *CompleteHistoryTaskRequest,
 ) error {
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return pr.execManager.CompleteHistoryTask(ctx, request)
 	}
 

--- a/common/reconciliation/store/blobstoreWriter.go
+++ b/common/reconciliation/store/blobstoreWriter.go
@@ -129,8 +129,8 @@ func getBlobstoreWriteFn(
 			},
 		}
 
-		operation := func(ctx1 context.Context) error {
-			ctx, cancel := context.WithTimeout(ctx1, Timeout)
+		operation := func(ctx context.Context) error {
+			ctx, cancel := context.WithTimeout(ctx, Timeout)
 			defer cancel()
 			_, err := client.Put(ctx, req)
 			return err

--- a/common/reconciliation/store/blobstoreWriter.go
+++ b/common/reconciliation/store/blobstoreWriter.go
@@ -129,8 +129,8 @@ func getBlobstoreWriteFn(
 			},
 		}
 
-		operation := func() error {
-			ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+		operation := func(ctx1 context.Context) error {
+			ctx, cancel := context.WithTimeout(ctx1, Timeout)
 			defer cancel()
 			_, err := client.Put(ctx, req)
 			return err

--- a/common/task/parallel_task_processor.go
+++ b/common/task/parallel_task_processor.go
@@ -162,7 +162,7 @@ func (p *parallelTaskProcessorImpl) executeTask(task Task, shutdownCh chan struc
 		}
 	}()
 
-	op := func() error {
+	op := func(ctx context.Context) error {
 		if err := task.Execute(); err != nil {
 			return task.HandleErr(err)
 		}

--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -1087,12 +1087,12 @@ func (adh *adminHandlerImpl) ReadDLQMessages(
 
 	var tasks []*types.ReplicationTask
 	var token []byte
-	var op func() error
+	var op func(ctx context.Context) error
 	switch request.GetType() {
 	case types.DLQTypeReplication:
 		return adh.GetHistoryClient().ReadDLQMessages(ctx, request)
 	case types.DLQTypeDomain:
-		op = func() error {
+		op = func(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -1142,12 +1142,12 @@ func (adh *adminHandlerImpl) PurgeDLQMessages(
 		request.InclusiveEndMessageID = common.Ptr(constants.InclusiveEndMessageID)
 	}
 
-	var op func() error
+	var op func(ctx context.Context) error
 	switch request.GetType() {
 	case types.DLQTypeReplication:
 		return adh.GetHistoryClient().PurgeDLQMessages(ctx, request)
 	case types.DLQTypeDomain:
-		op = func() error {
+		op = func(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -1217,13 +1217,13 @@ func (adh *adminHandlerImpl) MergeDLQMessages(
 	}
 
 	var token []byte
-	var op func() error
+	var op func(ctx context.Context) error
 	switch request.GetType() {
 	case types.DLQTypeReplication:
 		return adh.GetHistoryClient().MergeDLQMessages(ctx, request)
 	case types.DLQTypeDomain:
 
-		op = func() error {
+		op = func(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -341,7 +341,7 @@ func (wh *WorkflowHandler) PollForActivityTask(
 	}
 	pollerID := uuid.New().String()
 	var matchingResp *types.MatchingPollForActivityTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		matchingResp, err = wh.GetMatchingClient().PollForActivityTask(ctx, &types.MatchingPollForActivityTaskRequest{
 			DomainUUID:     domainID,
 			PollerID:       pollerID,
@@ -482,7 +482,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 
 	pollerID := uuid.New().String()
 	var matchingResp *types.MatchingPollForDecisionTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		matchingResp, err = wh.GetMatchingClient().PollForDecisionTask(ctx, &types.MatchingPollForDecisionTaskRequest{
 			DomainUUID:     domainID,
 			PollerID:       pollerID,

--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -645,7 +645,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
 				}).Return(&persistence.AppendHistoryNodesResponse{}, nil)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(context.Background(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{}, nil)
 
 				engine := engine.NewMockEngine(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(3)
@@ -774,7 +774,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
 				}).Return(&persistence.AppendHistoryNodesResponse{}, nil)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(context.Background(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{}, nil)
 
 				engine := engine.NewMockEngine(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(3)
@@ -907,7 +907,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
-				firstGetWfExecutionCall := decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).
+				firstGetWfExecutionCall := decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&persistence.GetWorkflowExecutionResponse{
 						State: &persistence.WorkflowMutableState{
 							ExecutionInfo: &persistence.WorkflowExecutionInfo{
@@ -920,7 +920,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 						},
 						MutableStateStats: &persistence.MutableStateStats{},
 					}, nil)
-				lastGetWfExecutionCall := decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).Return(nil, errors.New("some error occurred when loading workflow execution"))
+				lastGetWfExecutionCall := decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error occurred when loading workflow execution"))
 				gomock.InOrder(firstGetWfExecutionCall, lastGetWfExecutionCall)
 			},
 		},
@@ -960,7 +960,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(&persistence.AppendHistoryNodesResponse{}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx interface{}, request interface{}) (*persistence.GetWorkflowExecutionResponse, error) {
 						return &persistence.GetWorkflowExecutionResponse{
 							State: &persistence.WorkflowMutableState{
@@ -975,7 +975,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 							MutableStateStats: &persistence.MutableStateStats{},
 						}, nil
 					}).Times(2)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(context.Background(), gomock.Any()).Return(nil, errors.New("some error updating workflow execution"))
+				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error updating workflow execution"))
 				engine := engine.NewMockEngine(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(2)
 				engine.EXPECT().NotifyNewTransferTasks(gomock.Any())
@@ -1010,7 +1010,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					cluster.TestCurrentClusterName)
 				decisionHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomainByID(constants.TestDomainID).AnyTimes().Return(domainEntry, nil)
 
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&persistence.GetWorkflowExecutionResponse{
 						State: &persistence.WorkflowMutableState{
 							ExecutionInfo:  &persistence.WorkflowExecutionInfo{DomainID: constants.TestDomainID, WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID, DecisionScheduleID: 1},
@@ -1018,7 +1018,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 						},
 						MutableStateStats: &persistence.MutableStateStats{},
 					}, nil).Times(1)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&persistence.GetWorkflowExecutionResponse{
 						State: &persistence.WorkflowMutableState{
 							ExecutionInfo:  &persistence.WorkflowExecutionInfo{DomainID: constants.TestDomainID, WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID},
@@ -1026,7 +1026,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 						},
 						MutableStateStats: &persistence.MutableStateStats{},
 					}, nil).Times(1)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&persistence.GetWorkflowExecutionResponse{
 						State: &persistence.WorkflowMutableState{
 							ExecutionInfo:  &persistence.WorkflowExecutionInfo{DomainID: constants.TestDomainID, WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID, DecisionAttempt: 2},
@@ -1056,7 +1056,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					RunID:      constants.TestRunID,
 				}
 				decisionHandler.tokenSerializer.(*common.MockTaskTokenSerializer).EXPECT().Deserialize(serializedTestToken).Return(deserializedTestToken, nil)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), gomock.Any()).Times(1).Return(nil, errors.New("some random error"))
+				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.New("some random error"))
 			},
 		},
 		{
@@ -1151,7 +1151,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
 				}).Return(&persistence.AppendHistoryNodesResponse{}, nil)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(context.Background(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{}, nil)
+				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{}, nil)
 				engine := engine.NewMockEngine(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(3)
 				engine.EXPECT().NotifyNewHistoryEvent(events.NewNotification(constants.TestDomainID, &types.WorkflowExecution{WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID},
@@ -1477,7 +1477,7 @@ func expectGetWorkflowExecution(handler *handlerImpl, domainID string, state *pe
 	workflowExecutionResponse.State.ExecutionInfo.WorkflowID = constants.TestWorkflowID
 	workflowExecutionResponse.State.ExecutionInfo.RunID = constants.TestRunID
 
-	handler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(context.Background(), &persistence.GetWorkflowExecutionRequest{
+	handler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), &persistence.GetWorkflowExecutionRequest{
 		DomainID:   domainID,
 		DomainName: constants.TestDomainName,
 		Execution: types.WorkflowExecution{

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -361,9 +361,9 @@ func (c *cacheImpl) getCurrentExecutionWithRetry(
 	defer sw.Stop()
 
 	var response *persistence.GetCurrentExecutionResponse
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		var err error
-		response, err = c.executionManager.GetCurrentExecution(ctx1, request)
+		response, err = c.executionManager.GetCurrentExecution(ctx, request)
 
 		return err
 	}

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -361,9 +361,9 @@ func (c *cacheImpl) getCurrentExecutionWithRetry(
 	defer sw.Stop()
 
 	var response *persistence.GetCurrentExecutionResponse
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		var err error
-		response, err = c.executionManager.GetCurrentExecution(ctx, request)
+		response, err = c.executionManager.GetCurrentExecution(ctx1, request)
 
 		return err
 	}

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1150,7 +1150,7 @@ func appendHistoryV2EventsWithRetry(
 ) (*persistence.AppendHistoryNodesResponse, error) {
 
 	var resp *persistence.AppendHistoryNodesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = shardContext.AppendHistoryV2Events(ctx, request, domainID, execution)
 		return err
@@ -1172,7 +1172,7 @@ func createWorkflowExecutionWithRetry(
 ) (*persistence.CreateWorkflowExecutionResponse, error) {
 
 	var resp *persistence.CreateWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = shardContext.CreateWorkflowExecution(ctx, request)
 		return err
@@ -1217,7 +1217,7 @@ func getWorkflowExecutionWithRetry(
 	request *persistence.GetWorkflowExecutionRequest,
 ) (*persistence.GetWorkflowExecutionResponse, error) {
 	var resp *persistence.GetWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = shardContext.GetWorkflowExecution(ctx, request)
 		return err
@@ -1255,7 +1255,7 @@ func updateWorkflowExecutionWithRetry(
 ) (*persistence.UpdateWorkflowExecutionResponse, error) {
 
 	var resp *persistence.UpdateWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = shardContext.UpdateWorkflowExecution(ctx, request)
 		return err

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -526,7 +526,7 @@ func (t *transferQueueProcessorBase) readTasks(
 ) ([]persistence.Task, bool, error) {
 
 	var response *persistence.GetHistoryTasksResponse
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		var err error
 		response, err = t.shard.GetExecutionManager().GetHistoryTasks(context.Background(), &persistence.GetHistoryTasksRequest{
 			TaskCategory:        persistence.HistoryTaskCategoryTransfer,

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -526,7 +526,7 @@ func (t *transferQueueProcessorBase) readTasks(
 ) ([]persistence.Task, bool, error) {
 
 	var response *persistence.GetHistoryTasksResponse
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		var err error
 		response, err = t.shard.GetExecutionManager().GetHistoryTasks(context.Background(), &persistence.GetHistoryTasksRequest{
 			TaskCategory:        persistence.HistoryTaskCategoryTransfer,

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -393,12 +393,12 @@ func (p *taskProcessorImpl) handleSyncShardStatus(status *types.SyncShardStatus)
 }
 
 func (p *taskProcessorImpl) processSingleTask(replicationTask *types.ReplicationTask) error {
-	retryTransientError := func() error {
+	retryTransientError := func(ctx context.Context) error {
 		throttleRetry := backoff.NewThrottleRetry(
 			backoff.WithRetryPolicy(p.taskRetryPolicy),
 			backoff.WithRetryableError(isTransientRetryableError),
 		)
-		return throttleRetry.Do(context.Background(), func() error {
+		return throttleRetry.Do(context.Background(), func(ctx context.Context) error {
 			select {
 			case <-p.done:
 				// if the processor is stopping, skip the task
@@ -505,7 +505,7 @@ func (p *taskProcessorImpl) putReplicationTaskToDLQ(request *persistence.PutRepl
 		backoff.WithRetryableError(p.shouldRetryDLQ),
 	)
 	// The following is guaranteed to success or retry forever until processor is shutdown.
-	return throttleRetry.Do(context.Background(), func() error {
+	return throttleRetry.Do(context.Background(), func(ctx context.Context) error {
 		err := p.shard.GetExecutionManager().PutReplicationTaskToDLQ(context.Background(), request)
 		if err != nil {
 			p.logger.Error("Failed to put replication task to DLQ.", tag.Error(err))

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -398,7 +398,7 @@ func (p *taskProcessorImpl) processSingleTask(replicationTask *types.Replication
 			backoff.WithRetryPolicy(p.taskRetryPolicy),
 			backoff.WithRetryableError(isTransientRetryableError),
 		)
-		return throttleRetry.Do(context.Background(), func(ctx context.Context) error {
+		return throttleRetry.Do(ctx, func(ctx context.Context) error {
 			select {
 			case <-p.done:
 				// if the processor is stopping, skip the task
@@ -506,7 +506,7 @@ func (p *taskProcessorImpl) putReplicationTaskToDLQ(request *persistence.PutRepl
 	)
 	// The following is guaranteed to success or retry forever until processor is shutdown.
 	return throttleRetry.Do(context.Background(), func(ctx context.Context) error {
-		err := p.shard.GetExecutionManager().PutReplicationTaskToDLQ(context.Background(), request)
+		err := p.shard.GetExecutionManager().PutReplicationTaskToDLQ(ctx, request)
 		if err != nil {
 			p.logger.Error("Failed to put replication task to DLQ.", tag.Error(err))
 			p.metricsClient.IncCounter(metrics.ReplicationTaskFetcherScope, metrics.ReplicationDLQFailed)

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -143,9 +143,9 @@ func (m *TaskStore) Get(ctx context.Context, cluster string, info persistence.Ta
 	// Rate limit to not kill the database
 	m.rateLimiter.Wait(ctx)
 
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		var err error
-		task, err = m.hydrator.Hydrate(ctx1, info)
+		task, err = m.hydrator.Hydrate(ctx, info)
 		return err
 	}
 

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -143,11 +143,13 @@ func (m *TaskStore) Get(ctx context.Context, cluster string, info persistence.Ta
 	// Rate limit to not kill the database
 	m.rateLimiter.Wait(ctx)
 
-	err = m.throttleRetry.Do(ctx, func() error {
+	op := func(ctx1 context.Context) error {
 		var err error
-		task, err = m.hydrator.Hydrate(ctx, info)
+		task, err = m.hydrator.Hydrate(ctx1, info)
 		return err
-	})
+	}
+
+	err = m.throttleRetry.Do(ctx, op)
 
 	if err != nil {
 		m.scope.IncCounter(metrics.CacheFailures)

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1522,8 +1522,8 @@ func acquireShard(
 		return ok
 	}
 
-	getShard := func() error {
-		resp, err := shardItem.GetShardManager().GetShard(context.Background(), &persistence.GetShardRequest{
+	getShard := func(ctx context.Context) error {
+		resp, err := shardItem.GetShardManager().GetShard(ctx, &persistence.GetShardRequest{
 			ShardID: shardItem.shardID,
 		})
 		if err == nil {
@@ -1540,7 +1540,7 @@ func acquireShard(
 			RangeID:          0,
 			TransferAckLevel: 0,
 		}
-		return shardItem.GetShardManager().CreateShard(context.Background(), &persistence.CreateShardRequest{ShardInfo: shardInfo})
+		return shardItem.GetShardManager().CreateShard(ctx, &persistence.CreateShardRequest{ShardInfo: shardInfo})
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(

--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -253,8 +253,8 @@ func (t *timerTaskExecutorBase) deleteWorkflowExecution(
 	if err != nil {
 		return err
 	}
-	op := func(ctx1 context.Context) error {
-		return t.shard.GetExecutionManager().DeleteWorkflowExecution(ctx1, &persistence.DeleteWorkflowExecutionRequest{
+	op := func(ctx context.Context) error {
+		return t.shard.GetExecutionManager().DeleteWorkflowExecution(ctx, &persistence.DeleteWorkflowExecutionRequest{
 			DomainID:   task.DomainID,
 			WorkflowID: task.WorkflowID,
 			RunID:      task.RunID,
@@ -272,8 +272,8 @@ func (t *timerTaskExecutorBase) deleteCurrentWorkflowExecution(
 	if err != nil {
 		return err
 	}
-	op := func(ctx1 context.Context) error {
-		return t.shard.GetExecutionManager().DeleteCurrentWorkflowExecution(ctx1, &persistence.DeleteCurrentWorkflowExecutionRequest{
+	op := func(ctx context.Context) error {
+		return t.shard.GetExecutionManager().DeleteCurrentWorkflowExecution(ctx, &persistence.DeleteCurrentWorkflowExecutionRequest{
 			DomainID:   task.DomainID,
 			WorkflowID: task.WorkflowID,
 			RunID:      task.RunID,
@@ -289,7 +289,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowHistory(
 	msBuilder execution.MutableState,
 ) error {
 
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		branchToken, err := msBuilder.GetCurrentBranchToken()
 		if err != nil {
 			return err
@@ -317,7 +317,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
 	if errorDomainName != nil {
 		return errorDomainName
 	}
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		request := &persistence.VisibilityDeleteWorkflowExecutionRequest{
 			DomainID:   task.DomainID,
 			Domain:     domain,
@@ -326,7 +326,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
 			TaskID:     task.TaskID,
 		}
 		// TODO: expose GetVisibilityManager method on shardContext interface
-		return t.shard.GetService().GetVisibilityManager().DeleteWorkflowExecution(ctx1, request) // delete from db
+		return t.shard.GetService().GetVisibilityManager().DeleteWorkflowExecution(ctx, request) // delete from db
 	}
 	return t.throttleRetry.Do(ctx, op)
 }

--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -253,8 +253,8 @@ func (t *timerTaskExecutorBase) deleteWorkflowExecution(
 	if err != nil {
 		return err
 	}
-	op := func() error {
-		return t.shard.GetExecutionManager().DeleteWorkflowExecution(ctx, &persistence.DeleteWorkflowExecutionRequest{
+	op := func(ctx1 context.Context) error {
+		return t.shard.GetExecutionManager().DeleteWorkflowExecution(ctx1, &persistence.DeleteWorkflowExecutionRequest{
 			DomainID:   task.DomainID,
 			WorkflowID: task.WorkflowID,
 			RunID:      task.RunID,
@@ -272,8 +272,8 @@ func (t *timerTaskExecutorBase) deleteCurrentWorkflowExecution(
 	if err != nil {
 		return err
 	}
-	op := func() error {
-		return t.shard.GetExecutionManager().DeleteCurrentWorkflowExecution(ctx, &persistence.DeleteCurrentWorkflowExecutionRequest{
+	op := func(ctx1 context.Context) error {
+		return t.shard.GetExecutionManager().DeleteCurrentWorkflowExecution(ctx1, &persistence.DeleteCurrentWorkflowExecutionRequest{
 			DomainID:   task.DomainID,
 			WorkflowID: task.WorkflowID,
 			RunID:      task.RunID,
@@ -289,7 +289,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowHistory(
 	msBuilder execution.MutableState,
 ) error {
 
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		branchToken, err := msBuilder.GetCurrentBranchToken()
 		if err != nil {
 			return err
@@ -317,7 +317,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
 	if errorDomainName != nil {
 		return errorDomainName
 	}
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		request := &persistence.VisibilityDeleteWorkflowExecutionRequest{
 			DomainID:   task.DomainID,
 			Domain:     domain,
@@ -326,7 +326,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
 			TaskID:     task.TaskID,
 		}
 		// TODO: expose GetVisibilityManager method on shardContext interface
-		return t.shard.GetService().GetVisibilityManager().DeleteWorkflowExecution(ctx, request) // delete from db
+		return t.shard.GetService().GetVisibilityManager().DeleteWorkflowExecution(ctx1, request) // delete from db
 	}
 	return t.throttleRetry.Do(ctx, op)
 }

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1481,15 +1481,15 @@ func requestCancelExternalExecutionWithRetry(
 
 	requestCancelCtx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
 	defer cancel()
-	op := func() error {
-		return historyClient.RequestCancelWorkflowExecution(requestCancelCtx, request)
+	op := func(ctx1 context.Context) error {
+		return historyClient.RequestCancelWorkflowExecution(ctx1, request)
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(taskRetryPolicy),
 		backoff.WithRetryableError(common.IsServiceTransientError),
 	)
-	err := throttleRetry.Do(context.Background(), op)
+	err := throttleRetry.Do(requestCancelCtx, op)
 	switch err.(type) {
 	case *types.CancellationAlreadyRequestedError:
 		// err is CancellationAlreadyRequestedError
@@ -1532,15 +1532,15 @@ func signalExternalExecutionWithRetry(
 
 	signalCtx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
 	defer cancel()
-	op := func() error {
-		return historyClient.SignalWorkflowExecution(signalCtx, request)
+	op := func(ctx1 context.Context) error {
+		return historyClient.SignalWorkflowExecution(ctx1, request)
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(taskRetryPolicy),
 		backoff.WithRetryableError(common.IsServiceTransientError),
 	)
-	return throttleRetry.Do(context.Background(), op)
+	return throttleRetry.Do(signalCtx, op)
 }
 
 func removeSignalMutableStateWithRetry(
@@ -1561,15 +1561,15 @@ func removeSignalMutableStateWithRetry(
 		RequestID: signalRequestID,
 	}
 
-	op := func() error {
-		return historyClient.RemoveSignalMutableState(ctx, removeSignalRequest)
+	op := func(ctx1 context.Context) error {
+		return historyClient.RemoveSignalMutableState(ctx1, removeSignalRequest)
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(taskRetryPolicy),
 		backoff.WithRetryableError(common.IsServiceTransientError),
 	)
-	err := throttleRetry.Do(context.Background(), op)
+	err := throttleRetry.Do(ctx, op)
 	switch err.(type) {
 	case *types.EntityNotExistsError:
 		// it's safe to discard entity not exists error here
@@ -1639,8 +1639,8 @@ func startWorkflowWithRetry(
 	startWorkflowCtx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
 	defer cancel()
 	var response *types.StartWorkflowExecutionResponse
-	op := func() error {
-		response, err = historyClient.StartWorkflowExecution(startWorkflowCtx, historyStartReq)
+	op := func(ctx1 context.Context) error {
+		response, err = historyClient.StartWorkflowExecution(ctx1, historyStartReq)
 		return err
 	}
 
@@ -1648,7 +1648,7 @@ func startWorkflowWithRetry(
 		backoff.WithRetryPolicy(taskRetryPolicy),
 		backoff.WithRetryableError(common.IsServiceTransientError),
 	)
-	if err := throttleRetry.Do(context.Background(), op); err != nil {
+	if err := throttleRetry.Do(startWorkflowCtx, op); err != nil {
 		return "", err
 	}
 	return response.GetRunID(), nil

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1481,8 +1481,8 @@ func requestCancelExternalExecutionWithRetry(
 
 	requestCancelCtx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
 	defer cancel()
-	op := func(ctx1 context.Context) error {
-		return historyClient.RequestCancelWorkflowExecution(ctx1, request)
+	op := func(ctx context.Context) error {
+		return historyClient.RequestCancelWorkflowExecution(ctx, request)
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
@@ -1532,8 +1532,8 @@ func signalExternalExecutionWithRetry(
 
 	signalCtx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
 	defer cancel()
-	op := func(ctx1 context.Context) error {
-		return historyClient.SignalWorkflowExecution(ctx1, request)
+	op := func(ctx context.Context) error {
+		return historyClient.SignalWorkflowExecution(ctx, request)
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
@@ -1561,8 +1561,8 @@ func removeSignalMutableStateWithRetry(
 		RequestID: signalRequestID,
 	}
 
-	op := func(ctx1 context.Context) error {
-		return historyClient.RemoveSignalMutableState(ctx1, removeSignalRequest)
+	op := func(ctx context.Context) error {
+		return historyClient.RemoveSignalMutableState(ctx, removeSignalRequest)
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
@@ -1639,8 +1639,8 @@ func startWorkflowWithRetry(
 	startWorkflowCtx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
 	defer cancel()
 	var response *types.StartWorkflowExecutionResponse
-	op := func(ctx1 context.Context) error {
-		response, err = historyClient.StartWorkflowExecution(ctx1, historyStartReq)
+	op := func(ctx context.Context) error {
+		response, err = historyClient.StartWorkflowExecution(ctx, historyStartReq)
 		return err
 	}
 

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -1280,9 +1280,9 @@ func (e *matchingEngineImpl) recordDecisionTaskStarted(
 		PollRequest:       pollReq,
 	}
 	var resp *types.RecordDecisionTaskStartedResponse
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		var err error
-		resp, err = e.historyService.RecordDecisionTaskStarted(ctx1, request)
+		resp, err = e.historyService.RecordDecisionTaskStarted(ctx, request)
 		return err
 	}
 	throttleRetry := backoff.NewThrottleRetry(
@@ -1307,9 +1307,9 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 		PollRequest:       pollReq,
 	}
 	var resp *types.RecordActivityTaskStartedResponse
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		var err error
-		resp, err = e.historyService.RecordActivityTaskStarted(ctx1, request)
+		resp, err = e.historyService.RecordActivityTaskStarted(ctx, request)
 		return err
 	}
 	throttleRetry := backoff.NewThrottleRetry(

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -1280,9 +1280,9 @@ func (e *matchingEngineImpl) recordDecisionTaskStarted(
 		PollRequest:       pollReq,
 	}
 	var resp *types.RecordDecisionTaskStartedResponse
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		var err error
-		resp, err = e.historyService.RecordDecisionTaskStarted(ctx, request)
+		resp, err = e.historyService.RecordDecisionTaskStarted(ctx1, request)
 		return err
 	}
 	throttleRetry := backoff.NewThrottleRetry(
@@ -1307,9 +1307,9 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 		PollRequest:       pollReq,
 	}
 	var resp *types.RecordActivityTaskStartedResponse
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		var err error
-		resp, err = e.historyService.RecordActivityTaskStarted(ctx, request)
+		resp, err = e.historyService.RecordActivityTaskStarted(ctx1, request)
 		return err
 	}
 	throttleRetry := backoff.NewThrottleRetry(

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -90,7 +90,7 @@ func newTaskCompleter(tlMgr *taskListManagerImpl, retryPolicy backoff.RetryPolic
 }
 
 func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *InternalTask) error {
-	op := func(ctx1 context.Context) (err error) {
+	op := func(ctx context.Context) (err error) {
 		domainEntry, err := tc.domainCache.GetDomainByID(task.Event.TaskInfo.DomainID)
 		if err != nil {
 			return fmt.Errorf("unable to fetch domain from cache: %w", err)
@@ -111,7 +111,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 			},
 		}
 
-		workflowExecutionResponse, err := tc.historyService.DescribeWorkflowExecution(ctx1, req)
+		workflowExecutionResponse, err := tc.historyService.DescribeWorkflowExecution(ctx, req)
 
 		if errors.As(err, new(*types.EntityNotExistsError)) {
 			tc.logger.Warn("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))

--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -90,7 +90,7 @@ func newTaskCompleter(tlMgr *taskListManagerImpl, retryPolicy backoff.RetryPolic
 }
 
 func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *InternalTask) error {
-	op := func() (err error) {
+	op := func(ctx1 context.Context) (err error) {
 		domainEntry, err := tc.domainCache.GetDomainByID(task.Event.TaskInfo.DomainID)
 		if err != nil {
 			return fmt.Errorf("unable to fetch domain from cache: %w", err)
@@ -111,7 +111,7 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 			},
 		}
 
-		workflowExecutionResponse, err := tc.historyService.DescribeWorkflowExecution(ctx, req)
+		workflowExecutionResponse, err := tc.historyService.DescribeWorkflowExecution(ctx1, req)
 
 		if errors.As(err, new(*types.EntityNotExistsError)) {
 			tc.logger.Warn("Workflow execution not found while attempting to complete task on standby cluster", tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID))

--- a/service/matching/tasklist/task_completer_test.go
+++ b/service/matching/tasklist/task_completer_test.go
@@ -132,7 +132,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 			},
 			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient, timeSource clock.MockedTimeSource) {
 				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(nil, errors.New("error-describing-workflow-execution")).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(nil, errors.New("error-describing-workflow-execution")).Times(retryPolicyMaxAttempts + 1)
 			},
 			isTaskComplete: false,
 			err:            errors.New("error-describing-workflow-execution"),
@@ -155,7 +155,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient, timeSource clock.MockedTimeSource) {
 				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
 				resp := &types.DescribeWorkflowExecutionResponse{}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
 			},
 			isTaskComplete: false,
 			err:            errWorkflowExecutionInfoIsNil,
@@ -180,7 +180,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 				resp := &types.DescribeWorkflowExecutionResponse{
 					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
 			},
 			taskType:       999,
 			isTaskComplete: false,
@@ -211,7 +211,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						State:      types.PendingDecisionStateScheduled.Ptr(),
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
 			},
 			taskType:       persistence.TaskListTypeDecision,
 			isTaskComplete: false,
@@ -242,7 +242,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						State:      types.PendingDecisionStateScheduled.Ptr(),
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
 			},
 			taskType:       persistence.TaskListTypeDecision,
 			isTaskComplete: false,
@@ -275,7 +275,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						},
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(retryPolicyMaxAttempts + 1)
 			},
 			taskType:       persistence.TaskListTypeActivity,
 			isTaskComplete: false,
@@ -298,7 +298,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 			},
 			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient, timeSource clock.MockedTimeSource) {
 				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(retryPolicyMaxAttempts + 1)
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(nil, &types.EntityNotExistsError{}).Times(retryPolicyMaxAttempts + 1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(nil, &types.EntityNotExistsError{}).Times(retryPolicyMaxAttempts + 1)
 			},
 			isTaskComplete: false,
 			err:            errWaitTimeNotReachedForEntityNotExists,
@@ -320,7 +320,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 			},
 			setupMock: func(req *types.HistoryDescribeWorkflowExecutionRequest, mockDomainCache *cache.MockDomainCache, mockHistoryService *history.MockClient, timeSource clock.MockedTimeSource) {
 				mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalStandbyDomainEntry, nil).Times(1)
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(nil, &types.EntityNotExistsError{}).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(nil, &types.EntityNotExistsError{}).Times(1)
 				timeSource.Advance(time.Hour*24 + time.Second)
 			},
 			isTaskComplete: true,
@@ -349,7 +349,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						CloseStatus: types.WorkflowExecutionCloseStatusCompleted.Ptr(),
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(1)
 			},
 			taskType:       persistence.TaskListTypeDecision,
 			isTaskComplete: true,
@@ -376,7 +376,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 				resp := &types.DescribeWorkflowExecutionResponse{
 					WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(1)
 			},
 			taskType:       persistence.TaskListTypeDecision,
 			isTaskComplete: true,
@@ -406,7 +406,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						ScheduleID: 3,
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(1)
 			},
 			taskType:       persistence.TaskListTypeDecision,
 			isTaskComplete: true,
@@ -437,7 +437,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						State:      types.PendingDecisionStateStarted.Ptr(),
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(1)
 			},
 			taskType:       persistence.TaskListTypeDecision,
 			isTaskComplete: true,
@@ -474,7 +474,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						},
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(1)
 			},
 			taskType:       persistence.TaskListTypeActivity,
 			isTaskComplete: true,
@@ -507,7 +507,7 @@ func TestCompleteTaskIfStarted(t *testing.T) {
 						},
 					},
 				}
-				mockHistoryService.EXPECT().DescribeWorkflowExecution(ctx, req).Return(resp, nil).Times(1)
+				mockHistoryService.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(resp, nil).Times(1)
 			},
 			taskType:       persistence.TaskListTypeActivity,
 			isTaskComplete: true,

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -253,7 +253,7 @@ func (c *taskListManagerImpl) Start() error {
 
 	if !c.taskListID.IsRoot() && c.taskListKind == types.TaskListKindNormal {
 		var info *persistence.TaskListInfo
-		err := c.throttleRetry.Do(context.Background(), func(ctx1 context.Context) error {
+		err := c.throttleRetry.Do(context.Background(), func(ctx context.Context) error {
 			var err error
 			info, err = c.db.GetTaskListInfo(c.taskListID.GetRoot())
 			return err
@@ -394,7 +394,7 @@ func (c *taskListManagerImpl) RefreshTaskListPartitionConfig(ctx context.Context
 	if config == nil {
 		// if config is nil, we'll reload it from database
 		var info *persistence.TaskListInfo
-		err := c.throttleRetry.Do(ctx, func(ctx1 context.Context) error {
+		err := c.throttleRetry.Do(ctx, func(ctx context.Context) error {
 			var err error
 			info, err = c.db.GetTaskListInfo(c.taskListID.GetRoot())
 			return err
@@ -450,7 +450,7 @@ func (c *taskListManagerImpl) updatePartitionConfig(ctx context.Context, newConf
 			return nil, nil, nil
 		}
 	}
-	err = c.throttleRetry.Do(ctx, func(ctx1 context.Context) error {
+	err = c.throttleRetry.Do(ctx, func(ctx context.Context) error {
 		return c.db.UpdateTaskListPartitionConfig(toPersistenceConfig(version+1, newConfig))
 	})
 	if err != nil {
@@ -787,7 +787,7 @@ func (c *taskListManagerImpl) executeWithRetry(
 	operation func() (interface{}, error),
 ) (result interface{}, err error) {
 
-	op := func(ctx1 context.Context) error {
+	op := func(ctx context.Context) error {
 		result, err = operation()
 		return err
 	}

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -253,7 +253,7 @@ func (c *taskListManagerImpl) Start() error {
 
 	if !c.taskListID.IsRoot() && c.taskListKind == types.TaskListKindNormal {
 		var info *persistence.TaskListInfo
-		err := c.throttleRetry.Do(context.Background(), func() error {
+		err := c.throttleRetry.Do(context.Background(), func(ctx1 context.Context) error {
 			var err error
 			info, err = c.db.GetTaskListInfo(c.taskListID.GetRoot())
 			return err
@@ -394,7 +394,7 @@ func (c *taskListManagerImpl) RefreshTaskListPartitionConfig(ctx context.Context
 	if config == nil {
 		// if config is nil, we'll reload it from database
 		var info *persistence.TaskListInfo
-		err := c.throttleRetry.Do(ctx, func() error {
+		err := c.throttleRetry.Do(ctx, func(ctx1 context.Context) error {
 			var err error
 			info, err = c.db.GetTaskListInfo(c.taskListID.GetRoot())
 			return err
@@ -450,7 +450,7 @@ func (c *taskListManagerImpl) updatePartitionConfig(ctx context.Context, newConf
 			return nil, nil, nil
 		}
 	}
-	err = c.throttleRetry.Do(ctx, func() error {
+	err = c.throttleRetry.Do(ctx, func(ctx1 context.Context) error {
 		return c.db.UpdateTaskListPartitionConfig(toPersistenceConfig(version+1, newConfig))
 	})
 	if err != nil {
@@ -787,7 +787,7 @@ func (c *taskListManagerImpl) executeWithRetry(
 	operation func() (interface{}, error),
 ) (result interface{}, err error) {
 
-	op := func() error {
+	op := func(ctx1 context.Context) error {
 		result, err = operation()
 		return err
 	}

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -359,7 +359,7 @@ func (tr *taskReader) completeTask(task *persistence.TaskInfo, err error) {
 		// again the underlying reason for failing to start will be resolved.
 		// Note that RecordTaskStarted only fails after retrying for a long time, so a single task will not be
 		// re-written to persistence frequently.
-		op := func(ctx1 context.Context) error {
+		op := func(ctx context.Context) error {
 			_, err := tr.taskWriter.appendTask(task)
 			return err
 		}

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -257,7 +257,7 @@ getTasksPumpLoop:
 
 func (tr *taskReader) getTaskBatchWithRange(readLevel int64, maxReadLevel int64) ([]*persistence.TaskInfo, error) {
 	var response *persistence.GetTasksResponse
-	op := func() (err error) {
+	op := func(ctx context.Context) (err error) {
 		response, err = tr.db.GetTasks(readLevel, maxReadLevel, tr.config.GetTasksBatchSize())
 		return
 	}
@@ -359,7 +359,7 @@ func (tr *taskReader) completeTask(task *persistence.TaskInfo, err error) {
 		// again the underlying reason for failing to start will be resolved.
 		// Note that RecordTaskStarted only fails after retrying for a long time, so a single task will not be
 		// re-written to persistence frequently.
-		op := func() error {
+		op := func(ctx1 context.Context) error {
 			_, err := tr.taskWriter.appendTask(task)
 			return err
 		}

--- a/service/matching/tasklist/task_writer.go
+++ b/service/matching/tasklist/task_writer.go
@@ -183,7 +183,7 @@ func (w *taskWriter) allocTaskIDBlock(prevBlockEnd int64) (taskIDBlock, error) {
 
 func (w *taskWriter) renewLeaseWithRetry() (taskListState, error) {
 	var newState taskListState
-	op := func(ctx1 context.Context) (err error) {
+	op := func(ctx context.Context) (err error) {
 		newState, err = w.db.RenewLease()
 		return
 	}

--- a/service/matching/tasklist/task_writer.go
+++ b/service/matching/tasklist/task_writer.go
@@ -183,7 +183,7 @@ func (w *taskWriter) allocTaskIDBlock(prevBlockEnd int64) (taskIDBlock, error) {
 
 func (w *taskWriter) renewLeaseWithRetry() (taskListState, error) {
 	var newState taskListState
-	op := func() (err error) {
+	op := func(ctx1 context.Context) (err error) {
 		newState, err = w.db.RenewLease()
 		return
 	}

--- a/service/worker/replicator/domain_replication_processor.go
+++ b/service/worker/replicator/domain_replication_processor.go
@@ -176,13 +176,13 @@ func (p *domainReplicationProcessor) fetchDomainReplicationTasks() {
 
 	for taskIndex := range response.Messages.ReplicationTasks {
 		task := response.Messages.ReplicationTasks[taskIndex]
-		err := p.throttleRetry.Do(p.ctx, func() error {
+		err := p.throttleRetry.Do(p.ctx, func(ctx context.Context) error {
 			return p.handleDomainReplicationTask(task)
 		})
 
 		if err != nil {
 			p.logger.Error("Failed to apply domain replication tasks", tag.Error(err))
-			dlqErr := p.throttleRetry.Do(context.Background(), func() error {
+			dlqErr := p.throttleRetry.Do(context.Background(), func(ctx context.Context) error {
 				return p.putDomainReplicationTaskToDLQ(task)
 			})
 			if dlqErr != nil {

--- a/service/worker/scanner/tasklist/db.go
+++ b/service/worker/scanner/tasklist/db.go
@@ -123,8 +123,8 @@ func (s *Scavenger) deleteTaskList(info *p.TaskListInfo) error {
 	if errorDomain != nil {
 		return errorDomain
 	}
-	op := func(ctx1 context.Context) error {
-		return s.db.DeleteTaskList(ctx1, &p.DeleteTaskListRequest{
+	op := func(ctx context.Context) error {
+		return s.db.DeleteTaskList(ctx, &p.DeleteTaskListRequest{
 			DomainID:     info.DomainID,
 			TaskListName: info.Name,
 			TaskListType: info.TaskType,

--- a/service/worker/scanner/tasklist/db.go
+++ b/service/worker/scanner/tasklist/db.go
@@ -38,8 +38,8 @@ func (s *Scavenger) completeTasks(info *p.TaskListInfo, taskID int64, limit int)
 	if errorDomain != nil {
 		return 0, errorDomain
 	}
-	err = s.retryForever(func() error {
-		resp, err = s.db.CompleteTasksLessThan(s.ctx, &p.CompleteTasksLessThanRequest{
+	err = s.retryForever(func(ctx context.Context) error {
+		resp, err = s.db.CompleteTasksLessThan(ctx, &p.CompleteTasksLessThanRequest{
 			DomainID:     info.DomainID,
 			TaskListName: info.Name,
 			TaskType:     info.TaskType,
@@ -58,8 +58,8 @@ func (s *Scavenger) completeTasks(info *p.TaskListInfo, taskID int64, limit int)
 func (s *Scavenger) getOrphanTasks(limit int) (*p.GetOrphanTasksResponse, error) {
 	var tasks *p.GetOrphanTasksResponse
 	var err error
-	err = s.retryForever(func() error {
-		tasks, err = s.db.GetOrphanTasks(s.ctx, &p.GetOrphanTasksRequest{
+	err = s.retryForever(func(ctx context.Context) error {
+		tasks, err = s.db.GetOrphanTasks(ctx, &p.GetOrphanTasksRequest{
 			Limit: limit,
 		})
 		return err
@@ -73,8 +73,8 @@ func (s *Scavenger) completeTask(info *p.TaskListInfo, taskid int64) error {
 	if errorDomain != nil {
 		return errorDomain
 	}
-	err = s.retryForever(func() error {
-		err = s.db.CompleteTask(s.ctx, &p.CompleteTaskRequest{
+	err = s.retryForever(func(ctx context.Context) error {
+		err = s.db.CompleteTask(ctx, &p.CompleteTaskRequest{
 			TaskList:   info,
 			TaskID:     taskid,
 			DomainName: domainName,
@@ -91,8 +91,8 @@ func (s *Scavenger) getTasks(info *p.TaskListInfo, batchSize int) (*p.GetTasksRe
 	if errorDomain != nil {
 		return nil, errorDomain
 	}
-	err = s.retryForever(func() error {
-		resp, err = s.db.GetTasks(s.ctx, &p.GetTasksRequest{
+	err = s.retryForever(func(ctx context.Context) error {
+		resp, err = s.db.GetTasks(ctx, &p.GetTasksRequest{
 			DomainID:   info.DomainID,
 			TaskList:   info.Name,
 			TaskType:   info.TaskType,
@@ -108,8 +108,8 @@ func (s *Scavenger) getTasks(info *p.TaskListInfo, batchSize int) (*p.GetTasksRe
 func (s *Scavenger) listTaskList(pageSize int, pageToken []byte) (*p.ListTaskListResponse, error) {
 	var err error
 	var resp *p.ListTaskListResponse
-	err = s.retryForever(func() error {
-		resp, err = s.db.ListTaskList(s.ctx, &p.ListTaskListRequest{
+	err = s.retryForever(func(ctx context.Context) error {
+		resp, err = s.db.ListTaskList(ctx, &p.ListTaskListRequest{
 			PageSize:  pageSize,
 			PageToken: pageToken,
 		})
@@ -123,8 +123,8 @@ func (s *Scavenger) deleteTaskList(info *p.TaskListInfo) error {
 	if errorDomain != nil {
 		return errorDomain
 	}
-	op := func() error {
-		return s.db.DeleteTaskList(s.ctx, &p.DeleteTaskListRequest{
+	op := func(ctx1 context.Context) error {
+		return s.db.DeleteTaskList(ctx1, &p.DeleteTaskListRequest{
 			DomainID:     info.DomainID,
 			TaskListName: info.Name,
 			TaskListType: info.TaskType,
@@ -140,15 +140,15 @@ func (s *Scavenger) deleteTaskList(info *p.TaskListInfo) error {
 			return ok
 		}),
 	)
-	return throttleRetry.Do(context.Background(), op)
+	return throttleRetry.Do(s.ctx, op)
 }
 
-func (s *Scavenger) retryForever(op func() error) error {
+func (s *Scavenger) retryForever(op func(ctx context.Context) error) error {
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(retryForeverPolicy),
 		backoff.WithRetryableError(s.isRetryable),
 	)
-	return throttleRetry.Do(context.Background(), op)
+	return throttleRetry.Do(s.ctx, op)
 }
 
 func newRetryForeverPolicy() backoff.RetryPolicy {

--- a/service/worker/workercommon/util.go
+++ b/service/worker/workercommon/util.go
@@ -53,7 +53,7 @@ func StartWorkflowWithRetry(
 		backoff.WithRetryPolicy(policy),
 		backoff.WithRetryableError(func(_ error) bool { return true }),
 	)
-	err := throttleRetry.Do(context.Background(), func() error {
+	err := throttleRetry.Do(context.Background(), func(ctx context.Context) error {
 		return startWorkflow(sdkClient)
 	})
 	if err != nil {

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -132,7 +132,7 @@ func NewCQLClientWithRetry(cfg *CQLClientConfig, expectedConsistency gocql.Consi
 	cqlClient.cfg = cfg
 	cqlClient.nReplicas = cfg.NumReplicas
 
-	err := retrier.Do(context.Background(), func() error {
+	err := retrier.Do(context.Background(), func(ctx1 context.Context) error {
 		var err error
 		cqlClient.session, err = cassClient.CreateSession(gocql.ClusterConfig{
 			Hosts:                 cfg.Hosts,

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -132,7 +132,7 @@ func NewCQLClientWithRetry(cfg *CQLClientConfig, expectedConsistency gocql.Consi
 	cqlClient.cfg = cfg
 	cqlClient.nReplicas = cfg.NumReplicas
 
-	err := retrier.Do(context.Background(), func(ctx1 context.Context) error {
+	err := retrier.Do(context.Background(), func(ctx context.Context) error {
 		var err error
 		cqlClient.session, err = cassClient.CreateSession(gocql.ClusterConfig{
 			Hosts:                 cfg.Hosts,

--- a/tools/cli/admin_timers.go
+++ b/tools/cli/admin_timers.go
@@ -25,6 +25,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -274,7 +275,7 @@ func (cl *dbLoadCloser) Load() ([]*persistence.TimerTaskInfo, error) {
 
 		resp := &persistence.GetHistoryTasksResponse{}
 
-		op := func() error {
+		op := func(ctx context.Context) error {
 			ctx, cancel, err := newContext(cl.ctx)
 			defer cancel()
 			if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a new parameter of context.Context to the Operation in retryer & inject retryCount to retryable operations
Also refactor usage of all relevant usages

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to track retry count of each retryable operations to identify whether it's a retry storm

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
