### PR TITLE
Add helper functions for predicates

### DIFF
--- a/common/persistence/persistence-tests/shardPersistenceTest.go
+++ b/common/persistence/persistence-tests/shardPersistenceTest.go
@@ -169,6 +169,13 @@ func (s *ShardPersistenceSuite) TestUpdateShard() {
 									TaskID: updatedCurrentClusterTransferAckLevel + 10,
 								},
 							},
+							Predicate: &types.Predicate{
+								PredicateType: types.PredicateTypeDomainID,
+								DomainIDPredicateAttributes: &types.DomainIDPredicateAttributes{
+									DomainIDs:   []string{"domain1", "domain2"},
+									IsExclusive: common.Ptr(true),
+								},
+							},
 						},
 					},
 				},
@@ -339,6 +346,13 @@ func (s *ShardPersistenceSuite) TestCreateGetUpdateGetShard() {
 									},
 									ExclusiveMax: &types.TaskKey{
 										TaskID: currentClusterTransferAck + 10,
+									},
+								},
+								Predicate: &types.Predicate{
+									PredicateType: types.PredicateTypeDomainID,
+									DomainIDPredicateAttributes: &types.DomainIDPredicateAttributes{
+										DomainIDs:   []string{"domain1", "domain2"},
+										IsExclusive: common.Ptr(true),
 									},
 								},
 							},

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -8436,6 +8436,7 @@ func FromVirtualSliceState(t *types.VirtualSliceState) *shared.VirtualSliceState
 	}
 	return &shared.VirtualSliceState{
 		TaskRange: FromTaskRange(t.TaskRange),
+		Predicate: FromPredicate(t.Predicate),
 	}
 }
 
@@ -8445,6 +8446,7 @@ func ToVirtualSliceState(t *shared.VirtualSliceState) *types.VirtualSliceState {
 	}
 	return &types.VirtualSliceState{
 		TaskRange: ToTaskRange(t.TaskRange),
+		Predicate: ToPredicate(t.Predicate),
 	}
 }
 

--- a/common/types/predicate.go
+++ b/common/types/predicate.go
@@ -47,6 +47,13 @@ func (d *DomainIDPredicateAttributes) Copy() *DomainIDPredicateAttributes {
 	}
 }
 
+func (d *DomainIDPredicateAttributes) GetIsExclusive() bool {
+	if d.IsExclusive == nil {
+		return false
+	}
+	return *d.IsExclusive
+}
+
 type Predicate struct {
 	PredicateType                PredicateType
 	UniversalPredicateAttributes *UniversalPredicateAttributes
@@ -64,4 +71,14 @@ func (p *Predicate) Copy() *Predicate {
 		EmptyPredicateAttributes:     p.EmptyPredicateAttributes.Copy(),
 		DomainIDPredicateAttributes:  p.DomainIDPredicateAttributes.Copy(),
 	}
+}
+
+func (p *Predicate) GetDomainIDPredicateAttributes() *DomainIDPredicateAttributes {
+	if p == nil {
+		return nil
+	}
+	if p.PredicateType != PredicateTypeDomainID {
+		return nil
+	}
+	return p.DomainIDPredicateAttributes
 }

