### PR TITLE
Validate workflow reset based on requested event type

### DIFF
--- a/common/persistence/versionHistory.go
+++ b/common/persistence/versionHistory.go
@@ -72,7 +72,7 @@ func (item *VersionHistoryItem) ToInternalType() *types.VersionHistoryItem {
 	}
 }
 
-// Equals test if this version history itme and input version history item  are the same
+// Equals test if this version history item and input version history item are the same
 func (item *VersionHistoryItem) Equals(input *VersionHistoryItem) bool {
 	return item.Version == input.Version && item.EventID == input.EventID
 }

--- a/service/history/engine/engineimpl/history_engine_test.go
+++ b/service/history/engine/engineimpl/history_engine_test.go
@@ -5326,7 +5326,7 @@ func (s *engineSuite) TestReapplyEvents_ResetWorkflow() {
 	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	s.mockWorkflowResetter.EXPECT().ResetWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-		gomock.Any(),
+		gomock.Any(), gomock.Any(),
 	).Return(nil).Times(1)
 	err = s.mockHistoryEngine.ReapplyEvents(
 		context.Background(),

--- a/service/history/engine/engineimpl/reapply_events.go
+++ b/service/history/engine/engineimpl/reapply_events.go
@@ -147,6 +147,7 @@ func (e *historyEngineImpl) ReapplyEvents(
 					ndc.EventsReapplicationResetWorkflowReason,
 					toReapplyEvents,
 					false,
+					nil,
 				); err != nil {
 					return nil, err
 				}

--- a/service/history/engine/engineimpl/reset_workflow_execution.go
+++ b/service/history/engine/engineimpl/reset_workflow_execution.go
@@ -23,7 +23,6 @@ package engineimpl
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pborman/uuid"
 
@@ -43,6 +42,7 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 	domainID := resetRequest.GetDomainUUID()
 	workflowID := request.WorkflowExecution.GetWorkflowID()
 	baseRunID := request.WorkflowExecution.GetRunID()
+	decisionFinishEventID := request.GetDecisionFinishEventID()
 
 	baseContext, baseReleaseFn, err := e.executionCache.GetOrCreateWorkflowExecution(
 		ctx,
@@ -66,8 +66,8 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 			Message: "Cannot reset workflow without a decision task schedule.",
 		}
 	}
-	if request.GetDecisionFinishEventID() <= constants.FirstEventID ||
-		request.GetDecisionFinishEventID() > baseMutableState.GetNextEventID() {
+	if decisionFinishEventID <= constants.FirstEventID ||
+		decisionFinishEventID > baseMutableState.GetNextEventID() {
 		return nil, &types.BadRequestError{
 			Message: "Decision finish ID must be > 1 && <= workflow next event ID.",
 		}
@@ -84,13 +84,6 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	// validate if workflow is resettable
-	if err := e.isWorkflowResettable(baseMutableState, domainID); err != nil {
-		return nil, &types.BadRequestError{
-			Message: fmt.Sprintf("workflow is not resettable. Error: %v", err),
-		}
 	}
 
 	currentRunID := resp.RunID
@@ -132,7 +125,7 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 	}
 
 	resetRunID := uuid.New()
-	baseRebuildLastEventID := request.GetDecisionFinishEventID() - 1
+	baseRebuildLastEventID := decisionFinishEventID - 1
 	baseVersionHistories := baseMutableState.GetVersionHistories()
 	baseCurrentBranchToken, err := baseMutableState.GetCurrentBranchToken()
 	if err != nil {
@@ -176,6 +169,7 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 		request.GetReason(),
 		nil,
 		request.GetSkipSignalReapply(),
+		&decisionFinishEventID,
 	); err != nil {
 		if t, ok := persistence.AsDuplicateRequestError(err); ok {
 			if t.RequestType == persistence.WorkflowRequestTypeReset {
@@ -191,25 +185,4 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 	return &types.ResetWorkflowExecutionResponse{
 		RunID: resetRunID,
 	}, nil
-}
-
-/*
-If a workflow was started in a different cluster, it is not resettable because replication stack is not able to handle workflow start event.
-*/
-func (e *historyEngineImpl) isWorkflowResettable(baseMutableState execution.MutableState, domainID string) error {
-	startVersion, err := baseMutableState.GetStartVersion()
-	if err != nil {
-		return fmt.Errorf("fail to get failover version of workflow start event: %w", err)
-	}
-
-	startCluster, err := e.shard.GetActiveClusterManager().ClusterNameForFailoverVersion(startVersion, domainID)
-	if err != nil {
-		return fmt.Errorf("fail to get cluster name for failover version: %w", err)
-	}
-
-	if currentCluster := e.clusterMetadata.GetCurrentClusterName(); currentCluster != startCluster {
-		return fmt.Errorf("workflow was not started in the current cluster: failover to workflow start cluster %s before reset", startCluster)
-	}
-
-	return nil
 }

--- a/service/history/engine/engineimpl/reset_workflow_execution_test.go
+++ b/service/history/engine/engineimpl/reset_workflow_execution_test.go
@@ -153,6 +153,9 @@ func TestResetWorkflowExecution(t *testing.T) {
 						gomock.Eq(testRequestReason),
 						gomock.Nil(),
 						gomock.Eq(testRequestSkipSignalReapply),
+						mock.MatchedBy(func(p *int64) bool {
+							return p != nil && *p == 100
+						}),
 					).Return(nil).Times(1)
 				},
 			},
@@ -219,134 +222,13 @@ func TestResetWorkflowExecution(t *testing.T) {
 						gomock.Eq(testRequestReason),
 						gomock.Nil(),
 						gomock.Eq(testRequestSkipSignalReapply),
+						mock.MatchedBy(func(p *int64) bool {
+							return p != nil && *p == 50
+						}),
 					).Return(nil).Times(1)
 				},
 			},
 			// Can't assert on the result because the runID is random
