### PR TITLE
[wf-describe]Fix negative ExpirationTimestamp when activity retry has no expiration

### DIFF
--- a/service/history/engine/engineimpl/describe_workflow_execution.go
+++ b/service/history/engine/engineimpl/describe_workflow_execution.go
@@ -156,7 +156,9 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(
 			}
 			if ai.HasRetryPolicy {
 				p.Attempt = ai.Attempt
-				p.ExpirationTimestamp = common.Int64Ptr(ai.ExpirationTime.UnixNano())
+				if !ai.ExpirationTime.IsZero() {
+					p.ExpirationTimestamp = common.Int64Ptr(ai.ExpirationTime.UnixNano())
+				}
 				if ai.MaximumAttempts != 0 {
 					p.MaximumAttempts = ai.MaximumAttempts
 				}


### PR DESCRIPTION
When activities have retry policies without expiration time, ExpirationTime remains as zero time.Time. And calling UnixNano() on zero time returns a large negative value which gets converted to 30th of Aug 1754.

<!-- Describe what has changed in this PR -->
**What changed?**
Added IsZero() check to only set ExpirationTimestamp when a valid expiration time exists.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
