### PR TITLE
Add domain tag back to frontend's poller request metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2260,6 +2260,7 @@ const (
 
 	// common metrics that are emitted per task list
 	CadenceRequestsPerTaskList
+	CadenceRequestsPerTaskListWithoutRollup
 	CadenceFailuresPerTaskList
 	CadenceLatencyPerTaskList
 	CadenceErrBadRequestPerTaskListCounter
@@ -2972,6 +2973,9 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		// per task list common metrics
 		CadenceRequestsPerTaskList: {
 			metricName: "cadence_requests_per_tl", metricRollupName: "cadence_requests", metricType: Counter,
+		},
+		CadenceRequestsPerTaskListWithoutRollup: {
+			metricName: "cadence_requests_per_tl", metricType: Counter,
 		},
 		CadenceFailuresPerTaskList: {
 			metricName: "cadence_errors_per_tl", metricRollupName: "cadence_errors", metricType: Counter,

--- a/service/frontend/templates/metered.tmpl
+++ b/service/frontend/templates/metered.tmpl
@@ -84,10 +84,12 @@ func (h *{{$decorator}}) {{$method.Declaration}} {
 	{{- end}}
 	{{- if has $method.Name $pollerAPIs}}
 	scope := common.NewPerTaskListScope({{(index $method.Params 1).Name}}.Domain, {{(index $method.Params 1).Name}}.TaskList.GetName(), {{(index $method.Params 1).Name}}.TaskList.GetKind(), h.metricsClient, {{$scope}}).Tagged(metrics.GetContextTags(ctx)...)
-	scope.IncCounter(metrics.CadenceRequestsPerTaskList)
+	scope.IncCounter(metrics.CadenceRequestsPerTaskListWithoutRollup)
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer sw.Stop()
-	swPerDomain := h.metricsClient.Scope({{$scope}}).Tagged(append(metrics.GetContextTags(ctx), {{$domainMetricTag}})...).StartTimer(metrics.CadenceLatency)
+	scopePerDomain := h.metricsClient.Scope({{$scope}}).Tagged(append(metrics.GetContextTags(ctx), {{$domainMetricTag}})...)
+	scopePerDomain.IncCounter(metrics.CadenceRequests)
+	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer swPerDomain.Stop()
 	{{- else}}
 	scope := h.metricsClient.Scope({{$scope}}).Tagged(append(metrics.GetContextTags(ctx), {{$domainMetricTag}})...)

--- a/service/frontend/wrappers/metered/api_generated.go
+++ b/service/frontend/wrappers/metered/api_generated.go
@@ -313,10 +313,12 @@ func (h *apiHandler) PollForActivityTask(ctx context.Context, pp1 *types.PollFor
 	tags := []tag.Tag{tag.WorkflowHandlerName("PollForActivityTask")}
 	tags = append(tags, toPollForActivityTaskRequestTags(pp1)...)
 	scope := common.NewPerTaskListScope(pp1.Domain, pp1.TaskList.GetName(), pp1.TaskList.GetKind(), h.metricsClient, metrics.FrontendPollForActivityTaskScope).Tagged(metrics.GetContextTags(ctx)...)
-	scope.IncCounter(metrics.CadenceRequestsPerTaskList)
+	scope.IncCounter(metrics.CadenceRequestsPerTaskListWithoutRollup)
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer sw.Stop()
-	swPerDomain := h.metricsClient.Scope(metrics.FrontendPollForActivityTaskScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(pp1.GetDomain()))...).StartTimer(metrics.CadenceLatency)
+	scopePerDomain := h.metricsClient.Scope(metrics.FrontendPollForActivityTaskScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(pp1.GetDomain()))...)
+	scopePerDomain.IncCounter(metrics.CadenceRequests)
+	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer swPerDomain.Stop()
 	logger := h.logger.WithTags(tags...)
 
@@ -331,10 +333,12 @@ func (h *apiHandler) PollForDecisionTask(ctx context.Context, pp1 *types.PollFor
 	tags := []tag.Tag{tag.WorkflowHandlerName("PollForDecisionTask")}
 	tags = append(tags, toPollForDecisionTaskRequestTags(pp1)...)
 	scope := common.NewPerTaskListScope(pp1.Domain, pp1.TaskList.GetName(), pp1.TaskList.GetKind(), h.metricsClient, metrics.FrontendPollForDecisionTaskScope).Tagged(metrics.GetContextTags(ctx)...)
-	scope.IncCounter(metrics.CadenceRequestsPerTaskList)
+	scope.IncCounter(metrics.CadenceRequestsPerTaskListWithoutRollup)
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer sw.Stop()
-	swPerDomain := h.metricsClient.Scope(metrics.FrontendPollForDecisionTaskScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(pp1.GetDomain()))...).StartTimer(metrics.CadenceLatency)
+	scopePerDomain := h.metricsClient.Scope(metrics.FrontendPollForDecisionTaskScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(pp1.GetDomain()))...)
+	scopePerDomain.IncCounter(metrics.CadenceRequests)
+	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer swPerDomain.Stop()
 	logger := h.logger.WithTags(tags...)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add domain tag back to frontend's poller request metrics.

The affected handlers are PollForDecisionTask and PollForActivityTask. These metrics are emitted from the handlers:
- name: cadence_requests, operation: {pollfordecisiontask, pollforactivitytask} tags: domain name (added back by this PR)
- name: cadence_latency, operation: {pollfordecisiontask, pollforactivitytask} tags: domain name
- name: cadence_requests_per_tl, operation: {pollfordecisiontask, pollforactivitytask} tags: domain name, tasklist name, tasklist type
- name: cadence_latency_per_tl, operation: {pollfordecisiontask, pollforactivitytask} tags: domain name, tasklist name, tasklist type

<!-- Tell your future self why have you made these changes -->
**Why?**
Domain tag was removed from Frontend's Poller API request metrics previously which broke dashboard of customers. This PR bring it back to make sure the metric change is backward compatible.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
