### PR TITLE
[common] metricsfx separation of modules with external tally and without

### DIFF
--- a/common/metrics/metricsfx/metricsfx_test.go
+++ b/common/metrics/metricsfx/metricsfx_test.go
@@ -1,0 +1,40 @@
+package metricsfx
+
+import (
+	"testing"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/service"
+)
+
+func TestModule(t *testing.T) {
+	fxApp := fxtest.New(t,
+		testlogger.Module(t),
+		fx.Provide(fx.Annotated{
+			Target: func() string { return service.Frontend },
+			Name:   "service-full-name"},
+			func() config.Service {
+				return config.Service{}
+			}),
+		Module,
+		fx.Invoke(func(mc metrics.Client) {}))
+	fxApp.RequireStart().RequireStop()
+}
+
+func TestModuleWithExternalScope(t *testing.T) {
+	fxApp := fxtest.New(t,
+		testlogger.Module(t),
+		fx.Provide(func() tally.Scope { return tally.NoopScope },
+			fx.Annotated{
+				Target: func() string { return service.Frontend },
+				Name:   "service-full-name"}),
+		ModuleForExternalScope,
+		fx.Invoke(func(mc metrics.Client) {}))
+	fxApp.RequireStart().RequireStop()
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated metricsfx to separate FX modules with and without scope.


<!-- Tell your future self why have you made these changes -->
**Why?**
Mainly doing it to separate concerns for shard distributor customizations in the monorepo that uses different types for configurations.

The main concern:
If it is not provided, we need a configuration to build it.
I can make it optional, but then there could be missing metrics. Then I'll need to add validation for this config since it has a default noop value, so in case of missing metrics, it can start without metrics.

To make it clearer, I separate modules into two: one when it is configured from the outside and the other when it should be built from the configuration that must be provided.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
