### PR TITLE
Improve handling of unknown isolation groups

### DIFF
--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -685,6 +685,23 @@ func TestGetIsolationGroupForTask(t *testing.T) {
 			recentPollers:            []string{"b"},
 		},
 		{
+			name:                     "leak - unknown group",
+			taskIsolationGroup:       "a",
+			taskIsolationDuration:    time.Second,
+			availableIsolationGroups: []string{"b"},
+			expectedGroup:            "",
+			expectedDuration:         0,
+		},
+		{
+			name:                     "leak - unknown group even with recent poller",
+			taskIsolationGroup:       "a",
+			taskIsolationDuration:    time.Second,
+			availableIsolationGroups: []string{"b"},
+			expectedGroup:            "",
+			expectedDuration:         0,
+			recentPollers:            []string{"a"},
+		},
+		{
 			name:                     "leak - task latency",
 			taskIsolationGroup:       "a",
 			taskIsolationDuration:    time.Second,

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -327,8 +327,12 @@ func (tr *taskReader) addSingleTaskToBuffer(task *persistence.TaskInfo) bool {
 	}
 	// Ignore the isolation duration as we're just putting it into a buffer to be dispatched later.
 	isolationGroup, _ := tr.getIsolationGroupForTask(tr.cancelCtx, task)
+	buffer, ok := tr.taskBuffers[isolationGroup]
+	if !ok {
+		buffer = tr.taskBuffers[defaultTaskBufferIsolationGroup]
+	}
 	select {
-	case tr.taskBuffers[isolationGroup] <- task:
+	case buffer <- task:
 		return true
 	case <-tr.cancelCtx.Done():
 		return false


### PR DESCRIPTION
Include an explicit metric for unknown isolation groups and eagerly abandon isolation. This metric is useful for distinguishing between isolation groups that only exist in another region and isolation groups that exist but don't have pollers. This is another place we'll need to change should we switch to fully dynamic isolation group support.

Additionally update task_reader to defensively check whether a buffer exists before trying to dispatch a task to it. Dispatching to a nil channel blocks forever.

<!-- Describe what has changed in this PR -->
**What changed?**
- Eagerly leak tasks with unknown isolation groups
- Defensively check if buffers exist before sending to them

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prevent unknown isolation groups that have pollers from causing the task_reader to hang

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Low, this is adding additional checks

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
