### PR TITLE
add unit test for not like query in custom search attributes

### DIFF
--- a/common/elasticsearch/validator/queryValidator_test.go
+++ b/common/elasticsearch/validator/queryValidator_test.go
@@ -166,8 +166,8 @@ func TestValidateQuery(t *testing.T) {
 			},
 		},
 		{
-			msg:   "custom string search attribute support not like",
-			query: "CustomStringField not like 'value'",
+			msg:       "custom string search attribute support not like",
+			query:     "CustomStringField not like 'value'",
 			validated: "`Attr.CustomStringField` not like 'value'",
 			dcValid: map[string]interface{}{
 				"CustomStringField": types.IndexedValueTypeString,

--- a/common/elasticsearch/validator/queryValidator_test.go
+++ b/common/elasticsearch/validator/queryValidator_test.go
@@ -165,6 +165,14 @@ func TestValidateQuery(t *testing.T) {
 				"Custom-Field": types.IndexedValueTypeString,
 			},
 		},
+		{
+			msg:   "custom string search attribute support not like",
+			query: "CustomStringField not like 'value'",
+			validated: "`Attr.CustomStringField` not like 'value'",
+			dcValid: map[string]interface{}{
+				"CustomStringField": types.IndexedValueTypeString,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

unit test only change

<!-- Tell your future self why have you made these changes -->
**Why?**

not like query is already supported in custom string type search attributes. Adding a unit test for awareness

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
