### PR TITLE
Updating workflow_execution & activity_info types in Cassandra to support cron overlap policy, active-active domain, ephemeral tasklist features

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -48,6 +48,7 @@ CREATE TYPE workflow_execution (
   completion_event                 blob,   -- Completion event used to communicate result to parent workflow execution
   completion_event_data_encoding   text, -- Protocol used for history serialization
   task_list                        text,
+  task_list_kind                   int, -- enum TaskListKind {Normal, Sticky, Ephemeral},
   workflow_type_name               text,
   workflow_timeout                 int,  -- Workflow ExecutionStartToCloseTimeoutSeconds
   decision_task_timeout            int,  -- decision start to close timeout
@@ -89,13 +90,16 @@ CREATE TYPE workflow_execution (
   last_first_event_id              bigint,
   next_event_id                    bigint,
   cron_schedule                    text,
+  cron_overlap_policy              int, -- enum CronOverlapPolicy {Skip, BufferOne}
   expiration_seconds               int,    -- retry expiration duration in seconds
   last_event_task_id               bigint,
   auto_reset_points                blob, -- the resetting points for auto-reset feature
   auto_reset_points_encoding       text, -- encoding for auto_reset_points_data
   search_attributes                map<text, blob>,
   memo                             map<text, blob>,
-  partition_config                 map<text, text>
+  partition_config                 map<text, text>,
+  active_cluster_selection_policy blob, -- active cluster selection policy applicable to active-active domains
+  active_cluster_selection_policy_encoding text, -- encoding for active_cluster_selection_policy
 );
 
 -- Replication information for each cluster
@@ -187,6 +191,7 @@ CREATE TYPE activity_info (
   timer_task_status         int,    -- Indicates whether timers are created for this activity.
   attempt                   int,    -- starting from 0 (for initial non-retry)
   task_list                 text,
+  task_list_kind            int, -- enum TaskListKind {Normal, Sticky, Ephemeral},
   started_identity          text,   -- last started poller's identity
   has_retry_policy          boolean,-- If there is a retry policy
   init_interval             int,    -- initial retry interval, in seconds

--- a/schema/cassandra/cadence/versioned/v0.43/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.43/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.43",
+  "MinCompatibleVersion": "0.43",
+  "Description": "Adding new fields to workflow_execution and activity_info types to support following features: cron overlap policy, active-active domain, ephemeral task list",
+  "SchemaUpdateCqlFiles": [
+    "workflow_execution_new_fields.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.43/workflow_execution_new_fields.cql
+++ b/schema/cassandra/cadence/versioned/v0.43/workflow_execution_new_fields.cql
@@ -1,0 +1,5 @@
+ALTER TYPE workflow_execution ADD cron_overlap_policy int;
+ALTER TYPE workflow_execution ADD active_cluster_selection_policy blob;
+ALTER TYPE workflow_execution ADD active_cluster_selection_policy_encoding text;
+ALTER TYPE workflow_execution ADD task_list_kind int;
+ALTER TYPE activity_info ADD task_list_kind int;

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
New fields added to `workflow_execution` and `activity_info`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Cassandra schema changes to support new features

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
CI tests.
The actual changes to use these fields will be coming in follow up PRs and they should have corresponding tests.
