### PR TITLE
[shard-distributor] Change the configuration name

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -69,7 +69,7 @@ func Module(serviceName string) fx.Option {
 				FullName: service.FullName(serviceName),
 			}),
 			fx.Provide(func(cfg config.Config) shardDistributorCfg.ShardDistribution {
-				return shardDistributorCfg.GetLeaderElectionFromExternal(cfg.LeaderElection)
+				return shardDistributorCfg.GetLeaderElectionFromExternal(cfg.ShardDistribution)
 			}),
 			// Decorate both logger so all components use proper service name.
 			fx.Decorate(func(z *zap.Logger, l log.Logger) (*zap.Logger, log.Logger) {

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -68,7 +68,7 @@ func Module(serviceName string) fx.Option {
 				Name:     serviceName,
 				FullName: service.FullName(serviceName),
 			}),
-			fx.Provide(func(cfg config.Config) shardDistributorCfg.LeaderElection {
+			fx.Provide(func(cfg config.Config) shardDistributorCfg.ShardDistribution {
 				return shardDistributorCfg.GetLeaderElectionFromExternal(cfg.LeaderElection)
 			}),
 			// Decorate both logger so all components use proper service name.

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -69,7 +69,7 @@ func Module(serviceName string) fx.Option {
 				FullName: service.FullName(serviceName),
 			}),
 			fx.Provide(func(cfg config.Config) shardDistributorCfg.ShardDistribution {
-				return shardDistributorCfg.GetLeaderElectionFromExternal(cfg.ShardDistribution)
+				return shardDistributorCfg.GetShardDistributionFromExternal(cfg.ShardDistribution)
 			}),
 			// Decorate both logger so all components use proper service name.
 			fx.Decorate(func(z *zap.Logger, l log.Logger) (*zap.Logger, log.Logger) {

--- a/cmd/server/cadence/testdata/config/development.yaml
+++ b/cmd/server/cadence/testdata/config/development.yaml
@@ -1,4 +1,4 @@
-leaderElection:
+shardDistribution:
   enabled: true
   leaderStore:
     storageParams:

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -90,8 +90,8 @@ type (
 		// Note: This is not recommended for use, it's still experimental
 		ShardDistributorClient ShardDistributorClient `yaml:"shardDistributorClient"`
 
-		// LeaderElection is a config for the shard distributor leader election component that allows to run a single process per region and manage shard namespaces.
-		LeaderElection ShardDistribution `yaml:"leaderElection"`
+		// ShardDistribution is a config for the shard distributor leader election component that allows to run a single process per region and manage shard namespaces.
+		ShardDistribution ShardDistribution `yaml:"shardDistribution"`
 	}
 
 	// Membership holds peer provider configuration.

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -91,7 +91,7 @@ type (
 		ShardDistributorClient ShardDistributorClient `yaml:"shardDistributorClient"`
 
 		// LeaderElection is a config for the shard distributor leader election component that allows to run a single process per region and manage shard namespaces.
-		LeaderElection LeaderElection `yaml:"leaderElection"`
+		LeaderElection ShardDistribution `yaml:"leaderElection"`
 	}
 
 	// Membership holds peer provider configuration.
@@ -622,9 +622,9 @@ type (
 		Config *YamlNode `yaml:"config"`
 	}
 
-	// LeaderElection is a configuration for leader election running.
+	// ShardDistribution is a configuration for leader election running.
 	// This configuration should be in sync with sharddistributor.
-	LeaderElection struct {
+	ShardDistribution struct {
 		Enabled     bool          `yaml:"enabled"`
 		LeaderStore Store         `yaml:"leaderStore"`
 		Election    Election      `yaml:"election"`

--- a/service/sharddistributor/config/config.go
+++ b/service/sharddistributor/config/config.go
@@ -42,8 +42,8 @@ type (
 	}
 
 	StaticConfig struct {
-		// LeaderElection is the configuration for leader election mechanism that is used by Shard distributor to handle shard distribution per namespace.
-		LeaderElection ShardDistribution `yaml:"leaderElection"`
+		// ShardDistribution is the configuration for leader election mechanism that is used by Shard distributor to handle shard distribution per namespace.
+		ShardDistribution ShardDistribution `yaml:"shardDistribution"`
 	}
 
 	// ShardDistribution is a configuration for leader election running.

--- a/service/sharddistributor/config/config.go
+++ b/service/sharddistributor/config/config.go
@@ -96,8 +96,8 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string) *Config {
 	}
 }
 
-// GetLeaderElectionFromExternal converts other configs to an internal one.
-func GetLeaderElectionFromExternal(in config.ShardDistribution) ShardDistribution {
+// GetShardDistributionFromExternal converts other configs to an internal one.
+func GetShardDistributionFromExternal(in config.ShardDistribution) ShardDistribution {
 
 	namespaces := make([]Namespace, 0, len(in.Namespaces))
 	for _, namespace := range in.Namespaces {

--- a/service/sharddistributor/config/config.go
+++ b/service/sharddistributor/config/config.go
@@ -43,11 +43,11 @@ type (
 
 	StaticConfig struct {
 		// LeaderElection is the configuration for leader election mechanism that is used by Shard distributor to handle shard distribution per namespace.
-		LeaderElection LeaderElection `yaml:"leaderElection"`
+		LeaderElection ShardDistribution `yaml:"leaderElection"`
 	}
 
-	// LeaderElection is a configuration for leader election running.
-	LeaderElection struct {
+	// ShardDistribution is a configuration for leader election running.
+	ShardDistribution struct {
 		Enabled     bool          `yaml:"enabled"`
 		LeaderStore Store         `yaml:"leaderStore"`
 		Election    Election      `yaml:"election"`
@@ -97,14 +97,14 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string) *Config {
 }
 
 // GetLeaderElectionFromExternal converts other configs to an internal one.
-func GetLeaderElectionFromExternal(in config.LeaderElection) LeaderElection {
+func GetLeaderElectionFromExternal(in config.ShardDistribution) ShardDistribution {
 
 	namespaces := make([]Namespace, 0, len(in.Namespaces))
 	for _, namespace := range in.Namespaces {
 		namespaces = append(namespaces, Namespace(namespace))
 	}
 
-	return LeaderElection{
+	return ShardDistribution{
 		Enabled:     in.Enabled,
 		LeaderStore: Store(in.LeaderStore),
 		Store:       Store(in.Store),

--- a/service/sharddistributor/leader/election/election.go
+++ b/service/sharddistributor/leader/election/election.go
@@ -66,7 +66,7 @@ type FactoryParams struct {
 	fx.In
 
 	HostName       string `name:"hostname"`
-	Cfg            config.LeaderElection
+	Cfg            config.ShardDistribution
 	LeaderStore    store.Elector
 	Logger         log.Logger
 	Clock          clock.TimeSource

--- a/service/sharddistributor/leader/election/election_test.go
+++ b/service/sharddistributor/leader/election/election_test.go
@@ -62,7 +62,7 @@ func TestElector_Run(t *testing.T) {
 
 	factory := NewElectionFactory(FactoryParams{
 		HostName: _testHost,
-		Cfg: config.LeaderElection{
+		Cfg: config.ShardDistribution{
 			Election: config.Election{
 				LeaderPeriod:           _testLeaderPeriod,
 				MaxRandomDelay:         _testMaxRandomDelay,
@@ -241,7 +241,7 @@ func prepareRun(t *testing.T, onLeader, onResign ProcessFunc) (<-chan bool, runP
 
 	factory := NewElectionFactory(FactoryParams{
 		HostName: _testHost,
-		Cfg: config.LeaderElection{
+		Cfg: config.ShardDistribution{
 			Election: config.Election{
 				LeaderPeriod:           _testLeaderPeriod,
 				MaxRandomDelay:         _testMaxRandomDelay,

--- a/service/sharddistributor/leader/namespace/manager.go
+++ b/service/sharddistributor/leader/namespace/manager.go
@@ -20,7 +20,7 @@ var Module = fx.Module(
 )
 
 type Manager struct {
-	cfg             config.LeaderElection
+	cfg             config.ShardDistribution
 	logger          log.Logger
 	electionFactory election.Factory
 	namespaces      map[string]*namespaceHandler
@@ -39,7 +39,7 @@ type namespaceHandler struct {
 type ManagerParams struct {
 	fx.In
 
-	Cfg             config.LeaderElection
+	Cfg             config.ShardDistribution
 	Logger          log.Logger
 	ElectionFactory election.Factory
 	Lifecycle       fx.Lifecycle

--- a/service/sharddistributor/leader/namespace/manager_test.go
+++ b/service/sharddistributor/leader/namespace/manager_test.go
@@ -22,7 +22,7 @@ func TestNewManager(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	electionFactory := election.NewMockFactory(ctrl)
 
-	cfg := config.LeaderElection{
+	cfg := config.ShardDistribution{
 		Enabled: true,
 		Namespaces: []config.Namespace{
 			{Name: "test-namespace"},
@@ -49,7 +49,7 @@ func TestNewManagerNotEnabled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	electionFactory := election.NewMockFactory(ctrl)
 
-	cfg := config.LeaderElection{
+	cfg := config.ShardDistribution{
 		Enabled: false,
 		Namespaces: []config.Namespace{
 			{Name: "test-namespace"},
@@ -80,7 +80,7 @@ func TestStartManager(t *testing.T) {
 	leaderCh := make(chan bool)
 	elector.EXPECT().Run(gomock.Any()).Return((<-chan bool)(leaderCh))
 
-	cfg := config.LeaderElection{
+	cfg := config.ShardDistribution{
 		Enabled: true,
 		Namespaces: []config.Namespace{
 			{Name: "test-namespace"},
@@ -114,7 +114,7 @@ func TestStartManagerWithElectorError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	electionFactory := election.NewMockFactory(ctrl)
 
-	cfg := config.LeaderElection{
+	cfg := config.ShardDistribution{
 		Enabled: true,
 		Namespaces: []config.Namespace{
 			{Name: "test-namespace"},
@@ -152,7 +152,7 @@ func TestStopManager(t *testing.T) {
 	leaderCh := make(chan bool)
 	elector.EXPECT().Run(gomock.Any()).Return((<-chan bool)(leaderCh))
 
-	cfg := config.LeaderElection{
+	cfg := config.ShardDistribution{
 		Enabled: true,
 		Namespaces: []config.Namespace{
 			{Name: "test-namespace"},
@@ -187,7 +187,7 @@ func TestHandleNamespaceAlreadyExists(t *testing.T) {
 	mockElector := election.NewMockElector(ctrl)
 
 	manager := &Manager{
-		cfg:             config.LeaderElection{},
+		cfg:             config.ShardDistribution{},
 		logger:          logger,
 		electionFactory: electionFactory,
 		namespaces:      make(map[string]*namespaceHandler),
@@ -220,7 +220,7 @@ func TestRunElection(t *testing.T) {
 	leaderCh := make(chan bool)
 	elector.EXPECT().Run(gomock.Any()).Return((<-chan bool)(leaderCh))
 
-	cfg := config.LeaderElection{
+	cfg := config.ShardDistribution{
 		Enabled: true,
 		Namespaces: []config.Namespace{
 			{Name: "test-namespace"},

--- a/service/sharddistributor/leader/process/processor.go
+++ b/service/sharddistributor/leader/process/processor.go
@@ -72,7 +72,7 @@ func NewProcessorFactory(
 	logger log.Logger,
 	metricsClient metrics.Client,
 	timeSource clock.TimeSource,
-	cfg config.LeaderElection,
+	cfg config.ShardDistribution,
 ) Factory {
 	if cfg.Process.Period == 0 {
 		cfg.Process.Period = _defaultPeriod

--- a/service/sharddistributor/leader/process/processor_test.go
+++ b/service/sharddistributor/leader/process/processor_test.go
@@ -41,7 +41,7 @@ func setupProcessorTest(t *testing.T) *testDependencies {
 			testlogger.New(t),
 			metrics.NewNoopMetricsClient(),
 			mockedClock,
-			config.LeaderElection{
+			config.ShardDistribution{
 				Process: config.LeaderProcess{
 					Period:       time.Second,
 					HeartbeatTTL: time.Second,

--- a/service/sharddistributor/sharddistributorfx/fx_test.go
+++ b/service/sharddistributor/sharddistributorfx/fx_test.go
@@ -45,8 +45,8 @@ func TestFxServiceStartStop(t *testing.T) {
 				return store.NewMockStore(ctrl)
 			},
 			func() map[string]membership.SingleProvider { return make(map[string]membership.SingleProvider) },
-			func() config.LeaderElection {
-				return config.LeaderElection{
+			func() config.ShardDistribution {
+				return config.ShardDistribution{
 					Enabled: false,
 				}
 			},

--- a/service/sharddistributor/store/etcd/etcdleaderstore.go
+++ b/service/sharddistributor/store/etcd/etcdleaderstore.go
@@ -27,7 +27,7 @@ type LeaderStoreParams struct {
 
 	// Client could be provided externally.
 	Client    *clientv3.Client `optional:"true"`
-	Cfg       config.LeaderElection
+	Cfg       config.ShardDistribution
 	Lifecycle fx.Lifecycle
 }
 

--- a/service/sharddistributor/store/etcd/etcdleaderstore_test.go
+++ b/service/sharddistributor/store/etcd/etcdleaderstore_test.go
@@ -45,7 +45,7 @@ import (
 
 func TestNotEnabledLeaderElection(t *testing.T) {
 	store, err := NewLeaderStore(StoreParams{
-		Cfg: shardDistributorCfg.LeaderElection{Enabled: false},
+		Cfg: shardDistributorCfg.ShardDistribution{Enabled: false},
 	})
 	require.NoError(t, err)
 	assert.Nil(t, store)
@@ -259,7 +259,7 @@ func setupETCDCluster(t *testing.T) *testCluster {
 
 	// Create store
 	storeParams := StoreParams{
-		Cfg:       shardDistributorCfg.LeaderElection{Enabled: true, LeaderStore: shardDistributorCfg.Store{StorageParams: createConfig(t, testConfig)}},
+		Cfg:       shardDistributorCfg.ShardDistribution{Enabled: true, LeaderStore: shardDistributorCfg.Store{StorageParams: createConfig(t, testConfig)}},
 		Lifecycle: fxtest.NewLifecycle(t),
 	}
 

--- a/service/sharddistributor/store/etcd/etcdleaderstore_test.go
+++ b/service/sharddistributor/store/etcd/etcdleaderstore_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/uber/cadence/testflags"
 )
 
-func TestNotEnabledLeaderElection(t *testing.T) {
+func TestShardDistributionDisabled(t *testing.T) {
 	store, err := NewLeaderStore(StoreParams{
 		Cfg: shardDistributorCfg.ShardDistribution{Enabled: false},
 	})

--- a/service/sharddistributor/store/etcd/etcdstore.go
+++ b/service/sharddistributor/store/etcd/etcdstore.go
@@ -43,7 +43,7 @@ type StoreParams struct {
 	fx.In
 
 	Client    *clientv3.Client `optional:"true"`
-	Cfg       config.LeaderElection
+	Cfg       config.ShardDistribution
 	Lifecycle fx.Lifecycle
 }
 

--- a/service/sharddistributor/store/etcd/etcdstore_test.go
+++ b/service/sharddistributor/store/etcd/etcdstore_test.go
@@ -561,7 +561,7 @@ func TestGetShardOwnerErrors(t *testing.T) {
 type storeTestCluster struct {
 	store     *Store // Use concrete type to access buildExecutorKey
 	namespace string
-	leaderCfg shardDistributorCfg.LeaderElection
+	leaderCfg shardDistributorCfg.ShardDistribution
 	client    *clientv3.Client
 	lifecycle *fxtest.Lifecycle
 }
@@ -592,7 +592,7 @@ func setupStoreTestCluster(t *testing.T) *storeTestCluster {
 	err = yaml.Unmarshal(yamlCfg, &yamlNode)
 	require.NoError(t, err)
 
-	leaderCfg := shardDistributorCfg.LeaderElection{
+	leaderCfg := shardDistributorCfg.ShardDistribution{
 		Enabled:     true,
 		Store:       shardDistributorCfg.Store{StorageParams: yamlNode},
 		LeaderStore: shardDistributorCfg.Store{StorageParams: yamlNode},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed configuration name of the shard distribution, since now it hosts both configuration for storage, leader elected process and namespaces in general.

<!-- Tell your future self why have you made these changes -->
**Why?**
To provide proper name.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
