### PR TITLE
Consolidate and minor fix on retry behavior for GetHistoryTasks operation

### DIFF
--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -529,7 +529,7 @@ func (t *timerQueueProcessorBase) getTimerTasks(readLevel, maxReadLevel task.Key
 
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(timerTaskOperationRetryPolicy),
-		backoff.WithRetryableError(persistence.IsBackgroundTransientError),
+		backoff.WithRetryableError(func(err error) bool { return true }),
 	)
 	err := throttleRetry.Do(context.Background(), op)
 	if err != nil {

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -48,6 +48,7 @@ var (
 		time.Unix(0, math.MaxInt64),
 		0,
 	)
+	timerTaskOperationRetryPolicy = common.CreatePersistenceRetryPolicy()
 )
 
 type (
@@ -527,7 +528,7 @@ func (t *timerQueueProcessorBase) getTimerTasks(readLevel, maxReadLevel task.Key
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
-		backoff.WithRetryPolicy(common.CreateTaskProcessingRetryPolicy()),
+		backoff.WithRetryPolicy(timerTaskOperationRetryPolicy),
 		backoff.WithRetryableError(persistence.IsBackgroundTransientError),
 	)
 	err := throttleRetry.Do(context.Background(), op)

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -518,19 +518,24 @@ func (t *timerQueueProcessorBase) getTimerTasks(readLevel, maxReadLevel task.Key
 		PageSize:            batchSize,
 		NextPageToken:       nextPageToken,
 	}
-	var err error
+
 	var response *persistence.GetHistoryTasksResponse
-	retryCount := t.shard.GetConfig().TimerProcessorGetFailureRetryCount()
-	for attempt := 0; attempt < retryCount; attempt++ {
-		response, err = t.shard.GetExecutionManager().GetHistoryTasks(context.Background(), request)
-		if err == nil {
-			return response, nil
-		}
-		backoff := time.Duration(attempt*100) * time.Millisecond
-		t.logger.Debugf("Failed to get timer tasks from execution manager. error: %v, attempt: %d, retryCount: %d, backoff: %v", err, attempt, retryCount, backoff)
-		time.Sleep(backoff)
+	op := func(ctx context.Context) error {
+		var err error
+		response, err = t.shard.GetExecutionManager().GetHistoryTasks(ctx, request)
+		return err
 	}
-	return nil, err
+
+	throttleRetry := backoff.NewThrottleRetry(
+		backoff.WithRetryPolicy(persistenceOperationRetryPolicy),
+		backoff.WithRetryableError(persistence.IsBackgroundTransientError),
+	)
+	err := throttleRetry.Do(context.Background(), op)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 func (t *timerQueueProcessorBase) isProcessNow(expiryTime time.Time) bool {

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -527,7 +527,7 @@ func (t *timerQueueProcessorBase) getTimerTasks(readLevel, maxReadLevel task.Key
 	}
 
 	throttleRetry := backoff.NewThrottleRetry(
-		backoff.WithRetryPolicy(persistenceOperationRetryPolicy),
+		backoff.WithRetryPolicy(common.CreateTaskProcessingRetryPolicy()),
 		backoff.WithRetryableError(persistence.IsBackgroundTransientError),
 	)
 	err := throttleRetry.Do(context.Background(), op)

--- a/service/history/queue/timer_queue_processor_base_test.go
+++ b/service/history/queue/timer_queue_processor_base_test.go
@@ -495,7 +495,7 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_LookAheadFailed_No
 
 	mockExecutionMgr := s.mockShard.Resource.ExecutionMgr
 	mockExecutionMgr.On("GetHistoryTasks", mock.Anything, request).Return(response, nil).Once()
-	mockExecutionMgr.On("GetHistoryTasks", mock.Anything, lookAheadRequest).Return(nil, errors.New("some random error")).Times(s.mockShard.GetConfig().TimerProcessorGetFailureRetryCount())
+	mockExecutionMgr.On("GetHistoryTasks", mock.Anything, lookAheadRequest).Return(nil, errors.New("some random error")).Once()
 
 	timerQueueProcessBase, done := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
 	defer done()

--- a/service/history/queue/timer_queue_processor_base_test.go
+++ b/service/history/queue/timer_queue_processor_base_test.go
@@ -495,7 +495,7 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_LookAheadFailed_No
 
 	mockExecutionMgr := s.mockShard.Resource.ExecutionMgr
 	mockExecutionMgr.On("GetHistoryTasks", mock.Anything, request).Return(response, nil).Once()
-	mockExecutionMgr.On("GetHistoryTasks", mock.Anything, lookAheadRequest).Return(nil, errors.New("some random error")).Once()
+	mockExecutionMgr.On("GetHistoryTasks", mock.Anything, lookAheadRequest).Return(nil, errors.New("some random error")).Times(0)
 
 	timerQueueProcessBase, done := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
 	defer done()

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -528,7 +528,7 @@ func (t *transferQueueProcessorBase) readTasks(
 	var response *persistence.GetHistoryTasksResponse
 	op := func(ctx context.Context) error {
 		var err error
-		response, err = t.shard.GetExecutionManager().GetHistoryTasks(context.Background(), &persistence.GetHistoryTasksRequest{
+		response, err = t.shard.GetExecutionManager().GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
 			TaskCategory:        persistence.HistoryTaskCategoryTransfer,
 			InclusiveMinTaskKey: persistence.NewImmediateTaskKey(readLevel.(transferTaskKey).taskID + 1),
 			ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(maxReadLevel.(transferTaskKey).taskID + 1),

--- a/service/history/queue/transfer_queue_processor_test.go
+++ b/service/history/queue/transfer_queue_processor_test.go
@@ -208,7 +208,7 @@ func TestTransferQueueProcessor_FailoverDomain(t *testing.T) {
 						},
 					},
 				}
-				mockShard.GetExecutionManager().(*mocks.ExecutionManager).On("GetHistoryTasks", context.Background(), mock.Anything).Return(response, nil).Once()
+				mockShard.GetExecutionManager().(*mocks.ExecutionManager).On("GetHistoryTasks", mock.Anything, mock.Anything).Return(response, nil).Once()
 			},
 			processorStarted: true,
 		},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replace custom retry implementation in timer_queue_processor with standard backoff.WithRetryPolicy pattern
Fix context propagation for GetHistoryTasks operation in transfer_queue_processor

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to consolidate the retry behavior of GetHistoryTasks operation with the base throttle retry.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
