### PR TITLE
Add query consistency level support to CLI workflow commands

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -301,6 +301,11 @@ func getFlagsForShowID() []cli.Flag {
 			Name:  FlagResetPointsOnly,
 			Usage: "Only show events that are eligible for reset",
 		},
+		&cli.StringFlag{
+			Name:    FlagQueryConsistencyLevel,
+			Aliases: []string{"qcl"},
+			Usage:   "Optional flag to set query consistency level. Valid values are \"eventual\" and \"strong\"",
+		},
 	}
 }
 
@@ -754,6 +759,11 @@ func getFlagsForDescribeID() []cli.Flag {
 		&cli.BoolFlag{
 			Name:  FlagResetPointsOnly,
 			Usage: "Only show auto-reset points",
+		},
+		&cli.StringFlag{
+			Name:    FlagQueryConsistencyLevel,
+			Aliases: []string{"qcl"},
+			Usage:   "Optional flag to set query consistency level. Valid values are \"eventual\" and \"strong\"",
 		},
 	}
 }

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -183,7 +183,13 @@ func showHistoryHelper(c *cli.Context, wid, rid string) error {
 	if err != nil {
 		return commoncli.Problem("Error creating context: ", err)
 	}
-	history, err := GetHistory(ctx, wfClient, domain, wid, rid)
+
+	consistencyLevel, err := getOptionWithSerializer[types.QueryConsistencyLevel](c, FlagQueryConsistencyLevel, mapQueryConsistencyLevelFromFlag)
+	if err != nil {
+		return commoncli.Problem(err.Error(), nil)
+	}
+
+	history, err := GetHistory(ctx, wfClient, domain, wid, rid, consistencyLevel)
 	if err != nil {
 		return commoncli.Problem(fmt.Sprintf("Failed to get history on workflow id: %s, run id: %s.", wid, rid), err)
 	}
@@ -590,7 +596,7 @@ func printWorkflowProgress(c *cli.Context, domain, wid, rid string) error {
 	}
 
 	go func() {
-		iterator, err := GetWorkflowHistoryIterator(tcCtx, wfClient, domain, wid, rid, true, types.HistoryEventFilterTypeAllEvent.Ptr())
+		iterator, err := GetWorkflowHistoryIterator(tcCtx, wfClient, domain, wid, rid, true, types.HistoryEventFilterTypeAllEvent.Ptr(), nil)
 		if err != nil {
 			errChan <- fmt.Errorf("unable to get history events: %w", err)
 			return
@@ -898,31 +904,19 @@ func queryWorkflowHelper(c *cli.Context, queryType string) error {
 	if input != "" {
 		queryRequest.Query.QueryArgs = []byte(input)
 	}
-	if c.IsSet(FlagQueryRejectCondition) {
-		var rejectCondition types.QueryRejectCondition
-		switch c.String(FlagQueryRejectCondition) {
-		case "not_open":
-			rejectCondition = types.QueryRejectConditionNotOpen
-		case "not_completed_cleanly":
-			rejectCondition = types.QueryRejectConditionNotCompletedCleanly
-		default:
-			return commoncli.Problem(fmt.Sprintf("invalid reject condition %v, valid values are \"not_open\" and \"not_completed_cleanly\"", c.String(FlagQueryRejectCondition)), nil)
-		}
-		queryRequest.QueryRejectCondition = &rejectCondition
+
+	rejectCondition, err := getOptionWithSerializer(c, FlagQueryRejectCondition, mapQueryRejectConditionFromFlag)
+	if err != nil {
+		return commoncli.Problem(err.Error(), nil)
 	}
-	if c.IsSet(FlagQueryConsistencyLevel) {
-		// TODO consider using generic flag for all enum flags https://github.com/urfave/cli/issues/786
-		var consistencyLevel types.QueryConsistencyLevel
-		switch c.String(FlagQueryConsistencyLevel) {
-		case "eventual":
-			consistencyLevel = types.QueryConsistencyLevelEventual
-		case "strong":
-			consistencyLevel = types.QueryConsistencyLevelStrong
-		default:
-			return commoncli.Problem(fmt.Sprintf("invalid query consistency level %v, valid values are \"eventual\" and \"strong\"", c.String(FlagQueryConsistencyLevel)), nil)
-		}
-		queryRequest.QueryConsistencyLevel = &consistencyLevel
+	queryRequest.QueryRejectCondition = rejectCondition
+
+	consistencyLevel, err := getOptionWithSerializer(c, FlagQueryConsistencyLevel, mapQueryConsistencyLevelFromFlag)
+	if err != nil {
+		return commoncli.Problem(err.Error(), nil)
 	}
+	queryRequest.QueryConsistencyLevel = consistencyLevel
+
 	queryResponse, err := serviceClient.QueryWorkflow(tcCtx, queryRequest)
 	if err != nil {
 		return commoncli.Problem("Query workflow failed.", err)
@@ -1066,13 +1060,22 @@ func describeWorkflowHelper(c *cli.Context, wid, rid string) error {
 		return commoncli.Problem("Error creating context: ", err)
 	}
 
-	resp, err := frontendClient.DescribeWorkflowExecution(ctx, &types.DescribeWorkflowExecutionRequest{
+	request := &types.DescribeWorkflowExecutionRequest{
 		Domain: domain,
 		Execution: &types.WorkflowExecution{
 			WorkflowID: wid,
 			RunID:      rid,
 		},
-	})
+	}
+
+	consistencyLevel, err := getOptionWithSerializer[types.QueryConsistencyLevel](c, FlagQueryConsistencyLevel, mapQueryConsistencyLevelFromFlag)
+	if err != nil {
+		return commoncli.Problem(err.Error(), nil)
+	}
+	request.QueryConsistencyLevel = consistencyLevel
+
+	resp, err := frontendClient.DescribeWorkflowExecution(ctx, request)
+
 	if err != nil {
 		return commoncli.Problem("Describe workflow execution failed", err)
 	}
@@ -1784,6 +1787,9 @@ func ObserveHistory(c *cli.Context) error {
 	}
 	rid := c.String(FlagRunID)
 	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
 
 	printWorkflowProgress(c, domain, wid, rid)
 	return nil
@@ -2640,4 +2646,32 @@ OuterLoop:
 		return 0, printErrorAndReturn("Get DecisionFinishID failed", fmt.Errorf("no DecisionFinishID"))
 	}
 	return
+}
+
+func mapQueryConsistencyLevelFromFlag(flag string) (types.QueryConsistencyLevel, error) {
+	var consistencyLevel types.QueryConsistencyLevel
+	switch flag {
+	case "eventual":
+		consistencyLevel = types.QueryConsistencyLevelEventual
+	case "strong":
+		consistencyLevel = types.QueryConsistencyLevelStrong
+	default:
+		return consistencyLevel, fmt.Errorf("invalid query consistency level %q, valid values are \"eventual\" and \"strong\"", flag)
+	}
+
+	return consistencyLevel, nil
+}
+
+func mapQueryRejectConditionFromFlag(flag string) (types.QueryRejectCondition, error) {
+	var rejectCondition types.QueryRejectCondition
+	switch flag {
+	case "not_open":
+		rejectCondition = types.QueryRejectConditionNotOpen
+	case "not_completed_cleanly":
+		rejectCondition = types.QueryRejectConditionNotCompletedCleanly
+	default:
+		return rejectCondition, fmt.Errorf("invalid reject condition %v, valid values are \"not_open\" and \"not_completed_cleanly\"", flag)
+	}
+
+	return rejectCondition, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Add --query_consistency_level flag to 'workflow show' and 'workflow describe' commands to support strong and eventual consistency modes in multi-cluster Cadence deployments. 

<!-- Tell your future self why have you made these changes -->
**Why?**

This enables users to specify consistency requirements when querying workflow execution history and details across clusters.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Tested via unit tests & sanity checks with local docker. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