--- a/service/history/queuev2/predicate_operation.go
+++ b/service/history/queuev2/predicate_operation.go
@@ -1,0 +1,114 @@
+package queuev2
+
+import "fmt"
+
+func Not(predicate Predicate) Predicate {
+	switch p := predicate.(type) {
+	case *universalPredicate:
+		return &emptyPredicate{}
+	case *emptyPredicate:
+		return &universalPredicate{}
+	case *domainIDPredicate:
+		isExclusive := !p.isExclusive
+		if isExclusive && len(p.domainIDs) == 0 {
+			return &universalPredicate{}
+		}
+		return &domainIDPredicate{
+			domainIDs:   p.domainIDs,
+			isExclusive: isExclusive,
+		}
+	default:
+		panic(fmt.Sprintf("unknown predicate type: %T", p))
+	}
+}
+
+func And(p1, p2 Predicate) Predicate {
+	switch p1 := p1.(type) {
+	case *universalPredicate:
+		return p2
+	case *emptyPredicate:
+		return p1
+	case *domainIDPredicate:
+		switch p2 := p2.(type) {
+		case *universalPredicate:
+			return p1
+		case *emptyPredicate:
+			return p2
+		case *domainIDPredicate:
+			if p1.isExclusive {
+				if p2.isExclusive {
+					domainIDs := unionStringSet(p1.domainIDs, p2.domainIDs)
+					if len(domainIDs) == 0 {
+						return &emptyPredicate{}
+					}
+					return &domainIDPredicate{
+						domainIDs:   domainIDs,
+						isExclusive: true,
+					}
+				}
+				domainIDs := map[string]struct{}{}
+				for domainID := range p2.domainIDs {
+					if _, ok := p1.domainIDs[domainID]; !ok {
+						domainIDs[domainID] = struct{}{}
+					}
+				}
+				if len(domainIDs) == 0 {
+					return &emptyPredicate{}
+				}
+				return &domainIDPredicate{
+					domainIDs:   domainIDs,
+					isExclusive: false,
+				}
+			}
+			if p2.isExclusive {
+				domainIDs := map[string]struct{}{}
+				for domainID := range p1.domainIDs {
+					if _, ok := p2.domainIDs[domainID]; !ok {
+						domainIDs[domainID] = struct{}{}
+					}
+				}
+				if len(domainIDs) == 0 {
+					return &emptyPredicate{}
+				}
+				return &domainIDPredicate{
+					domainIDs:   domainIDs,
+					isExclusive: false,
+				}
+			}
+			domainIDs := intersectStringSet(p1.domainIDs, p2.domainIDs)
+			if len(domainIDs) == 0 {
+				return &emptyPredicate{}
+			}
+			return &domainIDPredicate{
+				domainIDs:   domainIDs,
+				isExclusive: false,
+			}
+
+		default:
+			panic(fmt.Sprintf("unknown predicate type: %T", p2))
+		}
+	default:
+		panic(fmt.Sprintf("unknown predicate type: %T", p1))
+	}
+}
+
+func unionStringSet(set1, set2 map[string]struct{}) map[string]struct{} {
+	result := make(map[string]struct{})
+	for domainID := range set1 {
+		result[domainID] = struct{}{}
+	}
+	for domainID := range set2 {
+		result[domainID] = struct{}{}
+	}
+	return result
+}
+
+func intersectStringSet(set1, set2 map[string]struct{}) map[string]struct{} {
+	result := make(map[string]struct{})
+	for domainID := range set1 {
+		if _, ok := set2[domainID]; ok {
+			result[domainID] = struct{}{}
+		}
+	}
+	return result
+}

