### PR TITLE
Add cronOverlapPolicy and activeClusterSelectionPolicy to mapping functions in replication and mutable statue builder

### DIFF
--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -504,6 +504,7 @@ func getStartRequest(
 		DelayStartSeconds:                   request.DelayStartSeconds,
 		JitterStartSeconds:                  request.JitterStartSeconds,
 		FirstRunAtTimeStamp:                 request.FirstRunAtTimestamp,
+		ActiveClusterSelectionPolicy:        request.ActiveClusterSelectionPolicy,
 	}
 
 	return common.CreateHistoryStartWorkflowRequest(domainID, req, time.Now(), partitionConfig)

--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -497,6 +497,7 @@ func getStartRequest(
 		WorkflowIDReusePolicy:               request.WorkflowIDReusePolicy,
 		RetryPolicy:                         request.RetryPolicy,
 		CronSchedule:                        request.CronSchedule,
+		CronOverlapPolicy:                   request.CronOverlapPolicy,
 		Memo:                                request.Memo,
 		SearchAttributes:                    request.SearchAttributes,
 		Header:                              request.Header,

--- a/service/history/execution/mutable_state_builder_methods_started.go
+++ b/service/history/execution/mutable_state_builder_methods_started.go
@@ -78,6 +78,7 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
 		Memo:                                attributes.Memo,
 		SearchAttributes:                    attributes.SearchAttributes,
 		JitterStartSeconds:                  attributes.JitterStartSeconds,
+		CronOverlapPolicy:                   attributes.CronOverlapPolicy,
 		ActiveClusterSelectionPolicy:        attributes.ActiveClusterSelectionPolicy,
 	}
 
@@ -244,6 +245,10 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(
 		e.executionInfo.InitiatedID = event.GetParentInitiatedEventID()
 	} else {
 		e.executionInfo.InitiatedID = constants.EmptyEventID
+	}
+
+	if event.CronOverlapPolicy != nil {
+		e.executionInfo.CronOverlapPolicy = *event.CronOverlapPolicy
 	}
 
 	e.executionInfo.Attempt = event.GetAttempt()

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1633,16 +1633,17 @@ func startWorkflowWithRetry(
 		ExecutionStartToCloseTimeoutSeconds: attributes.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      attributes.TaskStartToCloseTimeoutSeconds,
 		// Use the same request ID to dedupe StartWorkflowExecution calls
-		RequestID:             requestID,
-		WorkflowIDReusePolicy: attributes.WorkflowIDReusePolicy,
-		RetryPolicy:           attributes.RetryPolicy,
-		CronSchedule:          attributes.CronSchedule,
-		CronOverlapPolicy:     attributes.CronOverlapPolicy,
-		Memo:                  attributes.Memo,
-		SearchAttributes:      attributes.SearchAttributes,
-		DelayStartSeconds:     attributes.DelayStartSeconds,
-		JitterStartSeconds:    attributes.JitterStartSeconds,
-		FirstRunAtTimeStamp:   attributes.FirstRunAtTimestamp,
+		RequestID:                    requestID,
+		WorkflowIDReusePolicy:        attributes.WorkflowIDReusePolicy,
+		RetryPolicy:                  attributes.RetryPolicy,
+		CronSchedule:                 attributes.CronSchedule,
+		CronOverlapPolicy:            attributes.CronOverlapPolicy,
+		Memo:                         attributes.Memo,
+		SearchAttributes:             attributes.SearchAttributes,
+		DelayStartSeconds:            attributes.DelayStartSeconds,
+		JitterStartSeconds:           attributes.JitterStartSeconds,
+		FirstRunAtTimeStamp:          attributes.FirstRunAtTimestamp,
+		ActiveClusterSelectionPolicy: attributes.ActiveClusterSelectionPolicy,
 	}
 
 	historyStartReq, err := common.CreateHistoryStartWorkflowRequest(task.TargetDomainID, frontendStartReq, timeSource.Now(), partitionConfig)

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1637,6 +1637,7 @@ func startWorkflowWithRetry(
 		WorkflowIDReusePolicy: attributes.WorkflowIDReusePolicy,
 		RetryPolicy:           attributes.RetryPolicy,
 		CronSchedule:          attributes.CronSchedule,
+		CronOverlapPolicy:     attributes.CronOverlapPolicy,
 		Memo:                  attributes.Memo,
 		SearchAttributes:      attributes.SearchAttributes,
 		DelayStartSeconds:     attributes.DelayStartSeconds,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added missing `CronOverlapPolicy` and `ActiveClusterSelectionPolicy` field to mapping functions in three locations:
- `start_workflow_execution.go`: Added to `getStartRequest` function
- `mutable_state_builder_methods_started.go`: Added to `addWorkflowExecutionStartedEventForContinueAsNew` and `ReplicateWorkflowExecutionStartedEvent` functions  
- `transfer_active_task_executor.go`: Added to `startWorkflowWithRetry` function

<!-- Tell your future self why have you made these changes -->
**Why?**
The `CronOverlapPolicy` and `ActiveClusterSelectionPolicy` fields were missing.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
