### PR TITLE
Do not stop root virtual queue

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1181,3 +1181,8 @@ func PeerHostname(hostname string) Tag {
 func PendingTaskCount(count int) Tag {
 	return newInt("pending-task-count", count)
 }
+
+// VirtualQueueID returns a tag for virtual queue id
+func VirtualQueueID(id int64) Tag {
+	return newInt64("virtual-queue-id", id)
+}

--- a/service/history/queuev2/queue_base.go
+++ b/service/history/queuev2/queue_base.go
@@ -219,7 +219,6 @@ func (q *queueBase) processNewTasks() {
 
 	newVirtualSliceState, remainingVirtualSliceState, ok := q.newVirtualSliceState.TrySplitByTaskKey(newExclusiveMaxTaskKey)
 	if !ok {
-		q.logger.Warn("Failed to split new virtual slice", tag.Value(newExclusiveMaxTaskKey), tag.Value(q.newVirtualSliceState))
 		return
 	}
 	q.newVirtualSliceState = remainingVirtualSliceState

--- a/service/history/queuev2/virtual_queue_manager_test.go
+++ b/service/history/queuev2/virtual_queue_manager_test.go
@@ -389,6 +389,23 @@ func TestVirtualQueueManager_UpdateAndGetState(t *testing.T) {
 				mocks[2].EXPECT().Stop()
 			},
 		},
+		{
+			name: "empty root queue is not removed",
+			initialStates: map[int64][]VirtualSliceState{
+				0: {
+					{
+						Range: Range{
+							InclusiveMinTaskKey: persistence.NewImmediateTaskKey(1),
+							ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(10),
+						},
+					},
+				},
+			},
+			expectedStates: map[int64][]VirtualSliceState{},
+			setupMockQueues: func(mocks map[int64]*MockVirtualQueue) {
+				mocks[0].EXPECT().UpdateAndGetState().Return([]VirtualSliceState{})
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -521,7 +538,7 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 				},
 				status:        common.DaemonStatusInitialized,
 				virtualQueues: virtualQueues,
-				createVirtualQueueFn: func(s VirtualSlice) VirtualQueue {
+				createVirtualQueueFn: func(s VirtualSlice, queueID int64) VirtualQueue {
 					vq := NewMockVirtualQueue(ctrl)
 					vq.EXPECT().Start()
 					return vq


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not stop root virtual queue when it becomes empty
- Remove warn logs for split

<!-- Tell your future self why have you made these changes -->
**Why?**
Root queue expects more tasks to be added. In a test environment I saw it's being stopped and started continuously during bench test and this created lots of noisy logs for its state change. The warn logs for queue split is also noisy and it's not very useful.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
