### PR TITLE
[common][ringpopprovider] Fix fx ringpop initialization

### DIFF
--- a/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx.go
+++ b/common/peerprovider/ringpopprovider/ringpopfx/ringpopfx.go
@@ -38,16 +38,16 @@ var Module = fx.Module("ringpop", fx.Provide(buildRingpopProvider))
 type Params struct {
 	fx.In
 
-	Service       string `name:"service"`
-	Config        config.Config
-	ServiceConfig config.Service
-	Logger        log.Logger
-	RPCFactory    rpc.Factory
-	Lifecycle     fx.Lifecycle
+	ServiceFullName string `name:"service-full-name"`
+	Config          config.Config
+	ServiceConfig   config.Service
+	Logger          log.Logger
+	RPCFactory      rpc.Factory
+	Lifecycle       fx.Lifecycle
 }
 
 func buildRingpopProvider(params Params) (membership.PeerProvider, error) {
-	provider, err := ringpopprovider.New(params.Service, &params.Config.Ringpop, params.RPCFactory.GetTChannel(), membership.PortMap{
+	provider, err := ringpopprovider.New(params.ServiceFullName, &params.Config.Ringpop, params.RPCFactory.GetTChannel(), membership.PortMap{
 		membership.PortGRPC:     params.ServiceConfig.RPC.GRPCPort,
 		membership.PortTchannel: params.ServiceConfig.RPC.Port,
 	}, params.Logger)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixing ringpop initialization in fx component. There is a mix of service name and full service name across configurations.

<!-- Tell your future self why have you made these changes -->
**Why?**
For now it is unused and it will not affect shard distributor, but if it will be used in other service this will affect hostInfo.Identity.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested in the monorepo initialization.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
