### PR TITLE
[active-active] ListDomains shouldn't fill ActiveClusterName with current cluster

### DIFF
--- a/common/persistence/nosql/nosql_domain_store.go
+++ b/common/persistence/nosql/nosql_domain_store.go
@@ -197,7 +197,12 @@ func (m *nosqlDomainStore) ListDomains(
 		if row.Info.Data == nil {
 			row.Info.Data = map[string]string{}
 		}
-		row.ReplicationConfig.ActiveClusterName = cluster.GetOrUseDefaultActiveCluster(m.currentClusterName, row.ReplicationConfig.ActiveClusterName)
+
+		// for active-active domains, do not populate active cluster name with current cluster name if it is not set
+		if row.ReplicationConfig.ActiveClustersConfig == nil {
+			row.ReplicationConfig.ActiveClusterName = cluster.GetOrUseDefaultActiveCluster(m.currentClusterName, row.ReplicationConfig.ActiveClusterName)
+		}
+
 		row.ReplicationConfig.Clusters = cluster.GetOrUseDefaultClusters(m.currentClusterName, row.ReplicationConfig.Clusters)
 
 		domains = append(domains, &persistence.InternalGetDomainResponse{

--- a/common/persistence/nosql/nosql_domain_store_test.go
+++ b/common/persistence/nosql/nosql_domain_store_test.go
@@ -478,15 +478,20 @@ func TestListDomains(t *testing.T) {
 		{
 			name: "success",
 			setupMock: func(dbMock *nosqlplugin.MockDB) {
-				dbMock.EXPECT().SelectAllDomains(gomock.Any(), 1, []byte("token")).Return([]*nosqlplugin.DomainRow{
-					{
-						Info:              &persistence.DomainInfo{ID: "domain-id-1"},
-						ReplicationConfig: testFixtureDomainReplicationConfig(),
-					},
-				}, []byte("next-token"), nil).Times(1)
+				dbMock.EXPECT().SelectAllDomains(gomock.Any(), 2, []byte("token")).Return(
+					[]*nosqlplugin.DomainRow{
+						{
+							Info:              &persistence.DomainInfo{ID: "domain-id-1"},
+							ReplicationConfig: testFixtureDomainReplicationConfig(),
+						},
+						{
+							Info:              &persistence.DomainInfo{ID: "active-active-domain-id"},
+							ReplicationConfig: testFixtureDomainReplicationConfigActiveActive(),
+						},
+					}, []byte("next-token"), nil).Times(1)
 			},
 			request: &persistence.ListDomainsRequest{
-				PageSize:      1,
+				PageSize:      2,
 				NextPageToken: []byte("token"),
 			},
 			expectError: false,
@@ -495,6 +500,10 @@ func TestListDomains(t *testing.T) {
 					{
 						Info:              &persistence.DomainInfo{ID: "domain-id-1", Data: map[string]string{}},
 						ReplicationConfig: testFixtureDomainReplicationConfig(),
+					},
+					{
+						Info:              &persistence.DomainInfo{ID: "active-active-domain-id", Data: map[string]string{}},
+						ReplicationConfig: testFixtureDomainReplicationConfigActiveActive(),
 					},
 				},
 				NextPageToken: []byte("next-token"),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

`ListDomains` in nosql layer is auto-filling domain's ActiveClusterName when it's empty. However we should leave it empty for active-active domains to distinguish between
- fresh active-active domain
- migrated from active-passive

This is used in activecluster manager to handle migrated domains. 



<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test and replication simulations
