### PR TITLE
Fix npe in WorkflowExecutionInfo in thrift mapper

### DIFF
--- a/common/persistence/serialization/thrift_mapper.go
+++ b/common/persistence/serialization/thrift_mapper.go
@@ -332,7 +332,7 @@ func workflowExecutionInfoFromThrift(info *sqlblobs.WorkflowExecutionInfo) *Work
 		RetryNonRetryableErrors:              info.RetryNonRetryableErrors,
 		HasRetryPolicy:                       info.GetHasRetryPolicy(),
 		CronSchedule:                         info.GetCronSchedule(),
-		CronOverlapPolicy:                    *thrift.ToCronOverlapPolicy(info.CronOverlapPolicy),
+		CronOverlapPolicy:                    cronOverlapPolicyFromThrift(info.CronOverlapPolicy),
 		EventStoreVersion:                    info.GetEventStoreVersion(),
 		EventBranchToken:                     info.EventBranchToken,
 		SignalCount:                          info.GetSignalCount(),
@@ -836,4 +836,14 @@ func durationToSecondsInt64Ptr(t time.Duration) *int64 {
 
 func durationToDaysInt16Ptr(t time.Duration) *int16 {
 	return common.Int16Ptr(int16(common.DurationToDays(t)))
+}
+
+func cronOverlapPolicyFromThrift(t *shared.CronOverlapPolicy) types.CronOverlapPolicy {
+	if t == nil {
+		return types.CronOverlapPolicySkipped
+	}
+	if result := thrift.ToCronOverlapPolicy(t); result != nil {
+		return *result
+	}
+	return types.CronOverlapPolicySkipped
 }

--- a/common/persistence/serialization/thrift_mapper_test.go
+++ b/common/persistence/serialization/thrift_mapper_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/uber/cadence/.gen/go/shared"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 )
@@ -596,4 +598,18 @@ func TestReplicationTaskInfo(t *testing.T) {
 	assert.Equal(t, expected, actual)
 	assert.Nil(t, replicationTaskInfoFromThrift(nil))
 	assert.Nil(t, replicationTaskInfoToThrift(nil))
+}
+
+func TestCronOverlapPolicyFromThrift(t *testing.T) {
+	cases := []struct {
+		thrift *shared.CronOverlapPolicy
+		actual types.CronOverlapPolicy
+	}{
+		{nil, types.CronOverlapPolicySkipped},
+		{shared.CronOverlapPolicyBufferone.Ptr(), types.CronOverlapPolicyBufferOne},
+		{shared.CronOverlapPolicySkipped.Ptr(), types.CronOverlapPolicySkipped},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.actual, cronOverlapPolicyFromThrift(c.thrift))
+	}
 }

--- a/common/persistence/serialization/thrift_mapper_test.go
+++ b/common/persistence/serialization/thrift_mapper_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/cadence/.gen/go/shared"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
There was a nil pointer WorkflowExecutionInfo in thrift mapper, we fixed the npe by adding a check and default value when it's nil.

<!-- Tell your future self why have you made these changes -->
**Why?**
It's causing service to crash

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests on this specific scenario

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
