### PR TITLE
[shard-distributor] Add heartbeat cleanup loop

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -652,7 +652,8 @@ type (
 	}
 
 	LeaderProcess struct {
-		Period time.Duration `yaml:"period"`
+		Period       time.Duration `yaml:"period"`
+		HeartbeatTTL time.Duration `yaml:"heartbeatTTL"`
 	}
 )
 

--- a/common/log/tag/interface.go
+++ b/common/log/tag/interface.go
@@ -44,6 +44,12 @@ func newStringTag(key string, value string) Tag {
 	}
 }
 
+func newStringsTag(key string, value []string) Tag {
+	return Tag{
+		field: zap.Strings(key, value),
+	}
+}
+
 func newInt64(key string, value int64) Tag {
 	return Tag{
 		field: zap.Int64(key, value),

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1164,6 +1164,14 @@ func ShardNamespace(name string) Tag {
 	return newStringTag("shard-namespace", name)
 }
 
+func ShardExecutor(ID string) Tag {
+	return newStringTag("shard-executor", ID)
+}
+
+func ShardExecutors(executorIDs []string) Tag {
+	return newStringsTag("shard-executors", executorIDs)
+}
+
 func ElectionDelay(t time.Duration) Tag {
 	return newDurationTag("election-delay", t)
 }

--- a/service/sharddistributor/config/config.go
+++ b/service/sharddistributor/config/config.go
@@ -75,7 +75,8 @@ type (
 	}
 
 	LeaderProcess struct {
-		Period time.Duration `yaml:"period"`
+		Period       time.Duration `yaml:"period"`
+		HeartbeatTTL time.Duration `yaml:"heartbeatTTL"`
 	}
 )
 

--- a/service/sharddistributor/leader/process/processor.go
+++ b/service/sharddistributor/leader/process/processor.go
@@ -118,36 +118,53 @@ func (p *namespaceProcessor) Terminate(ctx context.Context) error {
 	return nil
 }
 
-// runProcess executes the actual processing logic
+// runProcess launches and manages the independent processing loops.
 func (p *namespaceProcessor) runProcess(ctx context.Context) {
 	defer p.wg.Done()
 
-	// TODO: this should be dynamic config.
+	var loopWg sync.WaitGroup
+	loopWg.Add(2) // We have two loops to manage.
+
+	// Launch the rebalancing process in its own goroutine.
+	go func() {
+		defer loopWg.Done()
+		p.runRebalancingLoop(ctx)
+	}()
+
+	// Launch the heartbeat cleanup process in its own goroutine.
+	go func() {
+		defer loopWg.Done()
+		p.runCleanupLoop(ctx)
+	}()
+
+	// Wait for both loops to exit.
+	loopWg.Wait()
+}
+
+// runRebalancingLoop handles shard assignment and redistribution.
+func (p *namespaceProcessor) runRebalancingLoop(ctx context.Context) {
 	ticker := p.timeSource.NewTicker(p.cfg.Period)
 	defer ticker.Stop()
 
 	// Perform an initial rebalance on startup.
 	p.rebalanceShards(ctx)
 
-	// Subscribe to state changes from the store.
 	updateChan, err := p.shardStore.Subscribe(ctx)
 	if err != nil {
-		p.logger.Error("Failed to subscribe to state changes, stopping process.", tag.Error(err))
+		p.logger.Error("Failed to subscribe to state changes, stopping rebalancing loop.", tag.Error(err))
 		return
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			p.logger.Info("Process cancelled")
+			p.logger.Info("Rebalancing loop cancelled.")
 			return
 		case latestRevision, ok := <-updateChan:
 			if !ok {
-				p.logger.Info("Update channel closed, stopping process.")
+				p.logger.Info("Update channel closed, stopping rebalancing loop.")
 				return
 			}
-			// If the incoming notification's revision is not newer than what we've
-			// already successfully processed, we can safely ignore this trigger.
 			if latestRevision <= p.lastAppliedRevision {
 				continue
 			}
@@ -156,6 +173,56 @@ func (p *namespaceProcessor) runProcess(ctx context.Context) {
 		case <-ticker.Chan():
 			p.logger.Info("Periodic reconciliation triggered, rebalancing.")
 			p.rebalanceShards(ctx)
+		}
+	}
+}
+
+// runCleanupLoop periodically removes stale executors.
+func (p *namespaceProcessor) runCleanupLoop(ctx context.Context) {
+	ticker := p.timeSource.NewTicker(p.cfg.HeartbeatTTL)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Cleanup loop cancelled.")
+			return
+		case <-ticker.Chan():
+			p.logger.Info("Periodic heartbeat cleanup triggered.")
+			p.cleanupStaleExecutors(ctx)
+		}
+	}
+}
+
+// cleanupStaleExecutors removes executors who have not reported a heartbeat recently.
+func (p *namespaceProcessor) cleanupStaleExecutors(ctx context.Context) {
+	// 1. Get the current heartbeat states. We don't need assignments for this operation.
+	heartbeatStates, _, _, err := p.shardStore.GetState(ctx)
+	if err != nil {
+		p.logger.Error("Failed to get state for heartbeat cleanup", tag.Error(err))
+		return
+	}
+
+	// 2. Identify expired executors.
+	var expiredExecutors []string
+	now := p.timeSource.Now().Unix()
+	heartbeatTTL := int64(p.cfg.HeartbeatTTL.Seconds())
+
+	for executorID, state := range heartbeatStates {
+		if (now - state.LastHeartbeat) > heartbeatTTL {
+			expiredExecutors = append(expiredExecutors, executorID)
+		}
+	}
+
+	if len(expiredExecutors) == 0 {
+		return // Nothing to do.
+	}
+
+	p.logger.Info("Removing stale executor", tag.ShardExecutors(expiredExecutors))
+	// 3. Remove the stale executors from the store.
+	for _, executorID := range expiredExecutors {
+		if err := p.shardStore.DeleteExecutor(ctx, executorID); err != nil {
+			p.logger.Error("Failed to delete stale executor", tag.Error(err), tag.ShardExecutor(executorID))
 		}
 	}
 }

