### PR TITLE
Remove soft fail from integration-test-sqlite

### DIFF
--- a/.buildkite/pipeline-master.yml
+++ b/.buildkite/pipeline-master.yml
@@ -256,10 +256,6 @@ steps:
   - label: ":golang: integration test with sqlite"
     artifact_paths:
       - ".build/coverage/*.out"
-    # sqlite persistence storage is still in development
-    # so persistence tests should not fail the build
-    # but we still want to run them
-    soft_fail: true
     retry:
       automatic:
         limit: 1

--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -269,10 +269,6 @@ steps:
   - label: ":golang: integration test with sqlite"
     artifact_paths:
       - ".build/coverage/*.out"
-    # sqlite persistence storage is still in development
-    # so persistence tests should not fail the build
-    # but we still want to run them
-    soft_fail: true
     retry:
       automatic:
         limit: 1


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* `soft_fail: true` has been removed from `integration-test-sqlite` Buildkite job 


<!-- Tell your future self why have you made these changes -->
**Why?**
SQLite storage plugin has been developed, so integration test should verify integration with SQLite storage too and fail if there are errors

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* CI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
