### PR TITLE
Use TaskListStatus.Empty to determine if a partition is empty

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1673,6 +1673,7 @@ const (
 
 	MatchingEnableGetNumberOfPartitionsFromCache
 	MatchingEnableAdaptiveScaler
+	MatchingEnablePartitionEmptyCheck
 
 	// key for history
 
@@ -4175,6 +4176,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "matching.enableAdaptiveScaler",
 		Filters:      []Filter{DomainName, TaskListName, TaskType},
 		Description:  "MatchingEnableAdaptiveScaler is to enable adaptive task list scaling",
+		DefaultValue: false,
+	},
+	MatchingEnablePartitionEmptyCheck: {
+		KeyName:      "matching.enablePartitionEmptyCheck",
+		Filters:      []Filter{DomainName, TaskListName, TaskType},
+		Description:  "MatchingEnablePartitionEmptyCheck enables using TaskListStatus.empty to check if a partition is empty",
 		DefaultValue: false,
 	},
 	EventsCacheGlobalEnable: {

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -64,6 +64,7 @@ type (
 		PartitionDownscaleSustainedDuration       dynamicproperties.DurationPropertyFnWithTaskListInfoFilters
 		AdaptiveScalerUpdateInterval              dynamicproperties.DurationPropertyFnWithTaskListInfoFilters
 		EnableAdaptiveScaler                      dynamicproperties.BoolPropertyFnWithTaskListInfoFilters
+		EnablePartitionEmptyCheck                 dynamicproperties.BoolPropertyFnWithTaskListInfoFilters
 		EnableStandbyTaskCompletion               dynamicproperties.BoolPropertyFnWithTaskListInfoFilters
 		EnableClientAutoConfig                    dynamicproperties.BoolPropertyFnWithTaskListInfoFilters
 		QPSTrackerInterval                        dynamicproperties.DurationPropertyFnWithTaskListInfoFilters
@@ -148,6 +149,7 @@ type (
 		NumReadPartitions                    func() int
 		EnableGetNumberOfPartitionsFromCache func() bool
 		EnableAdaptiveScaler                 func() bool
+		EnablePartitionEmptyCheck            func() bool
 		// isolation configuration
 		EnableTasklistIsolation func() bool
 		// A function which returns all the isolation groups
@@ -211,6 +213,7 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, getIsolationGroups
 		PartitionDownscaleSustainedDuration:       dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.MatchingPartitionDownscaleSustainedDuration),
 		AdaptiveScalerUpdateInterval:              dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.MatchingAdaptiveScalerUpdateInterval),
 		EnableAdaptiveScaler:                      dc.GetBoolPropertyFilteredByTaskListInfo(dynamicproperties.MatchingEnableAdaptiveScaler),
+		EnablePartitionEmptyCheck:                 dc.GetBoolPropertyFilteredByTaskListInfo(dynamicproperties.MatchingEnablePartitionEmptyCheck),
 		QPSTrackerInterval:                        dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.MatchingQPSTrackerInterval),
 		EnablePartitionIsolationGroupAssignment:   dc.GetBoolPropertyFilteredByTaskListInfo(dynamicproperties.EnablePartitionIsolationGroupAssignment),
 		IsolationGroupUpscaleSustainedDuration:    dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.MatchingIsolationGroupUpscaleSustainedDuration),

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -83,6 +83,7 @@ func TestNewConfig(t *testing.T) {
 		"AllIsolationGroups":                        {nil, []string{"zone-1", "zone-2"}},
 		"EnableTasklistOwnershipGuard":              {dynamicproperties.MatchingEnableTasklistGuardAgainstOwnershipShardLoss, false},
 		"EnableGetNumberOfPartitionsFromCache":      {dynamicproperties.MatchingEnableGetNumberOfPartitionsFromCache, false},
+		"EnablePartitionEmptyCheck":                 {dynamicproperties.MatchingEnablePartitionEmptyCheck, true},
 		"PartitionUpscaleRPS":                       {dynamicproperties.MatchingPartitionUpscaleRPS, 30},
 		"PartitionDownscaleFactor":                  {dynamicproperties.MatchingPartitionDownscaleFactor, 31.0},
 		"PartitionUpscaleSustainedDuration":         {dynamicproperties.MatchingPartitionUpscaleSustainedDuration, time.Duration(32)},

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -1104,6 +1104,9 @@ func newTaskListConfig(id *Identifier, cfg *config.Config, domainName string) *c
 		EnableAdaptiveScaler: func() bool {
 			return cfg.EnableAdaptiveScaler(domainName, taskListName, taskType)
 		},
+		EnablePartitionEmptyCheck: func() bool {
+			return cfg.EnablePartitionEmptyCheck(domainName, taskListName, taskType)
+		},
 		TaskIsolationDuration: func() time.Duration {
 			return cfg.TaskIsolationDuration(domainName, taskListName, taskType)
 		},


### PR DESCRIPTION
See https://github.com/cadence-workflow/cadence-idl/pull/212

<!-- Describe what has changed in this PR -->
**What changed?**
- Switch the AdaptiveScaler from using BacklogCountHint to Empty to determine when a partition is empty


<!-- Tell your future self why have you made these changes -->
**Why?**
- The BacklogCountHint can be inaccurate and isn't a reliable way to determine if a partition is empty

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests
- Will run load tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Since the default value of Empty is `false`, the largest risk is partitions not being dropped. This can reduce TaskList throughput as pollers sit on empty partitions.


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
