### PR TITLE
Define submodules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 replace (
 	github.com/uber/cadence/common/archiver/gcloud => ./common/archiver/gcloud
-	github.com/uber/cadence/service/sharddistributor/leader/leaderstore/etcd => ./service/sharddistributor/leader/leaderstore/etc
+	github.com/uber/cadence/service/sharddistributor/leader/leaderstore/etcd => ./service/sharddistributor/leader/leaderstore/etcd
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,11 @@ go 1.23
 
 toolchain go1.23.4
 
+replace (
+	github.com/uber/cadence/common/archiver/gcloud => ./common/archiver/gcloud
+	github.com/uber/cadence/service/sharddistributor/leader/leaderstore/etcd => ./service/sharddistributor/leader/leaderstore/etc
+)
+
 require (
 	github.com/MicahParks/keyfunc/v2 v2.1.0
 	github.com/Shopify/sarama v1.33.0


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Define replace for optional submodules with go.mod.
I've also modified go-lint rule in Makefile so it checks for all submodule dependencies and takes into account that replace rules are ok.

<!-- Tell your future self why have you made these changes -->
**Why?**
To be able to pull optional modules and define preleases they must be defined in the root go.mod
Otherwise, go get will return an error:
go: module github.com/uber/cadence@v1.3.1-prerelease06 found, but does not contain package github.com/uber/cadence/service/sharddistributor/leader/leaderstore/etcd
To resolve this, we should define them in the root, so we could pull them in.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