--- a/service/history/queuev2/predicate_operation_test.go
+++ b/service/history/queuev2/predicate_operation_test.go
@@ -1,0 +1,468 @@
+package queuev2
+
+import (
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence"
+)
+
+func TestNot(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Predicate
+		expected Predicate
+	}{
+		{
+			name:     "universalPredicate returns emptyPredicate",
+			input:    NewUniversalPredicate(),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "emptyPredicate returns universalPredicate",
+			input:    NewEmptyPredicate(),
+			expected: NewUniversalPredicate(),
+		},
+		{
+			name:     "domainIDPredicate with isExclusive=true returns isExclusive=false",
+			input:    NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+		},
+		{
+			name:     "domainIDPredicate with isExclusive=false returns isExclusive=true",
+			input:    NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+		},
+		{
+			name:     "domainIDPredicate with empty domains and isExclusive=true",
+			input:    NewDomainIDPredicate([]string{}, true),
+			expected: NewDomainIDPredicate([]string{}, false),
+		},
+		{
+			name:     "domainIDPredicate with empty domains and isExclusive=false",
+			input:    NewDomainIDPredicate([]string{}, false),
+			expected: NewUniversalPredicate(),
+		},
+		{
+			name:     "domainIDPredicate with single domain",
+			input:    NewDomainIDPredicate([]string{"single-domain"}, true),
+			expected: NewDomainIDPredicate([]string{"single-domain"}, false),
+		},
+		{
+			name:     "domainIDPredicate with multiple domains",
+			input:    NewDomainIDPredicate([]string{"domain1", "domain2", "domain3", "domain4"}, false),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2", "domain3", "domain4"}, true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Not(tt.input)
+			assert.NotNil(t, result)
+
+			// Use the Equals method to compare predicates
+			assert.True(t, tt.expected.Equals(result),
+				"expected %+v, got %+v", tt.expected, result)
+		})
+	}
+}
+
+func TestAnd(t *testing.T) {
+	tests := []struct {
+		name     string
+		p1       Predicate
+		p2       Predicate
+		expected Predicate
+	}{
+		// universalPredicate cases
+		{
+			name:     "universalPredicate AND universalPredicate",
+			p1:       NewUniversalPredicate(),
+			p2:       NewUniversalPredicate(),
+			expected: NewUniversalPredicate(),
+		},
+		{
+			name:     "universalPredicate AND emptyPredicate",
+			p1:       NewUniversalPredicate(),
+			p2:       NewEmptyPredicate(),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "universalPredicate AND domainIDPredicate",
+			p1:       NewUniversalPredicate(),
+			p2:       NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+		},
+
+		// emptyPredicate cases
+		{
+			name:     "emptyPredicate AND universalPredicate",
+			p1:       NewEmptyPredicate(),
+			p2:       NewUniversalPredicate(),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "emptyPredicate AND emptyPredicate",
+			p1:       NewEmptyPredicate(),
+			p2:       NewEmptyPredicate(),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "emptyPredicate AND domainIDPredicate",
+			p1:       NewEmptyPredicate(),
+			p2:       NewDomainIDPredicate([]string{"domain1"}, true),
+			expected: NewEmptyPredicate(),
+		},
+
+		// domainIDPredicate AND universalPredicate
+		{
+			name:     "domainIDPredicate AND universalPredicate",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+			p2:       NewUniversalPredicate(),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+		},
+
+		// domainIDPredicate AND emptyPredicate
+		{
+			name:     "domainIDPredicate AND emptyPredicate",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			p2:       NewEmptyPredicate(),
+			expected: NewEmptyPredicate(),
+		},
+
+		// domainIDPredicate AND domainIDPredicate cases
+		{
+			name:     "exclusive AND exclusive - union domains",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+			p2:       NewDomainIDPredicate([]string{"domain3", "domain4"}, true),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2", "domain3", "domain4"}, true),
+		},
+		{
+			name:     "exclusive AND exclusive - overlapping domains",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+			p2:       NewDomainIDPredicate([]string{"domain2", "domain3"}, true),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2", "domain3"}, true),
+		},
+		{
+			name:     "exclusive AND inclusive - p2 domains not in p1",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+			p2:       NewDomainIDPredicate([]string{"domain2", "domain3", "domain4"}, false),
+			expected: NewDomainIDPredicate([]string{"domain3", "domain4"}, false),
+		},
+		{
+			name:     "exclusive AND inclusive - all p2 domains in p1",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2", "domain3"}, true),
+			p2:       NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "inclusive AND exclusive - p1 domains not in p2",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2", "domain3"}, false),
+			p2:       NewDomainIDPredicate([]string{"domain2", "domain4"}, true),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain3"}, false),
+		},
+		{
+			name:     "inclusive AND exclusive - all p1 domains in p2",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			p2:       NewDomainIDPredicate([]string{"domain1", "domain2", "domain3"}, true),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "inclusive AND inclusive - intersection",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2", "domain3"}, false),
+			p2:       NewDomainIDPredicate([]string{"domain2", "domain3", "domain4"}, false),
+			expected: NewDomainIDPredicate([]string{"domain2", "domain3"}, false),
+		},
+		{
+			name:     "inclusive AND inclusive - no intersection",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			p2:       NewDomainIDPredicate([]string{"domain3", "domain4"}, false),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "inclusive AND inclusive - same domains",
+			p1:       NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			p2:       NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			expected: NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+		},
+
+		// Edge cases with empty domain lists
+		{
+			name:     "empty exclusive AND non-empty exclusive",
+			p1:       NewDomainIDPredicate([]string{}, true),
+			p2:       NewDomainIDPredicate([]string{"domain1"}, true),
+			expected: NewDomainIDPredicate([]string{"domain1"}, true),
+		},
+		{
+			name:     "empty inclusive AND non-empty inclusive",
+			p1:       NewDomainIDPredicate([]string{}, false),
+			p2:       NewDomainIDPredicate([]string{"domain1"}, false),
+			expected: NewEmptyPredicate(),
+		},
+		{
+			name:     "empty exclusive AND non-empty inclusive",
+			p1:       NewDomainIDPredicate([]string{}, true),
+			p2:       NewDomainIDPredicate([]string{"domain1"}, false),
+			expected: NewDomainIDPredicate([]string{"domain1"}, false),
+		},
+		{
+			name:     "non-empty inclusive AND empty exclusive",
+			p1:       NewDomainIDPredicate([]string{"domain1"}, false),
+			p2:       NewDomainIDPredicate([]string{}, true),
+			expected: NewDomainIDPredicate([]string{"domain1"}, false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := And(tt.p1, tt.p2)
+			assert.NotNil(t, result)
+
+			// Use the Equals method to compare predicates
+			assert.True(t, tt.expected.Equals(result),
+				"expected %+v, got %+v", tt.expected, result)
+		})
+	}
+}
+
+func predicateOperationFuzzGenerator(p *Predicate, c fuzz.Continue) {
+	switch c.Intn(3) {
+	case 0:
+		*p = NewUniversalPredicate()
+	case 1:
+		*p = NewEmptyPredicate()
+	case 2:
+		var domainIDPredicate domainIDPredicate
+		c.Fuzz(&domainIDPredicate)
+		*p = &domainIDPredicate
+	default:
+		panic("invalid predicate type")
+	}
+}
+
+func TestAnd_Commutativity(t *testing.T) {
+	f := fuzz.New().Funcs(predicateOperationFuzzGenerator)
+	for i := 0; i < 1000; i++ {
+		var p1, p2 Predicate
+		f.Fuzz(&p1)
+		f.Fuzz(&p2)
+
+		result1 := And(p1, p2)
+		result2 := And(p2, p1)
+
+		assert.True(t, result1.Equals(result2),
+			"And should be commutative: And(p1, p2) should equal And(p2, p1)")
+	}
+}
+
+func TestAnd_LogicalCorrectness(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	// Test data with different domain IDs
+	testTasks := []*persistence.MockTask{
+		// Task with domain1
+		func() *persistence.MockTask {
+			task := persistence.NewMockTask(ctrl)
+			task.EXPECT().GetDomainID().Return("domain1").AnyTimes()
+			return task
+		}(),
+		// Task with domain2
+		func() *persistence.MockTask {
+			task := persistence.NewMockTask(ctrl)
+			task.EXPECT().GetDomainID().Return("domain2").AnyTimes()
+			return task
+		}(),
+		// Task with domain3
+		func() *persistence.MockTask {
+			task := persistence.NewMockTask(ctrl)
+			task.EXPECT().GetDomainID().Return("domain3").AnyTimes()
+			return task
+		}(),
+		// Task with domain4
+		func() *persistence.MockTask {
+			task := persistence.NewMockTask(ctrl)
+			task.EXPECT().GetDomainID().Return("domain4").AnyTimes()
+			return task
+		}(),
+	}
+
+	// Test cases with different predicate combinations
+	testCases := []struct {
+		name string
+		p1   Predicate
+		p2   Predicate
+	}{
+		// Universal and Empty predicates
+		{
+			name: "universal AND universal",
+			p1:   NewUniversalPredicate(),
+			p2:   NewUniversalPredicate(),
+		},
+		{
+			name: "universal AND empty",
+			p1:   NewUniversalPredicate(),
+			p2:   NewEmptyPredicate(),
+		},
+		{
+			name: "empty AND universal",
+			p1:   NewEmptyPredicate(),
+			p2:   NewUniversalPredicate(),
+		},
+		{
+			name: "empty AND empty",
+			p1:   NewEmptyPredicate(),
+			p2:   NewEmptyPredicate(),
+		},
+
+		// Universal with domain predicates
+		{
+			name: "universal AND domain inclusive",
+			p1:   NewUniversalPredicate(),
+			p2:   NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+		},
+		{
+			name: "universal AND domain exclusive",
+			p1:   NewUniversalPredicate(),
+			p2:   NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+		},
+		{
+			name: "domain inclusive AND universal",
+			p1:   NewDomainIDPredicate([]string{"domain1", "domain3"}, false),
+			p2:   NewUniversalPredicate(),
+		},
+		{
+			name: "domain exclusive AND universal",
+			p1:   NewDomainIDPredicate([]string{"domain1", "domain3"}, true),
+			p2:   NewUniversalPredicate(),
+		},
+
+		// Empty with domain predicates
+		{
+			name: "empty AND domain inclusive",
+			p1:   NewEmptyPredicate(),
+			p2:   NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+		},
+		{
+			name: "empty AND domain exclusive",
+			p1:   NewEmptyPredicate(),
+			p2:   NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+		},
+		{
+			name: "domain inclusive AND empty",
+			p1:   NewDomainIDPredicate([]string{"domain2", "domain4"}, false),
+			p2:   NewEmptyPredicate(),
+		},
+		{
+			name: "domain exclusive AND empty",
+			p1:   NewDomainIDPredicate([]string{"domain2", "domain4"}, true),
+			p2:   NewEmptyPredicate(),
+		},
+
+		// Domain predicate combinations
+		{
+			name: "inclusive AND inclusive - overlapping",
+			p1:   NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			p2:   NewDomainIDPredicate([]string{"domain2", "domain3"}, false),
+		},
+		{
+			name: "inclusive AND inclusive - disjoint",
+			p1:   NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			p2:   NewDomainIDPredicate([]string{"domain3", "domain4"}, false),
+		},
+		{
+			name: "exclusive AND exclusive - overlapping",
+			p1:   NewDomainIDPredicate([]string{"domain1", "domain2"}, true),
+			p2:   NewDomainIDPredicate([]string{"domain2", "domain3"}, true),
+		},
+		{
+			name: "exclusive AND exclusive - disjoint",
+			p1:   NewDomainIDPredicate([]string{"domain1"}, true),
+			p2:   NewDomainIDPredicate([]string{"domain3"}, true),
+		},
+		{
+			name: "inclusive AND exclusive - overlapping",
+			p1:   NewDomainIDPredicate([]string{"domain1", "domain2", "domain3"}, false),
+			p2:   NewDomainIDPredicate([]string{"domain2", "domain4"}, true),
+		},
+		{
+			name: "exclusive AND inclusive - overlapping",
+			p1:   NewDomainIDPredicate([]string{"domain1", "domain3"}, true),
+			p2:   NewDomainIDPredicate([]string{"domain2", "domain3", "domain4"}, false),
+		},
+
+		// Edge cases with empty domain lists
+		{
+			name: "empty inclusive AND non-empty inclusive",
+			p1:   NewDomainIDPredicate([]string{}, false),
+			p2:   NewDomainIDPredicate([]string{"domain1"}, false),
+		},
+		{
+			name: "empty exclusive AND non-empty exclusive",
+			p1:   NewDomainIDPredicate([]string{}, true),
+			p2:   NewDomainIDPredicate([]string{"domain1"}, true),
+		},
+		{
+			name: "empty inclusive AND empty exclusive",
+			p1:   NewDomainIDPredicate([]string{}, false),
+			p2:   NewDomainIDPredicate([]string{}, true),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			andPredicate := And(tc.p1, tc.p2)
+
+			// Test the logical property for each task
+			for i, task := range testTasks {
+				p1Result := tc.p1.Check(task)
+				p2Result := tc.p2.Check(task)
+				expectedResult := p1Result && p2Result
+				actualResult := andPredicate.Check(task)
+
+				assert.Equal(t, expectedResult, actualResult,
+					"For task %d (domain=%s): And(p1, p2).Check(task) should equal p1.Check(task) && p2.Check(task). "+
+						"p1.Check(task)=%t, p2.Check(task)=%t, expected=%t, actual=%t",
+					i, task.GetDomainID(), p1Result, p2Result, expectedResult, actualResult)
+			}
+		})
+	}
+}
+
+func TestAnd_LogicalCorrectness_FuzzTesting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	// Create a variety of test tasks with different domain IDs
+	domains := []string{"domain1", "domain2", "domain3", "domain4", "domain5", ""}
+	testTasks := make([]*persistence.MockTask, len(domains))
+	for i, domain := range domains {
+		task := persistence.NewMockTask(ctrl)
+		task.EXPECT().GetDomainID().Return(domain).AnyTimes()
+		testTasks[i] = task
+	}
+
+	f := fuzz.New().Funcs(predicateOperationFuzzGenerator)
+	for i := 0; i < 500; i++ {
+		var p1, p2 Predicate
+		f.Fuzz(&p1)
+		f.Fuzz(&p2)
+
+		andPredicate := And(p1, p2)
+
+		// Test the logical property for each task
+		for _, task := range testTasks {
+			p1Result := p1.Check(task)
+			p2Result := p2.Check(task)
+			expectedResult := p1Result && p2Result
+			actualResult := andPredicate.Check(task)
+
+			assert.Equal(t, expectedResult, actualResult,
+				"Fuzz test iteration %d: And(p1, p2).Check(task) should equal p1.Check(task) && p2.Check(task). "+
+					"Task domain: %s, p1.Check(task)=%t, p2.Check(task)=%t, expected=%t, actual=%t, "+
+					"p1=%+v, p2=%+v",
+				i, task.GetDomainID(), p1Result, p2Result, expectedResult, actualResult, p1, p2)
+		}
+	}
+}

