### PR TITLE
[common] Fix CapturePanic to preserve stack in logs

### DIFF
--- a/common/log/panic.go
+++ b/common/log/panic.go
@@ -43,7 +43,7 @@ func CapturePanic(errPanic interface{}, logger Logger, retError *error) {
 
 		st := string(debug.Stack())
 
-		logger.Error("Panic is captured", tag.SysStackTrace(st), tag.Error(err))
+		logger.Helper().Error("Panic is captured", tag.SysStackTrace(st), tag.Error(err))
 
 		if retError != nil {
 			*retError = err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Marking log message CapturePanic to point to the panic stack, not logged message.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improving log visibility

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
