### PR TITLE
Disconnect sticky tasklist blocked pollers after domain failover

### DIFF
--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -1152,7 +1152,9 @@ func Test_domainChangeCallback(t *testing.T) {
 
 	mockTaskListManagerGlobal1 := tasklist.NewMockManager(mockCtrl)
 	mockTaskListManagerGlobal2 := tasklist.NewMockManager(mockCtrl)
+	mockStickyTaskListManagerGlobal2 := tasklist.NewMockManager(mockCtrl)
 	mockTaskListManagerGlobal3 := tasklist.NewMockManager(mockCtrl)
+	mockStickyTaskListManagerGlobal3 := tasklist.NewMockManager(mockCtrl)
 	mockTaskListManagerLocal1 := tasklist.NewMockManager(mockCtrl)
 	mockTaskListManagerActiveActive1 := tasklist.NewMockManager(mockCtrl)
 
@@ -1160,10 +1162,10 @@ func Test_domainChangeCallback(t *testing.T) {
 	tlIdentifierActivityGlobal1, _ := tasklist.NewIdentifier("global-domain-1-id", "global-domain-1", persistence.TaskListTypeActivity)
 	tlIdentifierDecisionGlobal2, _ := tasklist.NewIdentifier("global-domain-2-id", "global-domain-2", persistence.TaskListTypeDecision)
 	tlIdentifierActivityGlobal2, _ := tasklist.NewIdentifier("global-domain-2-id", "global-domain-2", persistence.TaskListTypeActivity)
-	tlIdentifierStickyGlobal2, _ := tasklist.NewIdentifier("global-domain-2-id", "global-domain-2", persistence.TaskListTypeDecision)
+	tlIdentifierStickyGlobal2, _ := tasklist.NewIdentifier("global-domain-2-id", "sticky-global-domain-2", persistence.TaskListTypeDecision)
 	tlIdentifierActivityGlobal3, _ := tasklist.NewIdentifier("global-domain-3-id", "global-domain-3", persistence.TaskListTypeActivity)
 	tlIdentifierDecisionGlobal3, _ := tasklist.NewIdentifier("global-domain-3-id", "global-domain-3", persistence.TaskListTypeDecision)
-	tlIdentifierStickyGlobal3, _ := tasklist.NewIdentifier("global-domain-3-id", "global-domain-3", persistence.TaskListTypeDecision)
+	tlIdentifierStickyGlobal3, _ := tasklist.NewIdentifier("global-domain-3-id", "sticky-global-domain-3", persistence.TaskListTypeDecision)
 	tlIdentifierDecisionLocal1, _ := tasklist.NewIdentifier("local-domain-1-id", "local-domain-1", persistence.TaskListTypeDecision)
 	tlIdentifierActivityLocal1, _ := tasklist.NewIdentifier("local-domain-1-id", "local-domain-1", persistence.TaskListTypeActivity)
 	tlIdentifierDecisionActiveActive1, _ := tasklist.NewIdentifier("active-active-domain-1-id", "active-active-domain-1", persistence.TaskListTypeDecision)
@@ -1179,10 +1181,10 @@ func Test_domainChangeCallback(t *testing.T) {
 			*tlIdentifierActivityGlobal1:       mockTaskListManagerGlobal1,
 			*tlIdentifierDecisionGlobal2:       mockTaskListManagerGlobal2,
 			*tlIdentifierActivityGlobal2:       mockTaskListManagerGlobal2,
-			*tlIdentifierStickyGlobal2:         mockTaskListManagerGlobal2,
+			*tlIdentifierStickyGlobal2:         mockStickyTaskListManagerGlobal2,
 			*tlIdentifierDecisionGlobal3:       mockTaskListManagerGlobal3,
 			*tlIdentifierActivityGlobal3:       mockTaskListManagerGlobal3,
-			*tlIdentifierStickyGlobal3:         mockTaskListManagerGlobal3,
+			*tlIdentifierStickyGlobal3:         mockStickyTaskListManagerGlobal3,
 			*tlIdentifierDecisionLocal1:        mockTaskListManagerLocal1,
 			*tlIdentifierActivityLocal1:        mockTaskListManagerLocal1,
 			*tlIdentifierDecisionActiveActive1: mockTaskListManagerActiveActive1,
@@ -1191,14 +1193,18 @@ func Test_domainChangeCallback(t *testing.T) {
 	}
 
 	mockTaskListManagerGlobal1.EXPECT().ReleaseBlockedPollers().Times(0)
-	mockTaskListManagerGlobal2.EXPECT().GetTaskListKind().Return(types.TaskListKindNormal).Times(2)
-	mockTaskListManagerGlobal2.EXPECT().GetTaskListKind().Return(types.TaskListKindSticky).Times(1)
-	mockTaskListManagerGlobal2.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(3)
-	mockTaskListManagerGlobal2.EXPECT().ReleaseBlockedPollers().Times(3)
-	mockTaskListManagerGlobal3.EXPECT().GetTaskListKind().Return(types.TaskListKindNormal).Times(2)
-	mockTaskListManagerGlobal3.EXPECT().GetTaskListKind().Return(types.TaskListKindSticky).Times(1)
-	mockTaskListManagerGlobal3.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(3)
-	mockTaskListManagerGlobal3.EXPECT().ReleaseBlockedPollers().Return(errors.New("some-error")).Times(3)
+	mockTaskListManagerGlobal2.EXPECT().GetTaskListKind().Return(types.TaskListKindNormal).Times(4)
+	mockStickyTaskListManagerGlobal2.EXPECT().GetTaskListKind().Return(types.TaskListKindSticky).Times(2)
+	mockTaskListManagerGlobal2.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(2)
+	mockStickyTaskListManagerGlobal2.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(1)
+	mockTaskListManagerGlobal2.EXPECT().ReleaseBlockedPollers().Times(2)
+	mockStickyTaskListManagerGlobal2.EXPECT().ReleaseBlockedPollers().Times(1)
+	mockTaskListManagerGlobal3.EXPECT().GetTaskListKind().Return(types.TaskListKindNormal).Times(4)
+	mockStickyTaskListManagerGlobal3.EXPECT().GetTaskListKind().Return(types.TaskListKindSticky).Times(2)
+	mockTaskListManagerGlobal3.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(2)
+	mockStickyTaskListManagerGlobal3.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(1)
+	mockTaskListManagerGlobal3.EXPECT().ReleaseBlockedPollers().Return(errors.New("some-error")).Times(2)
+	mockStickyTaskListManagerGlobal3.EXPECT().ReleaseBlockedPollers().Return(errors.New("some-error")).Times(1)
 	mockTaskListManagerLocal1.EXPECT().ReleaseBlockedPollers().Times(0)
 	mockTaskListManagerActiveActive1.EXPECT().ReleaseBlockedPollers().Times(0)
 

--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -1160,8 +1160,10 @@ func Test_domainChangeCallback(t *testing.T) {
 	tlIdentifierActivityGlobal1, _ := tasklist.NewIdentifier("global-domain-1-id", "global-domain-1", persistence.TaskListTypeActivity)
 	tlIdentifierDecisionGlobal2, _ := tasklist.NewIdentifier("global-domain-2-id", "global-domain-2", persistence.TaskListTypeDecision)
 	tlIdentifierActivityGlobal2, _ := tasklist.NewIdentifier("global-domain-2-id", "global-domain-2", persistence.TaskListTypeActivity)
+	tlIdentifierStickyGlobal2, _ := tasklist.NewIdentifier("global-domain-2-id", "global-domain-2", persistence.TaskListTypeDecision)
 	tlIdentifierActivityGlobal3, _ := tasklist.NewIdentifier("global-domain-3-id", "global-domain-3", persistence.TaskListTypeActivity)
 	tlIdentifierDecisionGlobal3, _ := tasklist.NewIdentifier("global-domain-3-id", "global-domain-3", persistence.TaskListTypeDecision)
+	tlIdentifierStickyGlobal3, _ := tasklist.NewIdentifier("global-domain-3-id", "global-domain-3", persistence.TaskListTypeDecision)
 	tlIdentifierDecisionLocal1, _ := tasklist.NewIdentifier("local-domain-1-id", "local-domain-1", persistence.TaskListTypeDecision)
 	tlIdentifierActivityLocal1, _ := tasklist.NewIdentifier("local-domain-1-id", "local-domain-1", persistence.TaskListTypeActivity)
 	tlIdentifierDecisionActiveActive1, _ := tasklist.NewIdentifier("active-active-domain-1-id", "active-active-domain-1", persistence.TaskListTypeDecision)
@@ -1177,8 +1179,10 @@ func Test_domainChangeCallback(t *testing.T) {
 			*tlIdentifierActivityGlobal1:       mockTaskListManagerGlobal1,
 			*tlIdentifierDecisionGlobal2:       mockTaskListManagerGlobal2,
 			*tlIdentifierActivityGlobal2:       mockTaskListManagerGlobal2,
+			*tlIdentifierStickyGlobal2:         mockTaskListManagerGlobal2,
 			*tlIdentifierDecisionGlobal3:       mockTaskListManagerGlobal3,
 			*tlIdentifierActivityGlobal3:       mockTaskListManagerGlobal3,
+			*tlIdentifierStickyGlobal3:         mockTaskListManagerGlobal3,
 			*tlIdentifierDecisionLocal1:        mockTaskListManagerLocal1,
 			*tlIdentifierActivityLocal1:        mockTaskListManagerLocal1,
 			*tlIdentifierDecisionActiveActive1: mockTaskListManagerActiveActive1,
@@ -1188,15 +1192,15 @@ func Test_domainChangeCallback(t *testing.T) {
 
 	mockTaskListManagerGlobal1.EXPECT().ReleaseBlockedPollers().Times(0)
 	mockTaskListManagerGlobal2.EXPECT().GetTaskListKind().Return(types.TaskListKindNormal).Times(2)
-	mockTaskListManagerGlobal2.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(2)
-	mockTaskListManagerGlobal2.EXPECT().ReleaseBlockedPollers().Times(2)
+	mockTaskListManagerGlobal2.EXPECT().GetTaskListKind().Return(types.TaskListKindSticky).Times(1)
+	mockTaskListManagerGlobal2.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(3)
+	mockTaskListManagerGlobal2.EXPECT().ReleaseBlockedPollers().Times(3)
 	mockTaskListManagerGlobal3.EXPECT().GetTaskListKind().Return(types.TaskListKindNormal).Times(2)
-	mockTaskListManagerGlobal3.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(2)
-	mockTaskListManagerGlobal3.EXPECT().ReleaseBlockedPollers().Return(errors.New("some-error")).Times(2)
+	mockTaskListManagerGlobal3.EXPECT().GetTaskListKind().Return(types.TaskListKindSticky).Times(1)
+	mockTaskListManagerGlobal3.EXPECT().DescribeTaskList(gomock.Any()).Return(&types.DescribeTaskListResponse{}).Times(3)
+	mockTaskListManagerGlobal3.EXPECT().ReleaseBlockedPollers().Return(errors.New("some-error")).Times(3)
 	mockTaskListManagerLocal1.EXPECT().ReleaseBlockedPollers().Times(0)
 	mockTaskListManagerActiveActive1.EXPECT().ReleaseBlockedPollers().Times(0)
-	mockDomainCache.EXPECT().GetDomainID("global-domain-2").Return("global-domain-2-id", nil).Times(1)
-	mockDomainCache.EXPECT().GetDomainID("global-domain-3").Return("global-domain-3-id", nil).Times(1)
 
 	domains := []*cache.DomainCacheEntry{
 		cache.NewDomainCacheEntryForTest(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add logic to disconnect the sticky tasklists when a domain failover happens.

<!-- Tell your future self why have you made these changes -->
**Why?**
Sticky tasklists are created on poll start and are also created on the standby cluster. Therefore they also have to be disconnected to avoid waiting on poll timeout.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test and local simulation

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If corrects the gap left by previous optimization.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
