### PR TITLE
[Wf-Diagnostics] add issue when HB timeout is equal or more than startToClose timeout

### DIFF
--- a/service/worker/diagnostics/invariant/retry/retry.go
+++ b/service/worker/diagnostics/invariant/retry/retry.go
@@ -87,6 +87,17 @@ func (r *retry) Check(ctx context.Context, params invariant.InvariantCheckInput)
 				})
 				issueID++
 			}
+			if attr.GetStartToCloseTimeoutSeconds() <= attr.GetHeartbeatTimeoutSeconds() {
+				result = append(result, invariant.InvariantCheckResult{
+					IssueID:       issueID,
+					InvariantType: ActivityHeartbeatIssue.String(),
+					Reason:        HeartBeatTimeoutEqualToStartToCloseTimeout.String(),
+					Metadata: invariant.MarshalData(RetryMetadata{
+						EventID: event.ID,
+					}),
+				})
+				issueID++
+			}
 		}
 	}
 

--- a/service/worker/diagnostics/invariant/retry/retry_test.go
+++ b/service/worker/diagnostics/invariant/retry/retry_test.go
@@ -62,6 +62,11 @@ func Test__Check(t *testing.T) {
 	}
 	invalidExpIntervalMetadataInBytes, err := json.Marshal(invalidExpIntervalMetadata)
 	require.NoError(t, err)
+	invalidHBMetadata := RetryMetadata{
+		EventID: 6,
+	}
+	invalidHBMetadataInBytes, err := json.Marshal(invalidHBMetadata)
+	require.NoError(t, err)
 	testCases := []struct {
 		name           string
 		testData       *types.GetWorkflowExecutionHistoryResponse
@@ -96,6 +101,12 @@ func Test__Check(t *testing.T) {
 					InvariantType: WorkflowRetryIssue.String(),
 					Reason:        RetryPolicyValidationExpInterval.String(),
 					Metadata:      invalidExpIntervalMetadataInBytes,
+				},
+				{
+					IssueID:       3,
+					InvariantType: ActivityHeartbeatIssue.String(),
+					Reason:        HeartBeatTimeoutEqualToStartToCloseTimeout.String(),
+					Metadata:      invalidHBMetadataInBytes,
 				},
 			},
 			err: nil,
@@ -138,6 +149,7 @@ func retriedWfHistory() *types.GetWorkflowExecutionHistoryResponse {
 }
 
 func invalidRetryPolicyWfHistory() *types.GetWorkflowExecutionHistoryResponse {
+	timeout := int32(5)
 	return &types.GetWorkflowExecutionHistoryResponse{
 		History: &types.History{
 			Events: []*types.HistoryEvent{
@@ -153,6 +165,8 @@ func invalidRetryPolicyWfHistory() *types.GetWorkflowExecutionHistoryResponse {
 				{
 					ID: 5,
 					ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+						HeartbeatTimeoutSeconds:    common.Int32Ptr(timeout),
+						StartToCloseTimeoutSeconds: common.Int32Ptr(timeout * 2),
 						RetryPolicy: &types.RetryPolicy{
 							InitialIntervalInSeconds: 1,
 							MaximumAttempts:          1,
@@ -162,7 +176,9 @@ func invalidRetryPolicyWfHistory() *types.GetWorkflowExecutionHistoryResponse {
 				{
 					ID: 6,
 					ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
-						RetryPolicy: nil,
+						HeartbeatTimeoutSeconds:    common.Int32Ptr(timeout),
+						StartToCloseTimeoutSeconds: common.Int32Ptr(timeout),
+						RetryPolicy:                nil,
 					},
 				},
 			},

--- a/service/worker/diagnostics/invariant/retry/types.go
+++ b/service/worker/diagnostics/invariant/retry/types.go
@@ -27,9 +27,10 @@ import "github.com/uber/cadence/common/types"
 type RetryType string
 
 const (
-	WorkflowRetryInfo  RetryType = "Workflow Retry configured and applied"
-	WorkflowRetryIssue RetryType = "Workflow Retry configured but invalid"
-	ActivityRetryIssue RetryType = "Activity Retry configured but invalid"
+	WorkflowRetryInfo      RetryType = "Workflow Retry configured and applied"
+	WorkflowRetryIssue     RetryType = "Workflow Retry configured but invalid"
+	ActivityRetryIssue     RetryType = "Activity Retry configured but invalid"
+	ActivityHeartbeatIssue RetryType = "Activity Heartbeat configured but invalid"
 )
 
 func (r RetryType) String() string {
@@ -39,8 +40,9 @@ func (r RetryType) String() string {
 type IssueType string
 
 const (
-	RetryPolicyValidationMaxAttempts IssueType = "MaximumAttempts set to 1 will not retry since maximum attempts includes the first attempt."
-	RetryPolicyValidationExpInterval IssueType = "ExpirationIntervalInSeconds less than  InitialIntervalInSeconds  will not retry."
+	RetryPolicyValidationMaxAttempts           IssueType = "MaximumAttempts set to 1 will not retry since maximum attempts includes the first attempt."
+	RetryPolicyValidationExpInterval           IssueType = "ExpirationIntervalInSeconds less than  InitialIntervalInSeconds  will not retry."
+	HeartBeatTimeoutEqualToStartToCloseTimeout IssueType = "Heartbeat timeout being equal or higher than StartToClose timeout will not provide any benefit."
 )
 
 func (i IssueType) String() string {

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -349,7 +349,7 @@ func retrieveFailureRootCause(rootCause []invariant.InvariantRootCauseResult) ([
 func retrieveRetryIssues(issues []invariant.InvariantCheckResult) ([]*retryIssuesResult, error) {
 	result := make([]*retryIssuesResult, 0)
 	for _, issue := range issues {
-		if issue.InvariantType == retry.WorkflowRetryIssue.String() || issue.InvariantType == retry.WorkflowRetryInfo.String() || issue.InvariantType == retry.ActivityRetryIssue.String() {
+		if issueRetryRelated(issue) {
 			var data retry.RetryMetadata
 			err := json.Unmarshal(issue.Metadata, &data)
 			if err != nil {
@@ -381,6 +381,15 @@ func rootCauseHeartBeatRelated(rootCause invariant.RootCause) bool {
 func rootCausePollersRelated(rootCause invariant.RootCause) bool {
 	for _, rc := range []invariant.RootCause{invariant.RootCauseTypePollersStatus, invariant.RootCauseTypeMissingPollers} {
 		if rc == rootCause {
+			return true
+		}
+	}
+	return false
+}
+
+func issueRetryRelated(issue invariant.InvariantCheckResult) bool {
+	for _, i := range []string{retry.WorkflowRetryIssue.String(), retry.WorkflowRetryInfo.String(), retry.ActivityRetryIssue.String(), retry.ActivityHeartbeatIssue.String()} {
+		if issue.InvariantType == i {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
diagnostics adds issue when HB timeout is equal or more than startToClose timeout

<!-- Tell your future self why have you made these changes -->
**Why?**
this is common case where users fail to leverage the benefit of HB timeout

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
