### PR TITLE
Fix gomod lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ $(BUILD)/gomod-lint: go.mod internal/tools/go.mod common/archiver/gcloud/go.mod 
 		SUBMODULES=$$(find . -type f -name "go.mod" -not -path "./go.mod" -not -path "./idls/*" -exec dirname {} \; | sed 's|^\./||'); \
 		for submodule in $$SUBMODULES; do \
 			submodule_path="$$MAIN_MODULE/$$submodule"; \
-			if grep -q "^require.*$$submodule_path" go.mod; then \
+			if grep -q "$$submodule_path" go.mod; then \
 				echo "ERROR: Root go.mod directly depends on submodule: $$submodule_path" >&2; \
 				exit 1; \
 			fi; \


### PR DESCRIPTION
Since I was looking closer at bd127c3fa846c92021aa4cc0f3327a578b2665b3 anyway...
The check didn't actually check anything:
```
❯ go get github.com/uber/cadence/common/archiver/gcloud
...

❯ make .build/gomod-lint
checking for direct submodule dependencies in root go.mod...
✓ No direct dependency on cmd/server
✓ No direct dependency on internal/tools
✓ No direct dependency on common/archiver/gcloud
✓ No direct dependency on service/sharddistributor/leader/leaderstore/etcd

❯ grep common/archiver/gcloud go.mod
        github.com/uber/cadence/common/archiver/gcloud v0.0.0-20250520010807-4b03f0710bac // indirect
```

You might get a `require ...` line if you add it by hand, but any `go mod tidy` will bundle it with others in a
```
require (
  ...
)
```
which needs a less-picky regex to catch.
Or `go mod why` or something, but grep does seem fine here.
