### PR TITLE
Add more metrics for history task processing

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2387,6 +2387,8 @@ const (
 	TaskLimitExceededCounterPerDomain
 	TaskProcessingLatencyPerDomain
 	TaskQueueLatencyPerDomain
+	TaskScheduleLatencyPerDomain
+	TaskEnqueueToFetchLatency
 	TransferTaskMissingEventCounterPerDomain
 	ReplicationTasksAppliedPerDomain
 	WorkflowTerminateCounterPerDomain
@@ -3140,6 +3142,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskLimitExceededCounterPerDomain:        {metricName: "task_errors_limit_exceeded_counter_per_domain", metricRollupName: "task_errors_limit_exceeded_counter", metricType: Counter},
 		TaskProcessingLatencyPerDomain:           {metricName: "task_latency_processing_per_domain", metricRollupName: "task_latency_processing", metricType: Timer},
 		TaskQueueLatencyPerDomain:                {metricName: "task_latency_queue_per_domain", metricRollupName: "task_latency_queue", metricType: Timer},
+		TaskScheduleLatencyPerDomain:             {metricName: "task_latency_schedule_per_domain", metricRollupName: "task_latency_schedule", metricType: Histogram, buckets: HistoryTaskLatencyBuckets},
+		TaskEnqueueToFetchLatency:                {metricName: "task_latency_enqueue_to_fetch", metricType: Histogram, buckets: HistoryTaskLatencyBuckets},
 		TransferTaskMissingEventCounterPerDomain: {metricName: "transfer_task_missing_event_counter_per_domain", metricRollupName: "transfer_task_missing_event_counter", metricType: Counter},
 		ReplicationTasksAppliedPerDomain:         {metricName: "replication_tasks_applied_per_domain", metricType: Counter},
 		WorkflowTerminateCounterPerDomain:        {metricName: "workflow_terminate_counter_per_domain", metricRollupName: "workflow_terminate_counter", metricType: Counter},
@@ -3651,6 +3655,27 @@ var (
 		120 * time.Hour,
 		144 * time.Hour,
 		168 * time.Hour, // one week
+	})
+
+	HistoryTaskLatencyBuckets = tally.DurationBuckets([]time.Duration{
+		1 * time.Millisecond,
+		5 * time.Millisecond,
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		250 * time.Millisecond,
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+		30 * time.Second,
+		1 * time.Minute,
+		5 * time.Minute,
+		10 * time.Minute,
+		1 * time.Hour,
 	})
 )
 

--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -285,6 +285,8 @@ func (q *virtualQueueImpl) loadAndSubmitTasks() {
 			q.redispatcher.RedispatchTask(task, scheduledTime)
 			continue
 		}
+		// shard level metrics for the duration between a task being written to a queue and being fetched from it
+		q.metricsScope.RecordHistogramDuration(metrics.TaskEnqueueToFetchLatency, now.Sub(task.GetVisibilityTimestamp()))
 
 		submitted, err := q.processor.TrySubmit(task)
 		if err != nil {

--- a/service/history/queuev2/virtual_queue_test.go
+++ b/service/history/queuev2/virtual_queue_test.go
@@ -636,6 +636,7 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	mockTask1.EXPECT().GetWorkflowID().Return("some random workflowID")
 	mockTask1.EXPECT().GetRunID().Return("some random runID")
 	mockTask1.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
+	mockTask1.EXPECT().GetVisibilityTimestamp().Return(mockTimeSource.Now().Add(time.Second * -1))
 	mockTask2 := task.NewMockTask(ctrl)
 	mockTask2.EXPECT().GetDomainID().Return("some random domainID")
 	mockTask2.EXPECT().GetWorkflowID().Return("some random workflowID")
@@ -646,6 +647,7 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	mockTask3.EXPECT().GetWorkflowID().Return("some random workflowID")
 	mockTask3.EXPECT().GetRunID().Return("some random runID")
 	mockTask3.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
+	mockTask3.EXPECT().GetVisibilityTimestamp().Return(mockTimeSource.Now().Add(time.Second * -1))
 
 	mockMonitor.EXPECT().GetTotalPendingTaskCount().Return(0)
 	mockPauseController.EXPECT().IsPaused().Return(false)

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -133,6 +133,10 @@ func (t *taskImpl) Execute() error {
 	if t.State() != ctask.TaskStatePending {
 		return nil
 	}
+	if t.GetAttempt() == 0 {
+		// domain level metrics for the duration between task being submitted to task scheduler and being executed
+		t.scope.RecordHistogramDuration(metrics.TaskScheduleLatencyPerDomain, time.Since(t.submitTime))
+	}
 
 	var err error
 	t.shouldProcessTask, err = t.taskFilter(t.Task)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add metrics for history task processing:
- task_latency_schedule_per_domain: the duration between task being submitted to task scheduler and being executed, it's emitted at domain level
- task_latency_enqueue_to_fetch: the duration between a task being written to a queue and being fetched from it, it's emitted at shard level

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve observability

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
