### PR TITLE
[shard-distributor] AssignShards method fills ownership of the shards

### DIFF
--- a/service/sharddistributor/leader/process/processor.go
+++ b/service/sharddistributor/leader/process/processor.go
@@ -337,6 +337,10 @@ func (p *namespaceProcessor) rebalanceShards(ctx context.Context) (err error) {
 		i++
 	}
 
+	if namespaceState.Shards == nil {
+		namespaceState.Shards = make(map[string]store.ShardState)
+	}
+
 	newState := make(map[string]store.AssignedState)
 	for executorID, shards := range currentAssignments {
 		assignedShardsMap := make(map[string]*types.ShardAssignment)

--- a/service/sharddistributor/leader/process/processor.go
+++ b/service/sharddistributor/leader/process/processor.go
@@ -226,7 +226,7 @@ func (p *namespaceProcessor) runCleanupLoop(ctx context.Context) {
 
 // cleanupStaleExecutors removes executors who have not reported a heartbeat recently.
 func (p *namespaceProcessor) cleanupStaleExecutors(ctx context.Context) {
-	heartbeatStates, _, _, err := p.shardStore.GetState(ctx, p.namespaceCfg.Name)
+	namespaceState, err := p.shardStore.GetState(ctx, p.namespaceCfg.Name)
 	if err != nil {
 		p.logger.Error("Failed to get state for heartbeat cleanup", tag.Error(err))
 		return
@@ -236,7 +236,7 @@ func (p *namespaceProcessor) cleanupStaleExecutors(ctx context.Context) {
 	now := p.timeSource.Now().Unix()
 	heartbeatTTL := int64(p.cfg.HeartbeatTTL.Seconds())
 
-	for executorID, state := range heartbeatStates {
+	for executorID, state := range namespaceState.Executors {
 		if (now - state.LastHeartbeat) > heartbeatTTL {
 			expiredExecutors = append(expiredExecutors, executorID)
 		}
@@ -270,17 +270,17 @@ func (p *namespaceProcessor) rebalanceShards(ctx context.Context) (err error) {
 		metricsLoopScope.RecordHistogramDuration(metrics.ShardDistributorAssignLoopShardRebalanceLatency, p.timeSource.Now().Sub(start))
 	}()
 
-	heartbeatStates, assignedStates, readRevision, err := p.shardStore.GetState(ctx, p.namespaceCfg.Name)
+	namespaceState, err := p.shardStore.GetState(ctx, p.namespaceCfg.Name)
 	if err != nil {
 		return fmt.Errorf("get state: %w", err)
 	}
 
-	if readRevision <= p.lastAppliedRevision {
+	if namespaceState.GlobalRevision <= p.lastAppliedRevision {
 		return nil
 	}
 
 	var activeExecutors []string
-	for id, state := range heartbeatStates {
+	for id, state := range namespaceState.Executors {
 		if state.Status == types.ExecutorStatusACTIVE {
 			activeExecutors = append(activeExecutors, id)
 		}
@@ -305,8 +305,8 @@ func (p *namespaceProcessor) rebalanceShards(ctx context.Context) (err error) {
 		currentAssignments[executorID] = []string{}
 	}
 
-	for executorID, state := range assignedStates {
-		isActive := heartbeatStates[executorID].Status == types.ExecutorStatusACTIVE
+	for executorID, state := range namespaceState.ShardAssignments {
+		isActive := namespaceState.Executors[executorID].Status == types.ExecutorStatusACTIVE
 		for shardID := range state.AssignedShards {
 			if _, ok := allShards[shardID]; ok {
 				delete(allShards, shardID)
@@ -326,7 +326,7 @@ func (p *namespaceProcessor) rebalanceShards(ctx context.Context) (err error) {
 	metricsLoopScope.UpdateGauge(metrics.ShardDistributorAssignLoopNumRebalancedShards, float64(len(shardsToReassign)))
 
 	if len(shardsToReassign) == 0 {
-		p.lastAppliedRevision = readRevision
+		p.lastAppliedRevision = namespaceState.GlobalRevision
 		return nil
 	}
 
@@ -342,6 +342,10 @@ func (p *namespaceProcessor) rebalanceShards(ctx context.Context) (err error) {
 		assignedShardsMap := make(map[string]*types.ShardAssignment)
 		for _, shardID := range shards {
 			assignedShardsMap[shardID] = &types.ShardAssignment{Status: types.AssignmentStatusREADY}
+			namespaceState.Shards[shardID] = store.ShardState{
+				ExecutorID: executorID,
+				Revision:   namespaceState.Shards[shardID].Revision,
+			}
 		}
 		newState[executorID] = store.AssignedState{
 			AssignedShards: assignedShardsMap,
@@ -349,14 +353,16 @@ func (p *namespaceProcessor) rebalanceShards(ctx context.Context) (err error) {
 		}
 	}
 
+	namespaceState.ShardAssignments = newState
+
 	p.logger.Info("Applying new shard distribution.")
 	// Use the leader guard for the assign operation.
-	err = p.shardStore.AssignShards(ctx, p.namespaceCfg.Name, newState, p.election.Guard())
+	err = p.shardStore.AssignShards(ctx, p.namespaceCfg.Name, namespaceState, p.election.Guard())
 	if err != nil {
 		return fmt.Errorf("assign shards: %w", err)
 	}
 
-	p.lastAppliedRevision = readRevision
+	p.lastAppliedRevision = namespaceState.GlobalRevision
 
 	return nil
 }

--- a/service/sharddistributor/store/state.go
+++ b/service/sharddistributor/store/state.go
@@ -14,3 +14,15 @@ type AssignedState struct {
 	AssignedShards map[string]*types.ShardAssignment `json:"assigned_shards"` // What we assigned
 	LastUpdated    int64                             `json:"last_updated"`
 }
+
+type NamespaceState struct {
+	Executors        map[string]HeartbeatState
+	Shards           map[string]ShardState
+	ShardAssignments map[string]AssignedState
+	GlobalRevision   int64
+}
+
+type ShardState struct {
+	ExecutorID string
+	Revision   int64
+}

--- a/service/sharddistributor/store/store.go
+++ b/service/sharddistributor/store/store.go
@@ -43,8 +43,8 @@ func NopGuard() GuardFunc {
 
 // Store is a composite interface that combines all storage capabilities.
 type Store interface {
-	GetState(ctx context.Context, namespace string) (map[string]HeartbeatState, map[string]AssignedState, int64, error)
-	AssignShards(ctx context.Context, namespace string, newState map[string]AssignedState, guard GuardFunc) error
+	GetState(ctx context.Context, namespace string) (*NamespaceState, error)
+	AssignShards(ctx context.Context, namespace string, newState *NamespaceState, guard GuardFunc) error
 	Subscribe(ctx context.Context, namespace string) (<-chan int64, error)
 	DeleteExecutors(ctx context.Context, namespace string, executorIDs []string, guard GuardFunc) error
 

--- a/service/sharddistributor/store/store_mock.go
+++ b/service/sharddistributor/store/store_mock.go
@@ -79,7 +79,7 @@ func (mr *MockStoreMockRecorder) AssignShard(ctx, namespace, shardID, executorID
 }
 
 // AssignShards mocks base method.
-func (m *MockStore) AssignShards(ctx context.Context, namespace string, newState map[string]AssignedState, guard GuardFunc) error {
+func (m *MockStore) AssignShards(ctx context.Context, namespace string, newState *NamespaceState, guard GuardFunc) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignShards", ctx, namespace, newState, guard)
 	ret0, _ := ret[0].(error)
@@ -138,14 +138,12 @@ func (mr *MockStoreMockRecorder) GetShardOwner(ctx, namespace, shardID any) *gom
 }
 
 // GetState mocks base method.
-func (m *MockStore) GetState(ctx context.Context, namespace string) (map[string]HeartbeatState, map[string]AssignedState, int64, error) {
+func (m *MockStore) GetState(ctx context.Context, namespace string) (*NamespaceState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetState", ctx, namespace)
-	ret0, _ := ret[0].(map[string]HeartbeatState)
-	ret1, _ := ret[1].(map[string]AssignedState)
-	ret2, _ := ret[2].(int64)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret0, _ := ret[0].(*NamespaceState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetState indicates an expected call of GetState.

--- a/service/sharddistributor/store/wrappers/metered/store_generated.go
+++ b/service/sharddistributor/store/wrappers/metered/store_generated.go
@@ -46,7 +46,7 @@ func (c *meteredStore) AssignShard(ctx context.Context, namespace string, shardI
 	return
 }
 
-func (c *meteredStore) AssignShards(ctx context.Context, namespace string, newState map[string]store.AssignedState, guard store.GuardFunc) (err error) {
+func (c *meteredStore) AssignShards(ctx context.Context, namespace string, newState *store.NamespaceState, guard store.GuardFunc) (err error) {
 	op := func() error {
 		err = c.wrapped.AssignShards(ctx, namespace, newState, guard)
 		return err
@@ -86,9 +86,9 @@ func (c *meteredStore) GetShardOwner(ctx context.Context, namespace string, shar
 	return
 }
 
-func (c *meteredStore) GetState(ctx context.Context, namespace string) (m1 map[string]store.HeartbeatState, m2 map[string]store.AssignedState, i1 int64, err error) {
+func (c *meteredStore) GetState(ctx context.Context, namespace string) (np1 *store.NamespaceState, err error) {
 	op := func() error {
-		m1, m2, i1, err = c.wrapped.GetState(ctx, namespace)
+		np1, err = c.wrapped.GetState(ctx, namespace)
 		return err
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
GetState and AssignShards methods now use shard ownership information that the shard assignment process could change.
Using this information, we can give a read-after-write guarantee, so that we won't have double assignments.
Process never entirely removes assignments, as we must assign all shards to the executor.
*Note:* rebalanceShards will fail if a conflict happens and will retry either by timer or because any other change will trigger redistribution.

<!-- Tell your future self why have you made these changes -->
**Why?**
AssignShards is the main process of the shard-distributor, and it must update shard ownership so it can be consumed with the GetShardOwner call.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
