### PR TITLE
[Wf-Diagnostics] Keep single link to runbook instead of list

### DIFF
--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -60,7 +60,7 @@ type DiagnosticsWorkflowResult struct {
 type timeoutDiagnostics struct {
 	Issues    []*timeoutIssuesResult
 	RootCause []*timeoutRootCauseResult
-	Runbooks  []string
+	Runbooks  string
 }
 
 type timeoutIssuesResult struct {
@@ -79,7 +79,7 @@ type timeoutRootCauseResult struct {
 type failureDiagnostics struct {
 	Issues    []*failureIssuesResult
 	RootCause []*failureRootCauseResult
-	Runbooks  []string
+	Runbooks  string
 }
 
 type failureIssuesResult struct {
@@ -97,7 +97,7 @@ type failureRootCauseResult struct {
 
 type retryDiagnostics struct {
 	Issues   []*retryIssuesResult
-	Runbooks []string
+	Runbooks string
 }
 
 type retryIssuesResult struct {
@@ -158,7 +158,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		timeoutsResult = &timeoutDiagnostics{
 			Issues:    timeoutIssues,
 			RootCause: timeoutRootCause,
-			Runbooks:  []string{linkToTimeoutsRunbook},
+			Runbooks:  linkToTimeoutsRunbook,
 		}
 	}
 
@@ -175,7 +175,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		failureResult = &failureDiagnostics{
 			Issues:    failureIssues,
 			RootCause: failureRootCause,
-			Runbooks:  []string{linkToFailuresRunbook},
+			Runbooks:  linkToFailuresRunbook,
 		}
 	}
 
@@ -187,7 +187,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	if len(retryIssues) > 0 {
 		retryResult = &retryDiagnostics{
 			Issues:   retryIssues,
-			Runbooks: []string{linkToRetriesRunbook},
+			Runbooks: linkToRetriesRunbook,
 		}
 	}
 

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -60,7 +60,7 @@ type DiagnosticsWorkflowResult struct {
 type timeoutDiagnostics struct {
 	Issues    []*timeoutIssuesResult
 	RootCause []*timeoutRootCauseResult
-	Runbooks  string
+	Runbook   string
 }
 
 type timeoutIssuesResult struct {
@@ -79,7 +79,7 @@ type timeoutRootCauseResult struct {
 type failureDiagnostics struct {
 	Issues    []*failureIssuesResult
 	RootCause []*failureRootCauseResult
-	Runbooks  string
+	Runbook   string
 }
 
 type failureIssuesResult struct {
@@ -96,8 +96,8 @@ type failureRootCauseResult struct {
 }
 
 type retryDiagnostics struct {
-	Issues   []*retryIssuesResult
-	Runbooks string
+	Issues  []*retryIssuesResult
+	Runbook string
 }
 
 type retryIssuesResult struct {
@@ -158,7 +158,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		timeoutsResult = &timeoutDiagnostics{
 			Issues:    timeoutIssues,
 			RootCause: timeoutRootCause,
-			Runbooks:  linkToTimeoutsRunbook,
+			Runbook:   linkToTimeoutsRunbook,
 		}
 	}
 
@@ -175,7 +175,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		failureResult = &failureDiagnostics{
 			Issues:    failureIssues,
 			RootCause: failureRootCause,
-			Runbooks:  linkToFailuresRunbook,
+			Runbook:   linkToFailuresRunbook,
 		}
 	}
 
@@ -186,8 +186,8 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 
 	if len(retryIssues) > 0 {
 		retryResult = &retryDiagnostics{
-			Issues:   retryIssues,
-			Runbooks: linkToRetriesRunbook,
+			Issues:  retryIssues,
+			Runbook: linkToRetriesRunbook,
 		}
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
runbook info in diagnostics result is a single string instead of a list

<!-- Tell your future self why have you made these changes -->
**Why?**
It is easier to consume the output when one runbook link is provided and additional info can branch from that link if needed

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
