### PR TITLE
Fix standby task processing for history queue v1

### DIFF
--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -77,7 +77,10 @@ func NewTimerStandbyTaskExecutor(
 		clusterName:     clusterName,
 		historyResender: historyResender,
 		getRemoteClusterNameFn: func(ctx context.Context, taskInfo persistence.Task) (string, error) {
-			return getRemoteClusterName(ctx, shard.GetClusterMetadata().GetCurrentClusterName(), shard.GetDomainCache(), shard.GetActiveClusterManager(), taskInfo)
+			if shard.GetConfig().EnableTimerQueueV2(shard.GetShardID()) {
+				return getRemoteClusterName(ctx, shard.GetClusterMetadata().GetCurrentClusterName(), shard.GetDomainCache(), shard.GetActiveClusterManager(), taskInfo)
+			}
+			return clusterName, nil
 		},
 	}
 }

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -70,7 +70,10 @@ func NewTransferStandbyTaskExecutor(
 		clusterName:     clusterName,
 		historyResender: historyResender,
 		getRemoteClusterNameFn: func(ctx context.Context, taskInfo persistence.Task) (string, error) {
-			return getRemoteClusterName(ctx, shard.GetClusterMetadata().GetCurrentClusterName(), shard.GetDomainCache(), shard.GetActiveClusterManager(), taskInfo)
+			if shard.GetConfig().EnableTransferQueueV2(shard.GetShardID()) {
+				return getRemoteClusterName(ctx, shard.GetClusterMetadata().GetCurrentClusterName(), shard.GetDomainCache(), shard.GetActiveClusterManager(), taskInfo)
+			}
+			return clusterName, nil
 		},
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This is a follow up PR of https://github.com/cadence-workflow/cadence/pull/7121. 
<!-- Tell your future self why have you made these changes -->
**Why?**
The previous PR fixed the issue except for some special cases that some type of history tasks are processed by both standby queue and active queue (see [this code](https://github.com/cadence-workflow/cadence/blob/master/service/history/queue/timer_queue_standby_processor.go#L59)). Those tasks are not handled correctly by the standby executor, because they're actually active tasks but processed by standby executor.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