--- a/service/history/queuev2/predicate_test.go
+++ b/service/history/queuev2/predicate_test.go
@@ -1,0 +1,324 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queuev2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence"
+)
+
+func TestNewUniversalPredicate(t *testing.T) {
+	predicate := NewUniversalPredicate()
+	assert.NotNil(t, predicate)
+	assert.IsType(t, &universalPredicate{}, predicate)
+}
+
+func TestUniversalPredicate_IsEmpty(t *testing.T) {
+	predicate := NewUniversalPredicate()
+	assert.False(t, predicate.IsEmpty())
+}
+
+func TestUniversalPredicate_Check(t *testing.T) {
+	predicate := NewUniversalPredicate()
+
+	// Test with nil task
+	assert.True(t, predicate.Check(nil))
+
+	// Test with mock task
+	ctrl := gomock.NewController(t)
+
+	task := persistence.NewMockTask(ctrl)
+	task.EXPECT().GetDomainID().Return("test-domain").AnyTimes()
+	assert.True(t, predicate.Check(task))
+
+	// Test with different domain ID
+	task2 := persistence.NewMockTask(ctrl)
+	task2.EXPECT().GetDomainID().Return("different-domain").AnyTimes()
+	assert.True(t, predicate.Check(task2))
+}
+
+func TestUniversalPredicate_Equals(t *testing.T) {
+	predicate1 := NewUniversalPredicate()
+	predicate2 := NewUniversalPredicate()
+	emptyPredicate := NewEmptyPredicate()
+	domainPredicate := NewDomainIDPredicate([]string{"test"}, false)
+
+	// Same type should be equal
+	assert.True(t, predicate1.Equals(predicate2))
+	assert.True(t, predicate2.Equals(predicate1))
+
+	// Different types should not be equal
+	assert.False(t, predicate1.Equals(emptyPredicate))
+	assert.False(t, predicate1.Equals(domainPredicate))
+	assert.False(t, predicate1.Equals(nil))
+}
+
+func TestNewEmptyPredicate(t *testing.T) {
+	predicate := NewEmptyPredicate()
+	assert.NotNil(t, predicate)
+	assert.IsType(t, &emptyPredicate{}, predicate)
+}
+
+func TestEmptyPredicate_IsEmpty(t *testing.T) {
+	predicate := NewEmptyPredicate()
+	assert.True(t, predicate.IsEmpty())
+}
+
+func TestEmptyPredicate_Check(t *testing.T) {
+	predicate := NewEmptyPredicate()
+
+	// Test with nil task
+	assert.False(t, predicate.Check(nil))
+
+	// Test with mock task
+	ctrl := gomock.NewController(t)
+
+	task := persistence.NewMockTask(ctrl)
+	task.EXPECT().GetDomainID().Return("test-domain").AnyTimes()
+	assert.False(t, predicate.Check(task))
+
+	// Test with different domain ID
+	task2 := persistence.NewMockTask(ctrl)
+	task2.EXPECT().GetDomainID().Return("different-domain").AnyTimes()
+	assert.False(t, predicate.Check(task2))
+}
+
+func TestEmptyPredicate_Equals(t *testing.T) {
+	predicate1 := NewEmptyPredicate()
+	predicate2 := NewEmptyPredicate()
+	universalPredicate := NewUniversalPredicate()
+	domainPredicate := NewDomainIDPredicate([]string{"test"}, false)
+
+	// Same type should be equal
+	assert.True(t, predicate1.Equals(predicate2))
+	assert.True(t, predicate2.Equals(predicate1))
+
+	// Different types should not be equal
+	assert.False(t, predicate1.Equals(universalPredicate))
+	assert.False(t, predicate1.Equals(domainPredicate))
+	assert.False(t, predicate1.Equals(nil))
+}
+
+func TestNewDomainIDPredicate(t *testing.T) {
+	// Test with empty domain IDs
+	predicate := NewDomainIDPredicate([]string{}, false)
+	assert.NotNil(t, predicate)
+	assert.IsType(t, &domainIDPredicate{}, predicate)
+
+	// Test with single domain ID
+	predicate = NewDomainIDPredicate([]string{"domain1"}, false)
+	assert.NotNil(t, predicate)
+
+	// Test with multiple domain IDs
+	predicate = NewDomainIDPredicate([]string{"domain1", "domain2", "domain3"}, true)
+	assert.NotNil(t, predicate)
+
+	// Test with duplicate domain IDs (should be deduplicated)
+	predicate = NewDomainIDPredicate([]string{"domain1", "domain1", "domain2"}, false)
+	assert.NotNil(t, predicate)
+}
+
+func TestDomainIDPredicate_IsEmpty(t *testing.T) {
+	// Empty domain IDs with inclusive mode
+	predicate := NewDomainIDPredicate([]string{}, false)
+	assert.True(t, predicate.IsEmpty())
+
+	// Empty domain IDs with exclusive mode
+	predicate = NewDomainIDPredicate([]string{}, true)
+	assert.False(t, predicate.IsEmpty())
+
+	// Non-empty domain IDs with inclusive mode
+	predicate = NewDomainIDPredicate([]string{"domain1"}, false)
+	assert.False(t, predicate.IsEmpty())
+
+	// Non-empty domain IDs with exclusive mode
+	predicate = NewDomainIDPredicate([]string{"domain1"}, true)
+	assert.False(t, predicate.IsEmpty())
+}
+
+func TestDomainIDPredicate_Check_Inclusive(t *testing.T) {
+	// Test inclusive mode (isExclusive = false)
+	predicate := NewDomainIDPredicate([]string{"domain1", "domain2"}, false)
+
+	ctrl := gomock.NewController(t)
+
+	// Task with domain in the list should pass
+	task1 := persistence.NewMockTask(ctrl)
+	task1.EXPECT().GetDomainID().Return("domain1").AnyTimes()
+	assert.True(t, predicate.Check(task1))
+
+	task2 := persistence.NewMockTask(ctrl)
+	task2.EXPECT().GetDomainID().Return("domain2").AnyTimes()
+	assert.True(t, predicate.Check(task2))
+
+	// Task with domain not in the list should fail
+	task3 := persistence.NewMockTask(ctrl)
+	task3.EXPECT().GetDomainID().Return("domain3").AnyTimes()
+	assert.False(t, predicate.Check(task3))
+
+	// Test with empty domain ID
+	task4 := persistence.NewMockTask(ctrl)
+	task4.EXPECT().GetDomainID().Return("").AnyTimes()
+	assert.False(t, predicate.Check(task4))
+}
+
+func TestDomainIDPredicate_Check_Exclusive(t *testing.T) {
+	// Test exclusive mode (isExclusive = true)
+	predicate := NewDomainIDPredicate([]string{"domain1", "domain2"}, true)
+
+	ctrl := gomock.NewController(t)
+
+	// Task with domain in the list should fail
+	task1 := persistence.NewMockTask(ctrl)
+	task1.EXPECT().GetDomainID().Return("domain1").AnyTimes()
+	assert.False(t, predicate.Check(task1))
+
+	task2 := persistence.NewMockTask(ctrl)
+	task2.EXPECT().GetDomainID().Return("domain2").AnyTimes()
+	assert.False(t, predicate.Check(task2))
+
+	// Task with domain not in the list should pass
+	task3 := persistence.NewMockTask(ctrl)
+	task3.EXPECT().GetDomainID().Return("domain3").AnyTimes()
+	assert.True(t, predicate.Check(task3))
+
+	// Test with empty domain ID
+	task4 := persistence.NewMockTask(ctrl)
+	task4.EXPECT().GetDomainID().Return("").AnyTimes()
+	assert.True(t, predicate.Check(task4))
+}
+
+func TestDomainIDPredicate_Check_EmptyList(t *testing.T) {
+	// Test with empty domain list and inclusive mode
+	predicate := NewDomainIDPredicate([]string{}, false)
+
+	ctrl := gomock.NewController(t)
+
+	task := persistence.NewMockTask(ctrl)
+	task.EXPECT().GetDomainID().Return("any-domain").AnyTimes()
+	assert.False(t, predicate.Check(task)) // No domains in list, so inclusive returns false
+
+	// Test with empty domain list and exclusive mode
+	predicate = NewDomainIDPredicate([]string{}, true)
+	assert.True(t, predicate.Check(task)) // No domains in list, so exclusive returns true
+}
+
+func TestDomainIDPredicate_Equals(t *testing.T) {
+	// Test equal predicates
+	predicate1 := NewDomainIDPredicate([]string{"domain1", "domain2"}, false)
+	predicate2 := NewDomainIDPredicate([]string{"domain1", "domain2"}, false)
+	assert.True(t, predicate1.Equals(predicate2))
+
+	// Test equal predicates with different order
+	predicate3 := NewDomainIDPredicate([]string{"domain2", "domain1"}, false)
+	assert.True(t, predicate1.Equals(predicate3))
+
+	// Test different domain sets
+	predicate4 := NewDomainIDPredicate([]string{"domain1", "domain3"}, false)
+	assert.False(t, predicate1.Equals(predicate4))
+
+	// Test different domain count
+	predicate5 := NewDomainIDPredicate([]string{"domain1"}, false)
+	assert.False(t, predicate1.Equals(predicate5))
+
+	// Test different exclusion mode
+	predicate6 := NewDomainIDPredicate([]string{"domain1", "domain2"}, true)
+	assert.False(t, predicate1.Equals(predicate6))
+
+	// Test against different predicate types
+	universalPredicate := NewUniversalPredicate()
+	emptyPredicate := NewEmptyPredicate()
+	assert.False(t, predicate1.Equals(universalPredicate))
+	assert.False(t, predicate1.Equals(emptyPredicate))
+	assert.False(t, predicate1.Equals(nil))
+}
+
+func TestDomainIDPredicate_Equals_EmptyLists(t *testing.T) {
+	// Test with both empty lists
+	predicate1 := NewDomainIDPredicate([]string{}, false)
+	predicate2 := NewDomainIDPredicate([]string{}, false)
+	assert.True(t, predicate1.Equals(predicate2))
+
+	// Test with one empty, one non-empty
+	predicate3 := NewDomainIDPredicate([]string{"domain1"}, false)
+	assert.False(t, predicate1.Equals(predicate3))
+
+	// Test with both empty but different exclusion mode
+	predicate4 := NewDomainIDPredicate([]string{}, true)
+	assert.False(t, predicate1.Equals(predicate4))
+}
+
+func TestDomainIDPredicate_DuplicateDomains(t *testing.T) {
+	// Test that duplicate domains are handled correctly
+	predicate := NewDomainIDPredicate([]string{"domain1", "domain1", "domain2", "domain2"}, false)
+
+	ctrl := gomock.NewController(t)
+
+	task1 := persistence.NewMockTask(ctrl)
+	task1.EXPECT().GetDomainID().Return("domain1").AnyTimes()
+	task2 := persistence.NewMockTask(ctrl)
+	task2.EXPECT().GetDomainID().Return("domain2").AnyTimes()
+	task3 := persistence.NewMockTask(ctrl)
+	task3.EXPECT().GetDomainID().Return("domain3").AnyTimes()
+
+	assert.True(t, predicate.Check(task1))
+	assert.True(t, predicate.Check(task2))
+	assert.False(t, predicate.Check(task3))
+
+	// Test equals with duplicate domains
+	predicate2 := NewDomainIDPredicate([]string{"domain1", "domain2"}, false)
+	assert.True(t, predicate.Equals(predicate2))
+}
+
+func TestPredicateIntegration(t *testing.T) {
+	// Test integration between different predicate types
+	universal := NewUniversalPredicate()
+	empty := NewEmptyPredicate()
+	domainInclusive := NewDomainIDPredicate([]string{"domain1"}, false)
+	domainExclusive := NewDomainIDPredicate([]string{"domain1"}, true)
+
+	ctrl := gomock.NewController(t)
+
+	task := persistence.NewMockTask(ctrl)
+	task.EXPECT().GetDomainID().Return("domain1").AnyTimes()
+
+	// Universal should always pass
+	assert.True(t, universal.Check(task))
+	assert.False(t, universal.IsEmpty())
+
+	// Empty should always fail
+	assert.False(t, empty.Check(task))
+	assert.True(t, empty.IsEmpty())
+
+	// Domain inclusive should pass for matching domain
+	assert.True(t, domainInclusive.Check(task))
+	assert.False(t, domainInclusive.IsEmpty())
+
+	// Domain exclusive should fail for matching domain
+	assert.False(t, domainExclusive.Check(task))
+	assert.False(t, domainExclusive.IsEmpty())
+}

