### PR TITLE
[shard-distributor] Rework fx initialization to self register routes in the rpc.Factory

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/uber-go/tally"
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock/clockfx"
@@ -36,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership/membershipfx"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/metricsfx"
@@ -68,6 +70,10 @@ func Module(serviceName string) fx.Option {
 			}),
 			fx.Provide(func(cfg config.Config) shardDistributorCfg.LeaderElection {
 				return shardDistributorCfg.GetLeaderElectionFromExternal(cfg.LeaderElection)
+			}),
+			// Decorate both logger so all components use proper service name.
+			fx.Decorate(func(z *zap.Logger, l log.Logger) (*zap.Logger, log.Logger) {
+				return z.With(zap.String("service", service.ShardDistributor)), l.WithTags(tag.Service(service.ShardDistributor))
 			}),
 			leaderstore.StoreModule("etcd"),
 

--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -57,7 +57,7 @@ require (
 	go.uber.org/multierr v1.10.0
 	go.uber.org/thriftrw v1.29.2 // indirect
 	go.uber.org/yarpc v1.70.3 // indirect
-	go.uber.org/zap v1.26.0 // indirect
+	go.uber.org/zap v1.26.0
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/common/membership/membershipfx/membershipfx.go
+++ b/common/membership/membershipfx/membershipfx.go
@@ -86,10 +86,6 @@ func startResolver(resolver membership.Resolver, rpcFactory rpc.Factory) func() 
 		if err != nil {
 			return fmt.Errorf("start rpc factory: %w", err)
 		}
-		err = rpcFactory.GetDispatcher().Start()
-		if err != nil {
-			return fmt.Errorf("start rpc factory dispatcher: %w", err)
-		}
 		resolver.Start()
 		return nil
 	}

--- a/common/membership/membershipfx/memebershipfx_test.go
+++ b/common/membership/membershipfx/memebershipfx_test.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/mock/gomock"
-	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
@@ -53,9 +52,6 @@ func TestFxStartStop(t *testing.T) {
 		}
 		factory := rpc.NewMockFactory(ctrl)
 		factory.EXPECT().Start(gomock.Any()).Return(nil)
