### PR TITLE
[active-active] Update replication simulation

### DIFF
--- a/common/activecluster/manager.go
+++ b/common/activecluster/manager.go
@@ -376,5 +376,11 @@ func (m *managerImpl) getClusterSelectionPolicy(ctx context.Context, domainID, w
 		return nil, err
 	}
 
+	if plcy == nil {
+		return nil, &types.EntityNotExistsError{
+			Message: "active cluster selection policy not found",
+		}
+	}
+
 	return plcy, nil
 }

--- a/common/activecluster/manager_test.go
+++ b/common/activecluster/manager_test.go
@@ -744,6 +744,29 @@ func TestLookupWorkflow(t *testing.T) {
 			},
 		},
 		{
+			name: "domain is active-active, activeness metadata is nil means region sticky",
+			activeClusterCfg: &types.ActiveClusters{
+				ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+					"us-west": {
+						ActiveClusterName: "cluster0",
+						FailoverVersion:   1,
+					},
+					"us-east": {
+						ActiveClusterName: "cluster1",
+						FailoverVersion:   3,
+					},
+				},
+			},
+			mockFn: func(em *persistence.MockExecutionManager) {
+				em.EXPECT().GetActiveClusterSelectionPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, nil)
+			},
+			expectedResult: &LookupResult{
+				ClusterName:     "cluster0",
+				FailoverVersion: 1,
+			},
+		},
+		{
 			name: "domain is active-active, activeness metadata shows region sticky",
 			activeClusterCfg: &types.ActiveClusters{
 				ActiveClustersByRegion: map[string]types.ActiveClusterInfo{

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -917,6 +917,11 @@ func (m *executionManagerImpl) GetActiveClusterSelectionPolicy(
 	if err != nil {
 		return nil, err
 	}
+	if blob == nil {
+		return nil, &types.EntityNotExistsError{
+			Message: "active cluster selection policy not found",
+		}
+	}
 	policy, err := m.serializer.DeserializeActiveClusterSelectionPolicy(blob)
 	if err != nil {
 		return nil, err

--- a/service/frontend/wrappers/metered/metered.go
+++ b/service/frontend/wrappers/metered/metered.go
@@ -38,7 +38,7 @@ import (
 )
 
 func (h *apiHandler) handleErr(err error, scope metrics.Scope, logger log.Logger) error {
-	logger.Helper()
+	logger = logger.Helper()
 
 	// attempt to extract hostname if possible
 	hostname, err := commonerrors.ExtractPeerHostname(err)

--- a/simulation/replication/testdata/replication_simulation_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive.yaml
@@ -13,29 +13,41 @@ primaryCluster: "cluster0"
 
 domains:
   test-domain-aa:
-    name: test-domain-aa
-    activeClusters:
-    - cluster0
-    - cluster1
+    activeClustersByRegion:
+      region0: cluster0
+      region1: cluster1
 
 operations:
+  # start workflow in cluster0
   - op: start_workflow
     at: 0s
-    workflowType: timer-activity-loop-workflow
     workflowID: wf1
+    workflowType: timer-activity-loop-workflow
     cluster: cluster0
     domain: test-domain-aa
-    workflowExecutionStartToCloseTimeout: 90s
-    workflowDuration: 60s
+    workflowExecutionStartToCloseTimeout: 65s
+    workflowDuration: 35s
 
+  # start workflow in cluster1
   - op: start_workflow
     at: 0s
     workflowID: wf2
+    workflowType: timer-activity-loop-workflow
     cluster: cluster1
     domain: test-domain-aa
-    workflowExecutionStartToCloseTimeout: 90s
-    workflowDuration: 60s
+    workflowExecutionStartToCloseTimeout: 65s
+    workflowDuration: 35s
 
+  # TODO: uncomment this
+  # # failover from cluster0 to cluster1
+  # - op: change_active_clusters
+  #   at: 20s
+  #   domain: test-domain-aa
+  #   newActiveClustersByRegion:
+  #     region0: cluster1 # this is changed from cluster0 to cluster1
+  #     region1: cluster1
+
+  # validate that wf1 is started in cluster0 and completed in cluster1
   - op: validate
     at: 70s
     workflowID: wf1
@@ -44,8 +56,9 @@ operations:
     want:
       status: completed
       startedByWorkersInCluster: cluster0
-      completedByWorkersInCluster: cluster1 # it should complete in cluster1 because of fake logic in activecluster/manager.go
+      completedByWorkersInCluster: cluster0 # TODO: change this to cluster1
 
+  # validate that wf2 is started and completed in cluster1
   - op: validate
     at: 70s
     workflowID: wf2

--- a/simulation/replication/testdata/replication_simulation_default.yaml
+++ b/simulation/replication/testdata/replication_simulation_default.yaml
@@ -13,9 +13,7 @@ primaryCluster: "cluster0"
 
 domains:
   test-domain:
-    name: test-domain
-    activeClusters:
-    - cluster0
+    activeClusterName: cluster0
 
 operations:
   - op: start_workflow
@@ -30,7 +28,7 @@ operations:
   - op: change_active_clusters # failover from cluster0 to cluster1
     at: 20s
     domain: test-domain
-    newActiveClusters: ["cluster1"]
+    newActiveCluster: cluster1
     # failoverTimeoutSec: 5 # unset means force failover. setting it means graceful failover request
 
   - op: validate

--- a/simulation/replication/testdata/replication_simulation_reset.yaml
+++ b/simulation/replication/testdata/replication_simulation_reset.yaml
@@ -14,13 +14,9 @@ primaryCluster: "cluster0"
 
 domains:
   test-domain:
-    name: test-domain
-    activeClusters:
-    - cluster0
+    activeClusterName: cluster0
   test-domain-2:
-    name: test-domain-2
-    activeClusters:
-    - cluster1
+    activeClusterName: cluster0
 
 operations:
   - op: start_workflow
@@ -44,7 +40,7 @@ operations:
   - op: change_active_clusters # failover from cluster0 to cluster1
     at: 20s
     domain: test-domain
-    newActiveClusters: ["cluster1"]
+    newActiveCluster: cluster1
     # failoverTimeoutSec: 5 # unset means force failover. setting it means graceful failover request
 
   - op: validate

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -64,8 +64,6 @@ type ReplicationSimulationConfig struct {
 }
 
 type ReplicationDomainConfig struct {
-	Name string `yaml:"name"`
-
 	ActiveClusterName string `yaml:"activeClusterName"`
 
 	ActiveClustersByRegion map[string]string `yaml:"activeClustersByRegion"`

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -66,10 +66,9 @@ type ReplicationSimulationConfig struct {
 type ReplicationDomainConfig struct {
 	Name string `yaml:"name"`
 
-	// ActiveClusters is the list of clusters that the test domain is active in
-	// If one cluster is specified, the test domain will be regular active-passive global domain.
-	// If multiple clusters are specified, the test domain will be active-active global domain.
-	ActiveClusters []string `yaml:"activeClusters"`
+	ActiveClusterName string `yaml:"activeClusterName"`
+
+	ActiveClustersByRegion map[string]string `yaml:"activeClustersByRegion"`
 }
 
 type Operation struct {
@@ -85,9 +84,10 @@ type Operation struct {
 
 	EventID int64 `yaml:"eventID"`
 
-	Domain            string   `yaml:"domain"`
-	NewActiveClusters []string `yaml:"newActiveClusters"`
-	FailoverTimeout   *int32   `yaml:"failoverTimeoutSec"`
+	Domain                    string            `yaml:"domain"`
+	NewActiveCluster          string            `yaml:"newActiveCluster"`
+	NewActiveClustersByRegion map[string]string `yaml:"newActiveClustersByRegion"`
+	FailoverTimeout           *int32            `yaml:"failoverTimeoutSec"`
 
 	Want Validation `yaml:"want"`
 }
@@ -164,11 +164,12 @@ func (s *ReplicationSimulationConfig) MustInitClientsFor(t *testing.T, clusterNa
 }
 
 func (s *ReplicationSimulationConfig) IsActiveActiveDomain(domainName string) bool {
-	return len(s.Domains[domainName].ActiveClusters) > 1
+	return len(s.Domains[domainName].ActiveClustersByRegion) > 0
 }
 
-func (s *ReplicationSimulationConfig) MustRegisterDomain(t *testing.T, domainName string) {
+func (s *ReplicationSimulationConfig) MustRegisterDomain(t *testing.T, domainName string, domainCfg ReplicationDomainConfig) {
 	Logf(t, "Registering domain: %s", domainName)
+
 	var clusters []*types.ClusterReplicationConfiguration
 	for name := range s.Clusters {
 		clusters = append(clusters, &types.ClusterReplicationConfiguration{
@@ -177,15 +178,22 @@ func (s *ReplicationSimulationConfig) MustRegisterDomain(t *testing.T, domainNam
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err := s.MustGetFrontendClient(t, s.PrimaryCluster).RegisterDomain(ctx, &types.RegisterDomainRequest{
+	req := &types.RegisterDomainRequest{
 		Name:                                   domainName,
 		Clusters:                               clusters,
 		WorkflowExecutionRetentionPeriodInDays: 1,
 		IsGlobalDomain:                         true,
-		ActiveClusterName:                      s.PrimaryCluster,
-		// TODO: Once API is updated to support ActiveClusterNames, update this
-		// ActiveClusterNames:                      s.DomainActiveClusters,
-	})
+	}
+
+	if len(domainCfg.ActiveClusterName) > 0 {
+		req.ActiveClusterName = domainCfg.ActiveClusterName
+	} else if len(domainCfg.ActiveClustersByRegion) > 0 {
+		req.ActiveClustersByRegion = domainCfg.ActiveClustersByRegion
+	} else {
+		require.Fail(t, "activeClusterName or activeClustersByRegion is required but missing for domain %s", domainName)
+	}
+
+	err := s.MustGetFrontendClient(t, s.PrimaryCluster).RegisterDomain(ctx, req)
 
 	if err != nil {
 		if _, ok := err.(*shared.DomainAlreadyExistsError); !ok {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updating replication simulation to support active-active domains and their failovers.
- Simulation config structure is updated to support single active cluster (regular global domain) & multiple active clusters (active-active)
- Failover operation implementation updated to support both


Misc change:
- Update execution manager to explicitly return `EntityNotExistsError` when there's no cluster selection policy for given workflow and handle it in active cluster manager.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Validate default simulation scenario passes:
```
./simulation/replication/run.sh default
```
- Validate activeactive scenario runs (aa domain creation, wf creation works). 
```
./simulation/replication/run.sh activeactive
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Next steps**
Frontend cluster redirection layer needs to be updated to lookup active cluster of given workflow. Currently this layer only checks the domain of the request. I need to update the template and policy implementation to plumb wf id and run id.