### PR TITLE
Add active-active basic simulation as CI job

### DIFF
--- a/.github/workflows/replication-simulation.yml
+++ b/.github/workflows/replication-simulation.yml
@@ -22,9 +22,36 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           max_attempts: 2
-          timeout_minutes: 30
+          timeout_minutes: 20
           command: |
             ./simulation/replication/run.sh clusterredirection
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./test.log
+
+  active-active:
+    name: Active-active basic checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.4'
+
+      - name: Run simulation
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 2
+          timeout_minutes: 20
+          command: |
+            ./simulation/replication/run.sh activeactive
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adding a new github action job to validate active-active basic simulation. 
Local equivalent: `./simulation/replication/run.sh activeactive`.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Validated the job running as part of this PR.