-		},
-		{
-			name: "Failure using version histories not started in current cluster",
-			// This corresponds to VersionHistories.Histories.Items.EventID
-			request: resetExecutionRequest(latestExecution, 50),
-			init: []InitFn{
-				withCurrentExecution(latestExecution),
-				withState(latestExecution, &persistence.WorkflowMutableState{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:    constants.TestDomainID,
-						WorkflowID:  constants.TestWorkflowID,
-						RunID:       latestRunID,
-						NextEventID: 100,
-						BranchToken: []byte("branch token"),
-					},
-					VersionHistories: &persistence.VersionHistories{
-						CurrentVersionHistoryIndex: 0,
-						Histories: []*persistence.VersionHistory{
-							{
-								BranchToken: []byte("yes"),
-								Items: []*persistence.VersionHistoryItem{
-									{
-										EventID: 1,
-										Version: 1001, // not current cluster
-									},
-									{
-										EventID: 50,
-										Version: 1002,
-									},
-									{
-										EventID: 51,
-										Version: 1003,
-									},
-								},
-							},
-						},
-					},
-					ExecutionStats: &persistence.ExecutionStats{HistorySize: 1},
-				}),
-				func(t *testing.T, engine *testdata.EngineForTest) {
-					ctrl := gomock.NewController(t)
-					mockResetter := reset.NewMockWorkflowResetter(ctrl)
-					engine.Engine.(*historyEngineImpl).workflowResetter = mockResetter
-				},
-			},
-			expectedErr: &types.BadRequestError{
-				Message: "workflow is not resettable. Error: workflow was not started in the current cluster: failover to workflow start cluster standby before reset",
-			},
-		},
-		{
-			name: "Failure using empty version histories",
-			// This corresponds to VersionHistories.Histories.Items.EventID
-			request: resetExecutionRequest(latestExecution, 50),
-			init: []InitFn{
-				withCurrentExecution(latestExecution),
-				withState(latestExecution, &persistence.WorkflowMutableState{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:    constants.TestDomainID,
-						WorkflowID:  constants.TestWorkflowID,
-						RunID:       latestRunID,
-						NextEventID: 100,
-						BranchToken: []byte("branch token"),
-					},
-					VersionHistories: &persistence.VersionHistories{
-						CurrentVersionHistoryIndex: 0,
-						Histories: []*persistence.VersionHistory{
-							{},
-						},
-					},
-					ExecutionStats: &persistence.ExecutionStats{HistorySize: 1},
-				}),
-				func(t *testing.T, engine *testdata.EngineForTest) {
-					ctrl := gomock.NewController(t)
-					mockResetter := reset.NewMockWorkflowResetter(ctrl)
-					engine.Engine.(*historyEngineImpl).workflowResetter = mockResetter
-				},
-			},
-			expectedErr: &types.BadRequestError{
-				Message: "workflow is not resettable. Error: fail to get failover version of workflow start event: version history is empty.",
-			},
-		},
-		{
-			name: "Failure using errorneous version histories",
-			// This corresponds to VersionHistories.Histories.Items.EventID
-			request: resetExecutionRequest(latestExecution, 50),
-			init: []InitFn{
-				withCurrentExecution(latestExecution),
-				withState(latestExecution, &persistence.WorkflowMutableState{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:    constants.TestDomainID,
-						WorkflowID:  constants.TestWorkflowID,
-						RunID:       latestRunID,
-						NextEventID: 100,
-						BranchToken: []byte("branch token"),
-					},
-					VersionHistories: &persistence.VersionHistories{
-						CurrentVersionHistoryIndex: 0,
-						Histories: []*persistence.VersionHistory{
-							{
-								BranchToken: []byte("yes"),
-								Items: []*persistence.VersionHistoryItem{
-									{
-										EventID: 1,
-										Version: 1004, // unknown version
-									},
-									{
-										EventID: 50,
-										Version: 1005, // unknown version
-									},
-								},
-							},
-						},
-					},
-					ExecutionStats: &persistence.ExecutionStats{HistorySize: 1},
-				}),
-				func(t *testing.T, engine *testdata.EngineForTest) {
-					ctrl := gomock.NewController(t)
-					mockResetter := reset.NewMockWorkflowResetter(ctrl)
-					engine.Engine.(*historyEngineImpl).workflowResetter = mockResetter
-				},
-			},
-			expectedErr: &types.BadRequestError{
-				Message: "workflow is not resettable. Error: fail to get cluster name for failover version: failed to resolve failover version to a cluster: could not resolve failover version: 1004",
-			},
 		},
 		{
 			name:    "Success using previous version",
@@ -397,6 +279,9 @@ func TestResetWorkflowExecution(t *testing.T) {
 						gomock.Eq(testRequestReason),
 						gomock.Nil(),
 						gomock.Eq(testRequestSkipSignalReapply),
+						mock.MatchedBy(func(p *int64) bool {
+							return p != nil && *p == 100
+						}),
 					).Return(nil).Times(1)
 				},
 			},
