### PR TITLE
[CLI] fix domain deprecation security flag to be optional

### DIFF
--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -414,10 +414,7 @@ func (d *domainCLIImpl) DeprecateDomain(c *cli.Context) error {
 		return commoncli.Problem("Required flag not provided: ", err)
 	}
 
-	securityToken, err := getRequiredOption(c, FlagSecurityToken)
-	if err != nil {
-		return commoncli.Problem("Required flag not provided: ", err)
-	}
+	securityToken := c.String(FlagSecurityToken)
 
 	ctx, cancel, err := newContext(c)
 	defer cancel()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

change security token flag to optional

<!-- Tell your future self why have you made these changes -->
**Why?**

domain deprecation command does not require security token. 

```
OPTIONS:
   --security_token value, --st value  Optional token for security check
   --force                             Deprecate domain regardless of domain history. (default: false)
   --help, -h                          show help
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

```
docker-compose -f docker/docker-compose-es.yml up
go run main.go --do some-domain-3 domain register
go run main.go --do some-domain-3 domain deprecate
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
