### PR TITLE
[active-active] Fix failover version updates during failover

### DIFF
--- a/common/activecluster/manager.go
+++ b/common/activecluster/manager.go
@@ -257,6 +257,7 @@ func (m *managerImpl) LookupWorkflow(ctx context.Context, domainID, wfID, rID st
 			tag.WorkflowID(wfID),
 			tag.WorkflowRunID(rID),
 			tag.ActiveClusterName(d.GetReplicationConfig().ActiveClusterName),
+			tag.FailoverVersion(d.GetFailoverVersion()),
 		)
 		return &LookupResult{
 			ClusterName:     d.GetReplicationConfig().ActiveClusterName,
@@ -278,6 +279,7 @@ func (m *managerImpl) LookupWorkflow(ctx context.Context, domainID, wfID, rID st
 				tag.WorkflowID(wfID),
 				tag.WorkflowRunID(rID),
 				tag.ActiveClusterName(d.GetReplicationConfig().ActiveClusterName),
+				tag.FailoverVersion(d.GetFailoverVersion()),
 			)
 			return &LookupResult{
 				ClusterName:     d.GetReplicationConfig().ActiveClusterName,
@@ -298,6 +300,7 @@ func (m *managerImpl) LookupWorkflow(ctx context.Context, domainID, wfID, rID st
 			tag.WorkflowRunID(rID),
 			tag.Region(region),
 			tag.ActiveClusterName(cluster.ActiveClusterName),
+			tag.FailoverVersion(cluster.FailoverVersion),
 		)
 		return &LookupResult{
 			Region:          region,
@@ -326,6 +329,7 @@ func (m *managerImpl) LookupWorkflow(ctx context.Context, domainID, wfID, rID st
 			tag.WorkflowExternalEntityKey(plcy.ExternalEntityKey),
 			tag.Region(externalEntity.Region),
 			tag.ActiveClusterName(cluster),
+			tag.FailoverVersion(externalEntity.FailoverVersion),
 		)
 		return &LookupResult{
 			Region:          externalEntity.Region,
@@ -350,6 +354,7 @@ func (m *managerImpl) LookupWorkflow(ctx context.Context, domainID, wfID, rID st
 		tag.WorkflowRunID(rID),
 		tag.Region(region),
 		tag.ActiveClusterName(cluster.ActiveClusterName),
+		tag.FailoverVersion(cluster.FailoverVersion),
 	)
 	return &LookupResult{
 		Region:          region,

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -1367,6 +1367,7 @@ func (d *handlerImpl) updateReplicationConfig(
 				// initialize failover version to the initial failover version of the cluster
 				activeCluster.FailoverVersion = d.clusterMetadata.GetNextFailoverVersion(activeCluster.ActiveClusterName, 0, domainName)
 				finalActiveClusters[region] = activeCluster
+				d.logger.Debugf("Setting activeCluster for region %v to %v. a cluster is being activated on a region", region, activeCluster)
 				continue
 			}
 
@@ -1376,9 +1377,11 @@ func (d *handlerImpl) updateReplicationConfig(
 				// set failover version to the next failover version of the newcluster that is greater than the existing active cluster's failover version
 				activeCluster.FailoverVersion = d.clusterMetadata.GetNextFailoverVersion(activeCluster.ActiveClusterName, existingActiveCluster.FailoverVersion, domainName)
 				finalActiveClusters[region] = activeCluster
+				d.logger.Debugf("Setting activeCluster for region %v to %v. a region is being pointed to a new cluster", region, activeCluster)
 			} else {
 				// no update case, just copy the existing active cluster
-				finalActiveClusters[region] = activeCluster
+				finalActiveClusters[region] = existingActiveCluster
+				d.logger.Debugf("Setting activeCluster for region %v to %v. no update case, just copy the existing active cluster", region, activeCluster)
 			}
 		}
 		config.ActiveClusters = &types.ActiveClusters{

--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -3080,7 +3080,7 @@ func serializeHistoryToken(token *getHistoryContinuationToken) ([]byte, error) {
 }
 
 func isFailoverRequest(updateRequest *types.UpdateDomainRequest) bool {
-	return updateRequest.ActiveClusterName != nil
+	return updateRequest.ActiveClusterName != nil || updateRequest.ActiveClusters != nil
 }
 
 func isGraceFailoverRequest(updateRequest *types.UpdateDomainRequest) bool {

--- a/service/frontend/api/request_validator_test.go
+++ b/service/frontend/api/request_validator_test.go
@@ -970,10 +970,26 @@ func TestValidateUpdateDomainRequest(t *testing.T) {
 			expectedError: "No permission to do this operation.",
 		},
 		{
-			name: "lockdown",
+			name: "lockdown rejects active-passive failover",
 			req: &types.UpdateDomainRequest{
 				Name:              "domain",
 				ActiveClusterName: common.Ptr("a"),
+			},
+			expectError:   true,
+			expectedError: "Domain is not accepting fail overs at this time due to lockdown.",
+		},
+		{
+			name: "lockdown rejects active-active failover",
+			req: &types.UpdateDomainRequest{
+				Name: "domain",
+				ActiveClusters: &types.ActiveClusters{
+					ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+						"region0": {
+							ActiveClusterName: "cluster0",
+							FailoverVersion:   1,
+						},
+					},
+				},
 			},
 			expectError:   true,
 			expectedError: "Domain is not accepting fail overs at this time due to lockdown.",

--- a/simulation/replication/testdata/replication_simulation_activeactive_regional_failover.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive_regional_failover.yaml
@@ -1,7 +1,7 @@
 # This file is a replication simulation scenario spec.
 # It is parsed into ReplicationSimulationConfig struct.
-# Replication simulation for this file can be run via ./simulation/replication/run.sh activeactive
-# Dynamic config overrides can be set via config/dynamicconfig/replication_simulation_activeactive.yml
+# Replication simulation for this file can be run via ./simulation/replication/run.sh activeactive_regional_failover
+# Dynamic config overrides can be set via config/dynamicconfig/replication_simulation_activeactive_regional_failover.yml
 clusters:
   cluster0:
     grpcEndpoint: "cadence-cluster0:7833"

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -85,7 +85,7 @@ var (
 		&cli.StringFlag{
 			Name:    FlagIsGlobalDomain,
 			Aliases: []string{"gd"},
-			Usage:   "Flag to indicate whether domain is a global domain. Default to true. Local domain is now legacy.",
+			Usage:   "Flag to indicate whether domain is a global domain (active-passive domain). Default to true. Local domain is now legacy.",
 			Value:   "true",
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Multiple bug fixes around active-active domain update handling:
- Fix a bug in domain update handler where the region->cluster entry is not changed but it overrides the FailoverVersion with user input. We should keep existing map entry intact.
- Update domain change callback so that it calls `notifyQueues` for active-active domain updates. Otherwise timer tasks may not get picked up quickly after failover if there's nothing going on in the shard.
- Update frontend handler to consider `ActiveClusters` field change as a failover request and enforce same validation as `ActiveClusterName` changed. e.g. reject if there's lockdown


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests
- Simulations
    - `./simulation/replication/run.sh activepassive_to_activeactive`
    - `./simulation/replication/run.sh activeactive`
    - `./simulation/replication/run.sh activeactive_regional_failover`