### PR TITLE
[domain-deletion]Drop graceful failover markers when domain is deprecated

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1471,6 +1471,16 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 			s.RUnlock()
 			return nil, err
 		}
+
+		// Check if the domain is deprecated
+		if domainEntry.GetInfo() != nil && domainEntry.GetInfo().Status == persistence.DomainStatusDeprecated {
+			s.logger.Info("Domain is deprecated marking failover marker for cleanup",
+				tag.WorkflowDomainName(domainEntry.GetInfo().Name),
+				tag.WorkflowDomainID(marker.GetDomainID()))
+			completedFailoverMarkers[marker] = struct{}{}
+			continue
+		}
+
 		isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 		if isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
 			completedFailoverMarkers[marker] = struct{}{}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -873,6 +873,7 @@ func (s *contextTestSuite) TestAppendHistoryV2Events() {
 }
 
 func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
+	// This test verifies that failover markers are processed when a domain becomes active
 	domainFailoverVersion := 100
 	domainCacheEntryInactiveCluster := cache.NewGlobalDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
@@ -911,9 +912,67 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 
 	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryActiveCluster, nil)
 
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+
 	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
 	s.NoError(err)
 	s.Empty(pendingFailoverMarkers, "all pending failover tasks should be cleaned up")
+}
+
+func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain() {
+	// This test verifies that failover markers are dropped (not processed) when a domain is deprecated
+	domainFailoverVersion := 100
+	domainCacheEntryInactiveCluster := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName, // active is TestCurrentClusterName
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+	)
+	domainCacheEntryActiveCluster := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName, // active cluster
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+	)
+	domainCacheEntryInactiveCluster.GetInfo().Status = persistence.DomainStatusDeprecated
+	domainCacheEntryActiveCluster.GetInfo().Status = persistence.DomainStatusDeprecated
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactiveCluster, nil).Times(2)
+
+	failoverMarker := types.FailoverMarkerAttributes{
+		DomainID:        testDomainID,
+		FailoverVersion: int64(domainFailoverVersion),
+	}
+
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+
+	// adding failover marker
+	domainFailoverVersion += 1
+	s.NoError(s.context.AddingPendingFailoverMarker(&failoverMarker))
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1, "we should have one failover marker saved since the cluster is not active")
+
+	// adding more failover markers
+	domainFailoverVersion += 1
+	s.NoError(s.context.AddingPendingFailoverMarker(&failoverMarker))
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryActiveCluster, nil).Times(2)
+
+	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
+	s.NoError(err)
+	s.Empty(pendingFailoverMarkers, "pending failover markers should be dropped when the domain is deprecated")
+	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "pending failover markers should be dropped from shard info when domain is deprecated")
 }
 
 func (s *contextTestSuite) TestGetAndUpdateProcessingQueueStates() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added domain status check in validate and update failover markers. If the domain is in a deprecated state all the markers will be marked as completed to drop them. 

<!-- Tell your future self why have you made these changes -->
**Why?**
There was an issue during the domain deletion, migrated domain, which was deprecated long time ago, was deleted, but it still had pending failover markers. There was no impact on the server side, but task processing was populating a lot of errors because of this. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
