### PR TITLE
Fail workflow if pending activity limit exceeds limit

### DIFF
--- a/service/history/decision/task_handler_test.go
+++ b/service/history/decision/task_handler_test.go
@@ -1671,3 +1671,191 @@ func newTaskHandlerForTest(t *testing.T) *taskHandlerImpl {
 	)
 	return taskHandler
 }
+
+func TestHandleFailWorkflowError(t *testing.T) {
+	tests := []struct {
+		name            string
+		expectMockCalls func(taskHandler *taskHandlerImpl)
+		asserts         func(t *testing.T, taskHandler *taskHandlerImpl, err error)
+	}{
+		{
+			name: "success - workflow fails due to too many pending activities",
+			expectMockCalls: func(taskHandler *taskHandlerImpl) {
+				// Mock GetPendingActivityInfos to return some activities
+				pendingActivities := map[int64]*persistence.ActivityInfo{
+					1: {ActivityID: "activity1"},
+					2: {ActivityID: "activity2"},
+					3: {ActivityID: "activity3"},
+				}
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetPendingActivityInfos().Return(pendingActivities)
+
+				// Get the actual config limit value
+				actualLimit := taskHandler.config.PendingActivitiesCountLimitError()
+				expectedDetails := fmt.Sprintf("Pending activities count: 3, limit: %d", actualLimit)
+
+				// Mock AddFailWorkflowEvent
+				expectedFailAttributes := &types.FailWorkflowExecutionDecisionAttributes{
+					Reason:  common.StringPtr("Workflow failed due to too many pending activities"),
+					Details: []byte(expectedDetails),
+				}
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddFailWorkflowEvent(
+					taskHandler.decisionTaskCompletedID,
+					expectedFailAttributes,
+				).Return(&types.HistoryEvent{}, nil)
+			},
+			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, err error) {
+				assert.Nil(t, err)
+				assert.True(t, taskHandler.stopProcessing)
+			},
+		},
+		{
+			name: "failure - AddFailWorkflowEvent returns error",
+			expectMockCalls: func(taskHandler *taskHandlerImpl) {
+				// Mock GetPendingActivityInfos to return some activities
+				pendingActivities := map[int64]*persistence.ActivityInfo{
+					1: {ActivityID: "activity1"},
+				}
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetPendingActivityInfos().Return(pendingActivities)
+
+				// Get the actual config limit value
+				actualLimit := taskHandler.config.PendingActivitiesCountLimitError()
+				expectedDetails := fmt.Sprintf("Pending activities count: 1, limit: %d", actualLimit)
+
+				// Mock AddFailWorkflowEvent to return error
+				expectedFailAttributes := &types.FailWorkflowExecutionDecisionAttributes{
+					Reason:  common.StringPtr("Workflow failed due to too many pending activities"),
+					Details: []byte(expectedDetails),
+				}
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddFailWorkflowEvent(
+					taskHandler.decisionTaskCompletedID,
+					expectedFailAttributes,
+				).Return(nil, errors.New("failed to add fail workflow event"))
+			},
+			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, "failed to add fail workflow event", err.Error())
+				assert.True(t, taskHandler.stopProcessing)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taskHandler := newTaskHandlerForTest(t)
+			if test.expectMockCalls != nil {
+				test.expectMockCalls(taskHandler)
+			}
+
+			err := taskHandler.handleFailWorkflowError()
+			test.asserts(t, taskHandler, err)
+		})
+	}
+}
+
+func TestHandleDecisionScheduleActivityWithTooManyPendingActivities(t *testing.T) {
+	domainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testdata.DomainID, Name: testdata.DomainName},
+		&persistence.DomainConfig{
+			Retention: 1,
+		},
+		cluster.TestCurrentClusterName)
+	executionInfo := &persistence.WorkflowExecutionInfo{
+		DomainID:        testdata.DomainID,
+		WorkflowID:      testdata.WorkflowID,
+		WorkflowTimeout: 100,
+	}
+	validAttr := &types.ScheduleActivityTaskDecisionAttributes{
+		Domain:                        testdata.DomainName,
+		TaskList:                      &types.TaskList{Name: testdata.TaskListName},
+		ActivityID:                    "some-activity-id",
+		ActivityType:                  &types.ActivityType{Name: testdata.ActivityTypeName},
+		ScheduleToCloseTimeoutSeconds: func(i int32) *int32 { return &i }(100),
+		ScheduleToStartTimeoutSeconds: func(i int32) *int32 { return &i }(20),
+		StartToCloseTimeoutSeconds:    func(i int32) *int32 { return &i }(80),
+		Input:                         []byte("some-input"),
+	}
+
+	tests := []struct {
+		name            string
+		expectMockCalls func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes)
+		attributes      *types.ScheduleActivityTaskDecisionAttributes
+		asserts         func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error)
+	}{
+		{
+			name:       "ErrTooManyPendingActivities - workflow fails",
+			attributes: validAttr,
+			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
+				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
+
+				// Mock AddActivityTaskScheduledEvent to return ErrTooManyPendingActivities
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(
+					context.Background(),
+					taskHandler.decisionTaskCompletedID,
+					attr,
+					taskHandler.activityCountToDispatch > 0,
+				).Return(nil, nil, nil, false, false, &types.InternalServiceError{Message: "Too many pending activities"})
+
+				// Mock GetPendingActivityInfos for the failure function
+				pendingActivities := map[int64]*persistence.ActivityInfo{
+					1: {ActivityID: "activity1"},
+					2: {ActivityID: "activity2"},
+				}
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetPendingActivityInfos().Return(pendingActivities)
+
+				// Get the actual config limit value
+				actualLimit := taskHandler.config.PendingActivitiesCountLimitError()
+				expectedDetails := fmt.Sprintf("Pending activities count: 2, limit: %d", actualLimit)
+
+				// Mock AddFailWorkflowEvent
+				expectedFailAttributes := &types.FailWorkflowExecutionDecisionAttributes{
+					Reason:  common.StringPtr("Workflow failed due to too many pending activities"),
+					Details: []byte(expectedDetails),
+				}
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddFailWorkflowEvent(
+					taskHandler.decisionTaskCompletedID,
+					expectedFailAttributes,
+				).Return(&types.HistoryEvent{}, nil)
+			},
+			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error) {
+				assert.Nil(t, err)
+				assert.Nil(t, res)
+				assert.True(t, taskHandler.stopProcessing)
+			},
+		},
+		{
+			name:       "Other InternalServiceError - passes through",
+			attributes: validAttr,
+			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
+				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
+
+				// Mock AddActivityTaskScheduledEvent to return different InternalServiceError
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(
+					context.Background(),
+					taskHandler.decisionTaskCompletedID,
+					attr,
+					taskHandler.activityCountToDispatch > 0,
+				).Return(nil, nil, nil, false, false, &types.InternalServiceError{Message: "Some other internal service error"})
+			},
+			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error) {
+				assert.NotNil(t, err)
+				assert.Equal(t, "Some other internal service error", err.Error())
+				assert.Nil(t, res)
+				assert.False(t, taskHandler.stopProcessing)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taskHandler := newTaskHandlerForTest(t)
+			if test.expectMockCalls != nil {
+				test.expectMockCalls(taskHandler, test.attributes)
+			}
+
+			res, err := taskHandler.handleDecisionScheduleActivity(context.Background(), test.attributes)
+			test.asserts(t, taskHandler, test.attributes, res, err)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

When a workflow tries to schedule too many activities at once, the workflow now fails immediately instead of retrying forever causing retry storm.

<!-- Tell your future self why have you made these changes -->
**Why?**

Before this change, workflows that hit the pending activities limit would keep retrying and eventually timeout. This was confusing and wasted resources. Now the workflow fails right away with a clear error message, making it easier to user to understand what went wrong.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- Added tests to make sure workflows fail properly when they hit the activities limit
- Added tests to make sure other errors still work the same way

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
