### PR TITLE
[shard-distributor] Add ElectedContext

### DIFF
--- a/service/sharddistributor/leader/election/election.go
+++ b/service/sharddistributor/leader/election/election.go
@@ -175,7 +175,7 @@ func (e *elector) runElection(ctx context.Context, leaderCh chan<- bool, OnLeade
 		return fmt.Errorf("failed to campaign: %w", err)
 	}
 
-	err = OnLeader(ctx)
+	err = OnLeader(election.ElectedContext(ctx))
 	if err != nil {
 		return fmt.Errorf("onLeader: %w", err)
 	}

--- a/service/sharddistributor/leader/election/election_test.go
+++ b/service/sharddistributor/leader/election/election_test.go
@@ -39,6 +39,7 @@ func TestElector_Run(t *testing.T) {
 	election := leaderstore.NewMockElection(ctrl)
 	election.EXPECT().Campaign(gomock.Any(), _testHost).Return(nil)
 	election.EXPECT().Done().Return(make(chan struct{}))
+	election.EXPECT().ElectedContext(gomock.Any()).Return(context.Background())
 
 	finished := make(chan struct{})
 	// once test is done cleanup will be called
@@ -229,6 +230,7 @@ func prepareRun(t *testing.T, onLeader, onResign ProcessFunc) (<-chan bool, runP
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	election.EXPECT().ElectedContext(gomock.Any()).Return(ctx)
 
 	// Default callbacks
 	if onLeader == nil {
@@ -275,6 +277,7 @@ func TestOnLeader_Error(t *testing.T) {
 	election.EXPECT().Campaign(gomock.Any(), _testHost).Return(nil)
 	// Expect resignation after onLeader failure
 	election.EXPECT().Resign(gomock.Any()).Return(nil)
+	election.EXPECT().ElectedContext(gomock.Any()).Return(context.Background())
 
 	store := leaderstore.NewMockStore(ctrl)
 	store.EXPECT().CreateElection(gomock.Any(), _testNamespace).Return(election, nil)

--- a/service/sharddistributor/leader/leaderstore/etcd/etcdstore.go
+++ b/service/sharddistributor/leader/leaderstore/etcd/etcdstore.go
@@ -13,6 +13,12 @@ import (
 	"github.com/uber/cadence/service/sharddistributor/leader/leaderstore"
 )
 
+type leaderContextKey string
+
+const (
+	_leaderContextKey = leaderContextKey("leader")
+)
+
 func init() {
 	leaderstore.RegisterStore("etcd", fx.Provide(NewStore))
 }
@@ -110,4 +116,16 @@ func (e *election) Campaign(ctx context.Context, host string) error {
 
 func (e *election) Done() <-chan struct{} {
 	return e.session.Done()
+}
+
+func (e *election) ElectedContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, _leaderContextKey, leaderContext{
+		leaderKey: e.election.Key(),
+		revision:  e.election.Rev(),
+	})
+}
+
+type leaderContext struct {
+	leaderKey string
+	revision  int64
 }

--- a/service/sharddistributor/leader/leaderstore/etcd/etcdstore_test.go
+++ b/service/sharddistributor/leader/leaderstore/etcd/etcdstore_test.go
@@ -87,6 +87,11 @@ func TestCampaign(t *testing.T) {
 	err = election.Campaign(ctx, host)
 	require.NoError(t, err)
 
+	electedCtx := election.ElectedContext(ctx)
+	val := electedCtx.Value(_leaderContextKey)
+	assert.NotNil(t, val)
+	assert.IsType(t, leaderContext{}, val)
+
 	// Verify leadership was obtained by checking the key in etcd
 	// First create a client to connect to etcd
 	client, err := clientv3.New(clientv3.Config{

--- a/service/sharddistributor/leader/leaderstore/leaderstore_mock.go
+++ b/service/sharddistributor/leader/leaderstore/leaderstore_mock.go
@@ -121,6 +121,20 @@ func (mr *MockElectionMockRecorder) Done() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockElection)(nil).Done))
 }
 
+// ElectedContext mocks base method.
+func (m *MockElection) ElectedContext(ctx context.Context) context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ElectedContext", ctx)
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// ElectedContext indicates an expected call of ElectedContext.
+func (mr *MockElectionMockRecorder) ElectedContext(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ElectedContext", reflect.TypeOf((*MockElection)(nil).ElectedContext), ctx)
+}
+
 // Resign mocks base method.
 func (m *MockElection) Resign(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/service/sharddistributor/leader/leaderstore/store.go
+++ b/service/sharddistributor/leader/leaderstore/store.go
@@ -25,6 +25,11 @@ type Election interface {
 	Done() <-chan struct{}
 	// Cleanup stops internal processes and releases keys.
 	Cleanup(ctx context.Context) error
+
+	// ElectedContext creates a context for a leader elected process. This can help to guard changes for leader elected logic.
+	// F.e. to guard regular shard assignments if the leader has changed during the assignment process.
+	// The guards itself should be defined inside the leaderstore. F.e. in etcd we can store leaderKey and leader revision to ensure that leader has not changed since election started.
+	ElectedContext(ctx context.Context) context.Context
 }
 
 // StoreImpl could be used to build an implementation in the registry.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added ElecteContext to the leader store interface.

<!-- Tell your future self why have you made these changes -->
**Why?**
ElectedContext allows building transaction-like functionality on top of the leader store, so that shard assignment is guarded by a check (introduced later) that ensures the leader has not changed since the election started.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
