### PR TITLE
[shard-distributor] Fix election tests not waiting for the election stop

### DIFF
--- a/service/sharddistributor/leader/election/election_test.go
+++ b/service/sharddistributor/leader/election/election_test.go
@@ -116,13 +116,19 @@ func TestElector_Run_Resign(t *testing.T) {
 		p.election.EXPECT().Resign(gomock.Any()).Return(nil)
 		p.cancel()
 		assert.False(t, <-leaderChan)
+		// Wait for the goroutine to exit
+		for range leaderChan {
+		}
 	})
 	t.Run("session_expired", func(t *testing.T) {
 		leaderChan, p := prepareRun(t, nil, nil)
 		p.election.EXPECT().Resign(gomock.Any()).Return(nil)
-		defer p.cancel()
 		close(p.electionCh)
 		assert.False(t, <-leaderChan)
+		p.cancel()
+		// Wait for the goroutine to exit
+		for range leaderChan {
+		}
 	})
 	t.Run("leader_resign", func(t *testing.T) {
 		// Verify onResign is called before resignation
@@ -131,7 +137,7 @@ func TestElector_Run_Resign(t *testing.T) {
 			onResignCalled = true
 			return nil
 		})
-		defer p.cancel()
+
 		// We should be blocked on the timer.
 		p.timeSource.BlockUntil(1)
 
@@ -143,6 +149,10 @@ func TestElector_Run_Resign(t *testing.T) {
 		p.timeSource.Advance(_testLeaderPeriod + 1)
 		p.timeSource.BlockUntil(1)
 		assert.False(t, <-leaderChan)
+		p.cancel()
+		// Wait for the goroutine to exit
+		for range leaderChan {
+		}
 	})
 
 	t.Run("onResign_error", func(t *testing.T) {
@@ -155,7 +165,6 @@ func TestElector_Run_Resign(t *testing.T) {
 		}
 
 		leaderChan, p := prepareRun(t, nil, onResign)
-		defer p.cancel()
 		p.election.EXPECT().Resign(gomock.Any()).Return(nil)
 		// We should be blocked on the timer.
 		p.timeSource.BlockUntil(1)
@@ -167,8 +176,9 @@ func TestElector_Run_Resign(t *testing.T) {
 		assert.True(t, onResignCalled, "OnResign callback should have been called")
 
 		p.cancel()
-		// Wait briefly for goroutines to clean up
-		time.Sleep(10 * time.Millisecond)
+		// Wait for the goroutine to exit
+		for range leaderChan {
+		}
 	})
 	t.Run("OnResign_and_resign_error", func(t *testing.T) {
 		// Set onResign to return an error
@@ -180,7 +190,6 @@ func TestElector_Run_Resign(t *testing.T) {
 		}
 
 		leaderChan, p := prepareRun(t, nil, onResign)
-		defer p.cancel()
 		p.election.EXPECT().Resign(gomock.Any()).Return(fmt.Errorf("failed to resign"))
 		// We should be blocked on the timer.
 		p.timeSource.BlockUntil(1)
@@ -192,8 +201,9 @@ func TestElector_Run_Resign(t *testing.T) {
 		assert.True(t, onResignCalled, "OnResign callback should have been called")
 
 		p.cancel()
-		// Wait briefly for goroutines to clean up
-		time.Sleep(10 * time.Millisecond)
+		// Wait for the goroutine to exit
+		for range leaderChan {
+		}
 	})
 }
 
@@ -207,6 +217,7 @@ type runParams struct {
 	onResign   ProcessFunc
 }
 
+// prepareRun now accepts a logger instance
 func prepareRun(t *testing.T, onLeader, onResign ProcessFunc) (<-chan bool, runParams) {
 	ctrl := gomock.NewController(t)
 	logger := testlogger.New(t)
@@ -343,8 +354,6 @@ func TestOnLeader_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "onLeader")
 	assert.Contains(t, err.Error(), "leader error")
 
-	cancel()
-
-	// Wait briefly for goroutines to clean up
-	time.Sleep(10 * time.Millisecond)
+	// No need to explicitly cancel as the context has a timeout
+	// and we are not testing the main Run loop here, just runElection.
 }

--- a/service/sharddistributor/leader/election/election_test.go
+++ b/service/sharddistributor/leader/election/election_test.go
@@ -217,7 +217,6 @@ type runParams struct {
 	onResign   ProcessFunc
 }
 
-// prepareRun now accepts a logger instance
 func prepareRun(t *testing.T, onLeader, onResign ProcessFunc) (<-chan bool, runParams) {
 	ctrl := gomock.NewController(t)
 	logger := testlogger.New(t)
@@ -353,7 +352,4 @@ func TestOnLeader_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "onLeader")
 	assert.Contains(t, err.Error(), "leader error")
-
-	// No need to explicitly cancel as the context has a timeout
-	// and we are not testing the main Run loop here, just runElection.
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed election tests which could cause race condition.
The issue was subtests not waiting properly for the goroutine to stop. Fixed with draining the channel before final stop.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fixing race in tests

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go test --count=100 -race
PASS
ok  	github.com/uber/cadence/service/sharddistributor/leader/election	1.708s
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
