### PR TITLE
Implement BufferOneCronWorkflow behavior to cron GetBackoffForNextSchedule

### DIFF
--- a/common/backoff/cron_test.go
+++ b/common/backoff/cron_test.go
@@ -65,7 +65,7 @@ func TestCron(t *testing.T) {
 				require.ErrorContains(t, err, "Invalid CronSchedule")
 			} else {
 				require.NoError(t, err)
-				backoff, err := GetBackoffForNextSchedule(sched, start, end, 0)
+				backoff, err := GetBackoffForNextSchedule(sched, start, end, 0, false)
 				require.NoError(t, err)
 				assert.Equal(t, tt.result, backoff, "The cron spec is %s and the expected result is %s", tt.cron, tt.result)
 			}
@@ -110,7 +110,7 @@ func TestCronWithJitterStart(t *testing.T) {
 			if tt.expectedResultSeconds != NoBackoff {
 				assert.NoError(t, err)
 			}
-			backoff, err := GetBackoffForNextSchedule(sched, start, end, tt.jitterStartSeconds)
+			backoff, err := GetBackoffForNextSchedule(sched, start, end, tt.jitterStartSeconds, false)
 			require.NoError(t, err)
 			fmt.Printf("Backoff time for test %d = %v\n", idx, backoff)
 			delta := time.Duration(tt.jitterStartSeconds) * time.Second
@@ -128,7 +128,7 @@ func TestCronWithJitterStart(t *testing.T) {
 			for i := 1; i < caseCount; i++ {
 				startTime := expectedResultTime
 
-				backoff, err := GetBackoffForNextSchedule(sched, startTime, startTime, tt.jitterStartSeconds)
+				backoff, err := GetBackoffForNextSchedule(sched, startTime, startTime, tt.jitterStartSeconds, false)
 				require.NoError(t, err)
 				expectedResultTime := startTime.Add(tt.expectedResultSeconds2)
 				backoffTime := startTime.Add(backoff)
@@ -153,6 +153,98 @@ func TestCronWithJitterStart(t *testing.T) {
 				t.Fatalf("Jittered when we weren't supposed to? Test specs = %v\n", tt)
 			}
 
+		})
+	}
+}
+
+func TestCronWithoutBufferOneCronWorkflow(t *testing.T) {
+	var bufferOneCronWorkflowTests = []struct {
+		startTime       string
+		closeTime       string
+		expectedBackoff time.Duration
+		description     string
+	}{
+		{
+			startTime:       "2018-12-17T10:00:00+00:00",
+			closeTime:       "2018-12-17T11:00:00+00:00",
+			expectedBackoff: time.Hour * 23,
+			description:     "Next schedule is next day at 10:00",
+		},
+		{
+			startTime:       "2018-12-17T10:00:00+00:00",
+			closeTime:       "2018-12-18T10:45:00+00:00",
+			expectedBackoff: time.Hour*23 + time.Minute*15,
+			description:     "Skip that run and schedule at next possible time",
+		},
+	}
+
+	for idx, tt := range bufferOneCronWorkflowTests {
+		t.Run(fmt.Sprintf("%d_%s", idx, tt.description), func(t *testing.T) {
+			start, err := time.Parse(time.RFC3339, tt.startTime)
+			require.NoError(t, err)
+			close, err := time.Parse(time.RFC3339, tt.closeTime)
+			require.NoError(t, err)
+
+			sched, err := ValidateSchedule("0 10 * * *")
+			require.NoError(t, err)
+
+			backoff, err := GetBackoffForNextSchedule(sched, start, close, 0, false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedBackoff, backoff,
+				"Test case %d failed: %s\nStart: %s\nClose: %s",
+				idx, tt.description, tt.startTime, tt.closeTime)
+		})
+	}
+}
+
+func TestCronWithBufferOneCronWorkflow(t *testing.T) {
+	var bufferOneCronWorkflowTests = []struct {
+		startTime       string
+		closeTime       string
+		expectedBackoff time.Duration
+		description     string
+	}{
+		{
+			startTime:       "2018-12-17T10:00:00+00:00",
+			closeTime:       "2018-12-17T11:00:00+00:00",
+			expectedBackoff: time.Hour * 23,
+			description:     "Next schedule is next day at 10:00",
+		},
+		{
+			startTime:       "2018-12-17T10:00:00+00:00",
+			closeTime:       "2018-12-18T10:45:00+00:00",
+			expectedBackoff: 0,
+			description:     "Start immediately after previous close time",
+		},
+		{
+			startTime:       "2018-12-17T10:00:00+00:00",
+			closeTime:       "2018-12-17T10:30:00+00:00",
+			expectedBackoff: time.Hour*23 + time.Minute*30,
+			description:     "Close time is after schedule time",
+		},
+		{
+			startTime:       "2018-12-17T10:00:00+00:00",
+			closeTime:       "2018-12-30T10:45:00+00:00",
+			expectedBackoff: 0,
+			description:     "Start immediately after previous close time even if previous one skipped multiple runs",
+		},
+	}
+
+	for idx, tt := range bufferOneCronWorkflowTests {
+		t.Run(fmt.Sprintf("%d_%s", idx, tt.description), func(t *testing.T) {
+			start, err := time.Parse(time.RFC3339, tt.startTime)
+			require.NoError(t, err)
+			close, err := time.Parse(time.RFC3339, tt.closeTime)
+			require.NoError(t, err)
+
+			sched, err := ValidateSchedule("0 10 * * *")
+			require.NoError(t, err)
+
+			backoff, err := GetBackoffForNextSchedule(sched, start, close, 0, true)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedBackoff, backoff,
+				"Test case %d failed: %s\nStart: %s\nClose: %s",
+				idx, tt.description, tt.startTime, tt.closeTime)
 		})
 	}
 }

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -411,9 +411,10 @@ type (
 		NonRetriableErrors []string
 		BranchToken        []byte
 		// Cron
-		CronSchedule      string
-		IsCron            bool
-		ExpirationSeconds int32 // TODO: is this field useful?
+		CronSchedule          string
+		IsCron                bool
+		BufferOneCronWorkflow bool
+		ExpirationSeconds     int32 // TODO: is this field useful?
 	}
 
 	// ExecutionStats is the statistics about workflow execution

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1016,7 +1016,7 @@ func (e *mutableStateBuilder) GetCronBackoffDuration(
 		time.Duration(workflowStartEvent.GetWorkflowExecutionStartedEventAttributes().GetFirstDecisionTaskBackoffSeconds()) * time.Second
 	executionTime = executionTime.Add(firstDecisionTaskBackoff)
 	jitterStartSeconds := workflowStartEvent.GetWorkflowExecutionStartedEventAttributes().GetJitterStartSeconds()
-	return backoff.GetBackoffForNextSchedule(sched, executionTime, e.timeSource.Now(), jitterStartSeconds)
+	return backoff.GetBackoffForNextSchedule(sched, executionTime, e.timeSource.Now(), jitterStartSeconds, info.BufferOneCronWorkflow)
 }
 
 // GetStartEvent retrieves the workflow start event from mutable state

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -181,7 +181,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_Wi
 
 	now := time.Now()
 	evenType := types.EventTypeWorkflowExecutionStarted
-	next, err := backoff.GetBackoffForNextSchedule(parsedSchedule, now, now, 0)
+	next, err := backoff.GetBackoffForNextSchedule(parsedSchedule, now, now, 0, false)
 	require.NoError(s.T(), err)
 	startWorkflowAttribute := &types.WorkflowExecutionStartedEventAttributes{
 		ParentWorkflowDomainID: common.StringPtr(constants.TestDomainID),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add BufferOneCronWorkflow behavior to cron GetBackoffForNextSchedule.
When this flag is enabled, the function will calculate the next schedule time based on the workflow's close time. This means if a workflow takes longer than expected and misses its scheduled time, the next run will be scheduled immediately after the current one completes, rather than waiting for the next scheduled interval.

<!-- Tell your future self why have you made these changes -->
**Why?**
This feature came from a customer's request where they want to ensure continuous workflow execution even when individual runs take longer than the scheduled interval. Without this feature, if a workflow run takes longer than expected, the system would skip the next scheduled run and wait for the following interval.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks since the flag is not active and does not interfere with existing behavior

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
