### PR TITLE
Make sure that task backlog metric is emitted in each gettaskspump run

### DIFF
--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -200,6 +200,7 @@ func (tr *taskReader) getTasksPump() {
 	defer updateAckTimer.Stop()
 getTasksPumpLoop:
 	for {
+		tr.scope.UpdateGauge(metrics.TaskBacklogPerTaskListGauge, float64(tr.taskAckManager.GetBacklogCount()))
 		select {
 		case <-tr.cancelCtx.Done():
 			break getTasksPumpLoop
@@ -253,7 +254,6 @@ getTasksPumpLoop:
 				updateAckTimer.Reset(tr.config.UpdateAckInterval())
 			}
 		}
-		tr.scope.UpdateGauge(metrics.TaskBacklogPerTaskListGauge, float64(tr.taskAckManager.GetBacklogCount()))
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make sure that task backlog metric is emitted in each gettaskspump run

<!-- Tell your future self why have you made these changes -->
**Why?**
We're unable to tell whether the getTasksPump background job is running or not when the metric is missing because it's possible that it goes to the notify branch and continues to the beginning of the loop.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
