### PR TITLE
Add capability to have multiple domains in replication simulation

### DIFF
--- a/docker/buildkite/docker-compose-local-replication-simulation.yml
+++ b/docker/buildkite/docker-compose-local-replication-simulation.yml
@@ -4,8 +4,8 @@ services:
     environment:
       - "MAX_HEAP_SIZE=256M"
       - "HEAP_NEWSIZE=128M"
-    expose:
-      - "9042"
+    ports:
+      - "9042:9042"
     networks:
       services-network:
         aliases:

--- a/simulation/replication/replication_simulation_test.go
+++ b/simulation/replication/replication_simulation_test.go
@@ -74,9 +74,7 @@ func TestReplicationSimulation(t *testing.T) {
 	}
 
 	// wait for domain data to be replicated and workers to start.
-	for domainName := range simCfg.Domains {
-		waitUntilWorkersReady(t, domainName)
-	}
+	waitUntilWorkersReady(t)
 
 	sort.Slice(simCfg.Operations, func(i, j int) bool {
 		return simCfg.Operations[i].At < simCfg.Operations[j].At
@@ -322,7 +320,7 @@ func mustJSON(t *testing.T, v interface{}) []byte {
 	return data
 }
 
-func waitUntilWorkersReady(t *testing.T, domainName string) {
+func waitUntilWorkersReady(t *testing.T) {
 	// workers expose :6060/health endpoint. Poll on them to check if they are healthy
 	simTypes.Logf(t, "Waiting for workers to start and report healthy")
 	workerEndpoints := []string{

--- a/simulation/replication/replication_simulation_test.go
+++ b/simulation/replication/replication_simulation_test.go
@@ -67,10 +67,16 @@ func TestReplicationSimulation(t *testing.T) {
 		simCfg.MustInitClientsFor(t, clusterName)
 	}
 
-	simCfg.MustRegisterDomain(t)
+	simTypes.Logf(t, "Registering domains")
+	for domainName := range simCfg.Domains {
+		simTypes.Logf(t, "Domain: %s", domainName)
+		simCfg.MustRegisterDomain(t, domainName)
+	}
 
 	// wait for domain data to be replicated and workers to start.
-	waitUntilWorkersReady(t)
+	for domainName := range simCfg.Domains {
+		waitUntilWorkersReady(t, domainName)
+	}
 
 	sort.Slice(simCfg.Operations, func(i, j int) bool {
 		return simCfg.Operations[i].At < simCfg.Operations[j].At
@@ -115,14 +121,14 @@ func startWorkflow(
 ) error {
 	t.Helper()
 
-	simTypes.Logf(t, "Starting workflow: %s on cluster: %s", op.WorkflowID, op.Cluster)
+	simTypes.Logf(t, "Starting workflow: %s on domain %s on cluster: %s", op.WorkflowID, op.Domain, op.Cluster)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	resp, err := simCfg.MustGetFrontendClient(t, op.Cluster).StartWorkflowExecution(ctx,
 		&types.StartWorkflowExecutionRequest{
 			RequestID:                           uuid.New(),
-			Domain:                              simCfg.Domain.Name,
+			Domain:                              op.Domain,
 			WorkflowID:                          op.WorkflowID,
 			WorkflowType:                        &types.WorkflowType{Name: simTypes.WorkflowName},
 			TaskList:                            &types.TaskList{Name: simTypes.TasklistName},
@@ -135,7 +141,7 @@ func startWorkflow(
 		return err
 	}
 
-	simTypes.Logf(t, "Started workflow: %s on cluster: %s. RunID: %s", op.WorkflowID, op.Cluster, resp.GetRunID())
+	simTypes.Logf(t, "Started workflow: %s on domain: %s on cluster: %s. RunID: %s", op.WorkflowID, op.Domain, op.Cluster, resp.GetRunID())
 
 	return nil
 }
@@ -147,16 +153,16 @@ func changeActiveClusters(
 ) error {
 	t.Helper()
 
-	simTypes.Logf(t, "Changing active clusters to: %v", op.NewActiveClusters)
+	simTypes.Logf(t, "Changing active clusters for domain %s to: %v", op.Domain, op.NewActiveClusters)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	descResp, err := simCfg.MustGetFrontendClient(t, simCfg.PrimaryCluster).DescribeDomain(ctx, &types.DescribeDomainRequest{Name: common.StringPtr(simCfg.Domain.Name)})
+	descResp, err := simCfg.MustGetFrontendClient(t, simCfg.PrimaryCluster).DescribeDomain(ctx, &types.DescribeDomainRequest{Name: common.StringPtr(op.Domain)})
 	if err != nil {
-		return fmt.Errorf("failed to describe domain %s: %w", simCfg.Domain.Name, err)
+		return fmt.Errorf("failed to describe domain %s: %w", op.Domain, err)
 	}
 
-	if !simCfg.IsActiveActiveDomain() {
+	if !simCfg.IsActiveActiveDomain(op.Domain) {
 		fromCluster := descResp.ReplicationConfiguration.ActiveClusterName
 		toCluster := op.NewActiveClusters[0]
 
@@ -164,7 +170,7 @@ func changeActiveClusters(
 		defer cancel()
 		_, err = simCfg.MustGetFrontendClient(t, simCfg.PrimaryCluster).UpdateDomain(ctx,
 			&types.UpdateDomainRequest{
-				Name:                     simCfg.Domain.Name,
+				Name:                     op.Domain,
 				ActiveClusterName:        &toCluster,
 				FailoverTimeoutInSeconds: op.FailoverTimeout,
 			})
@@ -196,7 +202,7 @@ func validate(
 	defer cancel()
 	resp, err := simCfg.MustGetFrontendClient(t, op.Cluster).DescribeWorkflowExecution(ctx,
 		&types.DescribeWorkflowExecutionRequest{
-			Domain: simCfg.Domain.Name,
+			Domain: op.Domain,
 			Execution: &types.WorkflowExecution{
 				WorkflowID: op.WorkflowID,
 			},
@@ -214,7 +220,7 @@ func validate(
 
 	// Get history to validate the worker identity that started and completed the workflow
 	// Some workflows start in cluster0 and complete in cluster1. This is to validate that
-	history, err := getAllHistory(t, simCfg, op.Cluster, op.WorkflowID)
+	history, err := getAllHistory(t, simCfg, op.Cluster, op.Domain, op.WorkflowID)
 	if err != nil {
 		return err
 	}
@@ -227,8 +233,8 @@ func validate(
 	if err != nil {
 		return err
 	}
-	if op.Want.StartedByWorkersInCluster != "" && startedWorker != simTypes.WorkerIdentityFor(op.Want.StartedByWorkersInCluster) {
-		return fmt.Errorf("workflow %s started by worker %s, expected %s", op.WorkflowID, startedWorker, simTypes.WorkerIdentityFor(op.Want.StartedByWorkersInCluster))
+	if op.Want.StartedByWorkersInCluster != "" && startedWorker != simTypes.WorkerIdentityFor(op.Want.StartedByWorkersInCluster, op.Domain) {
+		return fmt.Errorf("workflow %s started by worker %s, expected %s", op.WorkflowID, startedWorker, simTypes.WorkerIdentityFor(op.Want.StartedByWorkersInCluster, op.Domain))
 	}
 
 	completedWorker, err := lastDecisionTaskWorker(history)
@@ -236,8 +242,8 @@ func validate(
 		return err
 	}
 
-	if op.Want.CompletedByWorkersInCluster != "" && completedWorker != simTypes.WorkerIdentityFor(op.Want.CompletedByWorkersInCluster) {
-		return fmt.Errorf("workflow %s completed by worker %s, expected %s", op.WorkflowID, completedWorker, simTypes.WorkerIdentityFor(op.Want.CompletedByWorkersInCluster))
+	if op.Want.CompletedByWorkersInCluster != "" && completedWorker != simTypes.WorkerIdentityFor(op.Want.CompletedByWorkersInCluster, op.Domain) {
+		return fmt.Errorf("workflow %s completed by worker %s, expected %s", op.WorkflowID, completedWorker, simTypes.WorkerIdentityFor(op.Want.CompletedByWorkersInCluster, op.Domain))
 	}
 
 	return nil
@@ -273,14 +279,14 @@ func waitForOpTime(t *testing.T, op *simTypes.Operation, startTime time.Time) {
 	simTypes.Logf(t, "Operation time (t + %ds) reached: %v", int(op.At.Seconds()), startTime.Add(op.At))
 }
 
-func getAllHistory(t *testing.T, simCfg *simTypes.ReplicationSimulationConfig, clusterName, wfID string) ([]types.HistoryEvent, error) {
+func getAllHistory(t *testing.T, simCfg *simTypes.ReplicationSimulationConfig, clusterName, domainName, wfID string) ([]types.HistoryEvent, error) {
 	frontendCl := simCfg.MustGetFrontendClient(t, clusterName)
 	var nextPageToken []byte
 	var history []types.HistoryEvent
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		response, err := frontendCl.GetWorkflowExecutionHistory(ctx, &types.GetWorkflowExecutionHistoryRequest{
-			Domain: simCfg.Domain.Name,
+			Domain: domainName,
 			Execution: &types.WorkflowExecution{
 				WorkflowID: wfID,
 			},
@@ -316,7 +322,7 @@ func mustJSON(t *testing.T, v interface{}) []byte {
 	return data
 }
 
-func waitUntilWorkersReady(t *testing.T) {
+func waitUntilWorkersReady(t *testing.T, domainName string) {
 	// workers expose :6060/health endpoint. Poll on them to check if they are healthy
 	simTypes.Logf(t, "Waiting for workers to start and report healthy")
 	workerEndpoints := []string{

--- a/simulation/replication/testdata/replication_simulation_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive.yaml
@@ -11,29 +11,33 @@ clusters:
 # primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
 primaryCluster: "cluster0"
 
-domain:
-  name: test-domain-aa
-  activeClusters:
-  - cluster0
-  - cluster1
+domains:
+  test-domain-aa:
+    name: test-domain-aa
+    activeClusters:
+    - cluster0
+    - cluster1
 
 operations:
   - op: start_workflow
     at: 0s
     workflowID: wf1
     cluster: cluster0
+    domain: test-domain-aa
     workflowDuration: 60s
 
   - op: start_workflow
     at: 0s
     workflowID: wf2
     cluster: cluster1
+    domain: test-domain-aa
     workflowDuration: 60s
 
   - op: validate
     at: 70s
     workflowID: wf1
     cluster: cluster0
+    domain: test-domain-aa
     want:
       status: completed
       startedByWorkersInCluster: cluster0
@@ -43,6 +47,7 @@ operations:
     at: 70s
     workflowID: wf2
     cluster: cluster1
+    domain: test-domain-aa
     want:
       status: completed
       startedByWorkersInCluster: cluster1

--- a/simulation/replication/testdata/replication_simulation_default.yaml
+++ b/simulation/replication/testdata/replication_simulation_default.yaml
@@ -11,20 +11,27 @@ clusters:
 primaryCluster: "cluster0"
 
 
-domain:
-  name: test-domain
-  activeClusters:
-  - cluster0
+domains:
+  test-domain:
+    name: test-domain
+    activeClusters:
+    - cluster0
+  test-domain-2:
+    name: test-domain-2
+    activeClusters:
+    - cluster0
 
 operations:
   - op: start_workflow
     at: 0s
     workflowID: wf1
     cluster: cluster0
+    domain: test-domain
     workflowDuration: 35s
 
   - op: change_active_clusters # failover from cluster0 to cluster1
     at: 20s
+    domain: test-domain
     newActiveClusters: ["cluster1"]
     # failoverTimeoutSec: 5 # unset means force failover. setting it means graceful failover request
 
@@ -32,6 +39,7 @@ operations:
     at: 120s # todo: this should work at 40s mark
     workflowID: wf1
     cluster: cluster1
+    domain: test-domain
     want:
       status: completed
       startedByWorkersInCluster: cluster0

--- a/simulation/replication/testdata/replication_simulation_default.yaml
+++ b/simulation/replication/testdata/replication_simulation_default.yaml
@@ -16,10 +16,6 @@ domains:
     name: test-domain
     activeClusters:
     - cluster0
-  test-domain-2:
-    name: test-domain-2
-    activeClusters:
-    - cluster0
 
 operations:
   - op: start_workflow

--- a/simulation/replication/types/types.go
+++ b/simulation/replication/types/types.go
@@ -43,8 +43,11 @@ type WorkflowOutput struct {
 	Count int
 }
 
-func WorkerIdentityFor(clusterName string) string {
-	return fmt.Sprintf("worker-%s", clusterName)
+func WorkerIdentityFor(clusterName string, domainName string) string {
+	if domainName == "" {
+		return fmt.Sprintf("worker-%s", clusterName)
+	}
+	return fmt.Sprintf("worker-%s-%s", domainName, clusterName)
 }
 
 func Logf(t *testing.T, msg string, args ...interface{}) {

--- a/simulation/replication/worker/cmd/main.go
+++ b/simulation/replication/worker/cmd/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
-		Name: simTypes.WorkerIdentityFor(*clusterName),
+		Name: simTypes.WorkerIdentityFor(*clusterName, "test-domain"),
 		Outbounds: yarpc.Outbounds{
 			"cadence-frontend": {Unary: grpc.NewTransport().NewSingleOutbound(cluster.GRPCEndpoint)},
 		},
@@ -107,53 +107,71 @@ func main() {
 		}
 	})
 	go http.ListenAndServe(":6060", nil)
-	waitUntilDomainReady(logger, cadenceClient, simCfg)
-
-	workerOptions := worker.Options{
-		Identity:     simTypes.WorkerIdentityFor(*clusterName),
-		Logger:       logger,
-		MetricsScope: tally.NewTestScope(simTypes.TasklistName, map[string]string{"cluster": *clusterName}),
+	for domainName := range simCfg.Domains {
+		waitUntilDomainReady(logger, cadenceClient, domainName)
 	}
 
-	w := worker.New(
-		cadenceClient,
-		simCfg.Domain.Name,
-		simTypes.TasklistName,
-		workerOptions,
-	)
-
-	w.RegisterWorkflowWithOptions(TestWorkflow, workflow.RegisterOptions{Name: simTypes.WorkflowName})
-	w.RegisterActivityWithOptions(TestActivity, activity.RegisterOptions{Name: simTypes.ActivityName})
-
-	err = w.Start()
-	if err != nil {
-		logger.Fatal("Failed to start worker", zap.Error(err))
-	}
-	defer w.Stop()
-	logger.Info("Started worker", zap.String("cluster", *clusterName), zap.String("endpoint", cluster.GRPCEndpoint))
-
+	// Create a channel to receive termination signals
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	logger.Info("Waiting for SIGINT or SIGTERM")
+
+	// Create a slice to hold the started workers
+	var workers []worker.Worker
+
+	for domainName := range simCfg.Domains {
+		workerOptions := worker.Options{
+			Identity:     simTypes.WorkerIdentityFor(*clusterName, domainName),
+			Logger:       logger,
+			MetricsScope: tally.NewTestScope(simTypes.TasklistName, map[string]string{"cluster": *clusterName}),
+		}
+
+		w := worker.New(
+			cadenceClient,
+			domainName,
+			simTypes.TasklistName,
+			workerOptions,
+		)
+
+		w.RegisterWorkflowWithOptions(TestWorkflow, workflow.RegisterOptions{Name: simTypes.WorkflowName})
+		w.RegisterActivityWithOptions(TestActivity, activity.RegisterOptions{Name: simTypes.ActivityName})
+
+		err := w.Start()
+		if err != nil {
+			logger.Fatal("Failed to start worker", zap.Error(err))
+		}
+		workers = append(workers, w) // Add the worker to the slice
+
+		fmt.Printf("Started worker for domain: %s\n", domainName)
+		logger.Info("Started worker", zap.String("cluster", *clusterName), zap.String("endpoint", cluster.GRPCEndpoint))
+	}
+
+	logger.Info("All workers started. Waiting for SIGINT or SIGTERM")
 	sig := <-sigs
 	logger.Sugar().Infof("Received signal: %v so terminating", sig)
+
+	// Stop each worker gracefully
+	logger.Info("Stopping workers...")
+	for _, w := range workers {
+		w.Stop()
+		logger.Info("Stopped worker")
+	}
 }
 
-func waitUntilDomainReady(logger *zap.Logger, client workflowserviceclient.Interface, simCfg *simTypes.ReplicationSimulationConfig) {
+func waitUntilDomainReady(logger *zap.Logger, client workflowserviceclient.Interface, domainName string) {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_, err := client.DescribeDomain(ctx, &shared.DescribeDomainRequest{
-			Name: common.StringPtr(simCfg.Domain.Name),
+			Name: common.StringPtr(domainName),
 		})
 
 		cancel()
 		if err == nil {
-			logger.Info("Domain is ready", zap.String("domain", simCfg.Domain.Name))
+			logger.Info("Domains is ready", zap.String("domain", domainName))
 			atomic.StoreInt32(&ready, 1)
 			return
 		}
 
-		logger.Info("Domain not ready", zap.String("domain", simCfg.Domain.Name), zap.Error(err))
+		logger.Info("Domains not ready", zap.String("domain", domainName), zap.Error(err))
 		time.Sleep(2 * time.Second)
 	}
 }

--- a/simulation/replication/worker/cmd/main.go
+++ b/simulation/replication/worker/cmd/main.go
@@ -111,7 +111,9 @@ func main() {
 
 	wg := sync.WaitGroup{}
 	for domainName := range simCfg.Domains {
+		domainName := domainName
 		wg.Add(1)
+
 		go func() {
 			waitUntilDomainReady(logger, cadenceClient, domainName)
 			wg.Done()


### PR DESCRIPTION
**What changed?**
Add capability to have multiple domains in replication simulation. Allow workflows to target the domain where it will be created and create workers for all registered domains.

**Why?**
We want to simulate failover and replication involving multiple domains.

**How did you test it?**
Tested locally with the existing simulations

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
