### PR TITLE
Track pending task count per domain

### DIFF
--- a/service/history/queuev2/pending_task_tracker_mock.go
+++ b/service/history/queuev2/pending_task_tracker_mock.go
@@ -95,6 +95,20 @@ func (mr *MockPendingTaskTrackerMockRecorder) GetPendingTaskCount() *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingTaskCount", reflect.TypeOf((*MockPendingTaskTracker)(nil).GetPendingTaskCount))
 }
 
+// GetPerDomainPendingTaskCount mocks base method.
+func (m *MockPendingTaskTracker) GetPerDomainPendingTaskCount() map[string]int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPerDomainPendingTaskCount")
+	ret0, _ := ret[0].(map[string]int)
+	return ret0
+}
+
+// GetPerDomainPendingTaskCount indicates an expected call of GetPerDomainPendingTaskCount.
+func (mr *MockPendingTaskTrackerMockRecorder) GetPerDomainPendingTaskCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPerDomainPendingTaskCount", reflect.TypeOf((*MockPendingTaskTracker)(nil).GetPerDomainPendingTaskCount))
+}
+
 // GetTasks mocks base method.
 func (m *MockPendingTaskTracker) GetTasks() map[persistence.HistoryTaskKey]task.Task {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update pending task tracker to track the number of pending task per domain

<!-- Tell your future self why have you made these changes -->
**Why?**
To support virtual queue split by domain

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
