### PR TITLE
Add a panic recover in adminhandler for describeCluster

### DIFF
--- a/service/frontend/templates/accesscontrolled.tmpl
+++ b/service/frontend/templates/accesscontrolled.tmpl
@@ -81,6 +81,11 @@ func New{{$Decorator}}(handler {{$.Interface.Type}}, resource resource.Resource,
 
 {{range $method := .Interface.Methods}}
 func (a *{{$decorator}}) {{$method.Declaration}} {
+	{{- if eq $method.Name "DescribeCluster" }}
+	defer func() {
+		log.CapturePanic(recover(), a.GetLogger(), &err)
+	}()
+	{{- end }}
 {{- if or (eq $method.Name "Start") (eq $method.Name "Stop")}}
 	a.handler.{{$method.Call}}
 }
@@ -139,7 +144,12 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 		{{- end}}
 	}
 	{{- end}}
+	{{- if eq $method.Name "DescribeCluster" }}
+	{{- /* assign return values before returning */}}
+	dp1, err = a.handler.{{$method.Call}}
+	return dp1, err
+	{{- else }}
 	return a.handler.{{$method.Call}}
-}
+	{{- end }}}
 {{- end}}
 {{end}}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -119,6 +119,7 @@ func TestDescribeCluster(t *testing.T) {
 			mockSetup: func(authorizer *authorization.MockAuthorizer, adminHandler *admin.MockHandler, mockResource *resource.MockResource) {
 				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil)
 				adminHandler.EXPECT().DescribeCluster(gomock.Any()).Return(&types.DescribeClusterResponse{}, nil)
+				mockResource.EXPECT().GetLogger().Return(log.NewNoop())
 			},
 			wantErr: nil,
 		},
@@ -126,6 +127,7 @@ func TestDescribeCluster(t *testing.T) {
 			name: "Error case - unauthorized",
 			mockSetup: func(authorizer *authorization.MockAuthorizer, adminHandler *admin.MockHandler, mockResource *resource.MockResource) {
 				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
+				mockResource.EXPECT().GetLogger().Return(log.NewNoop())
 			},
 			wantErr: errUnauthorized,
 		},
@@ -133,6 +135,7 @@ func TestDescribeCluster(t *testing.T) {
 			name: "Error case - authorization error",
 			mockSetup: func(authorizer *authorization.MockAuthorizer, adminHandler *admin.MockHandler, mockResource *resource.MockResource) {
 				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{}, someErr)
+				mockResource.EXPECT().GetLogger().Return(log.NewNoop())
 			},
 			wantErr: someErr,
 		},

--- a/service/frontend/wrappers/accesscontrolled/admin_generated.go
+++ b/service/frontend/wrappers/accesscontrolled/admin_generated.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/uber/cadence/common/authorization"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/types"
@@ -103,6 +104,9 @@ func (a *adminHandler) DeleteWorkflow(ctx context.Context, ap1 *types.AdminDelet
 }
 
 func (a *adminHandler) DescribeCluster(ctx context.Context) (dp1 *types.DescribeClusterResponse, err error) {
+	defer func() {
+		log.CapturePanic(recover(), a.GetLogger(), &err)
+	}()
 	attr := &authorization.Attributes{
 		APIName:    "DescribeCluster",
 		Permission: authorization.PermissionRead,
@@ -114,7 +118,8 @@ func (a *adminHandler) DescribeCluster(ctx context.Context) (dp1 *types.Describe
 	if !isAuthorized {
 		return nil, errUnauthorized
 	}
-	return a.handler.DescribeCluster(ctx)
+	dp1, err = a.handler.DescribeCluster(ctx)
+	return dp1, err
 }
 
 func (a *adminHandler) DescribeHistoryHost(ctx context.Context, dp1 *types.DescribeHistoryHostRequest) (dp2 *types.DescribeHistoryHostResponse, err error) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed the template- accesscontrolled.tmpl for adminHandler's method describeCluster, so that it could have a panic recover. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The method: DescribeCluster's request body is empty.
When request body is nil in authorizer, it causes nil pointer and panic during the authorize() call. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
none

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