@@ -440,6 +325,9 @@ func TestResetWorkflowExecution(t *testing.T) {
 						gomock.Eq(testRequestReason),
 						gomock.Nil(),
 						gomock.Eq(testRequestSkipSignalReapply),
+						mock.MatchedBy(func(p *int64) bool {
+							return p != nil && *p == 100
+						}),
 					).Return(&persistence.DuplicateRequestError{
 						RequestType: persistence.WorkflowRequestTypeReset,
 						RunID:       "errorID",
@@ -488,6 +376,9 @@ func TestResetWorkflowExecution(t *testing.T) {
 						gomock.Eq(testRequestReason),
 						gomock.Nil(),
 						gomock.Eq(testRequestSkipSignalReapply),
+						mock.MatchedBy(func(p *int64) bool {
+							return p != nil && *p == 100
+						}),
 					).Return(&persistence.DuplicateRequestError{
 						RequestType: persistence.WorkflowRequestTypeStart,
 						RunID:       "errorID",
@@ -537,6 +428,9 @@ func TestResetWorkflowExecution(t *testing.T) {
 						gomock.Eq(testRequestReason),
 						gomock.Nil(),
 						gomock.Eq(testRequestSkipSignalReapply),
+						mock.MatchedBy(func(p *int64) bool {
+							return p != nil && *p == 100
+						}),
 					).Return(&types.BadRequestError{
 						Message: "didn't work",
 					}).Times(1)

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -59,6 +59,7 @@ type (
 			targetWorkflowIdentifier definition.WorkflowIdentifier,
 			targetBranchFn func() ([]byte, error),
 			requestID string,
+			resetEventID *int64,
 		) (MutableState, int64, error)
 	}
 
@@ -109,12 +110,19 @@ func (r *stateRebuilderImpl) Rebuild(
 	targetWorkflowIdentifier definition.WorkflowIdentifier,
 	targetBranchFn func() ([]byte, error),
 	requestID string,
+	resetEventID *int64,
 ) (MutableState, int64, error) {
+	lastEventID := baseLastEventID
+
+	// if resetEventID is provided, use that to include the reset event in the history events retrieved from the database
+	if resetEventID != nil {
+		lastEventID = *resetEventID
+	}
 
 	iter := collection.NewPagingIterator(r.getPaginationFn(
 		ctx,
 		constants.FirstEventID,
-		baseLastEventID+1,
+		lastEventID+1,
 		baseBranchToken,
 		targetWorkflowIdentifier.DomainID,
 	))
@@ -141,13 +149,32 @@ func (r *stateRebuilderImpl) Rebuild(
 		return nil, 0, err
 	}
 
+	// store firstEventBatch in case iter has no next items
+	events := firstEventBatch
+
 	for iter.HasNext() {
 		batch, err := iter.Next()
 		if err != nil {
 			return nil, 0, err
 		}
-		events := batch.(*types.History).Events
+
+		events = batch.(*types.History).Events
+
+		// if resetEventID is provided, check if the first event in the batch is >= to resetEventID
+		// if it is, all events have already been processed up to the reset event and can skip processing this batch
+		if resetEventID != nil && events[0].ID >= *resetEventID {
+			continue
+		}
+
 		if err := r.applyEvents(targetWorkflowIdentifier, stateBuilder, events, requestID); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	// if resetEventID is provided, we need to check if the reset event type is valid
+	if resetEventID != nil {
+		err := checkResetEventType(events, lastEventID)
+		if err != nil {
 			return nil, 0, err
 		}
 	}
@@ -277,4 +304,28 @@ func (r *stateRebuilderImpl) getPaginationFn(
 		}
 		return paginateItems, token, nil
 	}
+}
+
+// checkResetEventType checks the type of the reset event and only allows specific types to be resettable
+func checkResetEventType(events []*types.HistoryEvent, resetEventID int64) error {
+	for _, event := range events {
+		if event.ID == resetEventID {
+			switch *event.EventType {
+			case types.EventTypeDecisionTaskStarted:
+				return nil
+			case types.EventTypeDecisionTaskTimedOut:
+				return nil
+			case types.EventTypeDecisionTaskFailed:
+				return nil
+			case types.EventTypeDecisionTaskCompleted:
+				return nil
+			default:
+				return &types.BadRequestError{
+					Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", event.EventType.String()),
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("reset event ID %v not found in the history events", resetEventID)
 }

--- a/service/history/execution/state_rebuilder_mock.go
+++ b/service/history/execution/state_rebuilder_mock.go
@@ -44,9 +44,9 @@ func (m *MockStateRebuilder) EXPECT() *MockStateRebuilderMockRecorder {
 }
 
 // Rebuild mocks base method.
-func (m *MockStateRebuilder) Rebuild(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseLastEventID, baseLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string) (MutableState, int64, error) {
+func (m *MockStateRebuilder) Rebuild(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseLastEventID, baseLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string, resetEventID *int64) (MutableState, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rebuild", ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchFn, requestID)
+	ret := m.ctrl.Call(m, "Rebuild", ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchFn, requestID, resetEventID)
 	ret0, _ := ret[0].(MutableState)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
@@ -54,7 +54,7 @@ func (m *MockStateRebuilder) Rebuild(ctx context.Context, now time.Time, baseWor
 }
 
 // Rebuild indicates an expected call of Rebuild.
-func (mr *MockStateRebuilderMockRecorder) Rebuild(ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchFn, requestID any) *gomock.Call {
+func (mr *MockStateRebuilderMockRecorder) Rebuild(ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchFn, requestID, resetEventID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebuild", reflect.TypeOf((*MockStateRebuilder)(nil).Rebuild), ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchFn, requestID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebuild", reflect.TypeOf((*MockStateRebuilder)(nil).Rebuild), ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchFn, requestID, resetEventID)
 }

--- a/service/history/execution/state_rebuilder_test.go
+++ b/service/history/execution/state_rebuilder_test.go
@@ -22,6 +22,7 @@ package execution
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -67,6 +68,11 @@ type (
 		runID      string
 
 		nDCStateRebuilder *stateRebuilderImpl
+	}
+
+	testHistoryEvents struct {
+		Events []*types.HistoryEvent
+		Size   int
 	}
 )
 
@@ -123,7 +129,7 @@ func (s *stateRebuilderSuite) TestInitializeBuilders() {
 func (s *stateRebuilderSuite) TestApplyEvents() {
 
 	requestID := uuid.New()
-	events := []*types.HistoryEvent{
+	historyEvents := []*types.HistoryEvent{
 		{
 			ID:                                      1,
 			EventType:                               types.EventTypeWorkflowExecutionStarted.Ptr(),
@@ -146,11 +152,11 @@ func (s *stateRebuilderSuite) TestApplyEvents() {
 			WorkflowID: s.workflowID,
 			RunID:      s.runID,
 		},
-		events,
+		historyEvents,
 		[]*types.HistoryEvent(nil),
 	).Return(nil, nil).Times(1)
 
-	err := s.nDCStateRebuilder.applyEvents(workflowIdentifier, mockStateBuilder, events, requestID)
+	err := s.nDCStateRebuilder.applyEvents(workflowIdentifier, mockStateBuilder, historyEvents, requestID)
 	s.NoError(err)
 }
 
@@ -330,6 +336,7 @@ func (s *stateRebuilderSuite) TestRebuild() {
 		definition.NewWorkflowIdentifier(targetDomainID, targetWorkflowID, targetRunID),
 		targetBranchTokenFn,
 		requestID,
+		nil,
 	)
 	s.NoError(err)
 	s.NotNil(rebuildMutableState)
@@ -346,6 +353,497 @@ func (s *stateRebuilderSuite) TestRebuild() {
 		),
 	), rebuildMutableState.GetVersionHistories())
 	s.Equal(rebuildMutableState.GetExecutionInfo().StartTimestamp, now)
+}
+
+func (s *stateRebuilderSuite) TestRebuildResetEventIDNotNil() {
+	requestID := uuid.New()
+	version := int64(12)
+	branchToken := []byte("other random branch token")
+	targetBranchToken := []byte("some other random branch token")
+	now := time.Now()
+	partitionConfig := map[string]string{
+		"userid": uuid.New(),
+	}
+
+	targetDomainID := uuid.New()
+	targetDomainName := "other random domain name"
+	targetWorkflowID := "other random workflow ID"
+	targetRunID := uuid.New()
+
+	firstEventID := commonconstants.FirstEventID
+
+	workflowEvents := []*types.HistoryEvent{
+		{
+			ID:        1,
+			Version:   version,
+			EventType: types.EventTypeWorkflowExecutionStarted.Ptr(),
+			WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+				WorkflowType:                        &types.WorkflowType{Name: "some random workflow type"},
+				TaskList:                            &types.TaskList{Name: "some random workflow type"},
+				Input:                               []byte("some random input"),
+				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(123),
+				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(233),
+				Identity:                            "some random identity",
+				PartitionConfig:                     partitionConfig,
+			},
+		},
+		{
+			ID:                                   2,
+			Version:                              version,
+			EventType:                            types.EventTypeDecisionTaskScheduled.Ptr(),
+			DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{},
+		},
+		{
+			ID:        3,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+			DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+				ScheduledEventID: 2,
+			},
+		},
+		{
+			ID:        4,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+			DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+				ScheduledEventID: 2,
+				StartedEventID:   3,
+			},
+		},
+		{
+			ID:        5,
+			Version:   version,
+			EventType: types.EventTypeActivityTaskScheduled.Ptr(),
+			ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+				ActivityID: "1",
+			},
+		},
+		{
+			ID:        6,
+			Version:   version,
+			EventType: types.EventTypeActivityTaskStarted.Ptr(),
+			ActivityTaskStartedEventAttributes: &types.ActivityTaskStartedEventAttributes{
+				ScheduledEventID: 5,
+			},
+		},
+		{
+			ID:        7,
+			Version:   version,
+			EventType: types.EventTypeActivityTaskCompleted.Ptr(),
+			ActivityTaskCompletedEventAttributes: &types.ActivityTaskCompletedEventAttributes{
+				ScheduledEventID: 5,
+				StartedEventID:   6,
+			},
+		},
+		{
+			ID:                                   8,
+			Version:                              version,
+			EventType:                            types.EventTypeDecisionTaskScheduled.Ptr(),
+			DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{},
+		},
+		{
+			ID:        9,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskTimedOut.Ptr(),
+			DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
+				ScheduledEventID: 8,
+			},
+		},
+		{
+			ID:        10,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+			DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+				TaskList: &types.TaskList{Name: "some random workflow type"},
+			},
+		},
+		{
+			ID:        11,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+			DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+				ScheduledEventID: 10,
+			},
+		},
+		{
+			ID:        12,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskFailed.Ptr(),
+			DecisionTaskFailedEventAttributes: &types.DecisionTaskFailedEventAttributes{
+				ScheduledEventID: 10,
+				StartedEventID:   11,
+			},
+		},
+		{
+			ID:                                   13,
+			Version:                              version,
+			EventType:                            types.EventTypeDecisionTaskScheduled.Ptr(),
+			DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{},
+		},
+		{
+			ID:        14,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+			DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+				ScheduledEventID: 13,
+			},
+		},
+		{
+			ID:        15,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+			DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+				ScheduledEventID: 13,
+				StartedEventID:   14,
+			},
+		},
+		{
+			ID:                          16,
+			Version:                     version,
+			EventType:                   types.EventTypeTimerStarted.Ptr(),
+			TimerStartedEventAttributes: &types.TimerStartedEventAttributes{},
+		},
+		{
+			ID:                        17,
+			Version:                   version,
+			EventType:                 types.EventTypeTimerFired.Ptr(),
+			TimerFiredEventAttributes: &types.TimerFiredEventAttributes{},
+		},
+		{
+			ID:                                       18,
+			Version:                                  version,
+			EventType:                                types.EventTypeWorkflowExecutionSignaled.Ptr(),
+			WorkflowExecutionSignaledEventAttributes: &types.WorkflowExecutionSignaledEventAttributes{},
+		},
+		{
+			ID:                                   19,
+			Version:                              version,
+			EventType:                            types.EventTypeActivityTaskScheduled.Ptr(),
+			ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{},
+		},
+		{
+			ID:        20,
+			Version:   version,
+			EventType: types.EventTypeActivityTaskStarted.Ptr(),
+			ActivityTaskStartedEventAttributes: &types.ActivityTaskStartedEventAttributes{
+				ScheduledEventID: 19,
+			},
+		},
+		{
+			ID:        21,
+			Version:   version,
+			EventType: types.EventTypeActivityTaskFailed.Ptr(),
+			ActivityTaskCompletedEventAttributes: &types.ActivityTaskCompletedEventAttributes{
+				ScheduledEventID: 19,
+				StartedEventID:   20,
+			},
+		},
+		{
+			ID:                                   22,
+			Version:                              version,
+			EventType:                            types.EventTypeDecisionTaskScheduled.Ptr(),
+			DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{},
+		},
+		{
+			ID:        23,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+			DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+				ScheduledEventID: 22,
+			},
+		},
+		{
+			ID:        24,
+			Version:   version,
+			EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+			DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+				ScheduledEventID: 22,
+				StartedEventID:   23,
+			},
+		},
+		{
+			ID:        25,
+			Version:   version,
+			EventType: types.EventTypeWorkflowExecutionCompleted.Ptr(),
+			WorkflowExecutionCompletedEventAttributes: &types.WorkflowExecutionCompletedEventAttributes{},
+		},
+	}
+
+	history := []testHistoryEvents{
+		{
+			Events: workflowEvents[:2],
+			Size:   1,
+		},
+		{
+			Events: workflowEvents[2:3],
+			Size:   2,
+		},
+		{
+			Events: workflowEvents[3:6],
+			Size:   3,
+		},
+		{
+			Events: workflowEvents[6:8],
+			Size:   4,
+		},
+		{
+			Events: workflowEvents[8:10],
+			Size:   5,
+		},
+		{
+			Events: workflowEvents[10:11],
+			Size:   6,
+		},
+		{
+			Events: workflowEvents[11:13],
+			Size:   7,
+		},
+		{
+			Events: workflowEvents[13:14],
+			Size:   8,
+		},
+		{
+			Events: workflowEvents[14:16],
+			Size:   9,
+		},
+		{
+			Events: workflowEvents[16:19],
+			Size:   10,
+		},
+		{
+			Events: workflowEvents[19:22],
+			Size:   11,
+		},
+		{
+			Events: workflowEvents[22:23],
+			Size:   12,
+		},
+		{
+			Events: workflowEvents[23:24],
+			Size:   13,
+		},
+		{
+			Events: workflowEvents[24:25],
+			Size:   14,
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		resetEventID int64
+		setupMock    func(mockTaskRefresher *MockMutableStateTaskRefresher)
+		err          error
+	}{
+		{
+			name:         "error - reset on decision task scheduled",
+			resetEventID: 10,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[9].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on activity task scheduled",
+			resetEventID: 5,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[4].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on activity task started",
+			resetEventID: 6,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[5].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on activity task completed",
+			resetEventID: 7,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[6].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on timer started",
+			resetEventID: 16,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[15].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on timer fired",
+			resetEventID: 17,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[16].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on workflow execution signaled",
+			resetEventID: 18,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[17].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on activity task failed",
+			resetEventID: 21,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[20].EventType.String()),
+			},
+		},
+		{
+			name:         "error - reset on workflow execution completed",
+			resetEventID: 25,
+			setupMock:    func(mockTaskRefresher *MockMutableStateTaskRefresher) {},
+			err: &types.BadRequestError{
+				Message: fmt.Sprintf("reset event must be of type DecisionTaskStarted, DecisionTaskTimedOut, DecisionTaskFailed, or DecisionTaskCompleted. Attempting to reset on event type: %v", workflowEvents[24].EventType.String()),
+			},
+		},
+		{
+			name:         "success - reset on decision task started",
+			resetEventID: 23,
+			setupMock: func(mockTaskRefresher *MockMutableStateTaskRefresher) {
+				mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), now, gomock.Any()).Return(nil).Times(1)
+			},
+			err: nil,
+		},
+		{
+			name:         "success - reset on decision task timed out",
+			resetEventID: 9,
+			setupMock: func(mockTaskRefresher *MockMutableStateTaskRefresher) {
+				mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), now, gomock.Any()).Return(nil).Times(1)
+			},
+			err: nil,
+		},
+		{
+			name:         "success - reset on decision task failed",
+			resetEventID: 12,
+			setupMock: func(mockTaskRefresher *MockMutableStateTaskRefresher) {
+				mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), now, gomock.Any()).Return(nil).Times(1)
+			},
+			err: nil,
+		},
+		{
+			name:         "success - reset on decision task completed",
+			resetEventID: 24,
+			setupMock: func(mockTaskRefresher *MockMutableStateTaskRefresher) {
+				mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), now, gomock.Any()).Return(nil).Times(1)
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			pageToken := []byte("some random pagination token")
+			nextEventID := tc.resetEventID - 1 // reset passes next event ID as the reset event ID minus 1
+
+			s.mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return(targetDomainName, nil).AnyTimes()
+
+			s.nDCStateRebuilder = NewStateRebuilder(
+				s.mockShard,
+				s.logger,
+			).(*stateRebuilderImpl)
+
+			s.nDCStateRebuilder.taskRefresher = s.mockTaskRefresher
+
+			counter := int64(0)
+			historySize := 0
+			for index, historyBatch := range history {
+				token := pageToken
+
+				if index == 0 {
+					token = nil
+				}
+
+				counter += int64(len(historyBatch.Events))
+
+				if counter >= tc.resetEventID {
+					pageToken = nil
+				}
+
+				s.mockHistoryV2Mgr.On("ReadHistoryBranchByBatch", mock.Anything, &persistence.ReadHistoryBranchRequest{
+					BranchToken:   branchToken,
+					MinEventID:    firstEventID,
+					MaxEventID:    tc.resetEventID + 1, // Rebuild adds 1 to nextEventID
+					PageSize:      NDCDefaultPageSize,
+					NextPageToken: token,
+					ShardID:       common.IntPtr(s.mockShard.GetShardID()),
+					DomainName:    targetDomainName,
+				}).Return(&persistence.ReadHistoryBranchByBatchResponse{
+					History:       []*types.History{{Events: historyBatch.Events}},
+					NextPageToken: pageToken,
+					Size:          historyBatch.Size,
+				}, nil).Once()
+
+				historySize += historyBatch.Size
+
+				if counter >= tc.resetEventID {
+					break
+				}
+			}
+
+			s.mockDomainCache.EXPECT().GetDomainByID(targetDomainID).Return(cache.NewGlobalDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: targetDomainID, Name: targetDomainName},
+				&persistence.DomainConfig{},
+				&persistence.DomainReplicationConfig{
+					ActiveClusterName: cluster.TestCurrentClusterName,
+					Clusters: []*persistence.ClusterReplicationConfig{
+						{ClusterName: cluster.TestCurrentClusterName},
+						{ClusterName: cluster.TestAlternativeClusterName},
+					},
+				},
+				1234,
+			), nil).AnyTimes()
+
+			targetBranchTokenFn := func() ([]byte, error) {
+				return targetBranchToken, nil
+			}
+
+			tc.setupMock(s.mockTaskRefresher)
+
+			rebuildMutableState, rebuiltHistorySize, err := s.nDCStateRebuilder.Rebuild(
+				context.Background(),
+				now,
+				definition.NewWorkflowIdentifier(s.domainID, s.workflowID, s.runID),
+				branchToken,
+				nextEventID,
+				version,
+				definition.NewWorkflowIdentifier(targetDomainID, targetWorkflowID, targetRunID),
+				targetBranchTokenFn,
+				requestID,
+				&tc.resetEventID,
+			)
+
+			if tc.err != nil {
+				s.Error(err)
+				s.EqualError(err, tc.err.Error())
+			} else {
+				s.NoError(err)
+				s.NotNil(rebuildMutableState)
+				rebuildExecutionInfo := rebuildMutableState.GetExecutionInfo()
+				s.Equal(targetDomainID, rebuildExecutionInfo.DomainID)
+				s.Equal(targetWorkflowID, rebuildExecutionInfo.WorkflowID)
+				s.Equal(targetRunID, rebuildExecutionInfo.RunID)
+				s.Equal(partitionConfig, rebuildExecutionInfo.PartitionConfig)
+				s.Equal(int64(historySize), rebuiltHistorySize)
+				s.Equal(persistence.NewVersionHistories(
+					persistence.NewVersionHistory(
+						targetBranchToken,
+						[]*persistence.VersionHistoryItem{persistence.NewVersionHistoryItem(tc.resetEventID-1, version)},
+					),
+				), rebuildMutableState.GetVersionHistories())
+				s.Equal(rebuildMutableState.GetExecutionInfo().StartTimestamp, now)
+			}
+		})
+	}
 }
 
 func (s *stateRebuilderSuite) TestInvalidStateHandling() {
@@ -391,5 +889,6 @@ func (s *stateRebuilderSuite) TestInvalidStateHandling() {
 		definition.NewWorkflowIdentifier(targetDomainID, targetWorkflowID, targetRunID),
 		targetBranchTokenFn,
 		requestID,
+		nil,
 	)
 }

