### PR TITLE
We now use a raw tally scope for the client

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2870,13 +2870,6 @@ const (
 	ShardDistributorAssignLoopSuccess
 	ShardDistributorAssignLoopFail
 
-	ShardDistributorExecutorAssignLoopLatency
-	ShardDistributorExecutorOwnedShards
-	ShardDistributorExecutorShardsStarted
-	ShardDistributorExecutorShardsStopped
-	ShardDistributorExecutorAssignmentSkipped
-	ShardDistributorExecutorProcessorCreationFailures
-
 	ShardDistributorStoreExecutorNotFound
 	ShardDistributorStoreFailuresPerNamespace
 	ShardDistributorStoreRequestsPerNamespace
@@ -3629,13 +3622,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ShardDistributorAssignLoopAttempts:              {metricName: "shard_distrubutor_shard_assign_attempt", metricType: Counter},
 		ShardDistributorAssignLoopSuccess:               {metricName: "shard_distrubutor_shard_assign_success", metricType: Counter},
 		ShardDistributorAssignLoopFail:                  {metricName: "shard_distrubutor_shard_assign_fail", metricType: Counter},
-
-		ShardDistributorExecutorAssignLoopLatency:         {metricName: "shard_distributor_executor_assign_loop_latency", metricType: Histogram, buckets: ShardDistributorExecutorAssignLoopLatencyBuckets},
-		ShardDistributorExecutorOwnedShards:               {metricName: "shard_distributor_executor_owned_shards", metricType: Gauge},
-		ShardDistributorExecutorShardsStarted:             {metricName: "shard_distributor_executor_shards_started", metricType: Counter},
-		ShardDistributorExecutorShardsStopped:             {metricName: "shard_distributor_executor_shards_stopped", metricType: Counter},
-		ShardDistributorExecutorAssignmentSkipped:         {metricName: "shard_distributor_executor_assignment_skipped", metricType: Counter},
-		ShardDistributorExecutorProcessorCreationFailures: {metricName: "shard_distributor_executor_processor_creation_failures", metricType: Counter},
 
 		ShardDistributorStoreExecutorNotFound:             {metricName: "shard_distributor_store_executor_not_found", metricType: Counter},
 		ShardDistributorStoreFailuresPerNamespace:         {metricName: "shard_distributor_store_failures_per_namespace", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3690,8 +3690,6 @@ var (
 		60 * time.Second,
 	})
 
-	ShardDistributorExecutorAssignLoopLatencyBuckets = PersistenceLatencyBuckets
-
 	ShardDistributorExecutorStoreLatencyBuckets = tally.DurationBuckets([]time.Duration{
 		0,
 		5 * time.Millisecond,

--- a/service/sharddistributor/executorclient/client.go
+++ b/service/sharddistributor/executorclient/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/service/sharddistributor/executorclient/metricsconstants"
 )
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interface_mock.go . ShardProcessorFactory,ShardProcessor,Executor
@@ -57,7 +58,7 @@ func NewExecutor[SP ShardProcessor](params Params[SP]) (Executor[SP], error) {
 	executorID := uuid.New().String()
 
 	metricsScope := params.MetricsScope.Tagged(map[string]string{
-		metrics.OperationTagName: "ShardDistributorExecutor",
+		metrics.OperationTagName: metricsconstants.ShardDistributorExecutorOperationTagName,
 		"namespace":              params.Config.Namespace,
 	})
 

--- a/service/sharddistributor/executorclient/client.go
+++ b/service/sharddistributor/executorclient/client.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/uber-go/tally"
 	"go.uber.org/fx"
 
 	sharddistributorv1 "github.com/uber/cadence/.gen/proto/sharddistributor/v1"
 	"github.com/uber/cadence/client/sharddistributorexecutor"
 	"github.com/uber/cadence/client/wrappers/grpc"
-	"github.com/uber/cadence/client/wrappers/metered"
 	timeoutwrapper "github.com/uber/cadence/client/wrappers/timeout"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
@@ -40,7 +40,7 @@ type Params[SP ShardProcessor] struct {
 	fx.In
 
 	YarpcClient           sharddistributorv1.ShardDistributorExecutorAPIYARPCClient
-	MetricsClient         metrics.Client
+	MetricsScope          tally.Scope
 	Logger                log.Logger
 	ShardProcessorFactory ShardProcessorFactory[SP]
 	Config                Config
@@ -48,7 +48,7 @@ type Params[SP ShardProcessor] struct {
 }
 
 func NewExecutor[SP ShardProcessor](params Params[SP]) (Executor[SP], error) {
-	shardDistributorClient, err := createShardDistributorExecutorClient(params.YarpcClient, params.MetricsClient, params.Logger)
+	shardDistributorClient, err := createShardDistributorExecutorClient(params.YarpcClient, params.MetricsScope, params.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("create shard distributor executor client: %w", err)
 	}
@@ -56,7 +56,10 @@ func NewExecutor[SP ShardProcessor](params Params[SP]) (Executor[SP], error) {
 	// TODO: get executor ID from environment
 	executorID := uuid.New().String()
 
-	metricsScope := params.MetricsClient.Scope(metrics.ShardDistributorExecutorScope).Tagged(metrics.NamespaceTag(params.Config.Namespace))
+	metricsScope := params.MetricsScope.Tagged(map[string]string{
+		metrics.OperationTagName: "ShardDistributorExecutor",
+		"namespace":              params.Config.Namespace,
+	})
 
 	return &executorImpl[SP]{
 		logger:                 params.Logger,
@@ -71,13 +74,13 @@ func NewExecutor[SP ShardProcessor](params Params[SP]) (Executor[SP], error) {
 	}, nil
 }
 
-func createShardDistributorExecutorClient(yarpcClient sharddistributorv1.ShardDistributorExecutorAPIYARPCClient, metricsClient metrics.Client, logger log.Logger) (sharddistributorexecutor.Client, error) {
+func createShardDistributorExecutorClient(yarpcClient sharddistributorv1.ShardDistributorExecutorAPIYARPCClient, metricsScope tally.Scope, logger log.Logger) (sharddistributorexecutor.Client, error) {
 	shardDistributorExecutorClient := grpc.NewShardDistributorExecutorClient(yarpcClient)
 
 	shardDistributorExecutorClient = timeoutwrapper.NewShardDistributorExecutorClient(shardDistributorExecutorClient, timeoutwrapper.ShardDistributorExecutorDefaultTimeout)
 
-	if metricsClient != nil {
-		shardDistributorExecutorClient = metered.NewShardDistributorExecutorClient(shardDistributorExecutorClient, metricsClient)
+	if metricsScope != nil {
+		shardDistributorExecutorClient = NewMeteredShardDistributorExecutorClient(shardDistributorExecutorClient, metricsScope)
 	}
 
 	return shardDistributorExecutorClient, nil

--- a/service/sharddistributor/executorclient/client_test.go
+++ b/service/sharddistributor/executorclient/client_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 	uber_gomock "go.uber.org/mock/gomock"
@@ -15,7 +16,6 @@ import (
 	sharddistributorv1 "github.com/uber/cadence/.gen/proto/sharddistributor/v1"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/metrics"
 )
 
 func TestModule(t *testing.T) {
@@ -24,7 +24,6 @@ func TestModule(t *testing.T) {
 	uberCtrl := uber_gomock.NewController(t)
 	mockLogger := log.NewNoop()
 
-	mockMetricsClient := metrics.NewNoopMetricsClient()
 	mockShardProcessorFactory := NewMockShardProcessorFactory[*MockShardProcessor](uberCtrl)
 
 	// Create shard distributor yarpc client
@@ -46,7 +45,7 @@ func TestModule(t *testing.T) {
 	fxtest.New(t,
 		fx.Supply(
 			fx.Annotate(yarpcClient, fx.As(new(sharddistributorv1.ShardDistributorExecutorAPIYARPCClient))),
-			fx.Annotate(mockMetricsClient, fx.As(new(metrics.Client))),
+			fx.Annotate(tally.NoopScope, fx.As(new(tally.Scope))),
 			fx.Annotate(mockLogger, fx.As(new(log.Logger))),
 			fx.Annotate(mockShardProcessorFactory, fx.As(new(ShardProcessorFactory[*MockShardProcessor]))),
 			fx.Annotate(clock.NewMockedTimeSource(), fx.As(new(clock.TimeSource))),

--- a/service/sharddistributor/executorclient/clientimpl.go
+++ b/service/sharddistributor/executorclient/clientimpl.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
+
 	"github.com/uber/cadence/client/sharddistributorexecutor"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"

--- a/service/sharddistributor/executorclient/clientimpl_test.go
+++ b/service/sharddistributor/executorclient/clientimpl_test.go
@@ -6,13 +6,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/client/sharddistributorexecutor"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/sharddistributor/executorclient/syncgeneric"
 )
@@ -60,7 +60,7 @@ func TestHeartBeartLoop(t *testing.T) {
 	// Create the executor
 	executor := &executorImpl[*MockShardProcessor]{
 		logger:                 log.NewNoop(),
-		metrics:                metrics.NewNoopMetricsClient().Scope(metrics.ShardDistributorExecutorScope),
+		metrics:                tally.NoopScope,
 		shardDistributorClient: mockShardDistributorClient,
 		shardProcessorFactory:  mockShardProcessorFactory,
 		namespace:              "test-namespace",
@@ -129,7 +129,7 @@ func TestHeartbeat(t *testing.T) {
 		shardDistributorClient: shardDistributorClient,
 		namespace:              "test-namespace",
 		executorID:             "test-executor-id",
-		metrics:                metrics.NewNoopMetricsClient().Scope(metrics.ShardDistributorExecutorScope),
+		metrics:                tally.NoopScope,
 	}
 
 	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
@@ -161,7 +161,7 @@ func TestHeartBeartLoop_ShardAssignmentChange(t *testing.T) {
 	executor := &executorImpl[*MockShardProcessor]{
 		logger:                log.NewNoop(),
 		shardProcessorFactory: shardProcessorFactory,
-		metrics:               metrics.NewNoopMetricsClient().Scope(metrics.ShardDistributorExecutorScope),
+		metrics:               tally.NoopScope,
 	}
 
 	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))

--- a/service/sharddistributor/executorclient/meteredClientDecorater.go
+++ b/service/sharddistributor/executorclient/meteredClientDecorater.go
@@ -3,9 +3,9 @@ package executorclient
 import (
 	"context"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/yarpc"
 
-	"github.com/uber-go/tally"
 	"github.com/uber/cadence/client/sharddistributorexecutor"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"

--- a/service/sharddistributor/executorclient/meteredClientDecorater.go
+++ b/service/sharddistributor/executorclient/meteredClientDecorater.go
@@ -1,0 +1,44 @@
+package executorclient
+
+import (
+	"context"
+
+	"go.uber.org/yarpc"
+
+	"github.com/uber-go/tally"
+	"github.com/uber/cadence/client/sharddistributorexecutor"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
+)
+
+// TODO: consider using gowrap to generate this code
+type meteredShardDistributorExecutorClient struct {
+	client       sharddistributorexecutor.Client
+	metricsScope tally.Scope
+}
+
+// NewShardDistributorExecutorClient creates a new instance of sharddistributorexecutorClient with retry policy
+func NewMeteredShardDistributorExecutorClient(client sharddistributorexecutor.Client, metricsScope tally.Scope) sharddistributorexecutor.Client {
+	return &meteredShardDistributorExecutorClient{
+		client:       client,
+		metricsScope: metricsScope,
+	}
+}
+
+func (c *meteredShardDistributorExecutorClient) Heartbeat(ctx context.Context, ep1 *types.ExecutorHeartbeatRequest, p1 ...yarpc.CallOption) (ep2 *types.ExecutorHeartbeatResponse, err error) {
+	var scope tally.Scope
+	scope = c.metricsScope.Tagged(map[string]string{
+		metrics.OperationTagName: "ShardDistributorExecutorHeartbeat",
+	})
+
+	scope.Counter("shard_distributor_executor_client_requests").Inc(1)
+
+	sw := scope.Timer("shard_distributor_executor_client_latency").Start()
+	ep2, err = c.client.Heartbeat(ctx, ep1, p1...)
+	sw.Stop()
+
+	if err != nil {
+		scope.Counter("shard_distributor_executor_client_failures").Inc(1)
+	}
+	return ep2, err
+}

--- a/service/sharddistributor/executorclient/meteredClientDecorater.go
+++ b/service/sharddistributor/executorclient/meteredClientDecorater.go
@@ -9,6 +9,7 @@ import (
 	"github.com/uber/cadence/client/sharddistributorexecutor"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/sharddistributor/executorclient/metricsconstants"
 )
 
 // TODO: consider using gowrap to generate this code
@@ -28,17 +29,17 @@ func NewMeteredShardDistributorExecutorClient(client sharddistributorexecutor.Cl
 func (c *meteredShardDistributorExecutorClient) Heartbeat(ctx context.Context, ep1 *types.ExecutorHeartbeatRequest, p1 ...yarpc.CallOption) (ep2 *types.ExecutorHeartbeatResponse, err error) {
 	var scope tally.Scope
 	scope = c.metricsScope.Tagged(map[string]string{
-		metrics.OperationTagName: "ShardDistributorExecutorHeartbeat",
+		metrics.OperationTagName: metricsconstants.ShardDistributorExecutorHeartbeatOperationTagName,
 	})
 
-	scope.Counter("shard_distributor_executor_client_requests").Inc(1)
+	scope.Counter(metricsconstants.ShardDistributorExecutorClientRequests).Inc(1)
 
-	sw := scope.Timer("shard_distributor_executor_client_latency").Start()
+	sw := scope.Timer(metricsconstants.ShardDistributorExecutorClientLatency).Start()
 	ep2, err = c.client.Heartbeat(ctx, ep1, p1...)
 	sw.Stop()
 
 	if err != nil {
-		scope.Counter("shard_distributor_executor_client_failures").Inc(1)
+		scope.Counter(metricsconstants.ShardDistributorExecutorClientFailures).Inc(1)
 	}
 	return ep2, err
 }

--- a/service/sharddistributor/executorclient/metricsconstants/metrics.go
+++ b/service/sharddistributor/executorclient/metricsconstants/metrics.go
@@ -1,8 +1,10 @@
 package metricsconstants
 
-import "time"
+import (
+	"time"
 
-import "github.com/uber-go/tally"
+	"github.com/uber-go/tally"
+)
 
 const (
 	// Operation tag names for ShardDistributorExecutor metrics

--- a/service/sharddistributor/executorclient/metricsconstants/metrics.go
+++ b/service/sharddistributor/executorclient/metricsconstants/metrics.go
@@ -1,0 +1,63 @@
+package metrics_constants
+
+import "time"
+
+import "github.com/uber-go/tally"
+
+const (
+	// Operation tag names for ShardDistributorExecutor metrics
+	ShardDistributorExecutorOperationTagName          = "ShardDistributorExecutor"
+	ShardDistributorExecutorHeartbeatOperationTagName = "ShardDistributorExecutorHeartbeat"
+
+	// Counter metrics
+	ShardDistributorExecutorAssignmentSkipped            = "shard_distributor_executor_assignment_skipped"
+	ShardDistributorExecutorShardsStarted                = "shard_distributor_executor_shards_started"
+	ShardDistributorExecutorShardsStopped                = "shard_distributor_executor_shards_stopped"
+	ShardDistributorExecutorProcessorCreationFailures   = "shard_distributor_executor_processor_creation_failures"
+	ShardDistributorExecutorClientRequests              = "shard_distributor_executor_client_requests"
+	ShardDistributorExecutorClientFailures              = "shard_distributor_executor_client_failures"
+
+	// Gauge metrics
+	ShardDistributorExecutorOwnedShards = "shard_distributor_executor_owned_shards"
+
+	// Histogram/Timer metrics
+	ShardDistributorExecutorAssignLoopLatency = "shard_distributor_executor_assign_loop_latency"
+	ShardDistributorExecutorClientLatency     = "shard_distributor_executor_client_latency"
+)
+
+var (
+	// Histogram buckets for ShardDistributorExecutor metrics
+	ShardDistributorExecutorAssignLoopLatencyBuckets = tally.DurationBuckets([]time.Duration{
+		0,
+		1 * time.Millisecond,
+		5 * time.Millisecond,
+		10 * time.Millisecond,
+		25 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+		20 * time.Second,
+		60 * time.Second,
+	})
+
+	ShardDistributorExecutorStoreLatencyBuckets = tally.DurationBuckets([]time.Duration{
+		0,
+		1 * time.Millisecond,
+		5 * time.Millisecond,
+		10 * time.Millisecond,
+		25 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+	})
+)

--- a/service/sharddistributor/executorclient/metricsconstants/metrics.go
+++ b/service/sharddistributor/executorclient/metricsconstants/metrics.go
@@ -1,4 +1,4 @@
-package metrics_constants
+package metricsconstants
 
 import "time"
 
@@ -10,12 +10,12 @@ const (
 	ShardDistributorExecutorHeartbeatOperationTagName = "ShardDistributorExecutorHeartbeat"
 
 	// Counter metrics
-	ShardDistributorExecutorAssignmentSkipped            = "shard_distributor_executor_assignment_skipped"
-	ShardDistributorExecutorShardsStarted                = "shard_distributor_executor_shards_started"
-	ShardDistributorExecutorShardsStopped                = "shard_distributor_executor_shards_stopped"
-	ShardDistributorExecutorProcessorCreationFailures   = "shard_distributor_executor_processor_creation_failures"
-	ShardDistributorExecutorClientRequests              = "shard_distributor_executor_client_requests"
-	ShardDistributorExecutorClientFailures              = "shard_distributor_executor_client_failures"
+	ShardDistributorExecutorAssignmentSkipped         = "shard_distributor_executor_assignment_skipped"
+	ShardDistributorExecutorShardsStarted             = "shard_distributor_executor_shards_started"
+	ShardDistributorExecutorShardsStopped             = "shard_distributor_executor_shards_stopped"
+	ShardDistributorExecutorProcessorCreationFailures = "shard_distributor_executor_processor_creation_failures"
+	ShardDistributorExecutorClientRequests            = "shard_distributor_executor_client_requests"
+	ShardDistributorExecutorClientFailures            = "shard_distributor_executor_client_failures"
 
 	// Gauge metrics
 	ShardDistributorExecutorOwnedShards = "shard_distributor_executor_owned_shards"
@@ -43,21 +43,5 @@ var (
 		10 * time.Second,
 		20 * time.Second,
 		60 * time.Second,
-	})
-
-	ShardDistributorExecutorStoreLatencyBuckets = tally.DurationBuckets([]time.Duration{
-		0,
-		1 * time.Millisecond,
-		5 * time.Millisecond,
-		10 * time.Millisecond,
-		25 * time.Millisecond,
-		50 * time.Millisecond,
-		100 * time.Millisecond,
-		200 * time.Millisecond,
-		500 * time.Millisecond,
-		1 * time.Second,
-		2 * time.Second,
-		5 * time.Second,
-		10 * time.Second,
 	})
 )

--- a/service/sharddistributor/store/etcd/etcdstore.go
+++ b/service/sharddistributor/store/etcd/etcdstore.go
@@ -253,6 +253,7 @@ func (s *Store) Subscribe(ctx context.Context, namespace string) (<-chan int64, 
 		watchChan := s.client.Watch(ctx, watchPrefix, clientv3.WithPrefix())
 		for watchResp := range watchChan {
 			if err := watchResp.Err(); err != nil {
+				// TODO: log error
 				return
 			}
 			isSignificantChange := false

--- a/service/sharddistributor/store/etcd/etcdstore.go
+++ b/service/sharddistributor/store/etcd/etcdstore.go
@@ -253,7 +253,6 @@ func (s *Store) Subscribe(ctx context.Context, namespace string) (<-chan int64, 
 		watchChan := s.client.Watch(ctx, watchPrefix, clientv3.WithPrefix())
 		for watchResp := range watchChan {
 			if err := watchResp.Err(); err != nil {
-				// TODO: log error
 				return
 			}
 			isSignificantChange := false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Changed the executor SDK to use a raw tally scope instead of the Cadence wrapper
- Manually added a metered wrapper for the executor since the generated one only supports the internal Cadence one


<!-- Tell your future self why have you made these changes -->
**Why?**
The Cadence wrapper only supports the Cadence services - the client will be included in different services, so it cannot use the wrapper. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