--- a/service/sharddistributor/leader/store/etcd/shardstore.go
+++ b/service/sharddistributor/leader/store/etcd/shardstore.go
@@ -185,6 +185,21 @@ func (s *shardStore) Subscribe(ctx context.Context) (<-chan int64, error) {
 	return revisionChan, nil
 }
 
+// DeleteExecutor removes all keys associated with a specific executor.
+func (s *shardStore) DeleteExecutor(ctx context.Context, executorID string) error {
+	client := s.session.Client()
+
+	// The prefix for a single executor, e.g., /.../executors/executor-1/
+	executorPrefix := fmt.Sprintf("%s%s/", s.buildExecutorPrefix(), executorID)
+
+	// Delete all keys under this prefix.
+	_, err := client.Delete(ctx, executorPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("failed to delete executor %s from etcd: %w", executorID, err)
+	}
+	return nil
+}
+
 // buildExecutorPrefix returns the etcd prefix for all executors in this namespace
 func (s *shardStore) buildExecutorPrefix() string {
 	return fmt.Sprintf("%s/executors/", s.prefix)

--- a/service/sharddistributor/leader/store/store.go
+++ b/service/sharddistributor/leader/store/store.go
@@ -38,6 +38,8 @@ type ShardStore interface {
 	// Subscribe returns a channel that signals when a state change occurs.
 	// The channel sends a latest revision for notification.
 	Subscribe(ctx context.Context) (<-chan int64, error)
+	// DeleteExecutor removes all keys associated with a given executorID.
+	DeleteExecutor(ctx context.Context, executorID string) error
 }
 
 // Impl could be used to build an implementation in the registry.

--- a/service/sharddistributor/leader/store/store_mock.go
+++ b/service/sharddistributor/leader/store/store_mock.go
@@ -188,6 +188,20 @@ func (mr *MockShardStoreMockRecorder) AssignShards(ctx, newState any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignShards", reflect.TypeOf((*MockShardStore)(nil).AssignShards), ctx, newState)
 }
 
+// DeleteExecutor mocks base method.
+func (m *MockShardStore) DeleteExecutor(ctx context.Context, executorID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteExecutor", ctx, executorID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteExecutor indicates an expected call of DeleteExecutor.
+func (mr *MockShardStoreMockRecorder) DeleteExecutor(ctx, executorID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExecutor", reflect.TypeOf((*MockShardStore)(nil).DeleteExecutor), ctx, executorID)
+}
+
 // GetState mocks base method.
 func (m *MockShardStore) GetState(ctx context.Context) (map[string]HeartbeatState, map[string]AssignedState, int64, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding heartbeat cleanup loop.
We want to avoid extra writes to ETCD, so we perform manual batch cleanup for the heartbeats.

<!-- Tell your future self why have you made these changes -->
**Why?**
Heartbeat cleanup is a part of shard executor lifecycle. If shard executor stops reporting health to the shard distributor, we need to reallocate shards to other executors.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