--- a/service/history/ndc/conflict_resolver.go
+++ b/service/history/ndc/conflict_resolver.go
@@ -155,6 +155,7 @@ func (r *conflictResolverImpl) rebuild(
 		workflowIdentifier,
 		func() ([]byte, error) { return replayVersionHistory.GetBranchToken(), nil },
 		requestID,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/service/history/ndc/conflict_resolver_test.go
+++ b/service/history/ndc/conflict_resolver_test.go
@@ -161,7 +161,8 @@ func (s *conflictResolverSuite) TestRebuild() {
 		workflowIdentifier,
 		gomock.Any(),
 		requestID,
-	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string) (execution.MutableState, int64, error) {
+		nil,
+	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string, resetEventID *int64) (execution.MutableState, int64, error) {
 		targetBranchToken, err := targetBranchFn()
 		s.NoError(err)
 		s.Equal(branchToken1, targetBranchToken)
@@ -260,7 +261,8 @@ func (s *conflictResolverSuite) TestPrepareMutableState_Rebuild() {
 		workflowIdentifier,
 		gomock.Any(),
 		gomock.Any(),
-	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string) (execution.MutableState, int64, error) {
+		nil,
+	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string, resetEventID *int64) (execution.MutableState, int64, error) {
 		targetBranchToken, err := targetBranchFn()
 		s.NoError(err)
 		s.Equal(branchToken1, targetBranchToken)

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -369,6 +369,7 @@ func (r *transactionManagerImpl) backfillWorkflowEventsReapply(
 			EventsReapplicationResetWorkflowReason,
 			targetWorkflowEvents.Events,
 			false,
+			nil,
 		); err != nil {
 			return 0, execution.TransactionPolicyActive, err
 		}

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -225,6 +225,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Cl
 		EventsReapplicationResetWorkflowReason,
 		workflowEvents.Events,
 		false,
+		nil,
 	).Return(nil).Times(1)
 
 	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -144,6 +144,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 		),
 		resetBranchTokenFn,
 		requestID,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -183,7 +183,8 @@ func (s *workflowResetterSuite) TestResetWorkflow_NoError() {
 		),
 		gomock.Any(),
 		gomock.Any(),
-	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string) (execution.MutableState, int64, error) {
+		nil,
+	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string, resetEventID *int64) (execution.MutableState, int64, error) {
 		targetBranchToken, err := targetBranchFn()
 		s.NoError(err)
 		s.Equal(resetBranchToken, targetBranchToken)

--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -57,6 +57,7 @@ type (
 			resetReason string,
 			additionalReapplyEvents []*types.HistoryEvent,
 			skipSignalReapply bool,
+			resetEventID *int64,
 		) error
 	}
 
