### PR TITLE
[cmd/server] Fix metrics client initialization

### DIFF
--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/mock/gomock"
 
@@ -42,6 +43,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/common/resource"
@@ -108,7 +110,7 @@ func (s *ServerSuite) TestServerStartup() {
 		})
 
 	for _, svc := range services {
-		server := newServer(svc, cfg, logger, dynamicconfig.NewNopClient())
+		server := newServer(svc, cfg, logger, dynamicconfig.NewNopClient(), tally.NoopScope, metrics.NewNoopMetricsClient())
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/startreedata/pinot-client-go v0.2.0 // latest release supports pinot v0.12.0 which is also internal version
 	github.com/stretchr/testify v1.10.0
-	github.com/uber-go/tally v3.3.15+incompatible // indirect
+	github.com/uber-go/tally v3.3.15+incompatible
 	github.com/uber/cadence-idl v0.0.0-20250610164115-817eef8d1bb6
 	github.com/uber/ringpop-go v0.8.5 // indirect
 	github.com/uber/tchannel-go v1.22.2 // indirect

--- a/common/metrics/metricsfx/metricsfx.go
+++ b/common/metrics/metricsfx/metricsfx.go
@@ -51,9 +51,19 @@ type clientParams struct {
 	SvcCfg          config.Service
 }
 
-func buildClient(params clientParams) metrics.Client {
+type clientResult struct {
+	fx.Out
+
+	Scope  tally.Scope
+	Client metrics.Client
+}
+
+func buildClient(params clientParams) clientResult {
 	scope := params.SvcCfg.Metrics.NewScope(params.Logger, params.ServiceFullName)
-	return buildClientFromTally(scope, service.GetMetricsServiceIdx(params.ServiceFullName, params.Logger))
+	return clientResult{
+		Scope:  scope,
+		Client: buildClientFromTally(scope, service.GetMetricsServiceIdx(params.ServiceFullName, params.Logger)),
+	}
 }
 
 type serviceIdxParams struct {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed metrics client that was created two times. Scope creation starts metrics emission and connects the root scope for metrics.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fixing a bug that caused no metrics to be emitted.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started locally with --zone prometheus and checked localhost:8000/metrics

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Metrics emission is broken for customers using master auto setup and default cmd/server implementation

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
