### PR TITLE
Fix TestOfferOrTimeout_SyncMatchTimedOut flaky test in matcher_test

### DIFF
--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -770,17 +770,18 @@ func (t *MatcherTestSuite) TestOfferOrTimeout_SyncMatchTimedOut() {
 
 	t.disableRemoteForwarding()
 
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil, "")
+
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
+		time.Sleep(time.Millisecond * 100)
 		task, err := t.matcher.Poll(ctx, "")
 		if err == nil {
 			task.Finish(nil)
 		}
 	})
 
-	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil, "")
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	cancel()
+	defer cancel()
 	matched, err := t.matcher.OfferOrTimeout(ctx, time.Now(), task)
 	wait()
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added sleep before polling.

<!-- Tell your future self why have you made these changes -->
**Why?**
The test is testing a timeout, and it was possible that the poll started before the syncmatch timeout. By adding a sleep that has 100 times the duration as the syncmatch timeout after the syncmatch, it guarantees that it will expire before the poll.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