@@ -109,6 +110,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	resetReason string,
 	additionalReapplyEvents []*types.HistoryEvent,
 	skipSignalReapply bool,
+	resetEventID *int64,
 ) (retError error) {
 
 	domainEntry, err := r.domainCache.GetDomainByID(domainID)
@@ -145,6 +147,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 		resetReason,
 		additionalReapplyEvents,
 		skipSignalReapply,
+		resetEventID,
 	)
 	if err != nil {
 		return err
@@ -174,6 +177,7 @@ func (r *workflowResetterImpl) prepareResetWorkflow(
 	resetReason string,
 	additionalReapplyEvents []*types.HistoryEvent,
 	skipSignalReapply bool,
+	resetEventID *int64,
 ) (execution.Workflow, error) {
 
 	resetWorkflow, err := r.replayResetWorkflow(
@@ -186,6 +190,7 @@ func (r *workflowResetterImpl) prepareResetWorkflow(
 		baseRebuildLastEventVersion,
 		resetRunID,
 		resetRequestID,
+		resetEventID,
 	)
 	if err != nil {
 		return nil, err
@@ -318,6 +323,7 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 	baseRebuildLastEventVersion int64,
 	resetRunID string,
 	resetRequestID string,
+	resetEventID *int64,
 ) (execution.Workflow, error) {
 
 	resetContext := execution.NewContext(
@@ -361,6 +367,7 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 		),
 		resetBranchTokenFn,
 		resetRequestID,
+		resetEventID,
 	)
 	if err != nil {
 		return nil, err

--- a/service/history/reset/resetter_mock.go
+++ b/service/history/reset/resetter_mock.go
@@ -44,15 +44,15 @@ func (m *MockWorkflowResetter) EXPECT() *MockWorkflowResetterMockRecorder {
 }
 
 // ResetWorkflow mocks base method.
-func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, domainID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow execution.Workflow, resetReason string, additionalReapplyEvents []*types.HistoryEvent, skipSignalReapply bool) error {
+func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, domainID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow execution.Workflow, resetReason string, additionalReapplyEvents []*types.HistoryEvent, skipSignalReapply bool, resetEventID *int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResetWorkflow", ctx, domainID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, skipSignalReapply)
+	ret := m.ctrl.Call(m, "ResetWorkflow", ctx, domainID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, skipSignalReapply, resetEventID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ResetWorkflow indicates an expected call of ResetWorkflow.
-func (mr *MockWorkflowResetterMockRecorder) ResetWorkflow(ctx, domainID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, skipSignalReapply any) *gomock.Call {
+func (mr *MockWorkflowResetterMockRecorder) ResetWorkflow(ctx, domainID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, skipSignalReapply, resetEventID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetWorkflow", reflect.TypeOf((*MockWorkflowResetter)(nil).ResetWorkflow), ctx, domainID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, skipSignalReapply)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetWorkflow", reflect.TypeOf((*MockWorkflowResetter)(nil).ResetWorkflow), ctx, domainID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, skipSignalReapply, resetEventID)
 }

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -221,6 +221,7 @@ func (s *workflowResetterSuite) TestReplayResetWorkflow() {
 	baseRebuildLastEventID := int64(1233)
 	baseRebuildLastEventVersion := int64(12)
 	baseNodeID := baseRebuildLastEventID + 1
+	resetEventID := baseRebuildLastEventID + 1
 
 	resetBranchToken := []byte("some random reset branch token")
 	resetRequestID := uuid.New()
@@ -254,7 +255,8 @@ func (s *workflowResetterSuite) TestReplayResetWorkflow() {
 		),
 		gomock.Any(),
 		resetRequestID,
-	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string) (execution.MutableState, int64, error) {
+		&resetEventID,
+	).DoAndReturn(func(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseRebuildLastEventID int64, baseRebuildLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchFn func() ([]byte, error), requestID string, resetEventID *int64) (execution.MutableState, int64, error) {
 		targetBranchToken, err := targetBranchFn()
 		s.NoError(err)
 		s.Equal(resetBranchToken, targetBranchToken)
@@ -272,6 +274,7 @@ func (s *workflowResetterSuite) TestReplayResetWorkflow() {
 		baseRebuildLastEventVersion,
 		s.resetRunID,
 		resetRequestID,
+		&resetEventID,
 	)
 	s.NoError(err)
 	s.Equal(resetHistorySize, resetWorkflow.GetContext().GetHistorySize())

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1737,6 +1737,7 @@ func (t *transferActiveTaskExecutor) resetWorkflow(
 		reason,
 		nil,
 		false,
+		nil,
 	)
 
 	switch err.(type) {

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -2033,7 +2033,8 @@ func (s *transferActiveTaskExecutorSuite) testProcessResetWorkflowWithError(same
 		gomock.Any(),
 		"test-reason",
 		nil,
-		false).Return(resetError).Times(1)
+		false,
+		nil).Return(resetError).Times(1)
 
 	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added explicit checks on workflow event type to validate external workflow reset requests.

<!-- Tell your future self why have you made these changes -->
**Why?**
The server was not checking and guarding which event types a user could reset a workflow on. That could cause the workflow to be in a state not covered by the replication logic, causing the workflow to not be replicated and all subsequent tasks to fail to be applied to the standby cluster and go to the dlq.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and local tests with a multi cluster set up.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This code introduces changes to the rebuild and replay flows, as well as the reset. If the resetEventID is not provided, nothing should change. resetEventID is only provided on external reset workflow requests.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
