### PR TITLE
Check if history task is corrupted

### DIFF
--- a/common/persistence/tasks.go
+++ b/common/persistence/tasks.go
@@ -268,6 +268,15 @@ var (
 	immediateTaskKeyScheduleTime = time.Unix(0, 0).UTC()
 )
 
+func IsTaskCorrupted(task Task) bool {
+	switch task.(type) {
+	case *FailoverMarkerTask:
+		return task.GetDomainID() == ""
+	default:
+		return task.GetDomainID() == "" || task.GetWorkflowID() == "" || task.GetRunID() == ""
+	}
+}
+
 func NewImmediateTaskKey(taskID int64) HistoryTaskKey {
 	return HistoryTaskKey{
 		scheduledTime: immediateTaskKeyScheduleTime,

--- a/service/history/queuev2/virtual_queue_test.go
+++ b/service/history/queuev2/virtual_queue_test.go
@@ -564,10 +564,19 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	}
 
 	mockTask1 := task.NewMockTask(ctrl)
+	mockTask1.EXPECT().GetDomainID().Return("some random domainID")
+	mockTask1.EXPECT().GetWorkflowID().Return("some random workflowID")
+	mockTask1.EXPECT().GetRunID().Return("some random runID")
 	mockTask1.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
 	mockTask2 := task.NewMockTask(ctrl)
+	mockTask2.EXPECT().GetDomainID().Return("some random domainID")
+	mockTask2.EXPECT().GetWorkflowID().Return("some random workflowID")
+	mockTask2.EXPECT().GetRunID().Return("some random runID")
 	mockTask2.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*1), 2))
 	mockTask3 := task.NewMockTask(ctrl)
+	mockTask3.EXPECT().GetDomainID().Return("some random domainID")
+	mockTask3.EXPECT().GetWorkflowID().Return("some random workflowID")
+	mockTask3.EXPECT().GetRunID().Return("some random runID")
 	mockTask3.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
 
 	mockVirtualSlice1.EXPECT().GetTasks(gomock.Any(), 10).Return([]task.Task{mockTask1, mockTask2}, nil)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Check if history task is corrupted then log the task and skip it
- Remove panic statement from history queue v1 framework so that we're not stuck in a crash loop when encountering corrupted tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
The staging environment is stuck in a crash loop due to some empty tasks without any payload except their primary key columns. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If a valid task is misclassified as a corrupted task, we might the processing of a valid task.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
