### PR TITLE
[Wf-Diagnostics] handle pagination during fetching of history events

### DIFF
--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -108,7 +108,6 @@ func (w *dw) getWorkflowExecutionHistory(ctx context.Context, execution *types.W
 		}
 
 		nextPageToken = response.NextPageToken
-		time.Sleep(10 * time.Millisecond) // to prevent hitting rate limits
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
issue identification handles pagination of history events

<!-- Tell your future self why have you made these changes -->
**Why?**
needed when diagnostics is run on long workflows since GetWorkflowExecutionHistory has a default page limit of 1000

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
