### PR TITLE
Fix history task latency metric for timer queue v2

### DIFF
--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -422,6 +422,7 @@ func (t *transferQueueProcessorBase) processQueueCollections() {
 
 		tasks := make(map[task.Key]task.Task)
 		taskChFull := false
+		now := t.shard.GetTimeSource().Now()
 		for _, taskInfo := range transferTaskInfos {
 			if !domainFilter.Filter(taskInfo.GetDomainID()) {
 				t.logger.Debug("transfer task filtered", tag.TaskID(taskInfo.GetTaskID()))
@@ -436,6 +437,7 @@ func (t *transferQueueProcessorBase) processQueueCollections() {
 
 			task := t.taskInitializer(taskInfo)
 			tasks[newTransferTaskKey(taskInfo.GetTaskID())] = task
+			t.metricsScope.RecordHistogramDuration(metrics.TaskEnqueueToFetchLatency, now.Sub(taskInfo.GetVisibilityTimestamp()))
 			submitted, err := t.submitTask(task)
 			if err != nil {
 				// only err here is due to the fact that processor has been shutdown

--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -287,7 +287,7 @@ func (q *virtualQueueImpl) loadAndSubmitTasks() {
 		}
 		// shard level metrics for the duration between a task being written to a queue and being fetched from it
 		q.metricsScope.RecordHistogramDuration(metrics.TaskEnqueueToFetchLatency, now.Sub(task.GetVisibilityTimestamp()))
-
+		task.SetInitialSubmitTime(now)
 		submitted, err := q.processor.TrySubmit(task)
 		if err != nil {
 			select {

--- a/service/history/queuev2/virtual_queue_test.go
+++ b/service/history/queuev2/virtual_queue_test.go
@@ -637,6 +637,7 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	mockTask1.EXPECT().GetRunID().Return("some random runID")
 	mockTask1.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
 	mockTask1.EXPECT().GetVisibilityTimestamp().Return(mockTimeSource.Now().Add(time.Second * -1))
+	mockTask1.EXPECT().SetInitialSubmitTime(gomock.Any()).Times(1)
 	mockTask2 := task.NewMockTask(ctrl)
 	mockTask2.EXPECT().GetDomainID().Return("some random domainID")
 	mockTask2.EXPECT().GetWorkflowID().Return("some random workflowID")
@@ -648,6 +649,7 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	mockTask3.EXPECT().GetRunID().Return("some random runID")
 	mockTask3.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
 	mockTask3.EXPECT().GetVisibilityTimestamp().Return(mockTimeSource.Now().Add(time.Second * -1))
+	mockTask3.EXPECT().SetInitialSubmitTime(gomock.Any()).Times(1)
 
 	mockMonitor.EXPECT().GetTotalPendingTaskCount().Return(0)
 	mockPauseController.EXPECT().IsPaused().Return(false)

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -43,6 +43,7 @@ type (
 		GetShard() shard.Context
 		GetAttempt() int
 		GetInfo() persistence.Task
+		SetInitialSubmitTime(time.Time)
 	}
 
 	// CrossClusterTask is the interface for processing cross cluster task in the source cluster

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -335,6 +335,18 @@ func (mr *MockTaskMockRecorder) RetryErr(err any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryErr", reflect.TypeOf((*MockTask)(nil).RetryErr), err)
 }
 
+// SetInitialSubmitTime mocks base method.
+func (m *MockTask) SetInitialSubmitTime(arg0 time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetInitialSubmitTime", arg0)
+}
+
+// SetInitialSubmitTime indicates an expected call of SetInitialSubmitTime.
+func (mr *MockTaskMockRecorder) SetInitialSubmitTime(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInitialSubmitTime", reflect.TypeOf((*MockTask)(nil).SetInitialSubmitTime), arg0)
+}
+
 // SetPriority mocks base method.
 func (m *MockTask) SetPriority(arg0 int) {
 	m.ctrl.T.Helper()
@@ -809,6 +821,18 @@ func (m *MockCrossClusterTask) RetryErr(err error) bool {
 func (mr *MockCrossClusterTaskMockRecorder) RetryErr(err any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryErr", reflect.TypeOf((*MockCrossClusterTask)(nil).RetryErr), err)
+}
+
+// SetInitialSubmitTime mocks base method.
+func (m *MockCrossClusterTask) SetInitialSubmitTime(arg0 time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetInitialSubmitTime", arg0)
+}
+
+// SetInitialSubmitTime indicates an expected call of SetInitialSubmitTime.
+func (mr *MockCrossClusterTaskMockRecorder) SetInitialSubmitTime(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInitialSubmitTime", reflect.TypeOf((*MockCrossClusterTask)(nil).SetInitialSubmitTime), arg0)
 }
 
 // SetPriority mocks base method.

--- a/service/history/task/redispatcher.go
+++ b/service/history/task/redispatcher.go
@@ -247,6 +247,9 @@ func (r *redispatcherImpl) redispatchTasks(notification redispatchNotification) 
 				pq.Remove()
 				continue
 			}
+			if item.task.GetAttempt() == 0 {
+				item.task.SetInitialSubmitTime(now)
+			}
 			submitted, err := r.taskProcessor.TrySubmit(item.task)
 			if err != nil {
 				if r.isStopped() {

--- a/service/history/task/task_rate_limiter_test.go
+++ b/service/history/task/task_rate_limiter_test.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,6 +124,9 @@ func (s *noopTask) GetAttempt() int {
 
 func (s *noopTask) GetInfo() persistence.Task {
 	return s.Task
+}
+
+func (s *noopTask) SetInitialSubmitTime(submitTime time.Time) {
 }
 
 type taskRateLimiterMockDeps struct {

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -164,10 +164,10 @@ func (s *taskSuite) TestHandleErr_ErrTargetDomainNotActive() {
 
 	// we should always return the target domain not active error
 	// no matter that the submit time is
-	taskBase.submitTime = time.Now().Add(-cache.DomainCacheRefreshInterval*time.Duration(5) - time.Second)
+	taskBase.initialSubmitTime = time.Now().Add(-cache.DomainCacheRefreshInterval*time.Duration(5) - time.Second)
 	s.Equal(nil, taskBase.HandleErr(err), "should drop errors after a reasonable time")
 
-	taskBase.submitTime = time.Now()
+	taskBase.initialSubmitTime = time.Now()
 	s.Equal(err, taskBase.HandleErr(err))
 }
 
@@ -178,10 +178,10 @@ func (s *taskSuite) TestHandleErr_ErrDomainNotActive() {
 
 	err := &types.DomainNotActiveError{}
 
-	taskBase.submitTime = time.Now().Add(-cache.DomainCacheRefreshInterval*time.Duration(5) - time.Second)
+	taskBase.initialSubmitTime = time.Now().Add(-cache.DomainCacheRefreshInterval*time.Duration(5) - time.Second)
 	s.NoError(taskBase.HandleErr(err))
 
-	taskBase.submitTime = time.Now()
+	taskBase.initialSubmitTime = time.Now()
 	s.Equal(err, taskBase.HandleErr(err))
 }
 
@@ -190,7 +190,7 @@ func (s *taskSuite) TestHandleErr_ErrWorkflowRateLimited() {
 		return true, nil
 	}, nil)
 
-	taskBase.submitTime = time.Now()
+	taskBase.initialSubmitTime = time.Now()
 	s.Equal(errWorkflowRateLimited, taskBase.HandleErr(errWorkflowRateLimited))
 }
 
@@ -199,7 +199,7 @@ func (s *taskSuite) TestHandleErr_ErrShardRecentlyClosed() {
 		return true, nil
 	}, nil)
 
-	taskBase.submitTime = time.Now()
+	taskBase.initialSubmitTime = time.Now()
 
 	shardClosedError := &shard.ErrShardClosed{
 		Msg: "shard closed",
@@ -215,7 +215,7 @@ func (s *taskSuite) TestHandleErr_ErrTaskListNotOwnedByHost() {
 		return true, nil
 	}, nil)
 
-	taskBase.submitTime = time.Now()
+	taskBase.initialSubmitTime = time.Now()
 
 	taskListNotOwnedByHost := &cadence_errors.TaskListNotOwnedByHostError{
 		OwnedByIdentity: "HostNameOwnedBy",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix history task latency metric for timer queue v2
- Add enqueue to schedule latency metric for queue v1

<!-- Tell your future self why have you made these changes -->
**Why?**
- Timer tasks in history queuev2 can be created earlier than schedule time, we need to adjust the initial submit time for those tasks
- Add enqueue to schedule latency for queue v1 to compare the latency between v1 and v2

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
history queue latency metric will be messed up

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
