### PR TITLE
[domaindeletion]Remove enable domain deletion flag

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1640,12 +1640,6 @@ const (
 	// Default value: true
 	// Allowed filters: N/A
 	EnableQueryAttributeValidation
-	// EnableDomainDeletion is a feature flag to enable deletion of the domains.
-	// This feature flag will be removed after the change is rolled out in all the waves.
-	// KeyName: system.enableDomainDeletion
-	// Value type: bool
-	// Default value: false
-	EnableDomainDeletion
 
 	// key for matching
 
@@ -4131,11 +4125,6 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "frontend.enableQueryAttributeValidation",
 		Description:  "EnableQueryAttributeValidation enables validation of queries' search attributes against the dynamic config whitelist",
 		DefaultValue: true,
-	},
-	EnableDomainDeletion: {
-		KeyName:      "frontend.enableDomainDeletion",
-		Description:  "EnableDomainDeletion enables Delete Domain API to remove domain records from the persistence layer.",
-		DefaultValue: false,
 	},
 	MatchingEnableSyncMatch: {
 		KeyName:      "matching.enableSyncMatch",

--- a/common/dynamicconfig/dynamicproperties/constants_test.go
+++ b/common/dynamicconfig/dynamicproperties/constants_test.go
@@ -165,13 +165,6 @@ func (s *constantSuite) TestBoolKey() {
 			expectedDefaultValue: false,
 			expectedFilters:      []Filter{DomainName},
 		},
-		"EnableDomainDeletion": {
-			key:                  EnableDomainDeletion,
-			expectedString:       "frontend.enableDomainDeletion",
-			expectedDescription:  "EnableDomainDeletion enables Delete Domain API to remove domain records from the persistence layer.",
-			expectedDefaultValue: false,
-			expectedFilters:      nil,
-		},
 	}
 
 	for _, value := range testBoolKeys {

--- a/service/frontend/api/domain_handlers.go
+++ b/service/frontend/api/domain_handlers.go
@@ -155,10 +155,6 @@ func (wh *WorkflowHandler) DeleteDomain(ctx context.Context, deleteRequest *type
 		return err
 	}
 
-	if !wh.config.EnableDomainDeletion() {
-		return &types.BadRequestError{Message: "Domain deletion feature is not enabled."}
-	}
-
 	domainName := deleteRequest.GetName()
 	resp, err := wh.domainHandler.DescribeDomain(ctx, &types.DescribeDomainRequest{Name: &domainName})
 	if err != nil {

--- a/service/frontend/api/domain_handlers_test.go
+++ b/service/frontend/api/domain_handlers_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
@@ -402,24 +401,11 @@ func TestDeleteDomain(t *testing.T) {
 			expectError:   true,
 			expectedError: "delete domain error",
 		},
-		{
-			name: "failure_domain_deletion_feature_disabled",
-			req: &types.DeleteDomainRequest{
-				Name: domainName,
-			},
-			setupMocks: func(deps *mockDeps) {
-				assert.NoError(t, deps.dynamicClient.UpdateValue(dynamicproperties.EnableDomainDeletion, false))
-				deps.mockRequestValidator.EXPECT().ValidateDeleteDomainRequest(gomock.Any(), gomock.Any()).Return(nil)
-			},
-			expectError:   true,
-			expectedError: "Domain deletion feature is not enabled.",
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			wh, deps := setupMocksForWorkflowHandler(t)
-			assert.NoError(t, deps.dynamicClient.UpdateValue(dynamicproperties.EnableDomainDeletion, true))
 			tc.setupMocks(deps)
 
 			err := wh.DeleteDomain(context.Background(), tc.req)

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -70,9 +70,6 @@ type Config struct {
 	// isolation configuration
 	EnableTasklistIsolation dynamicproperties.BoolPropertyFnWithDomainFilter
 
-	// domain deletion api feature flag
-	EnableDomainDeletion dynamicproperties.BoolPropertyFn
-
 	// id length limits
 	MaxIDLengthWarnLimit  dynamicproperties.IntPropertyFn
 	DomainNameMaxLength   dynamicproperties.IntPropertyFnWithDomainFilter
@@ -187,7 +184,6 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		EmitSignalNameMetricsTag:                    dc.GetBoolPropertyFilteredByDomain(dynamicproperties.FrontendEmitSignalNameMetricsTag),
 		Lockdown:                                    dc.GetBoolPropertyFilteredByDomain(dynamicproperties.Lockdown),
 		EnableTasklistIsolation:                     dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableTasklistIsolation),
-		EnableDomainDeletion:                        dc.GetBoolProperty(dynamicproperties.EnableDomainDeletion),
 		DomainConfig: domain.Config{
 			MaxBadBinaryCount:      dc.GetIntPropertyFilteredByDomain(dynamicproperties.FrontendMaxBadBinaries),
 			MinRetentionDays:       dc.GetIntProperty(dynamicproperties.MinRetentionDays),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -106,7 +106,6 @@ func TestNewConfig(t *testing.T) {
 		"GlobalRatelimiterKeyMode":                    {dynamicproperties.FrontendGlobalRatelimiterMode, "disabled"},
 		"GlobalRatelimiterUpdateInterval":             {dynamicproperties.GlobalRatelimiterUpdateInterval, 3 * time.Second},
 		"PinotOptimizedQueryColumns":                  {dynamicproperties.PinotOptimizedQueryColumns, map[string]interface{}{"foo": "bar"}},
-		"EnableDomainDeletion":                        {dynamicproperties.EnableDomainDeletion, false},
 	}
 	domainFields := map[string]configTestCase{
 		"MaxBadBinaryCount":      {dynamicproperties.FrontendMaxBadBinaries, 40},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR removes a feature flag enableDomainDeletion. It was introduced to control access to the domain deletion API.
This feature has been rolled out to all waves and it is safe to remove it.

<!-- Tell your future self why have you made these changes -->
**Why?**
Domain deletion is available in all the clusters and replicated regions; there is no need to guard the feature with this flag anymore.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests & local testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
