### PR TITLE
[active-active] Emit workflow cluster/failoverversion lookup request metrics

### DIFF
--- a/common/activecluster/manager_test.go
+++ b/common/activecluster/manager_test.go
@@ -654,7 +654,7 @@ func TestLookupWorkflow(t *testing.T) {
 		getClusterSelectionPolicyFn func(ctx context.Context, domainID, wfID, rID string) (*types.ActiveClusterSelectionPolicy, error)
 		mockFn                      func(em *persistence.MockExecutionManager)
 		activeClusterCfg            *types.ActiveClusters
-		domainIdToNameErr           error
+		domainIDToNameErr           error
 		migratedFromActivePassive   bool
 		expectedResult              *LookupResult
 		expectedError               string
@@ -681,7 +681,7 @@ func TestLookupWorkflow(t *testing.T) {
 					},
 				},
 			},
-			domainIdToNameErr: errors.New("failed to find domain by id"),
+			domainIDToNameErr: errors.New("failed to find domain by id"),
 			expectedError:     "failed to find domain by id",
 		},
 		{
@@ -845,7 +845,7 @@ func TestLookupWorkflow(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
-				return getDomainCacheEntry(tc.activeClusterCfg, tc.migratedFromActivePassive), tc.domainIdToNameErr
+				return getDomainCacheEntry(tc.activeClusterCfg, tc.migratedFromActivePassive), tc.domainIDToNameErr
 			}
 
 			timeSrc := clock.NewMockedTimeSource()

--- a/common/activecluster/manager_test.go
+++ b/common/activecluster/manager_test.go
@@ -654,6 +654,7 @@ func TestLookupWorkflow(t *testing.T) {
 		getClusterSelectionPolicyFn func(ctx context.Context, domainID, wfID, rID string) (*types.ActiveClusterSelectionPolicy, error)
 		mockFn                      func(em *persistence.MockExecutionManager)
 		activeClusterCfg            *types.ActiveClusters
+		domainIdToNameErr           error
 		migratedFromActivePassive   bool
 		expectedResult              *LookupResult
 		expectedError               string
@@ -665,6 +666,23 @@ func TestLookupWorkflow(t *testing.T) {
 				ClusterName:     "cluster0",
 				FailoverVersion: 201,
 			},
+		},
+		{
+			name: "domain id to name fn returns error",
+			activeClusterCfg: &types.ActiveClusters{
+				ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+					"us-west": {
+						ActiveClusterName: "cluster0",
+						FailoverVersion:   1,
+					},
+					"us-east": {
+						ActiveClusterName: "cluster1",
+						FailoverVersion:   3,
+					},
+				},
+			},
+			domainIdToNameErr: errors.New("failed to find domain by id"),
+			expectedError:     "failed to find domain by id",
 		},
 		{
 			name: "domain is active-active, failed to fetch workflow activeness metadata",
@@ -827,7 +845,7 @@ func TestLookupWorkflow(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			domainIDToDomainFn := func(id string) (*cache.DomainCacheEntry, error) {
-				return getDomainCacheEntry(tc.activeClusterCfg, tc.migratedFromActivePassive), nil
+				return getDomainCacheEntry(tc.activeClusterCfg, tc.migratedFromActivePassive), tc.domainIdToNameErr
 			}
 
 			timeSrc := clock.NewMockedTimeSource()
@@ -883,7 +901,9 @@ func getDomainCacheEntry(cfg *types.ActiveClusters, migratedFromActivePassive bo
 		activeClusterName = "cluster0"
 	}
 	return cache.NewDomainCacheEntryForTest(
-		nil,
+		&persistence.DomainInfo{
+			Name: "test-domain-id",
+		},
 		nil,
 		true,
 		&persistence.DomainReplicationConfig{

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -876,6 +876,9 @@ const (
 	// LoadBalancerScope is the metrics scope for Round Robin load balancer
 	LoadBalancerScope
 
+	// ActiveClusterManager is the scope used by active cluster manager
+	ActiveClusterManager
+
 	NumCommonScopes
 )
 
@@ -1831,6 +1834,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ShardDistributorExecutorClientHeartbeatScope: {operation: "ShardDistributorExecutorHeartbeat"},
 
 		LoadBalancerScope: {operation: "RRLoadBalancer"},
+
+		ActiveClusterManager: {operation: "ActiveClusterManager"},
 	},
 	// Frontend Scope Names
 	Frontend: {
@@ -2381,6 +2386,12 @@ const (
 	BaseCacheCountLimitGauge
 	BaseCacheFullCounter
 	BaseCacheEvictCounter
+
+	// active cluster manager metrics
+	ActiveClusterManagerLookupRequestCount
+	ActiveClusterManagerLookupSuccessCount
+	ActiveClusterManagerLookupFailureCount
+	ActiveClusterManagerLookupLatency
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -3153,6 +3164,11 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		BaseCacheCountLimitGauge:    {metricName: "cache_count_limit", metricType: Gauge},
 		BaseCacheFullCounter:        {metricName: "cache_full", metricType: Counter},
 		BaseCacheEvictCounter:       {metricName: "cache_evict", metricType: Counter},
+
+		ActiveClusterManagerLookupRequestCount: {metricName: "active_cluster_manager_lookup_request_count", metricType: Counter},
+		ActiveClusterManagerLookupSuccessCount: {metricName: "active_cluster_manager_lookup_success_count", metricType: Counter},
+		ActiveClusterManagerLookupFailureCount: {metricName: "active_cluster_manager_lookup_failure_count", metricType: Counter},
+		ActiveClusterManagerLookupLatency:      {metricName: "active_cluster_manager_lookup_latency", metricType: Timer},
 	},
 	History: {
 		TaskRequests:             {metricName: "task_requests", metricType: Counter},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -359,3 +359,13 @@ func ReasonTag(reason string) Tag {
 func DecisionTag(decision string) Tag {
 	return metricWithUnknown("decision", decision)
 }
+
+// ActiveClusterLookupFnTag returns a new active cluster lookup function tag.
+func ActiveClusterLookupFnTag(fn string) Tag {
+	return metricWithUnknown("fn", fn)
+}
+
+// ActiveClusterSelectionStrategyTag returns a new active cluster selection strategy tag.
+func ActiveClusterSelectionStrategyTag(strategy string) Tag {
+	return metricWithUnknown("strategy", strategy)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added success, failure and latency metrics for `Lookup*` methods.
- `active_cluster_manager_lookup_request_count`
- `active_cluster_manager_lookup_success_count`
- `active_cluster_manager_lookup_failure_count`
- `active_cluster_manager_lookup_latency`

Added a new exponential duration buckets variable and used it. We are planning to consolidate histogram buckets and this new one will be used going forward. We will iterate on it further (e.g. rounding of durations to nearest ms/sec etc.)

<!-- Tell your future self why have you made these changes -->
**Why?**
- Ability to alert on failures
- Measure latencies and consider adding an LRU cache for existing workflow lookups

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test for new buckets
- Ran simulation and check prometheus
<img width="656" height="665" alt="Screenshot 2025-08-04 at 10 59 07 AM" src="https://github.com/user-attachments/assets/b5ff92aa-76bf-4810-a7b7-7dbc3e04e382" />

