### PR TITLE
[active-actove] Use active cluster selection policy to determine failover version of new workflows

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -319,10 +319,3 @@ func GetTaskPriority(
 
 // GRPCConnectionClosingError is the error message returned when a gRPC client connection is closing
 const GRPCConnectionClosingError = "grpc: the client connection is closing"
-
-const (
-	// ActiveActiveEntityTypeHeaderKey is the header key in workflow start request header for active-active entity type
-	ActiveActiveEntityTypeHeaderKey = "active-active-entity-type"
-	// ActiveActiveEntityKeyHeaderKey is the header key in workflow start request header for active-active entity key
-	ActiveActiveEntityKeyHeaderKey = "active-active-entity-key"
-)

--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -835,7 +835,6 @@ func (e *historyEngineImpl) createMutableState(
 		return nil, err
 	}
 
-	// TODO(active-active): Write unit tests to cover this
 	if domainEntry.GetReplicationConfig().IsActiveActive() {
 		v, err := e.shard.GetActiveClusterManager().FailoverVersionOfNewWorkflow(ctx, startRequest)
 		if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated activecluster.Manager to use the recently introduced policy instead of wf headers to determine failover version of new workflows for active-active domains.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new unit tests
