### PR TITLE
adding some utilities for scripting

### DIFF
--- a/common/scripting/exec.go
+++ b/common/scripting/exec.go
@@ -1,0 +1,105 @@
+package scripting
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Executor is a helper for running scripting
+type Executor interface {
+	BashExec(ctx context.Context, in string) (stdout string, stderr string, exitErr *exec.ExitError)
+	Exec(ctx context.Context, bin string, args ...string) (stdout string, stderr string, exitErr *exec.ExitError)
+	QuietBashExec(ctx context.Context, in string) (stdout string, stderr string, exitErr *exec.ExitError)
+	QuietExec(ctx context.Context, bin string, args ...string) (stdout string, stderr string, exitErr *exec.ExitError)
+}
+
+// New returns a new bash executor
+func New() Executor {
+	return &execImpl{}
+}
+
+type execImpl struct{}
+
+// BashExec is a helper function for ensuring the user
+// can read a legible streaming from a subprocess,
+// as well as allowing programmatic access to stdout, stderr and exit codes
+// it's highly unsafe for any kind of untrusted inputs as it's explicitly bypassing
+// go's exec safety args, so it *must not* come into contact with anything untrusted
+func (execImpl) BashExec(ctx context.Context, in string) (stdout string, stderr string, exitErr *exec.ExitError) {
+	cmd := exec.CommandContext(ctx, "bash", "-c", in)
+	var stdBuffer bytes.Buffer
+	var stdErrBuffer bytes.Buffer
+	mw := io.MultiWriter(os.Stdout, &stdBuffer)
+	mwErr := io.MultiWriter(os.Stderr, &stdErrBuffer)
+	cmd.Stdout = mw
+	cmd.Stderr = mwErr
+	err := cmd.Run()
+	var e *exec.ExitError
+	if errors.As(err, &e) && e.ExitCode() != 0 {
+		return stdBuffer.String(), stdErrBuffer.String(), e
+	} else if err != nil {
+		panic(err)
+	}
+	return stdBuffer.String(), stdErrBuffer.String(), nil
+}
+
+// Exec is a wrapper around exec.Command which adds some convenience
+// functionality to both capture standout/err as well as tee it to the user's UI in real time
+// meaning that the user doesn't need to wait for the command to complete.
+// It's value is fairly marginal and if it presents any problems the user should consider just
+// using exec.Command directly
+func (execImpl) Exec(ctx context.Context, bin string, args ...string) (stdout string, stderr string, exitErr *exec.ExitError) {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var stdBuffer bytes.Buffer
+	var stdErrBuffer bytes.Buffer
+	mw := io.MultiWriter(os.Stdout, &stdBuffer)
+	mwErr := io.MultiWriter(os.Stderr, &stdErrBuffer)
+	cmd.Stdout = mw
+	cmd.Stderr = mwErr
+	err := cmd.Run()
+	var e *exec.ExitError
+	if errors.As(err, &e) && e.ExitCode() != 0 {
+		return stdBuffer.String(), stdErrBuffer.String(), e
+	} else if err != nil {
+		panic(err)
+	}
+	return stdBuffer.String(), stdErrBuffer.String(), nil
+}
+
+// QuietBashExec ...
+func (execImpl) QuietBashExec(ctx context.Context, in string) (stdout string, stderr string, exitErr *exec.ExitError) {
+	cmd := exec.CommandContext(ctx, "bash", "-c", in)
+	var stdBuffer bytes.Buffer
+	var stdErrBuffer bytes.Buffer
+	cmd.Stdout = &stdBuffer
+	cmd.Stderr = &stdErrBuffer
+	err := cmd.Run()
+	var e *exec.ExitError
+	if errors.As(err, &e) && e.ExitCode() != 0 {
+		return stdBuffer.String(), stdErrBuffer.String(), e
+	} else if err != nil {
+		panic(err)
+	}
+	return stdBuffer.String(), stdErrBuffer.String(), nil
+}
+
+// QuietExec ...
+func (execImpl) QuietExec(ctx context.Context, bin string, args ...string) (stdout string, stderr string, exitErr *exec.ExitError) {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var stdBuffer bytes.Buffer
+	var stdErrBuffer bytes.Buffer
+	cmd.Stdout = &stdBuffer
+	cmd.Stderr = &stdErrBuffer
+	err := cmd.Run()
+	var e *exec.ExitError
+	if errors.As(err, &e) && e.ExitCode() != 0 {
+		return stdBuffer.String(), stdErrBuffer.String(), e
+	} else if err != nil {
+		panic(err)
+	}
+	return stdBuffer.String(), stdErrBuffer.String(), nil
+}

