### PR TITLE
minor: use t.fatal in fuzz tests

### DIFF
--- a/common/quotas/global/algorithm/requestweighted_fuzz_test.go
+++ b/common/quotas/global/algorithm/requestweighted_fuzz_test.go
@@ -72,7 +72,7 @@ func FuzzMultiUpdate(f *testing.F) {
 			GcAfter:        func(opts ...dynamicproperties.FilterOption) time.Duration { return time.Hour },
 		})
 		if err != nil {
-			f.Fatal(err)
+			t.Fatal(err)
 		}
 
 		// if it takes more than a couple seconds, fuzz considers it stuck.


### PR DESCRIPTION
Go 1.24 complains about `f.Fatal` inside a `f.Fuzz` callback:
```
❯ go test ./common/quotas/global/algorithm
# github.com/uber/cadence/common/quotas/global/algorithm
# [github.com/uber/cadence/common/quotas/global/algorithm]
common/quotas/global/algorithm/requestweighted_fuzz_test.go:75:4: fuzz target must not call any *F methods
FAIL    github.com/uber/cadence/common/quotas/global/algorithm [build failed]
FAIL
```

so that's now fixed.