--- a/service/history/queuev2/queue_state.go
+++ b/service/history/queuev2/queue_state.go
@@ -55,3 +55,16 @@ func (s *VirtualSliceState) TrySplitByTaskKey(taskKey persistence.HistoryTaskKey
 			Predicate: s.Predicate,
 		}, true
 }
+
+func (s *VirtualSliceState) TrySplitByPredicate(predicate Predicate) (VirtualSliceState, VirtualSliceState, bool) {
+	if predicate.Equals(&universalPredicate{}) || predicate.Equals(&emptyPredicate{}) || predicate.Equals(s.Predicate) {
+		return VirtualSliceState{}, VirtualSliceState{}, false
+	}
+	return VirtualSliceState{
+			Range:     s.Range,
+			Predicate: And(s.Predicate, predicate),
+		}, VirtualSliceState{
+			Range:     s.Range,
+			Predicate: And(s.Predicate, Not(predicate)),
+		}, true
+}

--- a/service/history/queuev2/queue_state_test.go
+++ b/service/history/queuev2/queue_state_test.go
@@ -104,3 +104,91 @@ func TestVirtualSliceState_TrySplitByTaskKey(t *testing.T) {
 	_, _, ok = state.TrySplitByTaskKey(persistence.NewHistoryTaskKey(time.Unix(0, 0), 101))
 	assert.False(t, ok)
 }
