### PR TITLE
Undo replace directives in main go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,6 @@ go 1.23
 
 toolchain go1.23.4
 
-replace (
-	github.com/uber/cadence/common/archiver/gcloud => ./common/archiver/gcloud
-	github.com/uber/cadence/service/sharddistributor/leader/leaderstore/etcd => ./service/sharddistributor/leader/leaderstore/etcd
-)
-
 require (
 	github.com/MicahParks/keyfunc/v2 v2.1.0
 	github.com/Shopify/sarama v1.33.0


### PR DESCRIPTION
This is a partial revert of commit bd127c3fa846c92021aa4cc0f3327a578b2665b3.

The more complete lint is great, but these replace directives are already handled by `go.work` in a less-problematic way.
