### PR TITLE
Active-passive to active-active domain migration support

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -640,7 +640,7 @@ func (d *handlerImpl) UpdateDomain(
 					now,
 					failoverType,
 					&currentActiveCluster,
-					updateRequest.ActiveClusterName,
+					nil,
 					currentActiveClusters,
 					replicationConfig.ActiveClusters,
 				))

--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -827,12 +827,23 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateGetDomai
 	s.Nil(err)
 
 	var failoverHistory []FailoverEvent
-	failoverHistory = append(failoverHistory, FailoverEvent{EventTime: s.handler.timeSource.Now(), FromCluster: prevActiveClusterName, ToCluster: nextActiveClusterName, FailoverType: constants.FailoverType(constants.FailoverTypeForce).String()})
+	failoverHistory = append(failoverHistory, FailoverEvent{
+		EventTime:    s.handler.timeSource.Now(),
+		FromCluster:  prevActiveClusterName,
+		ToCluster:    nextActiveClusterName,
+		FailoverType: constants.FailoverType(constants.FailoverTypeForce).String(),
+	})
 	failoverHistoryJSON, _ := json.Marshal(failoverHistory)
 	data[constants.DomainDataKeyForFailoverHistory] = string(failoverHistoryJSON)
 
-	fnTest := func(info *types.DomainInfo, config *types.DomainConfiguration,
-		replicationConfig *types.DomainReplicationConfiguration, isGlobalDomain bool, failoverVersion int64) {
+	fnTest := func(
+		info *types.DomainInfo,
+		config *types.DomainConfiguration,
+		replicationConfig *types.DomainReplicationConfiguration,
+		isGlobalDomain bool,
+		failoverVersion int64) {
+
+		s.T().Helper()
 		s.NotEmpty(info.GetUUID())
 		info.UUID = ""
 		s.Equal(&types.DomainInfo{

--- a/common/domain/replicationTaskExecutor.go
+++ b/common/domain/replicationTaskExecutor.go
@@ -263,9 +263,9 @@ func (h *domainReplicationTaskExecutorImpl) handleDomainUpdateReplicationTask(ct
 		request.ConfigVersion = task.GetConfigVersion()
 	}
 
-	// TODO: remove this log after testing
-	h.logger.Debugf("task.GetFailoverVersion(): %d, resp.FailoverVersion: %d", task.GetFailoverVersion(), resp.FailoverVersion)
-
+	// TODO(active-active): Domain's failover version has to be updated for the below case.
+	// However active-active domains don't need that field at all. We still increment it in domain handler whenever ActiveClusters change.
+	// Find another mechanism to indicate ActiveClusters changed and don't touch domain's top level failover version for active-active domains.
 	if resp.FailoverVersion < task.GetFailoverVersion() {
 		recordUpdated = true
 		request.ReplicationConfig.ActiveClusterName = task.ReplicationConfig.GetActiveClusterName()

--- a/common/domain/replicationTaskExecutor.go
+++ b/common/domain/replicationTaskExecutor.go
@@ -260,12 +260,16 @@ func (h *domainReplicationTaskExecutorImpl) handleDomainUpdateReplicationTask(ct
 			request.Config.BadBinaries = *task.Config.GetBadBinaries()
 		}
 		request.ReplicationConfig.Clusters = h.convertClusterReplicationConfigFromThrift(task.ReplicationConfig.Clusters)
-		request.ReplicationConfig.ActiveClusters = task.ReplicationConfig.GetActiveClusters()
 		request.ConfigVersion = task.GetConfigVersion()
 	}
+
+	// TODO: remove this log after testing
+	h.logger.Debugf("task.GetFailoverVersion(): %d, resp.FailoverVersion: %d", task.GetFailoverVersion(), resp.FailoverVersion)
+
 	if resp.FailoverVersion < task.GetFailoverVersion() {
 		recordUpdated = true
 		request.ReplicationConfig.ActiveClusterName = task.ReplicationConfig.GetActiveClusterName()
+		request.ReplicationConfig.ActiveClusters = task.ReplicationConfig.GetActiveClusters()
 		request.FailoverVersion = task.GetFailoverVersion()
 		request.FailoverNotificationVersion = notificationVersion
 		request.PreviousFailoverVersion = task.GetPreviousFailoverVersion()

--- a/common/domain/transmissionTaskHandler.go
+++ b/common/domain/transmissionTaskHandler.go
@@ -119,6 +119,9 @@ func (domainReplicator *domainReplicatorImpl) HandleTransmissionTask(
 		PreviousFailoverVersion: previousFailoverVersion,
 	}
 
+	// TODO: remove this log after testing
+	domainReplicator.logger.Debugf("publishing domain update message with active clusters %#v", task.ReplicationConfig.ActiveClusters)
+
 	return domainReplicator.replicationMessageSink.Publish(
 		ctx,
 		&types.ReplicationTask{

--- a/common/domain/transmissionTaskHandler.go
+++ b/common/domain/transmissionTaskHandler.go
@@ -119,9 +119,6 @@ func (domainReplicator *domainReplicatorImpl) HandleTransmissionTask(
 		PreviousFailoverVersion: previousFailoverVersion,
 	}
 
-	// TODO: remove this log after testing
-	domainReplicator.logger.Debugf("publishing domain update message with active clusters %#v", task.ReplicationConfig.ActiveClusters)
-
 	return domainReplicator.replicationMessageSink.Publish(
 		ctx,
 		&types.ReplicationTask{

--- a/config/dynamicconfig/replication_simulation_activeactive_regional_failover.yml
+++ b/config/dynamicconfig/replication_simulation_activeactive_regional_failover.yml
@@ -1,0 +1,18 @@
+# This file is used as dynamicconfig override for "activeactive" replication simulation scenario configured via host/testdata/replication_simulation_activeactive.yaml
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"
+history.replicatorTaskBatchSize:
+  - value: 25
+    constraints: {}
+frontend.failoverCoolDown:
+  - value: 5s
+history.ReplicationTaskProcessorStartWait: # default is 5s. repl task processor sleeps this much before processing received messages.
+  - value: 10ms
+history.standbyTaskMissingEventsResendDelay:
+  - value: 5s
+history.standbyTaskMissingEventsDiscardDelay:
+  - value: 10s
+history.standbyClusterDelay:
+  - value: 10s

--- a/config/dynamicconfig/replication_simulation_activepassive_to_activeactive.yml
+++ b/config/dynamicconfig/replication_simulation_activepassive_to_activeactive.yml
@@ -1,0 +1,18 @@
+# This file is used as dynamicconfig override for "activeactive" replication simulation scenario configured via host/testdata/replication_simulation_activeactive.yaml
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"
+history.replicatorTaskBatchSize:
+  - value: 25
+    constraints: {}
+frontend.failoverCoolDown:
+  - value: 5s
+history.ReplicationTaskProcessorStartWait: # default is 5s. repl task processor sleeps this much before processing received messages.
+  - value: 10ms
+history.standbyTaskMissingEventsResendDelay:
+  - value: 5s
+history.standbyTaskMissingEventsDiscardDelay:
+  - value: 10s
+history.standbyClusterDelay:
+  - value: 10s

--- a/docs/design/active-active/active-active.md
+++ b/docs/design/active-active/active-active.md
@@ -367,6 +367,41 @@ There's no change in the failover version to cluster mapping in entity failovers
 However, new task versions of workflows belonging to "seattle" entity will be 3 from now on and therefore they will be active in cluster3.
 
 
+**4. Active-passive to active-active migration:**
+
+When an active-passive domain is migrated to active-active,
+- The domain record will have the `ActiveClusters` field set
+- The existing `ActiveClusterName` field will be left as is.
+- The failover version of the domain will be incremented. Even though this is not used for task versions for active-active domains, it's incremented to indicate there was a change in replication config.
+
+
+Before migration:
+```
+ActiveClusterName: cluster0,
+FailoverVersion: 0
+```
+
+After migration:
+```
+ActiveClusterName: cluster0,
+FailoverVersion: 100,
+ActiveClusters:  {
+    RegionToClusterMap: {
+        us-west: {
+            ActiveClusterName: cluster0,
+            FailoverVersion: 0,
+        },
+        us-east: {
+            ActiveClusterName: cluster3,
+            FailoverVersion: 6,
+        },
+    },
+}
+```
+
+
+
+
 ### API Call Forwarding
 
 Cadence frontend proxies some API calls to the active cluster of the domain. Currently, this request to cluster lookup is done by checking the failover version of the active-passive domain.

--- a/service/frontend/api/domain_handlers.go
+++ b/service/frontend/api/domain_handlers.go
@@ -121,6 +121,9 @@ func (wh *WorkflowHandler) UpdateDomain(
 		isGraceFailover,
 		updateRequest))
 
+	// TODO: remove this log after testing
+	logger.Debugf("updateRequest.ActiveClusters: %#v", updateRequest.ActiveClusters)
+
 	if isGraceFailover {
 		if err := wh.checkOngoingFailover(
 			ctx,

--- a/service/frontend/api/domain_handlers.go
+++ b/service/frontend/api/domain_handlers.go
@@ -121,9 +121,6 @@ func (wh *WorkflowHandler) UpdateDomain(
 		isGraceFailover,
 		updateRequest))
 
-	// TODO: remove this log after testing
-	logger.Debugf("updateRequest.ActiveClusters: %#v", updateRequest.ActiveClusters)
-
 	if isGraceFailover {
 		if err := wh.checkOngoingFailover(
 			ctx,

--- a/simulation/replication/testdata/replication_simulation_activeactive_regional_failover.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive_regional_failover.yaml
@@ -38,6 +38,14 @@ operations:
     workflowExecutionStartToCloseTimeout: 65s
     workflowDuration: 35s
 
+  # failover from cluster0 to cluster1
+  - op: change_active_clusters
+    at: 20s
+    domain: test-domain-aa
+    newActiveClustersByRegion:
+      region0: cluster1 # this is changed from cluster0 to cluster1
+      region1: cluster1
+
   # validate that wf1 is started in cluster0 and completed in cluster1
   - op: validate
     at: 70s
@@ -47,7 +55,7 @@ operations:
     want:
       status: completed
       startedByWorkersInCluster: cluster0
-      completedByWorkersInCluster: cluster0
+      completedByWorkersInCluster: cluster1
 
   # validate that wf2 is started and completed in cluster1
   - op: validate

--- a/simulation/replication/testdata/replication_simulation_activepassive_to_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activepassive_to_activeactive.yaml
@@ -1,0 +1,64 @@
+# This file is a replication simulation scenario spec.
+# It is parsed into ReplicationSimulationConfig struct.
+# Replication simulation for this file can be run via ./simulation/replication/run.sh activepassive_to_activeactive
+# Dynamic config overrides can be set via config/dynamicconfig/replication_simulation_activepassive_to_activeactive.yml
+clusters:
+  cluster0:
+    grpcEndpoint: "cadence-cluster0:7833"
+  cluster1:
+    grpcEndpoint: "cadence-cluster1:7833"
+
+# primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
+primaryCluster: "cluster0"
+
+domains:
+  test-domain:
+    activeClusterName: cluster0
+
+
+operations:
+  # start wf1 for active-passive domain and validate it runs in cluster0
+  - op: start_workflow
+    at: 0s
+    workflowType: timer-activity-loop-workflow
+    workflowID: wf1
+    cluster: cluster0
+    domain: test-domain
+    workflowExecutionStartToCloseTimeout: 60s
+    workflowDuration: 30s
+  - op: validate
+    at: 35s
+    workflowID: wf1
+    cluster: cluster0
+    domain: test-domain
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster0
+      completedByWorkersInCluster: cluster0
+
+  # migrate domain to active-active
+  - op: migrate_domain_to_active_active
+    at: 40s
+    domain: test-domain
+    newActiveClusters:
+      region0: cluster0
+      region1: cluster1
+
+  # start wf2 for active-active domain and validate it runs in cluster1
+  - op: start_workflow
+    at: 45s
+    workflowType: timer-activity-loop-workflow
+    workflowID: wf2
+    cluster: cluster1
+    domain: test-domain
+    workflowExecutionStartToCloseTimeout: 60s
+    workflowDuration: 30s
+  - op: validate
+    at: 80s
+    workflowID: wf2
+    cluster: cluster1
+    domain: test-domain
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster1
+      completedByWorkersInCluster: cluster1

--- a/simulation/replication/testdata/replication_simulation_activepassive_to_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activepassive_to_activeactive.yaml
@@ -17,17 +17,18 @@ domains:
 
 
 operations:
-  # start wf1 for active-passive domain and validate it runs in cluster0
+  # start wf1 for active-passive domain and validate it runs in cluster0 smoothly
+  # while the domain is migrating to active-active
   - op: start_workflow
     at: 0s
     workflowType: timer-activity-loop-workflow
     workflowID: wf1
     cluster: cluster0
     domain: test-domain
-    workflowExecutionStartToCloseTimeout: 60s
-    workflowDuration: 30s
+    workflowExecutionStartToCloseTimeout: 90s
+    workflowDuration: 60s
   - op: validate
-    at: 35s
+    at: 100s
     workflowID: wf1
     cluster: cluster0
     domain: test-domain

--- a/simulation/replication/testdata/replication_simulation_activepassive_to_activeactive.yaml
+++ b/simulation/replication/testdata/replication_simulation_activepassive_to_activeactive.yaml
@@ -40,13 +40,14 @@ operations:
   - op: migrate_domain_to_active_active
     at: 40s
     domain: test-domain
-    newActiveClusters:
+    newActiveClustersByRegion:
       region0: cluster0
       region1: cluster1
 
-  # start wf2 for active-active domain and validate it runs in cluster1
+  # wait a bit so domain data is replicated to cluster1,
+  # and start wf2 for active-active domain and validate it runs in cluster1
   - op: start_workflow
-    at: 45s
+    at: 75s
     workflowType: timer-activity-loop-workflow
     workflowID: wf2
     cluster: cluster1
@@ -54,7 +55,7 @@ operations:
     workflowExecutionStartToCloseTimeout: 60s
     workflowDuration: 30s
   - op: validate
-    at: 80s
+    at: 110s
     workflowID: wf2
     cluster: cluster1
     domain: test-domain

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -44,12 +44,13 @@ import (
 type ReplicationSimulationOperation string
 
 const (
-	ReplicationSimulationOperationStartWorkflow           ReplicationSimulationOperation = "start_workflow"
-	ReplicationSimulationOperationResetWorkflow           ReplicationSimulationOperation = "reset_workflow"
-	ReplicationSimulationOperationChangeActiveClusters    ReplicationSimulationOperation = "change_active_clusters"
-	ReplicationSimulationOperationValidate                ReplicationSimulationOperation = "validate"
-	ReplicationSimulationOperationQueryWorkflow           ReplicationSimulationOperation = "query_workflow"
-	ReplicationSimulationOperationSignalWithStartWorkflow ReplicationSimulationOperation = "signal_with_start_workflow"
+	ReplicationSimulationOperationStartWorkflow               ReplicationSimulationOperation = "start_workflow"
+	ReplicationSimulationOperationResetWorkflow               ReplicationSimulationOperation = "reset_workflow"
+	ReplicationSimulationOperationChangeActiveClusters        ReplicationSimulationOperation = "change_active_clusters"
+	ReplicationSimulationOperationValidate                    ReplicationSimulationOperation = "validate"
+	ReplicationSimulationOperationQueryWorkflow               ReplicationSimulationOperation = "query_workflow"
+	ReplicationSimulationOperationSignalWithStartWorkflow     ReplicationSimulationOperation = "signal_with_start_workflow"
+	ReplicationSimulationOperationMigrateDomainToActiveActive ReplicationSimulationOperation = "migrate_domain_to_active_active"
 )
 
 type ReplicationSimulationConfig struct {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Updated replication simulation to support active-passive to active-active domain update operation
- Updated domain handler to support this case
	- Carry over domain's failover version to the corresponding entry in ActiveClusterbyRegion map
	- Increment top level failover version to indicate a cluster change/failover event occurred. Domain update propagation needs this.
- Update failover history entries to record 3 types of events:
	- active-passive domain failover
	- active-active domain failover 
	- active-passive to active-active migration

<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid requiring creating new domains to leverage active-active mode by supporting migration

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests for domain handler
- active-passive to active-active simulation: Validates domain is functioning as active-active afterwards
- active-active regional failover: Validates that we can do regional failover for active-active domains. e.g. region0-> region1. Workflows previously active on the cluster in region0 are resumed on the cluster in region1
