### PR TITLE
Truncate timestamp of scheduled tasks to the min precision of Database timestamp

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -66,6 +66,8 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+const DBTimestampMinPrecision = time.Millisecond
+
 // Domain status
 const (
 	DomainStatusRegistered = iota

--- a/service/history/queue/timer_queue_processor_base_test.go
+++ b/service/history/queue/timer_queue_processor_base_test.go
@@ -201,7 +201,7 @@ func (s *timerQueueProcessorBaseSuite) TestGetTimerTasks_NoMore() {
 }
 
 func (s *timerQueueProcessorBaseSuite) TestReadLookAheadTask() {
-	shardMaxReadLevel := s.mockShard.UpdateTimerMaxReadLevel(s.clusterName)
+	shardMaxReadLevel := s.mockShard.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, s.clusterName).GetScheduledTime()
 	readLevel := newTimerTaskKey(shardMaxReadLevel, 0)
 	maxReadLevel := newTimerTaskKey(shardMaxReadLevel.Add(10*time.Second), 0)
 

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -377,19 +377,17 @@ func (s *contextTestSuite) TestTimerMaxReadLevel() {
 	s.mockResource.TimeSource = clock.NewMockedTimeSource()
 
 	// get current cluster's level
-	gotLevel := s.context.UpdateTimerMaxReadLevel(cluster.TestCurrentClusterName)
-	wantLevel := s.mockResource.TimeSource.Now().Add(s.context.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
+	gotLevel := s.context.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, cluster.TestCurrentClusterName)
+	wantLevel := persistence.NewHistoryTaskKey(s.mockResource.TimeSource.Now().Add(s.context.config.TimerProcessorMaxTimeShift()).Truncate(persistence.DBTimestampMinPrecision), 0)
 	s.Equal(wantLevel, gotLevel)
-	s.Equal(wantLevel, s.context.GetTimerMaxReadLevel(cluster.TestCurrentClusterName))
 
 	// get remote cluster's level
 	remoteCluster := "remote-cluster"
 	now := time.Now()
 	s.context.SetCurrentTime(remoteCluster, now)
-	gotLevel = s.context.UpdateTimerMaxReadLevel(remoteCluster)
-	wantLevel = now.Add(s.context.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
+	gotLevel = s.context.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, remoteCluster)
+	wantLevel = persistence.NewHistoryTaskKey(now.Add(s.context.config.TimerProcessorMaxTimeShift()).Truncate(persistence.DBTimestampMinPrecision), 0)
 	s.Equal(wantLevel, gotLevel)
-	s.Equal(wantLevel, s.context.GetTimerMaxReadLevel(remoteCluster))
 }
 
 func (s *contextTestSuite) TestGenerateTransferTaskID() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Truncate timestamp of scheduled tasks to the min precision of Database timestamp
- Delete deprecated methods from shard context

<!-- Tell your future self why have you made these changes -->
**Why?**
The timestamps of scheduled tasks are truncated when they're stored in Cassandra. We've already truncated the range of query of timer tasks, so currently we're not losing any tasks in our queue processing components. We truncate the timestamp to unify the behavior across all types of databases and also improve our simulation tests because in simulation tests we compare the timestamp of timer tasks written to the database and timer tasks being read and executed to find tasks missed by the queue component.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests and integration tests

And with this change, the simulation test only has workflow deletion timer tasks created but not executed:
```
Tasks that were created but not executed:
ShardID: 0
  TaskCategory: timer, TaskType: 4
    TaskID: 1048601, ScheduledTime: 2025-05-29T18:52:37.834Z
    TaskID: 1048608, ScheduledTime: 2025-05-29T18:52:37.866Z
    TaskID: 1048641, ScheduledTime: 2025-05-29T18:52:38.08Z
    TaskID: 1048655, ScheduledTime: 2025-05-29T18:52:38.147Z
    TaskID: 1048668, ScheduledTime: 2025-05-29T18:52:38.173Z
    TaskID: 1048698, ScheduledTime: 2025-05-29T18:52:38.22Z
    TaskID: 1048705, ScheduledTime: 2025-05-29T18:52:38.231Z
    TaskID: 1048710, ScheduledTime: 2025-05-29T18:52:38.241Z
    TaskID: 1048730, ScheduledTime: 2025-05-29T18:52:38.278Z
    TaskID: 1048754, ScheduledTime: 2025-05-29T18:52:38.32Z
    TaskID: 1048759, ScheduledTime: 2025-05-29T18:52:38.33Z
    TaskID: 1048773, ScheduledTime: 2025-05-29T18:52:38.357Z
    TaskID: 1048805, ScheduledTime: 2025-05-29T18:52:38.818Z
    TaskID: 1048813, ScheduledTime: 2025-05-29T18:52:38.908Z
    TaskID: 1048821, ScheduledTime: 2025-05-29T18:52:38.972Z
    TaskID: 1048829, ScheduledTime: 2025-05-29T18:52:39.013Z
    TaskID: 1048837, ScheduledTime: 2025-05-29T18:52:39.117Z
    TaskID: 1048846, ScheduledTime: 2025-05-29T18:52:39.165Z
    TaskID: 1048853, ScheduledTime: 2025-05-29T18:52:39.181Z
    TaskID: 1048861, ScheduledTime: 2025-05-29T18:52:39.248Z
    TaskID: 1048869, ScheduledTime: 2025-05-29T18:52:39.295Z
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Timer tasks might be lost if the truncation is wrong

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