-		factory.EXPECT().GetDispatcher().Return(yarpc.NewDispatcher(yarpc.Config{
-			Name: "membership_test",
-		}))
 		return appParams{
 			Clock:         clock.NewMockedTimeSource(),
 			PeerProvider:  provider,

--- a/common/rpc/rpcfx/rpcfx.go
+++ b/common/rpc/rpcfx/rpcfx.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 
 	"go.uber.org/fx"
-	"go.uber.org/yarpc/api/transport"
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
@@ -62,9 +61,8 @@ func paramsBuilder(p paramsBuilderParams) (rpc.Params, error) {
 type factoryParams struct {
 	fx.In
 
-	Logger     log.Logger
-	RPCParams  rpc.Params
-	Procedures []transport.Procedure `group:"cadence-rpcfx"`
+	Logger    log.Logger
+	RPCParams rpc.Params
 
 	Lifecycle fx.Lifecycle
 }

--- a/config/bench/development.yaml
+++ b/config/bench/development.yaml
@@ -11,4 +11,4 @@ metrics:
   statsd: ~
   prometheus:
     timerType: "histogram"
-    listenAddress: "127.0.0.1:8004"
+    listenAddress: "127.0.0.1:8005"

--- a/config/development_prometheus.yaml
+++ b/config/development_prometheus.yaml
@@ -26,3 +26,10 @@ services:
       prometheus:
         timerType: "histogram"
         listenAddress: "127.0.0.1:8003"
+
+  shard-distributor:
+    metrics:
+      statsd: ~
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "127.0.0.1:8004"

--- a/service/sharddistributor/service.go
+++ b/service/sharddistributor/service.go
@@ -23,7 +23,6 @@ package sharddistributor
 import (
 	"sync/atomic"
 
-	"go.uber.org/fx"
 	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/common"
@@ -34,7 +33,6 @@ import (
 	"github.com/uber/cadence/common/membership"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"
-	"github.com/uber/cadence/common/rpc"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/service/sharddistributor/config"
 	"github.com/uber/cadence/service/sharddistributor/handler"
@@ -42,7 +40,8 @@ import (
 	"github.com/uber/cadence/service/sharddistributor/wrappers/metered"
 )
 
-// Service represents the shard distributor service
+// Service represents the shard distributor service for legacy resource based initialization.
+// DEPRECATED: use fx and sharddistributorfx to avoid creating start/stopper.
 type Service struct {
 	logger        log.Logger
 	metricsClient metrics.Client
@@ -55,53 +54,9 @@ type Service struct {
 	matchingRing membership.SingleProvider
 	historyRing  membership.SingleProvider
 
-	// DEPRECATED: does not affect fx lifecycle.
 	stopC    chan struct{}
 	status   int32
 	resource resource.Resource
-}
-
-type ServiceParams struct {
-	fx.In
-
-	Logger            log.Logger
-	MetricsClient     metrics.Client
-	RPCFactory        rpc.Factory
-	DynamicCollection *dynamicconfig.Collection
-
-	Lifecycle fx.Lifecycle
-
-	HostName string `name:"hostname"`
-
-	MembershipRings map[string]membership.SingleProvider
-}
-
-// FXService builds a new shard distributor service
-func FXService(params ServiceParams) *Service {
-	serviceConfig := config.NewConfig(params.DynamicCollection, params.HostName)
-
-	logger := params.Logger.WithTags(tag.Service("shard-distributor"))
-
-	dispatcher := params.RPCFactory.GetDispatcher()
-
-	svc := &Service{
-		config: serviceConfig,
-
-		logger:        logger,
-		metricsClient: params.MetricsClient,
-		dispatcher:    dispatcher,
-		matchingRing:  params.MembershipRings[service.Matching],
-		historyRing:   params.MembershipRings[service.History],
-	}
-
-	rawHandler := handler.NewHandler(logger, params.MetricsClient, svc.matchingRing, svc.historyRing)
-	svc.handler = metered.NewMetricsHandler(rawHandler, logger, params.MetricsClient)
-
-	grpcHandler := grpc.NewGRPCHandler(svc.handler)
-	grpcHandler.Register(svc.dispatcher)
-
-	params.Lifecycle.Append(fx.StartStopHook(svc.Start, svc.Stop))
-	return svc
 }
 
 // NewService is an adapter for legacy initialization without fx.
@@ -163,7 +118,7 @@ func NewService(
 	}, nil
 }
 
-// Start starts the service
+// Start legacy mode fx stops the component and ensures order/wait time between dependent components.
 func (s *Service) Start() {
 	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
@@ -171,37 +126,30 @@ func (s *Service) Start() {
 
 	s.logger.Info("starting")
 
-	// legacy mode, if resouce is provided
-	if s.resource != nil {
-		s.resource.Start()
-	}
+	s.resource.Start()
 
-	s.handler.Start()
+	if s.handler != nil {
+		s.handler.Start()
+	}
 
 	s.logger.Info("started")
 
-	// legacy mode, fx Lifecyle requires component to start and return nil
-	if s.stopC != nil {
-		<-s.stopC
-	}
+	<-s.stopC
 
 	return
 }
 
+// Stop legacy mode, fx stops the component and ensures order/wait time between dependent components.
 func (s *Service) Stop() {
 	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
 
-	// legacy mode, fx stops the component and ensures order/wait time between dependent components.
-	if s.stopC != nil {
-		close(s.stopC)
-	}
+	close(s.stopC)
 
 	s.handler.Stop()
-	if s.resource != nil {
-		s.resource.Stop()
-	}
+
+	s.resource.Stop()
 
 	s.logger.Info("stopped")
 }

--- a/service/sharddistributor/sharddistributorfx/fx_test.go
+++ b/service/sharddistributor/sharddistributorfx/fx_test.go
@@ -1,0 +1,58 @@
+package sharddistributorfx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/goleak"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/yarpc"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/rpc"
+	"github.com/uber/cadence/service/sharddistributor/config"
+	"github.com/uber/cadence/service/sharddistributor/leader/leaderstore"
+)
+
+func TestFxServiceStartStop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testDispatcher := yarpc.NewDispatcher(yarpc.Config{Name: "test"})
+	ctrl := gomock.NewController(t)
+	app := fxtest.New(t,
+		testlogger.Module(t),
+		fx.Provide(
+			func() metrics.Client { return metrics.NewNoopMetricsClient() },
+			func() rpc.Factory {
+				factory := rpc.NewMockFactory(ctrl)
+				factory.EXPECT().GetDispatcher().Return(testDispatcher)
+				return factory
+			},
+			func() *dynamicconfig.Collection {
+				return dynamicconfig.NewNopCollection()
+			},
+			fx.Annotated{Target: func() string { return "testHost" }, Name: "hostname"},
+			func() leaderstore.Store {
+				return leaderstore.NewMockStore(ctrl)
+			},
+			func() map[string]membership.SingleProvider { return make(map[string]membership.SingleProvider) },
+			func() config.LeaderElection {
+				return config.LeaderElection{
+					Enabled: false,
+				}
+			},
+			func() clock.TimeSource {
+				return clock.NewMockedTimeSource()
+			},
+		),
+		Module)
+	app.RequireStart().RequireStop()
+	// API should be registered inside dispatcher.
+	assert.True(t, len(testDispatcher.Introspect().Procedures) > 1)
+}

--- a/service/sharddistributor/wrappers/grpc/grpc_handler.go
+++ b/service/sharddistributor/wrappers/grpc/grpc_handler.go
@@ -38,5 +38,8 @@ func (g GRPCHandler) Register(dispatcher *yarpc.Dispatcher) {
 
 func (g GRPCHandler) Health(ctx context.Context, _ *apiv1.HealthRequest) (*apiv1.HealthResponse, error) {
 	response, err := g.h.Health(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return proto.FromHealthResponse(response), proto.FromError(err)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Reworking shard distributor fx initialization.

<!-- Tell your future self why have you made these changes -->
**Why?**
To resolve issues in service start and missing routes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration tests
Local execution

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
