### PR TITLE
Support building wildcard query

### DIFF
--- a/common/persistence/elasticsearch/es_visibility_store.go
+++ b/common/persistence/elasticsearch/es_visibility_store.go
@@ -1108,9 +1108,9 @@ func replaceDummyQuery(dsl *fastjson.Value) *fastjson.Value {
 	// Convert to string to find and remove the dummy query
 	dslStr := dsl.String()
 
-	// Remove the dummy match_phrase query
+	// Remove all dummy match_phrase queries
 	dummyQuery := `{"match_phrase":{"__dummy_field__":{"query":"__dummy_value__"}}}`
-	dslStr = strings.Replace(dslStr, dummyQuery, "", 1)
+	dslStr = strings.ReplaceAll(dslStr, dummyQuery, "")
 
 	// Clean up any trailing commas or empty arrays
 	dslStr = strings.Replace(dslStr, ",,", ",", -1)

--- a/common/persistence/elasticsearch/es_visibility_store.go
+++ b/common/persistence/elasticsearch/es_visibility_store.go
@@ -610,15 +610,38 @@ func getSQLFromCountRequest(request *p.CountWorkflowExecutionsRequest) string {
 }
 
 func getCustomizedDSLFromSQL(sql string, domainID string) (*fastjson.Value, error) {
-	dslStr, _, err := elasticsql.Convert(sql)
-	if err != nil {
+	likeClauses, strippedSQL := extractLikeClauses(sql)
+
+	// Step 1: Convert with elasticsql for the non-LIKE portion
+	var dsl *fastjson.Value
+	if hasRealConditions(strippedSQL) {
+		dslStr, _, err := elasticsql.Convert(strippedSQL)
+		if err != nil {
+			return nil, err
+		}
+		dsl, err = fastjson.Parse(dslStr)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Build a minimal query wrapper to attach wildcard clauses
+		dsl = fastjson.MustParse(`{
+			"query": {
+			  "bool": {
+				"must": []
+			  }
+			},
+			"from": 0,
+			"size": 1
+		  }`)
+	}
+
+	// Step 2: Patch wildcard queries back in
+	if err := injectWildcardQueries(dsl, likeClauses); err != nil {
 		return nil, err
 	}
-	dsl, err := fastjson.Parse(dslStr) // dsl.String() will be a compact json without spaces
-	if err != nil {
-		return nil, err
-	}
-	dslStr = dsl.String()
+
+	dslStr := dsl.String()
 	if strings.Contains(dslStr, jsonMissingStartTime) { // isUninitialized
 		dsl = replaceQueryForUninitialized(dsl)
 	}
@@ -994,4 +1017,87 @@ func cleanDSL(input string) string {
 	var re = regexp.MustCompile("(`)(Attr.\\w+)(`)")
 	result := re.ReplaceAllString(input, `$2`)
 	return result
+}
+
+type likeClause struct {
+	Field   string
+	Pattern string
+}
+
+func extractLikeClauses(sql string) ([]likeClause, string) {
+	var clauses []likeClause
+	re := regexp.MustCompile(`(?i)([\w\.]+)\s+LIKE\s+'([^']+)'`)
+	strippedSQL := sql
+
+	matches := re.FindAllStringSubmatch(sql, -1)
+	for _, match := range matches {
+		clauses = append(clauses, likeClause{
+			Field:   match[1],
+			Pattern: match[2],
+		})
+		// Remove LIKE clause from SQL
+		strippedSQL = strings.Replace(strippedSQL, match[0], "1=1", 1)
+	}
+	return clauses, strippedSQL
+}
+
+func injectWildcardQueries(dsl *fastjson.Value, likes []likeClause) error {
+	obj, err := dsl.Object()
+	if err != nil {
+		return err
+	}
+	queryObj := obj.Get("query")
+	if queryObj == nil {
+		return fmt.Errorf("missing 'query' field")
+	}
+
+	boolObj := queryObj.Get("bool")
+	if boolObj == nil {
+		return fmt.Errorf("missing 'bool' query")
+	}
+
+	mustArr := boolObj.GetArray("must")
+	if mustArr == nil {
+		// if must doesn't exist, create it
+		mustArr = []*fastjson.Value{}
+	}
+
+	for _, clause := range likes {
+		wildcardValue := strings.ReplaceAll(clause.Pattern, "%", "*")
+		wildcardValue = strings.ReplaceAll(wildcardValue, "_", "?")
+
+		wildcard := fmt.Sprintf(`{"wildcard": {"%s": {"value": "%s*"}}}`, clause.Field, wildcardValue)
+		v, err := fastjson.Parse(wildcard)
+		if err != nil {
+			return err
+		}
+		mustArr = append(mustArr, v)
+	}
+
+	// Inject updated must array
+	boolObj.Set("must", fastjson.MustParse(fmt.Sprintf("[%s]", joinFastjson(mustArr, ","))))
+	return nil
+}
+
+func joinFastjson(arr []*fastjson.Value, sep string) string {
+	parts := make([]string, len(arr))
+	for i, v := range arr {
+		parts[i] = v.String()
+	}
+	return strings.Join(parts, sep)
+}
+
+func hasRealConditions(sql string) bool {
+	sql = strings.ToLower(sql)
+
+	// Remove SQL keywords and placeholders
+	toRemove := []string{
+		"select", "from", "where", "*", "1=1", "true", "dummy", "dummy_table", "dummy_index",
+	}
+	for _, r := range toRemove {
+		sql = strings.ReplaceAll(sql, r, "")
+	}
+
+	sql = strings.TrimSpace(sql)
+	return len(sql) > 0
 }

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -792,7 +792,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 		s.True(strings.Contains(input.Query, `{"match_phrase":{"CloseStatus":{"query":"5"}}}`))
 		s.Equal(esIndexMaxResultWindow, input.MaxResultWindow)
 		return true
-	})).Return(testSearchResult, nil).Twice()
+	})).Return(testSearchResult, nil).Once()
 
 	request := &p.ListWorkflowExecutionsByQueryRequest{
 		DomainUUID: testDomainID,
@@ -806,6 +806,12 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 
 	_, err := s.visibilityStore.ListWorkflowExecutions(ctx, request)
 	s.NoError(err)
+
+	s.mockESClient.On("SearchByQuery", mock.Anything, mock.MatchedBy(func(input *es.SearchByQueryRequest) bool {
+		s.True(strings.Contains(input.Query, `{"wildcard":{"CloseStatus":"5*"}}`))
+		s.Equal(esIndexMaxResultWindow, input.MaxResultWindow)
+		return true
+	})).Return(testSearchResult, nil).Once()
 
 	requestWithLike := &p.ListWorkflowExecutionsByQueryRequest{
 		DomainUUID: testDomainID,

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -1121,3 +1121,36 @@ func matchQueryData(matchQuery query.MatchQuery) (Source, error) {
 	}
 	return to, nil
 }
+
+func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
+	sql := "select * from dummy where WorkflowID like 'wid'"
+	dsl, err := getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+
+	sql = "select * from dummy where Attr.CustomizedKeywordField like 'test'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+
+	sql = "select * from dummy where WorkflowID = 'wid'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"WorkflowID":{"query":"wid"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+
+	sql = "select * from dummy where Attr.CustomizedKeywordField = 'test'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"test"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+	/*
+	   sql = "select * from dummy where WorkflowID like 'wid' and Attr.CustomizedKeywordField = 'test'"
+	   dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	   s.NoError(err)
+	   s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"WorkflowID":{"query":"wid"}}},{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"test"}}}]}}]}}}`, dsl.String())
+
+	   sql = "select * from dummy where WorkflowID like 'like' and Attr.CustomizedKeywordField = 'like'"
+	   dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	   s.NoError(err)
+	   s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}}}`, dsl.String())
+	*/
+}

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -1123,10 +1123,10 @@ func matchQueryData(matchQuery query.MatchQuery) (Source, error) {
 }
 
 func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
