### PR TITLE
Remove poll time from scheduled queue

### DIFF
--- a/service/history/queuev2/queue_base_test.go
+++ b/service/history/queuev2/queue_base_test.go
@@ -164,7 +164,6 @@ func TestQueueBase_ProcessNewTasks(t *testing.T) {
 
 			// Verify
 			if !tt.expectError {
-				assert.NotNil(t, queueBase.lastPollTime)
 				assert.Equal(t, queueBase.newVirtualSliceState, tt.expectedNewVirtualSliceState)
 			}
 		})

--- a/service/history/queuev2/queue_scheduled.go
+++ b/service/history/queuev2/queue_scheduled.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -184,9 +185,6 @@ func (q *scheduledQueue) processEventLoop() {
 		case <-q.timerGate.Chan():
 			q.base.processNewTasks()
 			q.lookAheadTask()
-		case <-q.base.pollTimer.Chan():
-			q.base.processPollTimer()
-			q.lookAheadTask()
 		case <-q.base.updateQueueStateTimer.Chan():
 			q.base.updateQueueState(q.ctx)
 		case <-q.ctx.Done():
@@ -197,7 +195,10 @@ func (q *scheduledQueue) processEventLoop() {
 
 func (q *scheduledQueue) lookAheadTask() {
 	lookAheadMinTime := q.base.newVirtualSliceState.Range.InclusiveMinTaskKey.GetScheduledTime()
-	lookAheadMaxTime := lookAheadMinTime.Add(q.base.options.MaxPollInterval())
+	lookAheadMaxTime := lookAheadMinTime.Add(backoff.JitDuration(
+		q.base.options.MaxPollInterval(),
+		q.base.options.MaxPollIntervalJitterCoefficient(),
+	))
 
 	resp, err := q.base.queueReader.GetTask(q.ctx, &GetTaskRequest{
 		Progress: &GetTaskProgress{

--- a/service/history/queuev2/queue_scheduled_test.go
+++ b/service/history/queuev2/queue_scheduled_test.go
@@ -212,7 +212,7 @@ func TestScheduledQueue_LookAheadTask(t *testing.T) {
 				PageSize:                           dynamicproperties.GetIntPropertyFn(100),
 				PollBackoffInterval:                dynamicproperties.GetDurationPropertyFn(time.Second * 10),
 				MaxPollInterval:                    dynamicproperties.GetDurationPropertyFn(time.Second * 10),
-				MaxPollIntervalJitterCoefficient:   dynamicproperties.GetFloatPropertyFn(0.1),
+				MaxPollIntervalJitterCoefficient:   dynamicproperties.GetFloatPropertyFn(0.0),
 				UpdateAckInterval:                  dynamicproperties.GetDurationPropertyFn(time.Second * 10),
 				UpdateAckIntervalJitterCoefficient: dynamicproperties.GetFloatPropertyFn(0.1),
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR picks this commit from temporal: https://github.com/temporalio/temporal/pull/3364 (however, we don't have the bug in temporal)
- removes poll timer from scheduled queue because the timer gate guarantees that the tasks will be fetched at the look ahead time

<!-- Tell your future self why have you made these changes -->
**Why?**
Simplify code

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