--- a/common/scripting/exec_test.go
+++ b/common/scripting/exec_test.go
@@ -1,0 +1,117 @@
+package scripting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBashExec(t *testing.T) {
+	script := New()
+
+	stdout, stderr, err := script.BashExec(context.Background(), "echo test")
+	assert.Equal(t, "test\n", stdout)
+	assert.Equal(t, "", stderr)
+	assert.Nil(t, err)
+
+	stdout, stderr, err = script.BashExec(context.Background(), "echo test 1>&2")
+	assert.Equal(t, "test\n", stderr)
+	assert.Equal(t, "", stdout)
+	assert.Nil(t, err)
+
+	stdout, stderr, err = script.BashExec(context.Background(), "false")
+	assert.Equal(t, "", stderr)
+	assert.Equal(t, "", stdout)
+	assert.Error(t, err)
+
+	tests := map[string]struct {
+		args           string
+		expectedStdout string
+		expectedSterr  string
+		expectedErr    bool
+	}{
+		"stdout": {
+			args:           "echo test",
+			expectedStdout: "test\n",
+			expectedSterr:  "",
+			expectedErr:    false,
+		},
+		"stderr": {
+			args:           "echo test 1>&2",
+			expectedStdout: "",
+			expectedSterr:  "test\n",
+			expectedErr:    false,
+		},
+		"error": {
+			args:           "false",
+			expectedStdout: "",
+			expectedSterr:  "",
+			expectedErr:    true,
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr, err := script.BashExec(context.Background(), td.args)
+			assert.Equal(t, td.expectedStdout, stdout)
+			assert.Equal(t, td.expectedSterr, stderr)
+			if td.expectedErr {
+				assert.Error(t, err)
+			}
+
+			stdout, stderr, err = script.QuietBashExec(context.Background(), td.args)
+			assert.Equal(t, td.expectedStdout, stdout)
+			assert.Equal(t, td.expectedSterr, stderr)
+			if td.expectedErr {
+				assert.Error(t, err)
+			}
+		})
+	}
+
+}
+
+func TestExec(t *testing.T) {
+	script := New()
+
+	tests := map[string]struct {
+		bin            string
+		args           []string
+		expectedStdout string
+		expectedSterr  string
+		expectedErr    bool
+	}{
+		"stdout": {
+			bin:            "echo",
+			args:           []string{"test"},
+			expectedStdout: "test\n",
+			expectedSterr:  "",
+			expectedErr:    false,
+		},
+		"error": {
+			bin:            "false",
+			args:           []string{""},
+			expectedStdout: "",
+			expectedSterr:  "",
+			expectedErr:    true,
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr, err := script.Exec(context.Background(), td.bin, td.args...)
+			assert.Equal(t, td.expectedStdout, stdout)
+			assert.Equal(t, td.expectedSterr, stderr)
+			if td.expectedErr {
+				assert.Error(t, err)
+			}
+
+			stdout, stderr, err = script.QuietExec(context.Background(), td.bin, td.args...)
+			assert.Equal(t, td.expectedStdout, stdout)
+			assert.Equal(t, td.expectedSterr, stderr)
+			if td.expectedErr {
+				assert.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

The go stdlib os.Exec is a concrete type, so annoying to use when testing. I also found in tooling that I was repeatedly having to rewrite fiddly code which either streamed to the user's stdout or to a buffer such that I could interact with it programmatically (and eventually Steven put me out of my misery and came up with the mux pattern here). 

So coming up with a relatively straightforward wrapper interface and a few helpful defaults made a bunch of scripting less annoying. 

This was written and used elsewhere, but we were discussing scripting in this repo, so copy+pasta-ing them here in the hope the'll be useful (it came up in a recent discussion)


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