-	sql := "select * from dummy where WorkflowID like 'wid'"
+	sql := "select * from dummy where WorkflowID like 'wid' LIMIT 100"
 	dsl, err := getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
-	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}}]}}]}},"from":0,"size":100}`, dsl.String())
 
 	sql = "select * from dummy where Attr.CustomizedKeywordField like 'test'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
@@ -1142,15 +1142,14 @@ func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
 	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"test"}}}]}}]}},"from":0,"size":1}`, dsl.String())
-	/*
-	   sql = "select * from dummy where WorkflowID like 'wid' and Attr.CustomizedKeywordField = 'test'"
-	   dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
-	   s.NoError(err)
-	   s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"WorkflowID":{"query":"wid"}}},{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"test"}}}]}}]}}}`, dsl.String())
 
-	   sql = "select * from dummy where WorkflowID like 'like' and Attr.CustomizedKeywordField = 'like'"
-	   dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
-	   s.NoError(err)
-	   s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}}}`, dsl.String())
-	*/
+	sql = "select * from dummy where WorkflowID like 'wid' and Attr.CustomizedKeywordField = 'test'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"test"}}},{"wildcard":{"WorkflowID":{"value":"wid*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+
+	sql = "select * from dummy where WorkflowID like 'like' and Attr.CustomizedKeywordField = 'like'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"like"}}},{"wildcard":{"WorkflowID":{"value":"like*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
 }

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -1163,4 +1163,9 @@ func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
 	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"like"}}},{"wildcard":{"WorkflowID":{"value":"like*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+
+	sql = "select * from dummy where WorkflowID like 'wid' and Attr.CustomizedKeywordField like 'test'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Support parse and build wildcard queries for keyword field. If use input query `"key1 like 'value1'"`, it will be translated as 
```
 "wildcard": {
        "key1": {
            "value": "value1*"
        } 
 } 
```
This query is expensive, so only support prefix match for now.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test and manual test 
```
% ./cadence --do samples-domain wf list
Fetching 2 workflows...
  WORKFLOW TYPE | WORKFLOW ID |                RUN ID                | TASK LIST | IS CRON | START TIME | EXECUTION TIME | END TIME | CLOSE STATUS | HISTORY LENGTH | UPDATE TIME
  test          | test1-2     | ae2d3fc1-e19f-4b8e-afe4-6cac57f8c133 | tasklsit  | false   | 13:03:18   | 13:03:18       | 13:03:19 | TIMED_OUT    |              3 | 16:00:00
  test          | test-1      | 10326234-88a9-4db6-a873-72d8e62bcabb | tasklsit  | false   | 13:03:15   | 13:03:15       | 13:03:16 | TIMED_OUT    |              3 | 16:00:00

% ./cadence --do samples-domain wf list --query "WorkflowID like 'test1'"
Fetching 1 workflows...
  WORKFLOW TYPE | WORKFLOW ID |                RUN ID                | TASK LIST | IS CRON | START TIME | EXECUTION TIME | END TIME | CLOSE STATUS | HISTORY LENGTH | UPDATE TIME
  test          | test1-2     | ae2d3fc1-e19f-4b8e-afe4-6cac57f8c133 | tasklsit  | false   | 13:03:18   | 13:03:18       | 13:03:19 | TIMED_OUT    |              3 | 16:00:00

% ./cadence --do samples-domain wf list --query "WorkflowID = 'test1'"
Fetching 0 workflows...
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
