### PR TITLE
Add support of SQLite storage in cadence server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ worker*.log
 /cadence-bench
 /cadence-cassandra-tool
 /cadence-sql-tool
+
+# SQLite databases
+cadence.db*
+cadence_visibility.db*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ If running into any compiling issue
 >3. Check if this document is outdated by comparing with the building steps in [Dockerfile](https://github.com/cadence-workflow/cadence/blob/master/Dockerfile)
 
 ### 2. Setup Dependency
-NOTE: you may skip this section if you have installed the dependencies in any other ways, for example, using homebrew.
+NOTE: you may skip this section if you want to use SQLite or you have installed the dependencies in any other ways, for example, using homebrew.
 
 Cadence's core data model can be running with different persistence storages, including Cassandra,MySQL and Postgres.
 Please refer to [persistence documentation](https://github.com/cadence-workflow/cadence/blob/master/docs/persistence.md) if you want to learn more.
@@ -92,6 +92,7 @@ Also use `docker-compose -f ./docker/dev/cassandra.yml down` to stop and clean u
 ### 3. Schema installation
 Based on the above dependency setup, you also need to install the schemas.
 
+* If you use SQLite then run `make install-schema-sqlite` to install SQLite schemas
 * If you use `cassandra.yml` then run `make install-schema` to install Cassandra schemas
 * If you use `cassandra-esv7-kafka.yml` then run `make install-schema && make install-schema-es-v7` to install Cassandra & ElasticSearch schemas
 * If you use `cassandra-opensearch-kafka.yml` then run `make install-schema && make install-schema-es-opensearch` to install Cassandra & OpenSearch schemas
@@ -114,6 +115,7 @@ Once you have done all above, try running the local binaries:
 
 Then you will be able to run a basic local Cadence server for development.
 
+  * If you use SQLite, then run `./cadence server start --zone sqlite start`, which load , which will load `config/development.yaml` + `config/development_sqlite.yaml` as config
   * If you use `cassandra.yml`, then run `./cadence-server start`, which will load `config/development.yaml` as config
   * If you use `mysql.yml` then run `./cadence-server --zone mysql start`, which will load `config/development.yaml` + `config/development_mysql.yaml` as config
   * If you use `postgres.yml` then run `./cadence-server --zone postgres start` , which will load `config/development.yaml` + `config/development_postgres.yaml` as config

--- a/Makefile
+++ b/Makefile
@@ -568,9 +568,10 @@ tidy: ## `go mod tidy` all packages
 	$Q cd common/archiver/gcloud; go mod tidy || (echo "failed to tidy gcloud plugin, try manually copying go.mod contents into common/archiver/gcloud/go.mod and rerunning" >&2; exit 1)
 	$Q cd cmd/server; go mod tidy || (echo "failed to tidy main server module, try manually copying go.mod and common/archiver/gcloud/go.mod contents into cmd/server/go.mod and rerunning" >&2; exit 1)
 
-clean: ## Clean build products
+clean: ## Clean build products and SQLite database
 	rm -f $(BINS)
 	rm -Rf $(BUILD)
+	rm *.db
 	$(if \
 		$(wildcard $(STABLE_BIN)/*), \
 		$(warning usually-stable build tools still exist, delete the $(STABLE_BIN) folder to rebuild them),)
@@ -768,6 +769,12 @@ install-schema-postgres: cadence-sql-tool
 	./cadence-sql-tool -p 5432 -u postgres -pw cadence --pl postgres create --db cadence_visibility
 	./cadence-sql-tool -p 5432 -u postgres -pw cadence --pl postgres --db cadence_visibility setup-schema -v 0.0
 	./cadence-sql-tool -p 5432 -u postgres -pw cadence --pl postgres --db cadence_visibility update-schema -d ./schema/postgres/visibility/versioned
+
+install-schema-sqlite: cadence-sql-tool
+	./cadence-sql-tool -pl sqlite --db cadence.db setup -v 0.0
+	./cadence-sql-tool -pl sqlite --db cadence.db update-schema -d ./schema/sqlite/cadence/versioned
+	./cadence-sql-tool -pl sqlite --db cadence_visibility.db setup -v 0.0
+	./cadence-sql-tool -pl sqlite --db cadence_visibility.db update-schema -d ./schema/sqlite/visibility/versioned
 
 install-schema-es-v7:
 	curl -X PUT "http://127.0.0.1:9200/_template/cadence-visibility-template" -H 'Content-Type: application/json' -d @./schema/elasticsearch/v7/visibility/index_template.json

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public" // needed to load the default gocql client
 	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"                      // needed to load mysql plugin
 	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/postgres"                   // needed to load postgres plugin
+	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"                     // needed to load sqlite plugin
 	_ "github.com/uber/cadence/service/sharddistributor/leader/leaderstore/etcd"            // needed for shard distributor leader election
 )
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -333,7 +333,7 @@ type (
 		// Required if not useMultipleDatabases
 		ConnectAddr string `yaml:"connectAddr"`
 		// ConnectProtocol is the protocol that goes with the ConnectAddr ex - tcp, unix
-		ConnectProtocol string `yaml:"connectProtocol" validate:"nonzero"`
+		ConnectProtocol string `yaml:"connectProtocol"`
 		// ConnectAttributes is a set of key-value attributes to be sent as part of connect data_source_name url
 		ConnectAttributes map[string]string `yaml:"connectAttributes"`
 		// MaxConns the max number of connections to this datastore

--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -107,7 +107,8 @@ func (c *Persistence) Validate() error {
 			return fmt.Errorf("persistence config: datastore %v: must provide exactly one type of config, but provided %d", st, configCount)
 		}
 		if ds.SQL != nil {
-			if ds.SQL.UseMultipleDatabases {
+			switch {
+			case ds.SQL.UseMultipleDatabases:
 				if !useAdvancedVisibilityOnly {
 					return fmt.Errorf("sql persistence config: multipleSQLDatabases can only be used with advanced visibility only")
 				}
@@ -134,7 +135,9 @@ func (c *Persistence) Validate() error {
 						return fmt.Errorf("sql multipleDatabasesConfig persistence config: connectAddr can not be empty")
 					}
 				}
-			} else {
+
+			// SQLite plugin doesn't require ConnectAddr and DatabaseName
+			case ds.SQL.PluginName != "sqlite":
 				if ds.SQL.DatabaseName == "" {
 					return fmt.Errorf("sql persistence config: databaseName can not be empty")
 				}

--- a/common/persistence/sql/sqlplugin/sqlite/admin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/admin.go
@@ -22,7 +22,15 @@
 
 package sqlite
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
+
+const (
+	listTablesQuery = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+)
 
 // CreateDatabase is not supported by sqlite
 // each sqlite file is a database
@@ -34,4 +42,11 @@ func (mdb *DB) CreateDatabase(name string) error {
 // each sqlite file is a database
 func (mdb *DB) DropDatabase(name string) error {
 	return errors.New("sqlite doesn't support dropping database")
+}
+
+// ListTables returns a list of tables in this database
+func (mdb *DB) ListTables(_ string) ([]string, error) {
+	var tables []string
+	err := mdb.driver.SelectForSchemaQuery(sqlplugin.DbShardUndefined, &tables, listTablesQuery)
+	return tables, err
 }

--- a/common/persistence/sql/sqlplugin/sqlite/db.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db.go
@@ -49,25 +49,27 @@ var (
 type DB struct {
 	*mysql.DB
 
-	converter   mysql.DataConverter
-	driver      sqldriver.Driver
-	originalDBs []*sqlx.DB
-	numDBShards int
+	converter    mysql.DataConverter
+	driver       sqldriver.Driver
+	originalDBs  []*sqlx.DB
+	numDBShards  int
+	databaseName string
 }
 
 // NewDB returns an instance of DB, which contains a new created mysql.DB with sqlite specific methods
-func NewDB(xdbs []*sqlx.DB, tx *sqlx.Tx, dbShardID int, numDBShards int, dataConverter mysql.DataConverter) (*DB, error) {
+func NewDB(xdbs []*sqlx.DB, tx *sqlx.Tx, dbShardID int, numDBShards int, dataConverter mysql.DataConverter, databaseName string) (*DB, error) {
 	driver, err := sqldriver.NewDriver(xdbs, tx, dbShardID)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DB{
-		DB:          mysql.NewDBWithDriver(xdbs, driver, numDBShards, dataConverter),
-		driver:      driver,
-		originalDBs: xdbs,
-		numDBShards: numDBShards,
-		converter:   dataConverter,
+		DB:           mysql.NewDBWithDriver(xdbs, driver, numDBShards, dataConverter),
+		driver:       driver,
+		originalDBs:  xdbs,
+		numDBShards:  numDBShards,
+		converter:    dataConverter,
+		databaseName: databaseName,
 	}, nil
 }
 
@@ -83,5 +85,13 @@ func (mdb *DB) BeginTx(ctx context.Context, dbShardID int) (sqlplugin.Tx, error)
 		return nil, err
 	}
 
-	return NewDB(mdb.originalDBs, xtx, dbShardID, mdb.numDBShards, mdb.converter)
+	return NewDB(mdb.originalDBs, xtx, dbShardID, mdb.numDBShards, mdb.converter, mdb.databaseName)
+}
+
+func (mdb *DB) Close() error {
+	if mdb.databaseName == "" {
+		return mdb.DB.Close()
+	}
+
+	return closePolledDBConn(mdb.databaseName, mdb.DB.Close)
 }

--- a/common/persistence/sql/sqlplugin/sqlite/db.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db.go
@@ -93,5 +93,5 @@ func (mdb *DB) Close() error {
 		return mdb.DB.Close()
 	}
 
-	return closePolledDBConn(mdb.databaseName, mdb.DB.Close)
+	return closeSharedDBConn(mdb.databaseName, mdb.DB.Close)
 }

--- a/common/persistence/sql/sqlplugin/sqlite/db_pool.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db_pool.go
@@ -1,0 +1,57 @@
+package sqlite
+
+import (
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// SQLite database takes exclusive access to the database file during write operation.
+// If another process tries to do another write operation, it returns the error database to be locked.
+// To be sure that only database connection is created per one database file within the running process,
+// we use dbPool to keep track of the database connections and reuse them.
+// Each time when a new db connection creation is called, it will increment dbPoolCounter and returns already stored sql.DB
+// from dbPool. If the connection is requested to be closed, it will decrement dbPoolCounter.
+// When the counter reaches 0, it will close the database connection, as there are no more references to it.
+// Reference: https://github.com/mattn/go-sqlite3/issues/274#issuecomment-232942571
+var (
+	dbPool        = make(map[string]*sqlx.DB)
+	dbPoolCounter = make(map[string]int)
+	dbPoolMx      sync.Mutex
+)
+
+// createPolledDBConn creates a new database connection in the dbPool if it doesn't exist.
+func createPolledDBConn(databaseName string, createDBConnFn func() (*sqlx.DB, error)) (*sqlx.DB, error) {
+	dbPoolMx.Lock()
+	defer dbPoolMx.Unlock()
+
+	if db, ok := dbPool[databaseName]; ok {
+		dbPoolCounter[databaseName]++
+		return db, nil
+	}
+
+	db, err := createDBConnFn()
+	if err != nil {
+		return nil, err
+	}
+
+	dbPool[databaseName] = db
+	dbPoolCounter[databaseName]++
+
+	return db, nil
+}
+
+// createPolledDBConn closes the database connection in the dbPool if it exists.
+func closePolledDBConn(databaseName string, closeFn func() error) error {
+	dbPoolMx.Lock()
+	defer dbPoolMx.Unlock()
+
+	dbPoolCounter[databaseName]--
+	if dbPoolCounter[databaseName] != 0 {
+		return nil
+	}
+
+	delete(dbPool, databaseName)
+	delete(dbPoolCounter, databaseName)
+	return closeFn()
+}

--- a/common/persistence/sql/sqlplugin/sqlite/db_pool.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db_pool.go
@@ -6,13 +6,13 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// SQLite database takes exclusive access to the database file during write operation.
-// If another process tries to do another write operation, it returns the error database to be locked.
-// To be sure that only database connection is created per one database file within the running process,
-// we use dbPool to keep track of the database connections and reuse them.
-// Each time when a new db connection creation is called, it will increment dbPoolCounter and returns already stored sql.DB
-// from dbPool. If the connection is requested to be closed, it will decrement dbPoolCounter.
-// When the counter reaches 0, it will close the database connection, as there are no more references to it.
+// SQLite database takes exclusive access to the database file during write operations.
+// If another process attempts to perform a write operation, it receives a "database is locked" error.
+// To ensure only one database connection is created per database file within the running process,
+// we use dbPool to track and reuse database connections.
+// When a new database connection is requested, it increments dbPoolCounter and returns the existing sql.DB
+// from dbPool. When a connection is requested to be closed, it decrements dbPoolCounter.
+// Once the counter reaches 0, the database connection is closed as there are no more references to it.
 // Reference: https://github.com/mattn/go-sqlite3/issues/274#issuecomment-232942571
 var (
 	dbPool        = make(map[string]*sqlx.DB)

--- a/common/persistence/sql/sqlplugin/sqlite/db_pool.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db_pool.go
@@ -20,8 +20,8 @@ var (
 	dbPoolMx      sync.Mutex
 )
 
-// createPolledDBConn creates a new database connection in the dbPool if it doesn't exist.
-func createPolledDBConn(databaseName string, createDBConnFn func() (*sqlx.DB, error)) (*sqlx.DB, error) {
+// createSharedDBConn creates a new database connection in the dbPool if it doesn't exist.
+func createSharedDBConn(databaseName string, createDBConnFn func() (*sqlx.DB, error)) (*sqlx.DB, error) {
 	dbPoolMx.Lock()
 	defer dbPoolMx.Unlock()
 
@@ -41,8 +41,8 @@ func createPolledDBConn(databaseName string, createDBConnFn func() (*sqlx.DB, er
 	return db, nil
 }
 
-// createPolledDBConn closes the database connection in the dbPool if it exists.
-func closePolledDBConn(databaseName string, closeFn func() error) error {
+// closeSharedDBConn closes the database connection in the dbPool if it exists.
+func closeSharedDBConn(databaseName string, closeDBConnFn func() error) error {
 	dbPoolMx.Lock()
 	defer dbPoolMx.Unlock()
 
@@ -53,5 +53,5 @@ func closePolledDBConn(databaseName string, closeFn func() error) error {
 
 	delete(dbPool, databaseName)
 	delete(dbPoolCounter, databaseName)
-	return closeFn()
+	return closeDBConnFn()
 }

--- a/common/persistence/sql/sqlplugin/sqlite/plugin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/plugin.go
@@ -81,7 +81,7 @@ func (p *plugin) createSingleDBConn(cfg *config.SQL) (*sqlx.DB, error) {
 		return p.createDBConn(cfg)
 	}
 
-	return createPolledDBConn(cfg.DatabaseName, func() (*sqlx.DB, error) {
+	return createSharedDBConn(cfg.DatabaseName, func() (*sqlx.DB, error) {
 		return p.createDBConn(cfg)
 	})
 }

--- a/config/development_sqlite.yaml
+++ b/config/development_sqlite.yaml
@@ -1,0 +1,18 @@
+persistence:
+  defaultStore: sqlite-default
+  visibilityStore: sqlite-visibility
+  datastores:
+    sqlite-default:
+      sql:
+        pluginName: "sqlite"
+        maxConns: 20
+        maxIdleConns: 20
+        maxConnLifetime: "1h"
+        databaseName: "cadence.db"
+    sqlite-visibility:
+      sql:
+        pluginName: "sqlite"
+        maxConns: 20
+        maxIdleConns: 20
+        maxConnLifetime: "1h"
+        databaseName: "cadence_visibility.db"

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -30,8 +30,10 @@ import (
 	"github.com/uber/cadence/common/config"
 	mysql_db "github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"
 	postgres_db "github.com/uber/cadence/common/persistence/sql/sqlplugin/postgres"
+	sqlite_db "github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/schema/mysql"
 	"github.com/uber/cadence/schema/postgres"
+	"github.com/uber/cadence/schema/sqlite"
 	cliflag "github.com/uber/cadence/tools/common/flag"
 	"github.com/uber/cadence/tools/common/schema"
 )
@@ -50,6 +52,8 @@ func VerifyCompatibleVersion(
 			expectedVersion = mysql.Version
 		case postgres_db.PluginName:
 			expectedVersion = postgres.Version
+		case sqlite_db.PluginName:
+			expectedVersion = sqlite.Version
 		}
 		err := CheckCompatibleVersion(*ds.SQL, expectedVersion)
 		if err != nil {
@@ -64,6 +68,9 @@ func VerifyCompatibleVersion(
 			expectedVersion = mysql.VisibilityVersion
 		case postgres_db.PluginName:
 			expectedVersion = postgres.VisibilityVersion
+		case sqlite_db.PluginName:
+			expectedVersion = sqlite.VisibilityVersion
+
 		}
 		err := CheckCompatibleVersion(*ds.SQL, expectedVersion)
 		if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* `cadence-server` can be run with `sqlite` storage via `./cadence-server start --zone sqlite start`
* `make install-schema-sqlite` has been added to apply the schema to sqlite database
* `make clean` has been updated to delete local sqlite database
* `dbPool` has been added to assure that only one `sql.DB` per sqlite file database has been created
* SQLite option has been added to `CONTRIBUTING.md`


<!-- Tell your future self why have you made these changes -->
**Why?**
Local development with Cassandra and other dependencies increases development time, especially when there is no need for dependencies. The PR allows developers to develop/debug cadence server with SQLite storage.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Followed `CONTRIBUTING.md\`
  * Run cadence server locally
  * Run cadence web locally via `docker run -e "CADENCE_GRPC_PEERS=host.docker.internal:7833" -p "8088:8088" ubercadence/web:lates`
  * Run examples from `cadence-samples`
  * Verified that there is no `database is locked` errors 
* Unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
