### PR TITLE
[frontend/history] Mark common error handlers with logger.Helper()

### DIFF
--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -1517,9 +1517,10 @@ func (adh *adminHandlerImpl) startRequestProfile(ctx context.Context, scope int)
 }
 
 func (adh *adminHandlerImpl) error(err error, scope metrics.Scope) error {
+	logger := adh.GetLogger().Helper()
 	switch err.(type) {
 	case *types.InternalServiceError:
-		adh.GetLogger().Error("Internal service error", tag.Error(err))
+		logger.Error("Internal service error", tag.Error(err))
 		scope.IncCounter(metrics.CadenceFailures)
 		return err
 	case *types.BadRequestError:
@@ -1531,7 +1532,7 @@ func (adh *adminHandlerImpl) error(err error, scope metrics.Scope) error {
 	case *types.EntityNotExistsError:
 		return err
 	default:
-		adh.GetLogger().Error("Uncategorized error", tag.Error(err))
+		logger.Error("Uncategorized error", tag.Error(err))
 		scope.IncCounter(metrics.CadenceFailures)
 		return &types.InternalServiceError{Message: err.Error()}
 	}

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -2137,6 +2137,7 @@ func (h *handlerImpl) updateErrorMetric(
 	runID string,
 	err error,
 ) {
+	logger := h.GetLogger().Helper()
 
 	var yarpcE *yarpcerrors.Status
 
@@ -2203,7 +2204,7 @@ func (h *handlerImpl) updateErrorMetric(
 
 	} else if errors.As(err, &internalServiceError) {
 		scope.IncCounter(metrics.CadenceFailures)
-		h.GetLogger().Error("Internal service error",
+		logger.Error("Internal service error",
 			tag.Error(err),
 			tag.WorkflowID(workflowID),
 			tag.WorkflowRunID(runID),
@@ -2212,7 +2213,7 @@ func (h *handlerImpl) updateErrorMetric(
 	} else {
 		// Default / unknown error fallback
 		scope.IncCounter(metrics.CadenceFailures)
-		h.GetLogger().Error("Uncategorized error",
+		logger.Error("Uncategorized error",
 			tag.Error(err),
 			tag.WorkflowID(workflowID),
 			tag.WorkflowRunID(runID),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Marked common API error handlers with logger.Helper

<!-- Tell your future self why have you made these changes -->
**Why?**
To provide a clear error stack traces

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
