### PR TITLE
Better lifecycle management in the shard executor library

### DIFF
--- a/service/sharddistributor/executorclient/clientimpl.go
+++ b/service/sharddistributor/executorclient/clientimpl.go
@@ -62,7 +62,10 @@ type executorImpl[SP ShardProcessor] struct {
 
 func (e *executorImpl[SP]) Start(ctx context.Context) {
 	e.processLoopWG.Add(1)
-	go e.heartbeatloop(ctx)
+	go func() {
+		defer e.processLoopWG.Done()
+		e.heartbeatloop(ctx)
+	}()
 }
 
 func (e *executorImpl[SP]) Stop() {
@@ -80,8 +83,6 @@ func (e *executorImpl[SP]) GetShardProcess(shardID string) (SP, error) {
 }
 
 func (e *executorImpl[SP]) heartbeatloop(ctx context.Context) {
-	defer e.processLoopWG.Done()
-
 	heartBeatTicker := e.timeSource.NewTicker(e.heartBeatInterval)
 	defer heartBeatTicker.Stop()
 

--- a/service/sharddistributor/executorclient/clientimpl_test.go
+++ b/service/sharddistributor/executorclient/clientimpl_test.go
@@ -129,14 +129,8 @@ func TestHeartbeat(t *testing.T) {
 		executorID:             "test-executor-id",
 	}
 
-	executor.managedProcessors.Store("test-shard-id1", &managedProcessor[*MockShardProcessor]{
-		processor: shardProcessorMock1,
-		state:     processorStateStarted,
-	})
-	executor.managedProcessors.Store("test-shard-id2", &managedProcessor[*MockShardProcessor]{
-		processor: shardProcessorMock2,
-		state:     processorStateStarted,
-	})
+	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
+	executor.managedProcessors.Store("test-shard-id2", newManagedProcessor(shardProcessorMock2, processorStateStarted))
 
 	// Do the call to heartbeat
 	shardAssignments, err := executor.heartbeat(context.Background())
@@ -166,14 +160,8 @@ func TestHeartBeartLoop_ShardAssignmentChange(t *testing.T) {
 		shardProcessorFactory: shardProcessorFactory,
 	}
 
-	executor.managedProcessors.Store("test-shard-id1", &managedProcessor[*MockShardProcessor]{
-		processor: shardProcessorMock1,
-		state:     processorStateStarted,
-	})
-	executor.managedProcessors.Store("test-shard-id2", &managedProcessor[*MockShardProcessor]{
-		processor: shardProcessorMock2,
-		state:     processorStateStarted,
-	})
+	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
+	executor.managedProcessors.Store("test-shard-id2", newManagedProcessor(shardProcessorMock2, processorStateStarted))
 
 	// We expect to get a new assignment with shards 2 and 3 assigned to it
 	newAssignment := map[string]*types.ShardAssignment{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Better shutdown of the executor process loop
- Made the updateShardAssignment function use waitgroups, so it blocks until all the processors has started or stopped 
- Made sure we do not stop heartbeating if an assignment takes a long time. 
  - If we are still running an old assignment when we get a new one, we will skip the new one. 
- Protected the state of the managed processor with an atomic int


<!-- Tell your future self why have you made these changes -->
**Why?**
Make sure the life cycle management of the executor library is robust


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
