### PR TITLE
Don't convert yarpc Unknown errors to error string

### DIFF
--- a/common/types/mapper/proto/errors.go
+++ b/common/types/mapper/proto/errors.go
@@ -21,8 +21,6 @@
 package proto
 
 import (
-	"errors"
-
 	apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
 	"go.uber.org/yarpc/encoding/protobuf"
 	"go.uber.org/yarpc/yarpcerrors"
@@ -237,8 +235,6 @@ func ToError(err error) error {
 				Message: status.Message(),
 			}
 		}
-	case yarpcerrors.CodeUnknown:
-		return errors.New(status.Message())
 	}
 
 	// If error does not match anything, return raw yarpc status error

--- a/common/types/mapper/proto/errors_test.go
+++ b/common/types/mapper/proto/errors_test.go
@@ -52,10 +52,13 @@ func TestFromUnknownErrorMapsToUnknownError(t *testing.T) {
 	protobufErr := FromError(err)
 	assert.True(t, yarpcerrors.IsUnknown(protobufErr))
 
-	assert.Equal(t, err, ToError(protobufErr))
+	clientErr := ToError(protobufErr)
+
+	assert.True(t, yarpcerrors.IsUnknown(clientErr))
+	assert.ErrorContains(t, clientErr, err.Error())
 }
 
-func TestToUnknownErrorMapsToItself(t *testing.T) {
+func TestToDeadlineExceededMapsToItself(t *testing.T) {
 	timeout := yarpcerrors.DeadlineExceededErrorf("timeout")
 	assert.Equal(t, timeout, ToError(timeout))
 }


### PR DESCRIPTION
Retry logic relies on the type of the error. Converting unknown errors to error strings makes them unretryable.

This matches the existing tchannel behavior.

<!-- Describe what has changed in this PR -->
**What changed?**
- Maintain Unknown errors as yarpc errors for GRPC

<!-- Tell your future self why have you made these changes -->
**Why?**
- So they can be retried

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests, integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Error categorization and handling is typically high risk. Perhaps there were errors we were glad to stop retrying when moving from tchannel to GRPC.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
