### PR TITLE
Do not submit corrupted history tasks to scheduler

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2407,6 +2407,7 @@ const (
 	ProcessingQueueSelectedDomainSplitCounter
 	ProcessingQueueRandomSplitCounter
 	ProcessingQueueThrottledCounter
+	CorruptedHistoryTaskCounter
 
 	QueueValidatorLostTaskCounter
 	QueueValidatorDropTaskCounter
@@ -3157,6 +3158,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ProcessingQueueSelectedDomainSplitCounter:                    {metricName: "processing_queue_selected_domain_split_counter", metricType: Counter},
 		ProcessingQueueRandomSplitCounter:                            {metricName: "processing_queue_random_split_counter", metricType: Counter},
 		ProcessingQueueThrottledCounter:                              {metricName: "processing_queue_throttled_counter", metricType: Counter},
+		CorruptedHistoryTaskCounter:                                  {metricName: "corrupted_history_task_counter", metricType: Counter},
 		QueueValidatorLostTaskCounter:                                {metricName: "queue_validator_lost_task_counter", metricType: Counter},
 		QueueValidatorDropTaskCounter:                                {metricName: "queue_validator_drop_task_counter", metricType: Counter},
 		QueueValidatorInvalidLoadCounter:                             {metricName: "queue_validator_invalid_load_counter", metricType: Counter},

--- a/service/history/queue/processing_queue.go
+++ b/service/history/queue/processing_queue.go
@@ -28,7 +28,6 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
-	"github.com/uber/cadence/common/persistence"
 	t "github.com/uber/cadence/common/task"
 	"github.com/uber/cadence/service/history/task"
 )
@@ -189,11 +188,6 @@ func (q *processingQueueImpl) AddTasks(tasks map[task.Key]task.Task, newReadLeve
 			// do not submit this task again in transfer/timer queue processor base
 			q.logger.Debug(fmt.Sprintf("Skipping task: %+v. DomainID: %v, WorkflowID: %v, RunID: %v, Type: %v",
 				key, task.GetDomainID(), task.GetWorkflowID(), task.GetRunID(), task.GetTaskType()))
-			continue
-		}
-
-		if persistence.IsTaskCorrupted(task) {
-			q.logger.Error("Processing queue encountered a corrupted task", tag.Dynamic("task", task))
 			continue
 		}
 

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -305,6 +305,12 @@ func (t *timerQueueProcessorBase) processQueueCollections(levels map[int]struct{
 				continue
 			}
 
+			if persistence.IsTaskCorrupted(taskInfo) {
+				t.logger.Error("Processing queue encountered a corrupted task", tag.Dynamic("task", taskInfo))
+				t.metricsScope.IncCounter(metrics.CorruptedHistoryTaskCounter)
+				continue
+			}
+
 			task := t.taskInitializer(taskInfo)
 			tasks[newTimerTaskKey(taskInfo.GetVisibilityTimestamp(), taskInfo.GetTaskID())] = task
 			submitted, err := t.submitTask(task)

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -428,6 +428,12 @@ func (t *transferQueueProcessorBase) processQueueCollections() {
 				continue
 			}
 
+			if persistence.IsTaskCorrupted(taskInfo) {
+				t.logger.Error("Processing queue encountered a corrupted task", tag.Dynamic("task", taskInfo))
+				t.metricsScope.IncCounter(metrics.CorruptedHistoryTaskCounter)
+				continue
+			}
+
 			task := t.taskInitializer(taskInfo)
 			tasks[newTransferTaskKey(taskInfo.GetTaskID())] = task
 			submitted, err := t.submitTask(task)

--- a/service/history/queue/transfer_queue_processor_base_test.go
+++ b/service/history/queue/transfer_queue_processor_base_test.go
@@ -354,7 +354,9 @@ func (s *transferQueueProcessorBaseSuite) TestProcessQueueCollections_WithNextPa
 	taskInfos := []persistence.Task{
 		&persistence.DecisionTask{
 			WorkflowIdentifier: persistence.WorkflowIdentifier{
-				DomainID: "testDomain1",
+				DomainID:   "testDomain1",
+				WorkflowID: "testWorkflowID",
+				RunID:      "testRunID",
 			},
 			TaskData: persistence.TaskData{
 				TaskID: 500,

--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -243,6 +243,8 @@ func (q *virtualQueueImpl) loadAndSubmitTasks() {
 	for _, task := range tasks {
 		if persistence.IsTaskCorrupted(task) {
 			q.logger.Error("Virtual queue encountered a corrupted task", tag.Dynamic("task", task))
+			q.metricsScope.IncCounter(metrics.CorruptedHistoryTaskCounter)
+			task.Ack()
 			continue
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not submit corrupted history tasks to scheduler in queue v1
- Ack corrupted history tasks in queue v2
- Add metrics tracking the number of corrupted tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
Corrupted tasks should not be submitted to task scheduler or tracked by pending task tracker

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
