### PR TITLE
Modify mapper function to ensure data consistency between shared/thrift/proto encoding

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -681,6 +681,7 @@ func FromContinueAsNewWorkflowExecutionDecisionAttributes(t *types.ContinueAsNew
 		Memo:                         FromMemo(t.Memo),
 		SearchAttributes:             FromSearchAttributes(t.SearchAttributes),
 		JitterStart:                  secondsToDuration(t.JitterStartSeconds),
+		CronOverlapPolicy:            FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -705,6 +706,7 @@ func ToContinueAsNewWorkflowExecutionDecisionAttributes(t *apiv1.ContinueAsNewWo
 		Memo:                                ToMemo(t.Memo),
 		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
 		JitterStartSeconds:                  durationToSeconds(t.JitterStart),
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -3463,6 +3465,7 @@ func FromSignalWithStartWorkflowExecutionRequest(t *types.SignalWithStartWorkflo
 			DelayStart:                   secondsToDuration(t.DelayStartSeconds),
 			JitterStart:                  secondsToDuration(t.JitterStartSeconds),
 			FirstRunAt:                   unixNanoToTime(t.FirstRunAtTimestamp),
+			CronOverlapPolicy:            FromCronOverlapPolicy(t.CronOverlapPolicy),
 		},
 		SignalName:  t.SignalName,
 		SignalInput: FromPayload(t.SignalInput),
@@ -3496,6 +3499,7 @@ func ToSignalWithStartWorkflowExecutionRequest(t *apiv1.SignalWithStartWorkflowE
 		DelayStartSeconds:                   durationToSeconds(t.StartRequest.DelayStart),
 		JitterStartSeconds:                  durationToSeconds(t.StartRequest.JitterStart),
 		FirstRunAtTimestamp:                 timeToUnixNano(t.StartRequest.FirstRunAt),
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.StartRequest.CronOverlapPolicy),
 	}
 }
 
