### PR TITLE
Decouple workflowExecutionStartToCloseTimeout from workflowDuration in replication simulation

### DIFF
--- a/simulation/replication/replication_simulation_test.go
+++ b/simulation/replication/replication_simulation_test.go
@@ -130,7 +130,7 @@ func startWorkflow(
 			WorkflowID:                          op.WorkflowID,
 			WorkflowType:                        &types.WorkflowType{Name: simTypes.WorkflowName},
 			TaskList:                            &types.TaskList{Name: simTypes.TasklistName},
-			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(int32((op.WorkflowDuration + 30*time.Second).Seconds())),
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(int32((op.WorkflowExecutionStartToCloseTimeout).Seconds())),
 			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(5),
 			Input:                               mustJSON(t, &simTypes.WorkflowInput{Duration: op.WorkflowDuration}),
 		})

--- a/simulation/replication/replication_simulation_test.go
+++ b/simulation/replication/replication_simulation_test.go
@@ -123,6 +123,11 @@ func startWorkflow(
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+
+	if op.WorkflowExecutionStartToCloseTimeout == 0 || op.WorkflowExecutionStartToCloseTimeout < op.WorkflowDuration {
+		return fmt.Errorf("workflow execution start to close timeout must be specified and should be greater than workflow duration")
+	}
+
 	resp, err := simCfg.MustGetFrontendClient(t, op.Cluster).StartWorkflowExecution(ctx,
 		&types.StartWorkflowExecutionRequest{
 			RequestID:                           uuid.New(),

--- a/simulation/replication/testdata/replication_simulation_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive.yaml
@@ -24,6 +24,7 @@ operations:
     workflowID: wf1
     cluster: cluster0
     domain: test-domain-aa
+    workflowExecutionStartToCloseTimeout: 90s
     workflowDuration: 60s
 
   - op: start_workflow
@@ -31,6 +32,7 @@ operations:
     workflowID: wf2
     cluster: cluster1
     domain: test-domain-aa
+    workflowExecutionStartToCloseTimeout: 90s
     workflowDuration: 60s
 
   - op: validate

--- a/simulation/replication/testdata/replication_simulation_default.yaml
+++ b/simulation/replication/testdata/replication_simulation_default.yaml
@@ -23,6 +23,7 @@ operations:
     workflowID: wf1
     cluster: cluster0
     domain: test-domain
+    workflowExecutionStartToCloseTimeout: 65s
     workflowDuration: 35s
 
   - op: change_active_clusters # failover from cluster0 to cluster1

--- a/simulation/replication/testdata/replication_simulation_default.yaml
+++ b/simulation/replication/testdata/replication_simulation_default.yaml
@@ -33,7 +33,7 @@ operations:
     # failoverTimeoutSec: 5 # unset means force failover. setting it means graceful failover request
 
   - op: validate
-    at: 40s
+    at: 41s # with the current workflow implementation, it's possible that the workflow may finish right after the 40s mark
     workflowID: wf1
     cluster: cluster1
     domain: test-domain

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -76,8 +76,9 @@ type Operation struct {
 	At      time.Duration                  `yaml:"at"`
 	Cluster string                         `yaml:"cluster"`
 
-	WorkflowID       string        `yaml:"workflowID"`
-	WorkflowDuration time.Duration `yaml:"workflowDuration"`
+	WorkflowID                           string        `yaml:"workflowID"`
+	WorkflowExecutionStartToCloseTimeout time.Duration `yaml:"workflowExecutionStartToCloseTimeout"`
+	WorkflowDuration                     time.Duration `yaml:"workflowDuration"`
 
 	Domain            string   `yaml:"domain"`
 	NewActiveClusters []string `yaml:"newActiveClusters"`


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added the field workflowExecutionStartToCloseTimeout to Operation, allowing to set a timeout completely independent to the workflow duration that is currently used as an input to the workflow being used in the replication simulation.

<!-- Tell your future self why have you made these changes -->
**Why?**
Make it more flexible so we can create more simulations, for example, reset workflows.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally. Adjusted existing simulations to have the same behavior as before the change.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
