### PR TITLE
[active-active] Handle active cluster lookup for retired workflows

### DIFF
--- a/common/activecluster/manager.go
+++ b/common/activecluster/manager.go
@@ -254,44 +254,43 @@ func (m *managerImpl) LookupWorkflow(ctx context.Context, domainID, wfID, rID st
 	plcy, err := m.getClusterSelectionPolicy(ctx, domainID, wfID, rID)
 	if err != nil {
 		var notExistsErr *types.EntityNotExistsError
-		if errors.As(err, &notExistsErr) {
-			if d.GetReplicationConfig().ActiveClusterName != "" {
-				// Case 1.b: domain migrated from active-passive to active-active case
-				m.logger.Debug("LookupWorkflow: domain migrated from active-passive to active-active case. returning ActiveClusterName from domain entry",
-					tag.WorkflowDomainID(domainID),
-					tag.WorkflowID(wfID),
-					tag.WorkflowRunID(rID),
-					tag.ActiveClusterName(d.GetReplicationConfig().ActiveClusterName),
-				)
-				return &LookupResult{
-					ClusterName:     d.GetReplicationConfig().ActiveClusterName,
-					FailoverVersion: d.GetFailoverVersion(),
-				}, nil
-			} else {
-				// Case 1.c: workflow is retired. return current cluster and its failover version
-				region := m.clusterMetadata.GetCurrentRegion()
-				cluster, ok := d.GetReplicationConfig().ActiveClusters.ActiveClustersByRegion[region]
-				if !ok {
-					return nil, newRegionNotFoundForDomainError(region, domainID)
-				}
-
-				m.logger.Debug("LookupWorkflow: workflow is retired. returning region, cluster name and failover version",
-					tag.WorkflowDomainID(domainID),
-					tag.WorkflowID(wfID),
-					tag.WorkflowRunID(rID),
-					tag.Region(region),
-					tag.ActiveClusterName(cluster.ActiveClusterName),
-				)
-				return &LookupResult{
-					Region:          region,
-					ClusterName:     cluster.ActiveClusterName,
-					FailoverVersion: cluster.FailoverVersion,
-				}, nil
-			}
-
+		if !errors.As(err, &notExistsErr) {
+			return nil, err
 		}
 
-		return nil, err
+		// Case 1.b: domain migrated from active-passive to active-active case
+		if d.GetReplicationConfig().ActiveClusterName != "" {
+			m.logger.Debug("LookupWorkflow: domain migrated from active-passive to active-active case. returning ActiveClusterName from domain entry",
+				tag.WorkflowDomainID(domainID),
+				tag.WorkflowID(wfID),
+				tag.WorkflowRunID(rID),
+				tag.ActiveClusterName(d.GetReplicationConfig().ActiveClusterName),
+			)
+			return &LookupResult{
+				ClusterName:     d.GetReplicationConfig().ActiveClusterName,
+				FailoverVersion: d.GetFailoverVersion(),
+			}, nil
+		}
+
+		// Case 1.c: workflow is retired. return current cluster and its failover version
+		region := m.clusterMetadata.GetCurrentRegion()
+		cluster, ok := d.GetReplicationConfig().ActiveClusters.ActiveClustersByRegion[region]
+		if !ok {
+			return nil, newRegionNotFoundForDomainError(region, domainID)
+		}
+
+		m.logger.Debug("LookupWorkflow: workflow is retired. returning region, cluster name and failover version",
+			tag.WorkflowDomainID(domainID),
+			tag.WorkflowID(wfID),
+			tag.WorkflowRunID(rID),
+			tag.Region(region),
+			tag.ActiveClusterName(cluster.ActiveClusterName),
+		)
+		return &LookupResult{
+			Region:          region,
+			ClusterName:     cluster.ActiveClusterName,
+			FailoverVersion: cluster.FailoverVersion,
+		}, nil
 	}
 
 	if plcy.GetStrategy() == types.ActiveClusterSelectionStrategyExternalEntity {

--- a/common/activecluster/manager_test.go
+++ b/common/activecluster/manager_test.go
@@ -95,7 +95,7 @@ func TestStartStop(t *testing.T) {
 			defer goleak.VerifyNone(t)
 			ctrl := gomock.NewController(t)
 			domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
-				return getDomainCacheEntry(nil), nil
+				return getDomainCacheEntry(nil, false), nil
 			}
 
 			metricsCl := metrics.NewNoopMetricsClient()
@@ -122,7 +122,7 @@ func TestStartStop(t *testing.T) {
 func TestNotifyChangeCallbacks(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
-		return getDomainCacheEntry(nil), nil
+		return getDomainCacheEntry(nil, false), nil
 	}
 
 	metricsCl := metrics.NewNoopMetricsClient()
@@ -398,7 +398,7 @@ func TestClusterNameForFailoverVersion(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
-				return getDomainCacheEntry(tc.activeClusterCfg), nil
+				return getDomainCacheEntry(tc.activeClusterCfg, false), nil
 			}
 
 			metricsCl := metrics.NewNoopMetricsClient()
@@ -469,7 +469,7 @@ func TestLookupNewWorkflow(t *testing.T) {
 			activeClusterCfg: nil, // not active-active domain
 			expectedResult: &LookupResult{
 				ClusterName:     "cluster0",
-				FailoverVersion: 1,
+				FailoverVersion: 201,
 			},
 		},
 		{
@@ -582,7 +582,7 @@ func TestLookupNewWorkflow(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
-				return getDomainCacheEntry(tc.activeClusterCfg), nil
+				return getDomainCacheEntry(tc.activeClusterCfg, false), nil
 			}
 
 			timeSrc := clock.NewMockedTimeSource()
@@ -654,6 +654,7 @@ func TestLookupWorkflow(t *testing.T) {
 		getClusterSelectionPolicyFn func(ctx context.Context, domainID, wfID, rID string) (*types.ActiveClusterSelectionPolicy, error)
 		mockFn                      func(em *persistence.MockExecutionManager)
 		activeClusterCfg            *types.ActiveClusters
+		migratedFromActivePassive   bool
 		expectedResult              *LookupResult
 		expectedError               string
 	}{
@@ -662,7 +663,7 @@ func TestLookupWorkflow(t *testing.T) {
 			activeClusterCfg: nil,
 			expectedResult: &LookupResult{
 				ClusterName:     "cluster0",
-				FailoverVersion: 1,
+				FailoverVersion: 201,
 			},
 		},
 		{
@@ -686,7 +687,8 @@ func TestLookupWorkflow(t *testing.T) {
 			expectedError: "failed to fetch workflow activeness metadata",
 		},
 		{
-			name: "domain is active-active, activeness metadata not-found which means region sticky",
+			name:                      "domain is migrated from active-passive to active-active, activeness metadata not-found. falls back to domain's active cluster name and failover version",
+			migratedFromActivePassive: true,
 			activeClusterCfg: &types.ActiveClusters{
 				ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
 					"us-west": {
@@ -705,7 +707,31 @@ func TestLookupWorkflow(t *testing.T) {
 			},
 			expectedResult: &LookupResult{
 				ClusterName:     "cluster0",
-				FailoverVersion: 1,
+				FailoverVersion: 201,
+			},
+		},
+		{
+			name: "domain is active-active and NOT migrated from active-passive, activeness metadata not-found. return cluster name and failover version of current region",
+			activeClusterCfg: &types.ActiveClusters{
+				ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+					"us-west": {
+						ActiveClusterName: "cluster0",
+						FailoverVersion:   101,
+					},
+					"us-east": {
+						ActiveClusterName: "cluster1",
+						FailoverVersion:   3,
+					},
+				},
+			},
+			mockFn: func(em *persistence.MockExecutionManager) {
+				em.EXPECT().GetActiveClusterSelectionPolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, &types.EntityNotExistsError{})
+			},
+			expectedResult: &LookupResult{
+				ClusterName:     "cluster0",
+				FailoverVersion: 101,
+				Region:          "us-west",
 			},
 		},
 		{
@@ -729,6 +755,7 @@ func TestLookupWorkflow(t *testing.T) {
 			expectedResult: &LookupResult{
 				ClusterName:     "cluster0",
 				FailoverVersion: 1,
+				Region:          "us-west",
 			},
 		},
 		{
@@ -800,7 +827,7 @@ func TestLookupWorkflow(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
-				return getDomainCacheEntry(tc.activeClusterCfg), nil
+				return getDomainCacheEntry(tc.activeClusterCfg, tc.migratedFromActivePassive), nil
 			}
 
 			timeSrc := clock.NewMockedTimeSource()
@@ -848,17 +875,22 @@ func TestLookupWorkflow(t *testing.T) {
 	}
 }
 
-func getDomainCacheEntry(cfg *types.ActiveClusters) *cache.DomainCacheEntry {
+func getDomainCacheEntry(cfg *types.ActiveClusters, migratedFromActivePassive bool) *cache.DomainCacheEntry {
 	// only thing we care in domain cache entry is the active clusters config
+	// for domains migrated from active-passive to active-active, we set the failover version to 201
+	activeClusterName := ""
+	if migratedFromActivePassive || cfg == nil {
+		activeClusterName = "cluster0"
+	}
 	return cache.NewDomainCacheEntryForTest(
 		nil,
 		nil,
 		true,
 		&persistence.DomainReplicationConfig{
 			ActiveClusters:    cfg,
-			ActiveClusterName: "cluster0",
+			ActiveClusterName: activeClusterName,
 		},
-		1,
+		201,
 		nil,
 		1,
 		1,

--- a/common/activecluster/types.go
+++ b/common/activecluster/types.go
@@ -59,8 +59,8 @@ type Manager interface {
 	// Active-active domain logic:
 	//  1. Get ActivenessMetadata record of the workflow
 	//     1.a. If it's found, continue with step 2
-	//     1.b. If it's not found, the domain is migrated from active-passive to active-active and workflow is created before migration.
-	//     This case will fallback to active-passive logic and return domain's ActiveClusterName and FailoverVersion.
+	//     1.b. If it's not found and the domain is migrated from active-passive to active-active return domain's ActiveClusterName and FailoverVersion.
+	//     1.c. If it's not found and the domain is not migrated from active-passive to active-active, the workflow must have been retired. Return cluster name and failover version of current region.
 	//  2. Given ActivenessMetadata, return region and failover version
 	//     2.a. If workflow is region sticky (origin=regionA), find active cluster in that region in domain's active cluster config and return its name and failover version.
 	//     2.b. If workflow has external entity, locate the entity from EntityActiveRegion table and return that region and it's failover version.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Active cluster lookup logic is update to handle retired workflows. Details are documented in types.go.

<!-- Tell your future self why have you made these changes -->
**Why?**
Active cluster selection policy is removed when workflow is cleaned up. Requests for such workflow can handled by any cluster. Defaulting to active cluster in current region.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests