### PR TITLE
Fix task attempt metric

### DIFF
--- a/service/history/task/executor_wrapper.go
+++ b/service/history/task/executor_wrapper.go
@@ -29,7 +29,6 @@ import (
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
-	"github.com/uber/cadence/common/metrics"
 )
 
 type (
@@ -66,7 +65,7 @@ func (e *executorWrapper) Stop() {
 	e.standbyExecutor.Stop()
 }
 
-func (e *executorWrapper) Execute(task Task) (metrics.Scope, error) {
+func (e *executorWrapper) Execute(task Task) (ExecuteResponse, error) {
 	if e.isActiveTask(task) {
 		return e.activeExecutor.Execute(task)
 	}

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -63,7 +63,7 @@ type (
 
 	// Executor contains the execution logic for Task
 	Executor interface {
-		Execute(task Task) (metrics.Scope, error)
+		Execute(task Task) (ExecuteResponse, error)
 		Stop()
 	}
 
@@ -109,6 +109,11 @@ type (
 
 	// QueueType is the type of task queue
 	QueueType int
+
+	ExecuteResponse struct {
+		Scope        metrics.Scope
+		IsActiveTask bool
+	}
 )
 
 const (

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -16,7 +16,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	future "github.com/uber/cadence/common/future"
-	metrics "github.com/uber/cadence/common/metrics"
 	persistence "github.com/uber/cadence/common/persistence"
 	task "github.com/uber/cadence/common/task"
 	types "github.com/uber/cadence/common/types"
@@ -1005,10 +1004,10 @@ func (m *MockExecutor) EXPECT() *MockExecutorMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockExecutor) Execute(task Task) (metrics.Scope, error) {
+func (m *MockExecutor) Execute(task Task) (ExecuteResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", task)
-	ret0, _ := ret[0].(metrics.Scope)
+	ret0, _ := ret[0].(ExecuteResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -111,7 +111,10 @@ func (s *taskSuite) TestExecute_ExecutionErr() {
 	}, nil)
 
 	executionErr := errors.New("some random error")
-	s.mockTaskExecutor.EXPECT().Execute(task).Return(metrics.NoopScope, executionErr).Times(1)
+	s.mockTaskExecutor.EXPECT().Execute(task).Return(ExecuteResponse{
+		Scope:        metrics.NoopScope,
+		IsActiveTask: true,
+	}, executionErr).Times(1)
 
 	err := task.Execute()
 	s.Equal(executionErr, err)
@@ -122,7 +125,10 @@ func (s *taskSuite) TestExecute_Success() {
 		return true, nil
 	}, nil)
 
-	s.mockTaskExecutor.EXPECT().Execute(task).Return(metrics.NoopScope, nil).Times(1)
+	s.mockTaskExecutor.EXPECT().Execute(task).Return(ExecuteResponse{
+		Scope:        metrics.NoopScope,
+		IsActiveTask: true,
+	}, nil).Times(1)
 
 	err := task.Execute()
 	s.NoError(err)

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -77,7 +77,7 @@ func NewTimerActiveTaskExecutor(
 	}
 }
 
-func (t *timerActiveTaskExecutor) Execute(task Task) (metrics.Scope, error) {
+func (t *timerActiveTaskExecutor) Execute(task Task) (ExecuteResponse, error) {
 	simulation.LogEvents(simulation.E{
 		EventName:  simulation.EventNameExecuteHistoryTask,
 		Host:       t.shard.GetConfig().HostName,
@@ -92,37 +92,41 @@ func (t *timerActiveTaskExecutor) Execute(task Task) (metrics.Scope, error) {
 		},
 	})
 	scope := getOrCreateDomainTaggedScope(t.shard, GetTimerTaskMetricScope(task.GetTaskType(), true), task.GetDomainID(), t.logger)
+	executeResponse := ExecuteResponse{
+		Scope:        scope,
+		IsActiveTask: true,
+	}
 	switch timerTask := task.GetInfo().(type) {
 	case *persistence.UserTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return scope, t.executeUserTimerTimeoutTask(ctx, timerTask)
+		return executeResponse, t.executeUserTimerTimeoutTask(ctx, timerTask)
 	case *persistence.ActivityTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return scope, t.executeActivityTimeoutTask(ctx, timerTask)
+		return executeResponse, t.executeActivityTimeoutTask(ctx, timerTask)
 	case *persistence.DecisionTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return scope, t.executeDecisionTimeoutTask(ctx, timerTask)
+		return executeResponse, t.executeDecisionTimeoutTask(ctx, timerTask)
 	case *persistence.WorkflowTimeoutTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return scope, t.executeWorkflowTimeoutTask(ctx, timerTask)
+		return executeResponse, t.executeWorkflowTimeoutTask(ctx, timerTask)
 	case *persistence.ActivityRetryTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return scope, t.executeActivityRetryTimerTask(ctx, timerTask)
+		return executeResponse, t.executeActivityRetryTimerTask(ctx, timerTask)
 	case *persistence.WorkflowBackoffTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 		defer cancel()
-		return scope, t.executeWorkflowBackoffTimerTask(ctx, timerTask)
+		return executeResponse, t.executeWorkflowBackoffTimerTask(ctx, timerTask)
 	case *persistence.DeleteHistoryEventTask:
 		ctx, cancel := context.WithTimeout(t.ctx, time.Duration(t.config.DeleteHistoryEventContextTimeout())*time.Second)
 		defer cancel()
-		return scope, t.executeDeleteHistoryEventTask(ctx, timerTask)
+		return executeResponse, t.executeDeleteHistoryEventTask(ctx, timerTask)
 	default:
-		return scope, errUnknownTimerTask
+		return executeResponse, errUnknownTimerTask
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Reset task attempt when there is a failover

<!-- Tell your future self why have you made these changes -->
**Why?**
In history queue v2, the activeness of a history task is determined when the task is executed and if there is a failover, the task execution will fail and be retried with a different executor and we should reset the attempt because the task wasn't executed with the new executor.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
metric can be messed up


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