+
+func TestVirtualSliceState_TrySplitByPredicate(t *testing.T) {
+	baseRange := Range{
+		InclusiveMinTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 1), 0),
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(time.Unix(0, 10), 100),
+	}
+	basePredicate := NewDomainIDPredicate([]string{"domain1", "domain2"}, false)
+
+	tests := []struct {
+		name           string
+		state          VirtualSliceState
+		splitPredicate Predicate
+		expectedSplit  bool
+		expectedFirst  VirtualSliceState
+		expectedSecond VirtualSliceState
+	}{
+		{
+			name: "universal predicate should not split",
+			state: VirtualSliceState{
+				Range:     baseRange,
+				Predicate: basePredicate,
+			},
+			splitPredicate: NewUniversalPredicate(),
+			expectedSplit:  false,
+			expectedFirst:  VirtualSliceState{},
+			expectedSecond: VirtualSliceState{},
+		},
+		{
+			name: "empty predicate should not split",
+			state: VirtualSliceState{
+				Range:     baseRange,
+				Predicate: basePredicate,
+			},
+			splitPredicate: NewEmptyPredicate(),
+			expectedSplit:  false,
+			expectedFirst:  VirtualSliceState{},
+			expectedSecond: VirtualSliceState{},
+		},
+		{
+			name: "identical predicate should not split",
+			state: VirtualSliceState{
+				Range:     baseRange,
+				Predicate: basePredicate,
+			},
+			splitPredicate: NewDomainIDPredicate([]string{"domain1", "domain2"}, false),
+			expectedSplit:  false,
+			expectedFirst:  VirtualSliceState{},
+			expectedSecond: VirtualSliceState{},
+		},
+		{
+			name: "different predicate should split successfully",
+			state: VirtualSliceState{
+				Range:     baseRange,
+				Predicate: basePredicate,
+			},
+			splitPredicate: NewDomainIDPredicate([]string{"domain3"}, false),
+			expectedSplit:  true,
+			expectedFirst: VirtualSliceState{
+				Range:     baseRange,
+				Predicate: And(basePredicate, NewDomainIDPredicate([]string{"domain3"}, false)),
+			},
+			expectedSecond: VirtualSliceState{
+				Range:     baseRange,
+				Predicate: And(basePredicate, Not(NewDomainIDPredicate([]string{"domain3"}, false))),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first, second, split := tt.state.TrySplitByPredicate(tt.splitPredicate)
+
+			assert.Equal(t, tt.expectedSplit, split)
+
+			if tt.expectedSplit {
+				assert.Equal(t, tt.expectedFirst.Range, first.Range)
+				assert.Equal(t, tt.expectedSecond.Range, second.Range)
+				// For predicates, we check if they produce the same results rather than exact equality
+				// since the And and Not operations create new predicate instances
+				assert.True(t, tt.expectedFirst.Predicate.Equals(first.Predicate))
+				assert.True(t, tt.expectedSecond.Predicate.Equals(second.Predicate))
+			} else {
+				assert.Equal(t, tt.expectedFirst, first)
+				assert.Equal(t, tt.expectedSecond, second)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Define internal types for predicates
- Add helper functions and methods for predicates
- Update persistence tests to verify predicate types

<!-- Tell your future self why have you made these changes -->
**Why?**
To support virtual queue split

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
