### PR TITLE
Add workflowType to operation parameters in replication simulation

### DIFF
--- a/simulation/replication/replication_simulation_test.go
+++ b/simulation/replication/replication_simulation_test.go
@@ -105,7 +105,7 @@ func TestReplicationSimulation(t *testing.T) {
 	// Print the test summary.
 	// Don't change the start/end line format as it is used by scripts to parse the summary info
 	executionTime := time.Since(startTime)
-	testSummary := []string{}
+	var testSummary []string
 	testSummary = append(testSummary, "Simulation Summary:")
 	testSummary = append(testSummary, fmt.Sprintf("Simulation Duration: %v", executionTime))
 	testSummary = append(testSummary, "End of Simulation Summary")
@@ -133,7 +133,7 @@ func startWorkflow(
 			RequestID:                           uuid.New(),
 			Domain:                              op.Domain,
 			WorkflowID:                          op.WorkflowID,
-			WorkflowType:                        &types.WorkflowType{Name: simTypes.WorkflowName},
+			WorkflowType:                        &types.WorkflowType{Name: op.WorkflowType},
 			TaskList:                            &types.TaskList{Name: simTypes.TasklistName},
 			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(int32((op.WorkflowExecutionStartToCloseTimeout).Seconds())),
 			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(5),

--- a/simulation/replication/testdata/replication_simulation_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive.yaml
@@ -21,6 +21,7 @@ domains:
 operations:
   - op: start_workflow
     at: 0s
+    workflowType: test-workflow
     workflowID: wf1
     cluster: cluster0
     domain: test-domain-aa

--- a/simulation/replication/testdata/replication_simulation_default.yaml
+++ b/simulation/replication/testdata/replication_simulation_default.yaml
@@ -20,6 +20,7 @@ domains:
 operations:
   - op: start_workflow
     at: 0s
+    workflowType: test-workflow
     workflowID: wf1
     cluster: cluster0
     domain: test-domain

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -76,6 +76,7 @@ type Operation struct {
 	At      time.Duration                  `yaml:"at"`
 	Cluster string                         `yaml:"cluster"`
 
+	WorkflowType                         string        `yaml:"workflowType"`
 	WorkflowID                           string        `yaml:"workflowID"`
 	WorkflowExecutionStartToCloseTimeout time.Duration `yaml:"workflowExecutionStartToCloseTimeout"`
 	WorkflowDuration                     time.Duration `yaml:"workflowDuration"`

--- a/simulation/replication/types/types.go
+++ b/simulation/replication/types/types.go
@@ -29,8 +29,6 @@ import (
 const (
 	DefaultTestCase = "testdata/replication_simulation_default.yaml"
 	TasklistName    = "test-tasklist"
-	WorkflowName    = "test-workflow"
-	ActivityName    = "test-activity"
 
 	TimerInterval = 5 * time.Second
 )

--- a/simulation/replication/worker/cmd/main.go
+++ b/simulation/replication/worker/cmd/main.go
@@ -142,8 +142,13 @@ func main() {
 			workerOptions,
 		)
 
-		w.RegisterWorkflowWithOptions(TestWorkflow, workflow.RegisterOptions{Name: simTypes.WorkflowName})
-		w.RegisterActivityWithOptions(TestActivity, activity.RegisterOptions{Name: simTypes.ActivityName})
+		for name, wf := range workflows {
+			w.RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{Name: name})
+		}
+
+		for name, act := range activities {
+			w.RegisterActivityWithOptions(act, activity.RegisterOptions{Name: name})
+		}
 
 		err := w.Start()
 		if err != nil {

--- a/simulation/replication/worker/cmd/workflow.go
+++ b/simulation/replication/worker/cmd/workflow.go
@@ -31,6 +31,11 @@ import (
 	"github.com/uber/cadence/simulation/replication/types"
 )
 
+var (
+	workflows  = map[string]any{"test-workflow": TestWorkflow}
+	activities = map[string]any{"test-activity": TestActivity}
+)
+
 func TestWorkflow(ctx workflow.Context, input types.WorkflowInput) (types.WorkflowOutput, error) {
 	logger := workflow.GetLogger(ctx)
 	logger.Sugar().Infof("testWorkflow started with input: %+v", input)
@@ -44,7 +49,7 @@ func TestWorkflow(ctx workflow.Context, input types.WorkflowInput) (types.Workfl
 			TaskList:               types.TasklistName,
 			ScheduleToStartTimeout: 10 * time.Second,
 			StartToCloseTimeout:    10 * time.Second,
-		}), types.ActivityName, "World")
+		}), TestActivity, "World")
 		selector.AddFuture(activityFuture, func(f workflow.Future) {
 			logger.Info("testWorkflow completed activity")
 		})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add workflowType to operation parameters in replication simulation

<!-- Tell your future self why have you made these changes -->
**Why?**
Allow the replication simulation to have more than one workflow type and also be able to choose the workflow type on the configuration.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally implementing the change but maintaining the existing behavior

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