@@ -3567,6 +3571,7 @@ func FromStartChildWorkflowExecutionDecisionAttributes(t *types.StartChildWorkfl
 		Header:                       FromHeader(t.Header),
 		Memo:                         FromMemo(t.Memo),
 		SearchAttributes:             FromSearchAttributes(t.SearchAttributes),
+		CronOverlapPolicy:            FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -3590,6 +3595,7 @@ func ToStartChildWorkflowExecutionDecisionAttributes(t *apiv1.StartChildWorkflow
 		Header:                              ToHeader(t.Header),
 		Memo:                                ToMemo(t.Memo),
 		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -3647,6 +3653,7 @@ func FromStartChildWorkflowExecutionInitiatedEventAttributes(t *types.StartChild
 		DelayStart:                   secondsToDuration(t.DelayStartSeconds),
 		JitterStart:                  secondsToDuration(t.JitterStartSeconds),
 		FirstRunAt:                   unixNanoToTime(t.FirstRunAtTimestamp),
+		CronOverlapPolicy:            FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -3674,6 +3681,7 @@ func ToStartChildWorkflowExecutionInitiatedEventAttributes(t *apiv1.StartChildWo
 		DelayStartSeconds:                   durationToSeconds(t.DelayStart),
 		JitterStartSeconds:                  durationToSeconds(t.JitterStart),
 		FirstRunAtTimestamp:                 timeToUnixNano(t.FirstRunAt),
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -3824,6 +3832,7 @@ func FromStartWorkflowExecutionRequest(t *types.StartWorkflowExecutionRequest) *
 		DelayStart:                   secondsToDuration(t.DelayStartSeconds),
 		JitterStart:                  secondsToDuration(t.JitterStartSeconds),
 		FirstRunAt:                   unixNanoToTime(t.FirstRunAtTimeStamp),
+		CronOverlapPolicy:            FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -3850,6 +3859,7 @@ func ToStartWorkflowExecutionRequest(t *apiv1.StartWorkflowExecutionRequest) *ty
 		DelayStartSeconds:                   durationToSeconds(t.DelayStart),
 		JitterStartSeconds:                  durationToSeconds(t.JitterStart),
 		FirstRunAtTimeStamp:                 timeToUnixNano(t.FirstRunAt),
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -4893,6 +4903,7 @@ func FromWorkflowExecutionInfo(t *types.WorkflowExecutionInfo) *apiv1.WorkflowEx
 		TaskList:            t.TaskList,
 		PartitionConfig:     t.PartitionConfig,
 		IsCron:              t.IsCron,
+		CronOverlapPolicy:   FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -4918,6 +4929,7 @@ func ToWorkflowExecutionInfo(t *apiv1.WorkflowExecutionInfo) *types.WorkflowExec
 		TaskList:          t.TaskList,
 		PartitionConfig:   t.PartitionConfig,
 		IsCron:            t.IsCron,
+		CronOverlapPolicy: ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -4976,6 +4988,7 @@ func FromWorkflowExecutionStartedEventAttributes(t *types.WorkflowExecutionStart
 		Header:                       FromHeader(t.Header),
 		PartitionConfig:              t.PartitionConfig,
 		RequestId:                    t.RequestID,
+		CronOverlapPolicy:            FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5013,6 +5026,7 @@ func ToWorkflowExecutionStartedEventAttributes(t *apiv1.WorkflowExecutionStarted
 		Header:                              ToHeader(t.Header),
 		PartitionConfig:                     t.PartitionConfig,
 		RequestID:                           t.RequestId,
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -6277,4 +6291,29 @@ func ToAutoConfigHint(t *apiv1.AutoConfigHint) *types.AutoConfigHint {
 		PollerWaitTimeInMs: t.PollerWaitTimeInMs,
 		EnableAutoConfig:   t.EnableAutoConfig,
 	}
+}
+
+func FromCronOverlapPolicy(p *types.CronOverlapPolicy) apiv1.CronOverlapPolicy {
+	if p == nil {
+		return apiv1.CronOverlapPolicy_CRON_OVERLAP_POLICY_INVALID
+	}
+	switch *p {
+	case types.CronOverlapPolicyBufferOne:
+		return apiv1.CronOverlapPolicy_CRON_OVERLAP_POLICY_BUFFER_ONE
+	case types.CronOverlapPolicySkipped:
+		return apiv1.CronOverlapPolicy_CRON_OVERLAP_POLICY_SKIPPED
+	}
+	return apiv1.CronOverlapPolicy_CRON_OVERLAP_POLICY_INVALID
+}
+
+func ToCronOverlapPolicy(p apiv1.CronOverlapPolicy) *types.CronOverlapPolicy {
+	switch p {
+	case apiv1.CronOverlapPolicy_CRON_OVERLAP_POLICY_BUFFER_ONE:
+		return types.CronOverlapPolicyBufferOne.Ptr()
+	case apiv1.CronOverlapPolicy_CRON_OVERLAP_POLICY_SKIPPED:
+		return types.CronOverlapPolicySkipped.Ptr()
+	case apiv1.CronOverlapPolicy_CRON_OVERLAP_POLICY_INVALID:
+		return nil
+	}
+	return nil
 }

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -914,6 +914,7 @@ func FromContinueAsNewWorkflowExecutionDecisionAttributes(t *types.ContinueAsNew
 		Memo:                                FromMemo(t.Memo),
 		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
 		JitterStartSeconds:                  t.JitterStartSeconds,
+		CronOverlapPolicy:                   FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -939,6 +940,7 @@ func ToContinueAsNewWorkflowExecutionDecisionAttributes(t *shared.ContinueAsNewW
 		Memo:                                ToMemo(t.Memo),
 		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
 		JitterStartSeconds:                  t.JitterStartSeconds,
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5168,6 +5170,7 @@ func FromSignalWithStartWorkflowExecutionRequest(t *types.SignalWithStartWorkflo
 		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
 		Header:                              FromHeader(t.Header),
 		FirstRunAtTimestamp:                 t.FirstRunAtTimestamp,
+		CronOverlapPolicy:                   FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5196,6 +5199,7 @@ func ToSignalWithStartWorkflowExecutionRequest(t *shared.SignalWithStartWorkflow
 		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
 		Header:                              ToHeader(t.Header),
 		FirstRunAtTimestamp:                 t.FirstRunAtTimestamp,
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5252,6 +5256,7 @@ func FromStartChildWorkflowExecutionDecisionAttributes(t *types.StartChildWorkfl
 		Header:                              FromHeader(t.Header),
 		Memo:                                FromMemo(t.Memo),
 		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+		CronOverlapPolicy:                   FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5276,6 +5281,7 @@ func ToStartChildWorkflowExecutionDecisionAttributes(t *shared.StartChildWorkflo
 		Header:                              ToHeader(t.Header),
 		Memo:                                ToMemo(t.Memo),
 		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5336,6 +5342,7 @@ func FromStartChildWorkflowExecutionInitiatedEventAttributes(t *types.StartChild
 		DelayStartSeconds:                   t.DelayStartSeconds,
 		JitterStartSeconds:                  t.JitterStartSeconds,
 		FirstRunAtTimestamp:                 t.FirstRunAtTimestamp,
+		CronOverlapPolicy:                   FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5364,6 +5371,7 @@ func ToStartChildWorkflowExecutionInitiatedEventAttributes(t *shared.StartChildW
 		DelayStartSeconds:                   t.DelayStartSeconds,
 		JitterStartSeconds:                  t.JitterStartSeconds,
 		FirstRunAtTimestamp:                 t.FirstRunAtTimestamp,
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5499,6 +5507,7 @@ func FromStartWorkflowExecutionRequest(t *types.StartWorkflowExecutionRequest) *
 		DelayStartSeconds:                   t.DelayStartSeconds,
 		JitterStartSeconds:                  t.JitterStartSeconds,
 		FirstRunAtTimestamp:                 t.FirstRunAtTimeStamp,
+		CronOverlapPolicy:                   FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -5526,6 +5535,7 @@ func ToStartWorkflowExecutionRequest(t *shared.StartWorkflowExecutionRequest) *t
 		DelayStartSeconds:                   t.DelayStartSeconds,
 		JitterStartSeconds:                  t.JitterStartSeconds,
 		FirstRunAtTimeStamp:                 t.FirstRunAtTimestamp,
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -6511,24 +6521,25 @@ func FromWorkflowExecutionInfo(t *types.WorkflowExecutionInfo) *shared.WorkflowE
 		return nil
 	}
 	return &shared.WorkflowExecutionInfo{
-		Execution:        FromWorkflowExecution(t.Execution),
-		Type:             FromWorkflowType(t.Type),
-		StartTime:        t.StartTime,
-		CloseTime:        t.CloseTime,
-		CloseStatus:      FromWorkflowExecutionCloseStatus(t.CloseStatus),
-		HistoryLength:    &t.HistoryLength,
-		ParentDomainId:   t.ParentDomainID,
-		ParentDomainName: t.ParentDomain,
-		ParentInitatedId: t.ParentInitiatedID,
-		ParentExecution:  FromWorkflowExecution(t.ParentExecution),
-		ExecutionTime:    t.ExecutionTime,
-		Memo:             FromMemo(t.Memo),
-		SearchAttributes: FromSearchAttributes(t.SearchAttributes),
-		AutoResetPoints:  FromResetPoints(t.AutoResetPoints),
-		TaskList:         &t.TaskList,
-		IsCron:           &t.IsCron,
-		UpdateTime:       t.UpdateTime,
-		PartitionConfig:  t.PartitionConfig,
+		Execution:         FromWorkflowExecution(t.Execution),
+		Type:              FromWorkflowType(t.Type),
+		StartTime:         t.StartTime,
+		CloseTime:         t.CloseTime,
+		CloseStatus:       FromWorkflowExecutionCloseStatus(t.CloseStatus),
+		HistoryLength:     &t.HistoryLength,
+		ParentDomainId:    t.ParentDomainID,
+		ParentDomainName:  t.ParentDomain,
+		ParentInitatedId:  t.ParentInitiatedID,
+		ParentExecution:   FromWorkflowExecution(t.ParentExecution),
+		ExecutionTime:     t.ExecutionTime,
+		Memo:              FromMemo(t.Memo),
+		SearchAttributes:  FromSearchAttributes(t.SearchAttributes),
+		AutoResetPoints:   FromResetPoints(t.AutoResetPoints),
+		TaskList:          &t.TaskList,
+		IsCron:            &t.IsCron,
+		UpdateTime:        t.UpdateTime,
+		PartitionConfig:   t.PartitionConfig,
+		CronOverlapPolicy: FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -6556,6 +6567,7 @@ func ToWorkflowExecutionInfo(t *shared.WorkflowExecutionInfo) *types.WorkflowExe
 		IsCron:            t.GetIsCron(),
 		UpdateTime:        t.UpdateTime,
 		PartitionConfig:   t.PartitionConfig,
+		CronOverlapPolicy: ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -6620,6 +6632,7 @@ func FromWorkflowExecutionStartedEventAttributes(t *types.WorkflowExecutionStart
 		Header:                              FromHeader(t.Header),
 		PartitionConfig:                     t.PartitionConfig,
 		RequestId:                           &t.RequestID,
+		CronOverlapPolicy:                   FromCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -6658,6 +6671,7 @@ func ToWorkflowExecutionStartedEventAttributes(t *shared.WorkflowExecutionStarte
 		Header:                              ToHeader(t.Header),
 		PartitionConfig:                     t.PartitionConfig,
 		RequestID:                           t.GetRequestId(),
+		CronOverlapPolicy:                   ToCronOverlapPolicy(t.CronOverlapPolicy),
 	}
 }
 
@@ -8430,4 +8444,30 @@ func ToQueueState(t *shared.QueueState) *types.QueueState {
 		VirtualQueueStates:    ToVirtualQueueStateMap(t.VirtualQueueStates),
 		ExclusiveMaxReadLevel: ToTaskKey(t.ExclusiveMaxReadLevel),
 	}
+}
+
+func FromCronOverlapPolicy(t *types.CronOverlapPolicy) *shared.CronOverlapPolicy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.CronOverlapPolicyBufferOne:
+		return shared.CronOverlapPolicyBufferone.Ptr()
+	case types.CronOverlapPolicySkipped:
+		return shared.CronOverlapPolicySkipped.Ptr()
+	}
+	return nil
+}
+
+func ToCronOverlapPolicy(t *shared.CronOverlapPolicy) *types.CronOverlapPolicy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.CronOverlapPolicyBufferone:
+		return types.CronOverlapPolicyBufferOne.Ptr()
+	case shared.CronOverlapPolicySkipped:
+		return types.CronOverlapPolicySkipped.Ptr()
+	}
+	return nil
 }

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -7899,7 +7899,7 @@ func (v *WorkflowExecutionStartedEventAttributes) GetFirstExecutionRunID() (o st
 	return
 }
 
-// Get
+// GetFirstScheduledTime is an internal getter (TBD...)
 func (v *WorkflowExecutionStartedEventAttributes) GetFirstScheduledTime() (o time.Time) {
 	if v != nil && v.FirstScheduleTime != nil {
 		return *v.FirstScheduleTime

--- a/common/types/testdata/common.go
+++ b/common/types/testdata/common.go
@@ -365,6 +365,7 @@ var (
 		AutoResetPoints:   &ResetPoints,
 		TaskList:          TaskListName,
 		PartitionConfig:   PartitionConfig,
+		CronOverlapPolicy: &CronOverlapPolicy,
 	}
 	CronWorkflowExecutionInfo = types.WorkflowExecutionInfo{
 		Execution:         &WorkflowExecution,
@@ -477,4 +478,5 @@ var (
 		},
 		ExclusiveMaxReadLevel: &TaskKey,
 	}
+	CronOverlapPolicy = types.CronOverlapPolicySkipped
 )

--- a/common/types/testdata/decision.go
+++ b/common/types/testdata/decision.go
@@ -121,6 +121,7 @@ var (
 		Memo:                                &Memo,
 		SearchAttributes:                    &SearchAttributes,
 		JitterStartSeconds:                  &Duration1,
+		CronOverlapPolicy:                   &CronOverlapPolicy,
 	}
 	FailWorkflowExecutionDecisionAttributes = types.FailWorkflowExecutionDecisionAttributes{
 		Reason:  &FailureReason,
@@ -179,6 +180,7 @@ var (
 		Header:                              &Header,
 		Memo:                                &Memo,
 		SearchAttributes:                    &SearchAttributes,
+		CronOverlapPolicy:                   &CronOverlapPolicy,
 	}
 	StartTimerDecisionAttributes = types.StartTimerDecisionAttributes{
 		TimerID:                   TimerID,

--- a/common/types/testdata/history.go
+++ b/common/types/testdata/history.go
@@ -276,6 +276,7 @@ var (
 		Header:                              &Header,
 		PartitionConfig:                     PartitionConfig,
 		RequestID:                           RequestID,
+		CronOverlapPolicy:                   &CronOverlapPolicy,
 	}
 	WorkflowExecutionCompletedEventAttributes = types.WorkflowExecutionCompletedEventAttributes{
 		Result:                       Payload1,
@@ -495,6 +496,7 @@ var (
 		DelayStartSeconds:                   &Duration3,
 		JitterStartSeconds:                  &Duration4,
 		FirstRunAtTimestamp:                 &Timestamp1,
+		CronOverlapPolicy:                   &CronOverlapPolicy,
 	}
 	StartChildWorkflowExecutionFailedEventAttributes = types.StartChildWorkflowExecutionFailedEventAttributes{
 		Domain:                       DomainName,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Modified mapper functions in both proto and thrift encoders to include `CronOverlapPolicy` field mapping in following structs:

**Modified Structs**
- `ContinueAsNewWorkflowExecutionDecisionAttributes`
- `SignalWithStartWorkflowExecutionRequest`
- `StartChildWorkflowExecutionDecisionAttributes`
- `StartChildWorkflowExecutionInitiatedEventAttributes`
- `StartWorkflowExecutionRequest`
- `WorkflowExecutionInfo`
- `WorkflowExecutionStartedEventAttributes`

Added new mapper functions `FromCronOverlapPolicy` and `ToCronOverlapPolicy` to handle the conversion between different encoding representations.

<!-- Tell your future self why have you made these changes -->
**Why?**
The `CronOverlapPolicy` field was missing from the mapper functions, causing data inconsistency between different encoding formats (shared/thrift/proto).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low risks since the field won't be input/read yet.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
