### PR TITLE
[persistence] Mark logger.Error messages from wrapping layers as a Helper

### DIFF
--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -81,6 +81,8 @@ func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainT
 }
 
 func (p *base) updateErrorMetric(scope int, err error, metricsScope metrics.Scope) {
+	logger := p.logger.Helper()
+
 	switch {
 	case errors.As(err, new(*types.DomainAlreadyExistsError)):
 		metricsScope.IncCounter(metrics.PersistenceErrDomainAlreadyExistsCounter)
@@ -109,9 +111,9 @@ func (p *base) updateErrorMetric(scope int, err error, metricsScope metrics.Scop
 	case errors.As(err, new(*persistence.DBUnavailableError)):
 		metricsScope.IncCounter(metrics.PersistenceErrDBUnavailableCounter)
 		metricsScope.IncCounter(metrics.PersistenceFailures)
-		p.logger.Error("DBUnavailable Error:", tag.Error(err), tag.MetricScope(scope))
+		logger.Error("DBUnavailable Error:", tag.Error(err), tag.MetricScope(scope))
 	default:
-		p.logger.Error("Operation failed with internal error.", tag.Error(err), tag.MetricScope(scope))
+		logger.Error("Operation failed with internal error.", tag.Error(err), tag.MetricScope(scope))
 		metricsScope.IncCounter(metrics.PersistenceFailures)
 	}
 }

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -161,7 +161,7 @@ func (p *base) callWithoutDomainTag(scope int, op func() error, tags ...metrics.
 		metricsScope.RecordHistogramDuration(metrics.PersistenceLatencyHistogram, duration)
 	}
 	if err != nil {
-		p.updateErrorMetric(scope, err, metricsScope)
+		p.updateErrorMetric(scope, err, metricsScope, p.logger.Helper())
 	}
 	return err
 }
@@ -187,7 +187,7 @@ func (p *base) callWithDomainAndShardScope(scope int, op func() error, domainTag
 		domainMetricsScope.RecordHistogramDuration(metrics.PersistenceLatencyHistogram, duration)
 	}
 	if err != nil {
-		p.updateErrorMetricPerDomain(scope, err, domainMetricsScope)
+		p.updateErrorMetricPerDomain(scope, err, domainMetricsScope, p.logger.Helper())
 	}
 	return err
 }

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -43,6 +43,8 @@ type base struct {
 }
 
 func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainTag metrics.Scope) {
+	logger := p.logger.Helper()
+
 	switch {
 	case errors.As(err, new(*types.DomainAlreadyExistsError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrDomainAlreadyExistsCounterPerDomain)
@@ -71,9 +73,9 @@ func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainT
 	case errors.As(err, new(*persistence.DBUnavailableError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrDBUnavailableCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.PersistenceFailuresPerDomain)
-		p.logger.Error("DBUnavailable Error:", tag.Error(err), tag.MetricScope(scope))
+		logger.Error("DBUnavailable Error:", tag.Error(err), tag.MetricScope(scope))
 	default:
-		p.logger.Error("Operation failed with internal error.", tag.Error(err), tag.MetricScope(scope))
+		logger.Error("Operation failed with internal error.", tag.Error(err), tag.MetricScope(scope))
 		scopeWithDomainTag.IncCounter(metrics.PersistenceFailuresPerDomain)
 	}
 }

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -42,8 +42,8 @@ type base struct {
 	enableShardIDMetrics          dynamicproperties.BoolPropertyFn
 }
 
-func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainTag metrics.Scope) {
-	logger := p.logger.Helper()
+func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainTag metrics.Scope, logger log.Logger) {
+	logger = logger.Helper()
 
 	switch {
 	case errors.As(err, new(*types.DomainAlreadyExistsError)):
@@ -80,8 +80,8 @@ func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainT
 	}
 }
 
-func (p *base) updateErrorMetric(scope int, err error, metricsScope metrics.Scope) {
-	logger := p.logger.Helper()
+func (p *base) updateErrorMetric(scope int, err error, metricsScope metrics.Scope, logger log.Logger) {
+	logger = logger.Helper()
 
 	switch {
 	case errors.As(err, new(*types.DomainAlreadyExistsError)):
@@ -137,11 +137,13 @@ func (p *base) call(scope int, op func() error, tags ...metrics.Tag) error {
 	if p.enableLatencyHistogramMetrics {
 		metricsScope.RecordHistogramDuration(metrics.PersistenceLatencyHistogram, duration)
 	}
+
+	logger := p.logger.Helper()
 	if err != nil {
 		if len(tags) > 0 {
-			p.updateErrorMetricPerDomain(scope, err, metricsScope)
+			p.updateErrorMetricPerDomain(scope, err, metricsScope, logger)
 		} else {
-			p.updateErrorMetric(scope, err, metricsScope)
+			p.updateErrorMetric(scope, err, metricsScope, logger)
 		}
 	}
 	return err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Marking Perisistence metered layer error messages as logger.Helper to point stack to the actual error instead of a helper method.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve debuaggability from logs

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
