### PR TITLE
Fix task priority assigner for history queue v2

### DIFF
--- a/service/history/queuev2/queue_base.go
+++ b/service/history/queuev2/queue_base.go
@@ -109,9 +109,9 @@ func newQueueBase(
 	)
 	var queueType task.QueueType
 	if category == persistence.HistoryTaskCategoryTransfer {
-		queueType = task.QueueTypeActiveTransfer
+		queueType = task.QueueTypeTransfer
 	} else if category == persistence.HistoryTaskCategoryTimer {
-		queueType = task.QueueTypeActiveTimer
+		queueType = task.QueueTypeTimer
 	}
 	taskInitializer := func(t persistence.Task) task.Task {
 		return task.NewHistoryTask(

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -117,16 +117,18 @@ type (
 )
 
 const (
-	// QueueTypeActiveTransfer is the queue type for active transfer queue processor
+	// QueueTypeActiveTransfer is the queue type for active transfer queue processor (TODO: remove this when history queue v1 is deprecated)
 	QueueTypeActiveTransfer QueueType = iota + 1
-	// QueueTypeStandbyTransfer is the queue type for standby transfer queue processor
+	// QueueTypeStandbyTransfer is the queue type for standby transfer queue processor (TODO: remove this when history queue v1 is deprecated)
 	QueueTypeStandbyTransfer
-	// QueueTypeActiveTimer is the queue type for active timer queue processor
+	// QueueTypeActiveTimer is the queue type for active timer queue processor (TODO: remove this when history queue v1 is deprecated)
 	QueueTypeActiveTimer
-	// QueueTypeStandbyTimer is the queue type for standby timer queue processor
+	// QueueTypeStandbyTimer is the queue type for standby timer queue processor (TODO: remove this when history queue v1 is deprecated)
 	QueueTypeStandbyTimer
 	// QueueTypeReplication is the queue type for replication queue processor
 	QueueTypeReplication
-	// QueueTypeCrossCluster is the queue type for cross cluster queue processor
-	QueueTypeCrossCluster
+	// QueueTypeTransfer is the queue type for transfer queue processor
+	QueueTypeTransfer
+	// QueueTypeTimer is the queue type for timer queue processor
+	QueueTypeTimer
 )

--- a/service/history/task/priority_assigner.go
+++ b/service/history/task/priority_assigner.go
@@ -88,7 +88,7 @@ func (a *priorityAssignerImpl) Assign(queueTask Task) error {
 	}
 
 	// timer, transfer or cross cluster task, first check if task is active or not and if domain is active or not
-	isActiveTask := queueType == QueueTypeActiveTimer || queueType == QueueTypeActiveTransfer || queueType == QueueTypeCrossCluster
+	isActiveTask := queueType == QueueTypeActiveTimer || queueType == QueueTypeActiveTransfer
 	domainName, isActiveDomain, err := a.getDomainInfo(queueTask.GetDomainID())
 	if err != nil {
 		return err
@@ -118,8 +118,6 @@ func (a *priorityAssignerImpl) Assign(queueTask Task) error {
 			taggedScope.IncCounter(metrics.TransferTaskThrottledCounter)
 		case QueueTypeActiveTimer, QueueTypeStandbyTimer:
 			taggedScope.IncCounter(metrics.TimerTaskThrottledCounter)
-		case QueueTypeCrossCluster:
-			taggedScope.IncCounter(metrics.CrossClusterTaskThrottledCounter)
 		}
 		return nil
 	}

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -420,7 +420,7 @@ func (t *taskImpl) shouldResubmitOnNack() bool {
 	// we can also consider resubmit standby tasks that fails due to certain error types
 	// this may require change the Nack() interface to Nack(error)
 	return t.GetAttempt() < activeTaskResubmitMaxAttempts &&
-		(t.queueType == QueueTypeActiveTransfer || t.queueType == QueueTypeActiveTimer)
+		(t.queueType == QueueTypeActiveTransfer || t.queueType == QueueTypeActiveTimer || ((t.queueType == QueueTypeTransfer || t.queueType == QueueTypeTimer) && t.isPreviousExecutorActive))
 }
 
 func (t *taskImpl) backoffDuration(attempt int) time.Duration {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set standby task to low priority in history queue v2

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix. The task priority assigner assigns high priority to tasks from active queue, even if it's from a standby domain. There is no active queue in history queue v2, we should assign low priority to tasks from standby domains.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests
also verified in docstore-staging

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
