### PR TITLE
[active-active] Update new workflow lookup interface

### DIFF
--- a/common/activecluster/manager.go
+++ b/common/activecluster/manager.go
@@ -214,7 +214,7 @@ func (m *managerImpl) LookupNewWorkflow(ctx context.Context, domainID string, po
 		return nil, fmt.Errorf("unsupported active cluster selection strategy: %s", policy.GetStrategy())
 	}
 
-	// look up cluster name for failover version of the external entity
+	// find cluster name & failover version of the external entity
 	externalEntity, err := m.getExternalEntity(ctx, policy.ExternalEntityType, policy.ExternalEntityKey)
 	if err != nil {
 		return nil, err

--- a/common/activecluster/manager.go
+++ b/common/activecluster/manager.go
@@ -177,53 +177,58 @@ func (m *managerImpl) notifyChangeCallbacksPeriodically() {
 	}
 }
 
-func (m *managerImpl) FailoverVersionOfNewWorkflow(ctx context.Context, req *types.HistoryStartWorkflowExecutionRequest) (int64, error) {
-	if req == nil {
-		return 0, errors.New("request is nil")
-	}
-
-	d, err := m.domainIDToDomainFn(req.DomainUUID)
+func (m *managerImpl) LookupNewWorkflow(ctx context.Context, domainID string, policy *types.ActiveClusterSelectionPolicy) (*LookupResult, error) {
+	d, err := m.domainIDToDomainFn(domainID)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	if !d.GetReplicationConfig().IsActiveActive() {
 		// Not an active-active domain. return failover version of the domain entry
-		return d.GetFailoverVersion(), nil
+		return &LookupResult{
+			ClusterName:     d.GetReplicationConfig().ActiveClusterName,
+			FailoverVersion: d.GetFailoverVersion(),
+		}, nil
 	}
 
-	if req.StartRequest == nil {
-		return 0, errors.New("start request is nil")
-	}
-
-	plcy := req.StartRequest.ActiveClusterSelectionPolicy
 	// region sticky policy
-	if plcy.GetStrategy() == types.ActiveClusterSelectionStrategyRegionSticky {
+	if policy.GetStrategy() == types.ActiveClusterSelectionStrategyRegionSticky {
 		// use current region for nil policy, otherwise use sticky region from policy
 		region := m.clusterMetadata.GetCurrentRegion()
-		if plcy != nil {
-			region = plcy.StickyRegion
+		if policy != nil {
+			region = policy.StickyRegion
 		}
 
 		cluster, ok := d.GetReplicationConfig().ActiveClusters.ActiveClustersByRegion[region]
 		if !ok {
-			return 0, newRegionNotFoundForDomainError(region, req.DomainUUID)
+			return nil, newRegionNotFoundForDomainError(region, domainID)
 		}
 
-		return cluster.FailoverVersion, nil
+		return &LookupResult{
+			ClusterName:     cluster.ActiveClusterName,
+			FailoverVersion: cluster.FailoverVersion,
+		}, nil
 	}
 
-	if plcy.GetStrategy() != types.ActiveClusterSelectionStrategyExternalEntity {
-		return 0, fmt.Errorf("unsupported active cluster selection strategy: %s", plcy.GetStrategy())
+	if policy.GetStrategy() != types.ActiveClusterSelectionStrategyExternalEntity {
+		return nil, fmt.Errorf("unsupported active cluster selection strategy: %s", policy.GetStrategy())
 	}
 
-	// Return failover version of the external entity
-	externalEntity, err := m.getExternalEntity(ctx, plcy.ExternalEntityType, plcy.ExternalEntityKey)
+	// look up cluster name for failover version of the external entity
+	externalEntity, err := m.getExternalEntity(ctx, policy.ExternalEntityType, policy.ExternalEntityKey)
 	if err != nil {
-		return 0, err
+		return nil, err
+	}
+	cluster, err := m.ClusterNameForFailoverVersion(externalEntity.FailoverVersion, domainID)
+	if err != nil {
+		return nil, err
 	}
 
-	return externalEntity.FailoverVersion, nil
+	return &LookupResult{
+		Region:          externalEntity.Region,
+		ClusterName:     cluster,
+		FailoverVersion: externalEntity.FailoverVersion,
+	}, nil
 }
 
 func (m *managerImpl) LookupWorkflow(ctx context.Context, domainID, wfID, rID string) (*LookupResult, error) {

--- a/common/activecluster/manager_mock.go
+++ b/common/activecluster/manager_mock.go
@@ -71,19 +71,19 @@ func (mr *MockManagerMockRecorder) CurrentRegion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentRegion", reflect.TypeOf((*MockManager)(nil).CurrentRegion))
 }
 
-// FailoverVersionOfNewWorkflow mocks base method.
-func (m *MockManager) FailoverVersionOfNewWorkflow(ctx context.Context, req *types.HistoryStartWorkflowExecutionRequest) (int64, error) {
+// LookupNewWorkflow mocks base method.
+func (m *MockManager) LookupNewWorkflow(ctx context.Context, domainID string, policy *types.ActiveClusterSelectionPolicy) (*LookupResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FailoverVersionOfNewWorkflow", ctx, req)
-	ret0, _ := ret[0].(int64)
+	ret := m.ctrl.Call(m, "LookupNewWorkflow", ctx, domainID, policy)
+	ret0, _ := ret[0].(*LookupResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FailoverVersionOfNewWorkflow indicates an expected call of FailoverVersionOfNewWorkflow.
-func (mr *MockManagerMockRecorder) FailoverVersionOfNewWorkflow(ctx, req any) *gomock.Call {
+// LookupNewWorkflow indicates an expected call of LookupNewWorkflow.
+func (mr *MockManagerMockRecorder) LookupNewWorkflow(ctx, domainID, policy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailoverVersionOfNewWorkflow", reflect.TypeOf((*MockManager)(nil).FailoverVersionOfNewWorkflow), ctx, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupNewWorkflow", reflect.TypeOf((*MockManager)(nil).LookupNewWorkflow), ctx, domainID, policy)
 }
 
 // LookupWorkflow mocks base method.

--- a/common/activecluster/types.go
+++ b/common/activecluster/types.go
@@ -43,17 +43,17 @@ import (
 type Manager interface {
 	common.Daemon
 
-	// FailoverVersionOfNewWorkflow returns failover version of given new workflow.
+	// LookupNewWorkflow returns active cluster, region and failover version of given new workflow.
 	//  1. If domain is local:
-	//     	Returns domain entry's failover version.
+	//     	Returns info from domain entry.
 	//  2. If domain is active-passive global:
-	//     	Returns domain entry's failover version.
+	//     	Returns info from domain entry.
 	//  3. If domain is active-active global:
-	//     	3.1. if workflow is region sticky, returns failover version of current cluster.
-	//     	3.2. if workflow has external entity, returns failover version of corresponding row in EntityActiveRegion lookup table.
+	//     	3.1. if workflow is region sticky, returns current cluster and its 	failover version.
+	//     	3.2. if workflow has external entity, returns region, cluster name and failover version of corresponding row in EntityActiveRegion lookup table.
 	LookupNewWorkflow(ctx context.Context, domainID string, policy *types.ActiveClusterSelectionPolicy) (*LookupResult, error)
 
-	// LookupWorkflow returns active cluster, region and failover version of given workflow.
+	// LookupWorkflow returns active cluster, region and failover version of given existing workflow.
 	// Returns the info from domain entry for local and active-passive domains
 	//
 	// Active-active domain logic:

--- a/common/activecluster/types.go
+++ b/common/activecluster/types.go
@@ -51,7 +51,7 @@ type Manager interface {
 	//  3. If domain is active-active global:
 	//     	3.1. if workflow is region sticky, returns failover version of current cluster.
 	//     	3.2. if workflow has external entity, returns failover version of corresponding row in EntityActiveRegion lookup table.
-	FailoverVersionOfNewWorkflow(ctx context.Context, req *types.HistoryStartWorkflowExecutionRequest) (int64, error)
+	LookupNewWorkflow(ctx context.Context, domainID string, policy *types.ActiveClusterSelectionPolicy) (*LookupResult, error)
 
 	// LookupWorkflow returns active cluster, region and failover version of given workflow.
 	// Returns the info from domain entry for local and active-passive domains

--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -836,11 +836,11 @@ func (e *historyEngineImpl) createMutableState(
 	}
 
 	if domainEntry.GetReplicationConfig().IsActiveActive() {
-		v, err := e.shard.GetActiveClusterManager().FailoverVersionOfNewWorkflow(ctx, startRequest)
+		res, err := e.shard.GetActiveClusterManager().LookupNewWorkflow(ctx, domainEntry.GetInfo().ID, startRequest.StartRequest.ActiveClusterSelectionPolicy)
 		if err != nil {
 			return nil, err
 		}
-		newMutableState.UpdateCurrentVersion(v, true)
+		newMutableState.UpdateCurrentVersion(res.FailoverVersion, true)
 	}
 
 	return newMutableState, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
While working on frontend redirection layer, I noticed the new workflow cluster lookup function was missing in activecluster manager. It only exposes failover version of a new workflow but no reason to not return both clustername and failover version.  So changing it as below
- before
```
FailoverVersionOfNewWorkflow(ctx context.Context, req *types.HistoryStartWorkflowExecutionRequest) (int64, error)
```
- after
```
LookupNewWorkflow(ctx context.Context, domainID string, policy *types.ActiveClusterSelectionPolicy) (*LookupResult, error)
```
