### PR TITLE
Implement handler for queue pending task count alert

### DIFF
--- a/service/history/queuev2/mitigator.go
+++ b/service/history/queuev2/mitigator.go
@@ -2,10 +2,20 @@
 package queuev2
 
 import (
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/uber/cadence/common/collection"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
+)
+
+const (
+	targetLoadFactor           = 0.8
+	clearSliceThrottleDuration = 10 * time.Second
 )
 
 type (
@@ -25,6 +35,13 @@ type (
 		options             *MitigatorOptions
 
 		handlers map[AlertType]func(Alert)
+	}
+
+	pendingTaskStats struct {
+		totalPendingTaskCount             int
+		pendingTaskCountPerDomain         map[string]int
+		pendingTaskCountPerDomainPerSlice map[VirtualSlice]map[string]int
+		slicesPerDomain                   map[string][]VirtualSlice
 	}
 )
 
@@ -56,11 +73,134 @@ func (m *mitigatorImpl) Mitigate(alert Alert) {
 	handler(alert)
 
 	m.monitor.ResolveAlert(alert.AlertType)
+	m.logger.Info("mitigated queue alert", tag.AlertType(int(alert.AlertType)))
 }
 
 func (m *mitigatorImpl) handleQueuePendingTaskCount(alert Alert) {
-	// TODO: implement the algorithm to mitigate the queue pending task count
-	// the idea is to scan all the virtual queues and get the number of pending tasks in each domain per virtual slice
-	// use a greedy algorithm to split virtual slices by the domain with the most number of pending tasks, clear tasks from that domain
-	// until the total number of pending tasks is below the critical pending task count
+	// First, try cleaning up tasks that has already been acknowledged to see if we can reduce the pending task count
+	virtualQueues := m.virtualQueueManager.VirtualQueues()
+	for _, virtualQueue := range virtualQueues {
+		virtualQueue.UpdateAndGetState()
+	}
+	if m.monitor.GetTotalPendingTaskCount() <= alert.AlertAttributesQueuePendingTaskCount.CriticalPendingTaskCount {
+		return
+	}
+	// Second, getting the stats of pending tasks. We need:
+	stats := m.collectPendingTaskStats()
+
+	// Third, find virtual slices to split given the target pending task count and the stats of pending tasks
+	targetPendingTaskCount := int(float64(alert.AlertAttributesQueuePendingTaskCount.CriticalPendingTaskCount) * targetLoadFactor)
+	domainsToClearPerSlice := m.findDomainsToClear(stats, targetPendingTaskCount)
+
+	// Finally, split and clear the slices
+	m.processQueueSplitsAndClear(virtualQueues, domainsToClearPerSlice)
+}
+
+// The stats of pending tasks are used to calculate the domains to clear. We need:
+// 1. The total number of pending tasks per domain
+// 2. The number of pending tasks per domain per slice
+// 3. The slices that contains the tasks for each domain
+func (m *mitigatorImpl) collectPendingTaskStats() pendingTaskStats {
+	stats := pendingTaskStats{
+		pendingTaskCountPerDomain:         make(map[string]int),
+		pendingTaskCountPerDomainPerSlice: make(map[VirtualSlice]map[string]int),
+		slicesPerDomain:                   make(map[string][]VirtualSlice),
+	}
+
+	for _, virtualQueue := range m.virtualQueueManager.VirtualQueues() {
+		virtualQueue.IterateSlices(func(slice VirtualSlice) {
+			perDomain := slice.PendingTaskStats().PendingTaskCountPerDomain
+			stats.pendingTaskCountPerDomainPerSlice[slice] = perDomain
+			for domain, count := range perDomain {
+				stats.totalPendingTaskCount += count
+				stats.pendingTaskCountPerDomain[domain] += count
+				stats.slicesPerDomain[domain] = append(stats.slicesPerDomain[domain], slice)
+			}
+		})
+	}
+
+	for _, slicesList := range stats.slicesPerDomain {
+		slices.SortFunc(slicesList, func(a, b VirtualSlice) int {
+			return b.GetState().Range.InclusiveMinTaskKey.Compare(a.GetState().Range.InclusiveMinTaskKey)
+		})
+	}
+	return stats
+}
+
+func (m *mitigatorImpl) findDomainsToClear(stats pendingTaskStats, targetCount int) map[VirtualSlice][]string {
+	domainsToClear := make(map[VirtualSlice][]string)
+
+	pq := collection.NewPriorityQueue(
+		func(a, b string) bool {
+			return stats.pendingTaskCountPerDomain[a] > stats.pendingTaskCountPerDomain[b]
+		},
+		slices.Collect(maps.Keys(stats.pendingTaskCountPerDomain))...,
+	)
+
+	for stats.totalPendingTaskCount > targetCount && !pq.IsEmpty() {
+		domain, err := pq.Remove()
+		if err != nil {
+			// this should never happen because we check the priority queue is not empty before calling Remove
+			// but just want to be future proof
+			m.logger.Error("failed to remove domain from priority queue with unexpected error", tag.Error(err))
+			panic(err)
+		}
+		if len(stats.slicesPerDomain[domain]) == 0 {
+			continue
+		}
+		slice := stats.slicesPerDomain[domain][0]
+		stats.slicesPerDomain[domain] = stats.slicesPerDomain[domain][1:]
+
+		taskCount := stats.pendingTaskCountPerDomainPerSlice[slice][domain]
+		stats.totalPendingTaskCount -= taskCount
+		stats.pendingTaskCountPerDomain[domain] -= taskCount
+		if stats.pendingTaskCountPerDomain[domain] > 0 {
+			pq.Add(domain)
+		}
+		domainsToClear[slice] = append(domainsToClear[slice], domain)
+	}
+	return domainsToClear
+}
+
+func (m *mitigatorImpl) processQueueSplitsAndClear(virtualQueues map[int64]VirtualQueue, domainsToClear map[VirtualSlice][]string) {
+	maxQueueID := m.options.MaxVirtualQueueCount() - 1
+	for queueID, vq := range virtualQueues {
+		if queueID >= int64(maxQueueID) {
+			// Clear slices in the last queue
+			cleared := false
+			vq.ClearSlices(func(slice VirtualSlice) bool {
+				_, ok := domainsToClear[slice]
+				cleared = cleared || ok
+				return ok
+			})
+			if cleared {
+				vq.Pause(clearSliceThrottleDuration)
+			}
+			continue
+		}
+
+		var slicesToMove []VirtualSlice
+		vq.SplitSlices(func(slice VirtualSlice) ([]VirtualSlice, bool) {
+			domains := domainsToClear[slice]
+			if len(domains) == 0 {
+				return nil, false
+			}
+			predicate := NewDomainIDPredicate(domains, false)
+			splitSlice, remainingSlice, ok := slice.TrySplitByPredicate(predicate)
+			if !ok {
+				slice.Clear()
+				slicesToMove = append(slicesToMove, slice)
+				return nil, true
+			}
+			splitSlice.Clear()
+			slicesToMove = append(slicesToMove, splitSlice)
+			return []VirtualSlice{remainingSlice}, true
+		})
+
+		if len(slicesToMove) > 0 {
+			nextQueue := m.virtualQueueManager.GetOrCreateVirtualQueue(queueID + 1)
+			nextQueue.Pause(clearSliceThrottleDuration)
+			nextQueue.MergeSlices(slicesToMove...)
+		}
+	}
 }

--- a/service/history/queuev2/mitigator_test.go
+++ b/service/history/queuev2/mitigator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
 )
 
 func TestNewMitigator(t *testing.T) {
@@ -115,4 +116,620 @@ func TestMitigator_Mitigate_UnknownAlertType(t *testing.T) {
 	}
 
 	mitigator.Mitigate(alert)
+}
+
+func TestMitigator_collectPendingTaskStats(t *testing.T) {
+	tests := []struct {
+		name                              string
+		setupMocks                        func(*gomock.Controller) (*MockVirtualQueueManager, map[string][]VirtualSlice, map[VirtualSlice]map[string]int)
+		expectedTotalPendingTaskCount     int
+		expectedPendingTaskCountPerDomain map[string]int
+		expectedSlicesPerDomainLength     map[string]int
+		validateResults                   func(*testing.T, pendingTaskStats, map[string][]VirtualSlice, map[VirtualSlice]map[string]int)
+	}{
+		{
+			name: "empty virtual queues",
+			setupMocks: func(ctrl *gomock.Controller) (*MockVirtualQueueManager, map[string][]VirtualSlice, map[VirtualSlice]map[string]int) {
+				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+				mockVirtualQueueManager.EXPECT().VirtualQueues().Return(map[int64]VirtualQueue{}).Times(1)
+				return mockVirtualQueueManager, map[string][]VirtualSlice{}, map[VirtualSlice]map[string]int{}
+			},
+			expectedTotalPendingTaskCount:     0,
+			expectedPendingTaskCountPerDomain: map[string]int{},
+			expectedSlicesPerDomainLength:     map[string]int{},
+			validateResults: func(t *testing.T, stats pendingTaskStats, expectedSlicesPerDomain map[string][]VirtualSlice, expectedPendingTaskCountPerDomainPerSlice map[VirtualSlice]map[string]int) {
+				assert.Empty(t, stats.pendingTaskCountPerDomain)
+				assert.Empty(t, stats.pendingTaskCountPerDomainPerSlice)
+				assert.Empty(t, stats.slicesPerDomain)
+				assert.Empty(t, stats.pendingTaskCountPerDomainPerSlice)
+			},
+		},
+		{
+			name: "single queue single slice",
+			setupMocks: func(ctrl *gomock.Controller) (*MockVirtualQueueManager, map[string][]VirtualSlice, map[VirtualSlice]map[string]int) {
+				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+				mockVirtualQueue := NewMockVirtualQueue(ctrl)
+				mockVirtualSlice := NewMockVirtualSlice(ctrl)
+
+				virtualQueues := map[int64]VirtualQueue{0: mockVirtualQueue}
+				pendingTaskStats := PendingTaskStats{
+					PendingTaskCountPerDomain: map[string]int{
+						"domain1": 10,
+						"domain2": 5,
+					},
+				}
+
+				mockVirtualQueueManager.EXPECT().VirtualQueues().Return(virtualQueues).Times(1)
+				mockVirtualQueue.EXPECT().IterateSlices(gomock.Any()).DoAndReturn(func(f func(VirtualSlice)) {
+					f(mockVirtualSlice)
+				}).Times(1)
+				mockVirtualSlice.EXPECT().PendingTaskStats().Return(pendingTaskStats).Times(1)
+				mockVirtualSlice.EXPECT().GetState().Return(VirtualSliceState{
+					Range: Range{
+						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+						ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(200),
+					},
+					Predicate: NewUniversalPredicate(),
+				}).AnyTimes()
+
+				expectedSlicesPerDomain := map[string][]VirtualSlice{
+					"domain1": {mockVirtualSlice},
+					"domain2": {mockVirtualSlice},
+				}
+
+				expectedPendingTaskCountPerDomainPerSlice := map[VirtualSlice]map[string]int{
+					mockVirtualSlice: {
+						"domain1": 10,
+						"domain2": 5,
+					},
+				}
+
+				return mockVirtualQueueManager, expectedSlicesPerDomain, expectedPendingTaskCountPerDomainPerSlice
+			},
+			expectedTotalPendingTaskCount: 15,
+			expectedPendingTaskCountPerDomain: map[string]int{
+				"domain1": 10,
+				"domain2": 5,
+			},
+			expectedSlicesPerDomainLength: map[string]int{
+				"domain1": 1,
+				"domain2": 1,
+			},
+			validateResults: func(t *testing.T, stats pendingTaskStats, expectedSlicesPerDomain map[string][]VirtualSlice, expectedPendingTaskCountPerDomainPerSlice map[VirtualSlice]map[string]int) {
+				assert.Equal(t, expectedSlicesPerDomain, stats.slicesPerDomain)
+				assert.Equal(t, expectedPendingTaskCountPerDomainPerSlice, stats.pendingTaskCountPerDomainPerSlice)
+			},
+		},
+		{
+			name: "multiple queues multiple slices",
+			setupMocks: func(ctrl *gomock.Controller) (*MockVirtualQueueManager, map[string][]VirtualSlice, map[VirtualSlice]map[string]int) {
+				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+				mockVirtualQueue1 := NewMockVirtualQueue(ctrl)
+				mockVirtualQueue2 := NewMockVirtualQueue(ctrl)
+				mockVirtualSlice1 := NewMockVirtualSlice(ctrl)
+				mockVirtualSlice2 := NewMockVirtualSlice(ctrl)
+				mockVirtualSlice3 := NewMockVirtualSlice(ctrl)
+
+				virtualQueues := map[int64]VirtualQueue{
+					0: mockVirtualQueue1,
+					1: mockVirtualQueue2,
+				}
+
+				pendingTaskStats1 := PendingTaskStats{
+					PendingTaskCountPerDomain: map[string]int{
+						"domain1": 10,
+						"domain2": 5,
+					},
+				}
+				pendingTaskStats2 := PendingTaskStats{
+					PendingTaskCountPerDomain: map[string]int{
+						"domain1": 8,
+						"domain3": 3,
+					},
+				}
+				pendingTaskStats3 := PendingTaskStats{
+					PendingTaskCountPerDomain: map[string]int{
+						"domain2": 7,
+						"domain3": 4,
+					},
+				}
+
+				mockVirtualQueueManager.EXPECT().VirtualQueues().Return(virtualQueues).Times(1)
+				mockVirtualQueue1.EXPECT().IterateSlices(gomock.Any()).DoAndReturn(func(f func(VirtualSlice)) {
+					f(mockVirtualSlice1)
+					f(mockVirtualSlice2)
+				}).Times(1)
+				mockVirtualQueue2.EXPECT().IterateSlices(gomock.Any()).DoAndReturn(func(f func(VirtualSlice)) {
+					f(mockVirtualSlice3)
+				}).Times(1)
+
+				mockVirtualSlice1.EXPECT().PendingTaskStats().Return(pendingTaskStats1).Times(1)
+				mockVirtualSlice2.EXPECT().PendingTaskStats().Return(pendingTaskStats2).Times(1)
+				mockVirtualSlice3.EXPECT().PendingTaskStats().Return(pendingTaskStats3).Times(1)
+
+				mockVirtualSlice1.EXPECT().GetState().Return(VirtualSliceState{
+					Range: Range{
+						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(0),
+						ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(100),
+					},
+					Predicate: NewUniversalPredicate(),
+				}).AnyTimes()
+				mockVirtualSlice2.EXPECT().GetState().Return(VirtualSliceState{
+					Range: Range{
+						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(200),
+						ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(300),
+					},
+					Predicate: NewUniversalPredicate(),
+				}).AnyTimes()
+				mockVirtualSlice3.EXPECT().GetState().Return(VirtualSliceState{
+					Range: Range{
+						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(100),
+						ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(400),
+					},
+					Predicate: NewUniversalPredicate(),
+				}).AnyTimes()
+
+				// Expected slices sorted by InclusiveMinTaskKey in descending order
+				// slice1=0, slice2=200, slice3=100 -> sorted: slice2(200), slice3(100), slice1(0)
+				expectedSlicesPerDomain := map[string][]VirtualSlice{
+					"domain1": {mockVirtualSlice2, mockVirtualSlice1}, // slice2[200] > slice1[0]
+					"domain2": {mockVirtualSlice3, mockVirtualSlice1}, // slice3[100] > slice1[0]
+					"domain3": {mockVirtualSlice2, mockVirtualSlice3}, // slice2[200] > slice3[100]
+				}
+
+				expectedPendingTaskCountPerDomainPerSlice := map[VirtualSlice]map[string]int{
+					mockVirtualSlice1: {
+						"domain1": 10,
+						"domain2": 5,
+					},
+					mockVirtualSlice2: {
+						"domain1": 8,
+						"domain3": 3,
+					},
+					mockVirtualSlice3: {
+						"domain2": 7,
+						"domain3": 4,
+					},
+				}
+
+				return mockVirtualQueueManager, expectedSlicesPerDomain, expectedPendingTaskCountPerDomainPerSlice
+			},
+			expectedTotalPendingTaskCount: 37, // 10+5 + 8+3 + 7+4 = 37
+			expectedPendingTaskCountPerDomain: map[string]int{
+				"domain1": 18, // 10+8
+				"domain2": 12, // 5+7
+				"domain3": 7,  // 3+4
+			},
+			expectedSlicesPerDomainLength: map[string]int{
+				"domain1": 2, // slice1, slice2
+				"domain2": 2, // slice1, slice3
+				"domain3": 2, // slice2, slice3
+			},
+			validateResults: func(t *testing.T, stats pendingTaskStats, expectedSlicesPerDomain map[string][]VirtualSlice, expectedPendingTaskCountPerDomainPerSlice map[VirtualSlice]map[string]int) {
+				// Verify the exact slice order
+				assert.Equal(t, expectedSlicesPerDomain, stats.slicesPerDomain)
+				// Verify the pendingTaskCountPerDomainPerSlice
+				assert.Equal(t, expectedPendingTaskCountPerDomainPerSlice, stats.pendingTaskCountPerDomainPerSlice)
+			},
+		},
+		{
+			name: "empty slices",
+			setupMocks: func(ctrl *gomock.Controller) (*MockVirtualQueueManager, map[string][]VirtualSlice, map[VirtualSlice]map[string]int) {
+				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+				mockVirtualQueue := NewMockVirtualQueue(ctrl)
+				mockVirtualSlice := NewMockVirtualSlice(ctrl)
+
+				virtualQueues := map[int64]VirtualQueue{0: mockVirtualQueue}
+				emptyPendingTaskStats := PendingTaskStats{
+					PendingTaskCountPerDomain: map[string]int{},
+				}
+
+				mockVirtualQueueManager.EXPECT().VirtualQueues().Return(virtualQueues).Times(1)
+				mockVirtualQueue.EXPECT().IterateSlices(gomock.Any()).DoAndReturn(func(f func(VirtualSlice)) {
+					f(mockVirtualSlice)
+				}).Times(1)
+				mockVirtualSlice.EXPECT().PendingTaskStats().Return(emptyPendingTaskStats).Times(1)
+				mockVirtualSlice.EXPECT().GetState().Return(VirtualSliceState{
+					Range: Range{
+						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(0),
+						ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(100),
+					},
+					Predicate: NewUniversalPredicate(),
+				}).AnyTimes()
+
+				expectedSlicesPerDomain := map[string][]VirtualSlice{}
+				expectedPendingTaskCountPerDomainPerSlice := map[VirtualSlice]map[string]int{
+					mockVirtualSlice: {},
+				}
+
+				return mockVirtualQueueManager, expectedSlicesPerDomain, expectedPendingTaskCountPerDomainPerSlice
+			},
+			expectedTotalPendingTaskCount:     0,
+			expectedPendingTaskCountPerDomain: map[string]int{},
+			expectedSlicesPerDomainLength:     map[string]int{},
+			validateResults: func(t *testing.T, stats pendingTaskStats, expectedSlicesPerDomain map[string][]VirtualSlice, expectedPendingTaskCountPerDomainPerSlice map[VirtualSlice]map[string]int) {
+				assert.Empty(t, stats.slicesPerDomain)
+				assert.Equal(t, expectedPendingTaskCountPerDomainPerSlice, stats.pendingTaskCountPerDomainPerSlice)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockMonitor := NewMockMonitor(ctrl)
+			logger := testlogger.New(t)
+			metricsScope := metrics.NoopScope
+			options := &MitigatorOptions{
+				MaxVirtualQueueCount: dynamicproperties.GetIntPropertyFn(10),
+			}
+
+			mockVirtualQueueManager, expectedSlicesPerDomain, expectedPendingTaskCountPerDomainPerSlice := tt.setupMocks(ctrl)
+
+			mitigator := NewMitigator(
+				mockVirtualQueueManager,
+				mockMonitor,
+				logger,
+				metricsScope,
+				options,
+			)
+
+			impl, ok := mitigator.(*mitigatorImpl)
+			require.True(t, ok)
+			impl.virtualQueueManager = mockVirtualQueueManager
+
+			stats := impl.collectPendingTaskStats()
+
+			// Verify basic aggregated data
+			assert.Equal(t, tt.expectedTotalPendingTaskCount, stats.totalPendingTaskCount)
+			assert.Equal(t, tt.expectedPendingTaskCountPerDomain, stats.pendingTaskCountPerDomain)
+
+			// Verify slices per domain lengths
+			for domain, expectedLength := range tt.expectedSlicesPerDomainLength {
+				assert.Len(t, stats.slicesPerDomain[domain], expectedLength, "domain: %s", domain)
+			}
+
+			// Run custom validation if provided
+			if tt.validateResults != nil {
+				tt.validateResults(t, stats, expectedSlicesPerDomain, expectedPendingTaskCountPerDomainPerSlice)
+			}
+		})
+	}
+}
+
+func TestMitigator_findDomainsToClear(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupStats  func(*gomock.Controller) (pendingTaskStats, map[VirtualSlice][]string)
+		targetCount int
+	}{
+		{
+			name: "target count zero - clear everything",
+			setupStats: func(ctrl *gomock.Controller) (pendingTaskStats, map[VirtualSlice][]string) {
+				mockSlice1 := NewMockVirtualSlice(ctrl)
+				mockSlice2 := NewMockVirtualSlice(ctrl)
+				mockSlice3 := NewMockVirtualSlice(ctrl)
+				stats := pendingTaskStats{
+					totalPendingTaskCount: 142,
+					pendingTaskCountPerDomain: map[string]int{
+						"domain1": 35, // higher priority
+						"domain2": 45,
+						"domain3": 62,
+					},
+					pendingTaskCountPerDomainPerSlice: map[VirtualSlice]map[string]int{
+						mockSlice1: {"domain1": 21, "domain2": 34, "domain3": 55},
+						mockSlice2: {"domain1": 13, "domain2": 8, "domain3": 5},
+						mockSlice3: {"domain1": 1, "domain2": 3, "domain3": 2},
+					},
+					slicesPerDomain: map[string][]VirtualSlice{
+						"domain1": {mockSlice1, mockSlice2, mockSlice3},
+						"domain2": {mockSlice2, mockSlice3, mockSlice1},
+						"domain3": {mockSlice3, mockSlice1, mockSlice2},
+					},
+				}
+				expectedResult := map[VirtualSlice][]string{
+					mockSlice1: {"domain3", "domain1", "domain2"},
+					mockSlice2: {"domain2", "domain1", "domain3"},
+					mockSlice3: {"domain3", "domain2", "domain1"},
+				}
+				return stats, expectedResult
+			},
+			targetCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockMonitor := NewMockMonitor(ctrl)
+			logger := testlogger.New(t)
+			metricsScope := metrics.NoopScope
+			options := &MitigatorOptions{
+				MaxVirtualQueueCount: dynamicproperties.GetIntPropertyFn(10),
+			}
+
+			mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+			mitigator := NewMitigator(
+				mockVirtualQueueManager,
+				mockMonitor,
+				logger,
+				metricsScope,
+				options,
+			)
+
+			impl, ok := mitigator.(*mitigatorImpl)
+			require.True(t, ok)
+
+			stats, expectedResult := tt.setupStats(ctrl)
+			result := impl.findDomainsToClear(stats, tt.targetCount)
+
+			// Verify the actual result content
+			assert.Equal(t, expectedResult, result, "Result should contain the expected slice-to-domains mapping")
+		})
+	}
+}
+
+func TestMitigator_processQueueSplitsAndClear(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupMocks func(*gomock.Controller) (map[int64]VirtualQueue, map[VirtualSlice][]string, int)
+	}{
+		{
+			name: "no domains to clear - no operations",
+			setupMocks: func(ctrl *gomock.Controller) (map[int64]VirtualQueue, map[VirtualSlice][]string, int) {
+				mockVQ := NewMockVirtualQueue(ctrl)
+
+				// SplitSlices is still called, but the split function should return false for all slices
+				mockVQ.EXPECT().SplitSlices(gomock.Any()).Do(func(splitFunc func(VirtualSlice) ([]VirtualSlice, bool)) {
+					// Since domainsToClear is empty, any slice should return split=false
+					mockSlice := NewMockVirtualSlice(nil)
+					remaining, split := splitFunc(mockSlice)
+					require.False(t, split)
+					require.Nil(t, remaining)
+				}).Times(1)
+
+				virtualQueues := map[int64]VirtualQueue{
+					0: mockVQ,
+				}
+				domainsToClear := map[VirtualSlice][]string{}
+				maxQueueCount := 3
+				return virtualQueues, domainsToClear, maxQueueCount
+			},
+		},
+		{
+			name: "clear slices in last queue - no splitting",
+			setupMocks: func(ctrl *gomock.Controller) (map[int64]VirtualQueue, map[VirtualSlice][]string, int) {
+				mockSlice1 := NewMockVirtualSlice(ctrl)
+				mockSlice2 := NewMockVirtualSlice(ctrl)
+				mockVQ := NewMockVirtualQueue(ctrl)
+
+				// Should call ClearSlices with a predicate function
+				mockVQ.EXPECT().ClearSlices(gomock.Any()).Do(func(predicate func(VirtualSlice) bool) {
+					// Verify the predicate returns true for slices in domainsToClear
+					clearedCount := 0
+					for _, slice := range []VirtualSlice{mockSlice1, mockSlice2} {
+						if predicate(slice) {
+							clearedCount++
+						}
+					}
+					// Since both slices are in domainsToClear, both should be cleared
+					require.Equal(t, 1, clearedCount)
+				}).Times(1)
+
+				// Should pause the queue after clearing
+				mockVQ.EXPECT().Pause(clearSliceThrottleDuration).Times(1)
+
+				virtualQueues := map[int64]VirtualQueue{
+					2: mockVQ, // queueID >= maxQueueCount-1 (2)
+				}
+				domainsToClear := map[VirtualSlice][]string{
+					mockSlice1: {"domain1"},
+				}
+				maxQueueCount := 3
+				return virtualQueues, domainsToClear, maxQueueCount
+			},
+		},
+		{
+			name: "split and move slices - successful split",
+			setupMocks: func(ctrl *gomock.Controller) (map[int64]VirtualQueue, map[VirtualSlice][]string, int) {
+				mockSlice := NewMockVirtualSlice(ctrl)
+				mockSplitSlice := NewMockVirtualSlice(ctrl)
+				mockRemainingSlice := NewMockVirtualSlice(ctrl)
+				mockVQ := NewMockVirtualQueue(ctrl)
+
+				// Set up split behavior
+				mockSlice.EXPECT().TrySplitByPredicate(gomock.Any()).Return(mockSplitSlice, mockRemainingSlice, true).AnyTimes()
+				mockSplitSlice.EXPECT().Clear().AnyTimes()
+
+				// Should call SplitSlices with a function
+				mockVQ.EXPECT().SplitSlices(gomock.Any()).Do(func(splitFunc func(VirtualSlice) ([]VirtualSlice, bool)) {
+					// Call the split function with our mock slice
+					remaining, split := splitFunc(mockSlice)
+					// Should return split=true and remaining slice
+					require.True(t, split)
+					require.Len(t, remaining, 1)
+				}).Times(1)
+
+				virtualQueues := map[int64]VirtualQueue{
+					0: mockVQ, // queueID < maxQueueCount-1
+				}
+				domainsToClear := map[VirtualSlice][]string{
+					mockSlice: {"domain1", "domain2"},
+				}
+				maxQueueCount := 3
+
+				return virtualQueues, domainsToClear, maxQueueCount
+			},
+		},
+		{
+			name: "clear slice when split fails",
+			setupMocks: func(ctrl *gomock.Controller) (map[int64]VirtualQueue, map[VirtualSlice][]string, int) {
+				mockSlice := NewMockVirtualSlice(ctrl)
+				mockVQ := NewMockVirtualQueue(ctrl)
+
+				// Set up split behavior to fail
+				mockSlice.EXPECT().TrySplitByPredicate(gomock.Any()).Return(nil, nil, false).AnyTimes()
+				mockSlice.EXPECT().Clear().AnyTimes()
+
+				mockVQ.EXPECT().SplitSlices(gomock.Any()).Do(func(splitFunc func(VirtualSlice) ([]VirtualSlice, bool)) {
+					remaining, split := splitFunc(mockSlice)
+					require.True(t, split)
+					require.Nil(t, remaining)
+				}).Times(1)
+
+				virtualQueues := map[int64]VirtualQueue{
+					1: mockVQ,
+				}
+				domainsToClear := map[VirtualSlice][]string{
+					mockSlice: {"domain1"},
+				}
+				maxQueueCount := 4
+
+				return virtualQueues, domainsToClear, maxQueueCount
+			},
+		},
+		{
+			name: "multiple queues with mixed operations",
+			setupMocks: func(ctrl *gomock.Controller) (map[int64]VirtualQueue, map[VirtualSlice][]string, int) {
+				// Queue 0: split and move
+				mockSlice1 := NewMockVirtualSlice(ctrl)
+				mockSplitSlice1 := NewMockVirtualSlice(ctrl)
+				mockRemainingSlice1 := NewMockVirtualSlice(ctrl)
+				mockVQ0 := NewMockVirtualQueue(ctrl)
+
+				// Queue 1: split and move
+				mockSlice2 := NewMockVirtualSlice(ctrl)
+				mockSplitSlice2 := NewMockVirtualSlice(ctrl)
+				mockRemainingSlice2 := NewMockVirtualSlice(ctrl)
+				mockVQ1 := NewMockVirtualQueue(ctrl)
+
+				// Queue 2: clear (last queue)
+				mockSlice3 := NewMockVirtualSlice(ctrl)
+				mockVQ2 := NewMockVirtualQueue(ctrl)
+
+				// Set up split behaviors
+				mockSlice1.EXPECT().TrySplitByPredicate(gomock.Any()).Return(mockSplitSlice1, mockRemainingSlice1, true).AnyTimes()
+				mockSplitSlice1.EXPECT().Clear().AnyTimes()
+
+				mockSlice2.EXPECT().TrySplitByPredicate(gomock.Any()).Return(mockSplitSlice2, mockRemainingSlice2, true).AnyTimes()
+				mockSplitSlice2.EXPECT().Clear().AnyTimes()
+
+				// Queue 0: should split
+				mockVQ0.EXPECT().SplitSlices(gomock.Any()).Times(1)
+
+				// Queue 1: should split
+				mockVQ1.EXPECT().SplitSlices(gomock.Any()).Times(1)
+
+				// Queue 2: should clear (last queue)
+				var cleared bool
+				mockVQ2.EXPECT().ClearSlices(gomock.Any()).Do(func(predicate func(VirtualSlice) bool) {
+					// Simulate that mockSlice3 exists in the queue and is checked
+					if predicate(mockSlice3) {
+						cleared = true
+					}
+				}).Times(1)
+
+				// Pause should only be called if cleared is true
+				mockVQ2.EXPECT().Pause(clearSliceThrottleDuration).Do(func(duration interface{}) {
+					require.True(t, cleared, "Pause should only be called if slices were cleared")
+				}).Times(1)
+
+				virtualQueues := map[int64]VirtualQueue{
+					0: mockVQ0,
+					1: mockVQ1,
+					2: mockVQ2, // Last queue (>= maxQueueCount-1)
+				}
+				domainsToClear := map[VirtualSlice][]string{
+					mockSlice1: {"domain1"},
+					mockSlice2: {"domain2"},
+					mockSlice3: {"domain3"},
+				}
+				maxQueueCount := 3
+
+				return virtualQueues, domainsToClear, maxQueueCount
+			},
+		},
+		{
+			name: "empty domains to clear for some slices",
+			setupMocks: func(ctrl *gomock.Controller) (map[int64]VirtualQueue, map[VirtualSlice][]string, int) {
+				mockSlice1 := NewMockVirtualSlice(ctrl) // Has domains to clear
+				mockSplitSlice1 := NewMockVirtualSlice(ctrl)
+				mockRemainingSlice1 := NewMockVirtualSlice(ctrl)
+				mockVQ := NewMockVirtualQueue(ctrl)
+
+				// Set up split behavior for slice that has domains to clear
+				mockSlice1.EXPECT().TrySplitByPredicate(gomock.Any()).Return(mockSplitSlice1, mockRemainingSlice1, true).AnyTimes()
+				mockSplitSlice1.EXPECT().Clear().AnyTimes()
+
+				mockVQ.EXPECT().SplitSlices(gomock.Any()).Do(func(splitFunc func(VirtualSlice) ([]VirtualSlice, bool)) {
+					// Test with slice that has domains to clear
+					remaining, split := splitFunc(mockSlice1)
+					require.True(t, split)
+					require.Len(t, remaining, 1)
+
+					// Test with slice that has no domains to clear
+					mockSlice2 := NewMockVirtualSlice(nil)
+					remaining, split = splitFunc(mockSlice2)
+					require.False(t, split)
+					require.Nil(t, remaining)
+				}).Times(1)
+
+				virtualQueues := map[int64]VirtualQueue{
+					0: mockVQ,
+				}
+				domainsToClear := map[VirtualSlice][]string{
+					mockSlice1: {"domain1"},
+					// mockSlice2 intentionally not in domainsToClear
+				}
+				maxQueueCount := 3
+
+				return virtualQueues, domainsToClear, maxQueueCount
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockMonitor := NewMockMonitor(ctrl)
+			logger := testlogger.New(t)
+			metricsScope := metrics.NoopScope
+			options := &MitigatorOptions{
+				MaxVirtualQueueCount: dynamicproperties.GetIntPropertyFn(3),
+			}
+
+			virtualQueues, domainsToClear, maxQueueCount := tt.setupMocks(ctrl)
+			options.MaxVirtualQueueCount = dynamicproperties.GetIntPropertyFn(maxQueueCount)
+
+			// Create a mock VirtualQueueManager that returns our test queues
+			mockVQManager := NewMockVirtualQueueManager(ctrl)
+
+			// Set up expectations for GetOrCreateVirtualQueue calls if needed
+			for queueID := range virtualQueues {
+				if queueID < int64(maxQueueCount-1) {
+					// Expect calls to create next queues for moving slices
+					nextQueueID := queueID + 1
+					if _, exists := virtualQueues[nextQueueID]; !exists {
+						mockNextVQ := NewMockVirtualQueue(ctrl)
+						mockNextVQ.EXPECT().Pause(clearSliceThrottleDuration).AnyTimes()
+						mockNextVQ.EXPECT().MergeSlices(gomock.Any()).AnyTimes()
+						mockVQManager.EXPECT().GetOrCreateVirtualQueue(nextQueueID).Return(mockNextVQ).AnyTimes()
+					}
+				}
+			}
+
+			mitigator := &mitigatorImpl{
+				virtualQueueManager: mockVQManager,
+				monitor:             mockMonitor,
+				logger:              logger,
+				metricsScope:        metricsScope,
+				options:             options,
+			}
+
+			// Execute the method
+			mitigator.processQueueSplitsAndClear(virtualQueues, domainsToClear)
+		})
+	}
 }

--- a/service/history/queuev2/queue_base_test.go
+++ b/service/history/queuev2/queue_base_test.go
@@ -521,6 +521,11 @@ func TestNewQueueBase(t *testing.T) {
 	)
 
 	assert.Equal(t, persistence.NewImmediateTaskKey(400), queueBase.newVirtualSliceState.Range.InclusiveMinTaskKey)
+	virtualQueues := queueBase.virtualQueueManager.VirtualQueues()
+	states := make(map[int64][]VirtualSliceState)
+	for queueID, virtualQueue := range virtualQueues {
+		states[queueID] = virtualQueue.GetState()
+	}
 	assert.Equal(t, map[int64][]VirtualSliceState{
 		rootQueueID: {
 			{
@@ -538,5 +543,5 @@ func TestNewQueueBase(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 			},
 		},
-	}, queueBase.virtualQueueManager.GetState())
+	}, states)
 }

--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
@@ -55,6 +56,8 @@ type (
 		ClearSlices(func(VirtualSlice) bool)
 		// SplitSlices applies the split function to the slices in the virtual queue and return the remaining slices that should be kept in the virtual queue and whether the split is applied
 		SplitSlices(func(VirtualSlice) (remaining []VirtualSlice, split bool))
+		// Pause pauses the virtual queue for a while
+		Pause(time.Duration)
 	}
 
 	VirtualQueueOptions struct {
@@ -272,6 +275,10 @@ func (q *virtualQueueImpl) SplitSlices(f func(VirtualSlice) (remaining []Virtual
 	q.virtualSlices.Init()
 	q.virtualSlices = remainingSlices
 	q.resetNextReadSliceLocked()
+}
+
+func (q *virtualQueueImpl) Pause(duration time.Duration) {
+	q.pauseController.Pause(duration)
 }
 
 func (q *virtualQueueImpl) notify() {

--- a/service/history/queuev2/virtual_queue_manager.go
+++ b/service/history/queuev2/virtual_queue_manager.go
@@ -43,7 +43,8 @@ const (
 type (
 	VirtualQueueManager interface {
 		common.Daemon
-		GetState() map[int64][]VirtualSliceState
+		VirtualQueues() map[int64]VirtualQueue
+		GetOrCreateVirtualQueue(int64) VirtualQueue
 		UpdateAndGetState() map[int64][]VirtualSliceState
 		// Add a new virtual slice to the root queue. This is used when new tasks are generated and max read level is updated.
 		// By default, all new tasks belong to the root queue, so we need to add a new virtual slice to the root queue.
@@ -60,7 +61,8 @@ type (
 		timeSource          clock.TimeSource
 		taskLoadRateLimiter quotas.Limiter
 		monitor             Monitor
-		options             *VirtualQueueOptions
+		rootQueueOptions    *VirtualQueueOptions
+		nonRootQueueOptions *VirtualQueueOptions
 
 		sync.RWMutex
 		status               int32
@@ -79,7 +81,8 @@ func NewVirtualQueueManager(
 	timeSource clock.TimeSource,
 	taskLoadRateLimiter quotas.Limiter,
 	monitor Monitor,
-	options *VirtualQueueOptions,
+	rootQueueOptions *VirtualQueueOptions,
+	nonRootQueueOptions *VirtualQueueOptions,
 	virtualQueueStates map[int64][]VirtualSliceState,
 ) VirtualQueueManager {
 	virtualQueues := make(map[int64]VirtualQueue)
@@ -87,6 +90,12 @@ func NewVirtualQueueManager(
 		virtualSlices := make([]VirtualSlice, len(states))
 		for i, state := range states {
 			virtualSlices[i] = NewVirtualSlice(state, taskInitializer, queueReader, NewPendingTaskTracker())
+		}
+		var options *VirtualQueueOptions
+		if queueID == rootQueueID {
+			options = rootQueueOptions
+		} else {
+			options = nonRootQueueOptions
 		}
 		virtualQueues[queueID] = NewVirtualQueue(processor, redispatcher, logger.WithTags(tag.VirtualQueueID(queueID)), metricsScope, timeSource, taskLoadRateLimiter, monitor, virtualSlices, options)
 	}
@@ -100,10 +109,17 @@ func NewVirtualQueueManager(
 		timeSource:          timeSource,
 		taskLoadRateLimiter: taskLoadRateLimiter,
 		monitor:             monitor,
-		options:             options,
+		rootQueueOptions:    rootQueueOptions,
+		nonRootQueueOptions: nonRootQueueOptions,
 		status:              common.DaemonStatusInitialized,
 		virtualQueues:       virtualQueues,
 		createVirtualQueueFn: func(s VirtualSlice, queueID int64) VirtualQueue {
+			var options *VirtualQueueOptions
+			if queueID == rootQueueID {
+				options = rootQueueOptions
+			} else {
+				options = nonRootQueueOptions
+			}
 			return NewVirtualQueue(processor, redispatcher, logger.WithTags(tag.VirtualQueueID(queueID)), metricsScope, timeSource, taskLoadRateLimiter, monitor, []VirtualSlice{s}, options)
 		},
 	}
@@ -135,19 +151,27 @@ func (m *virtualQueueManagerImpl) Stop() {
 	}
 }
 
-func (m *virtualQueueManagerImpl) GetState() map[int64][]VirtualSliceState {
+func (m *virtualQueueManagerImpl) VirtualQueues() map[int64]VirtualQueue {
 	m.RLock()
 	defer m.RUnlock()
+	return m.virtualQueues
+}
 
-	virtualQueueStates := make(map[int64][]VirtualSliceState)
-	for key, vq := range m.virtualQueues {
-		state := vq.GetState()
-		if len(state) > 0 {
-			virtualQueueStates[key] = state
-		}
+func (m *virtualQueueManagerImpl) GetOrCreateVirtualQueue(queueID int64) VirtualQueue {
+	m.RLock()
+	if vq, ok := m.virtualQueues[queueID]; ok {
+		m.RUnlock()
+		return vq
 	}
+	m.RUnlock()
 
-	return virtualQueueStates
+	m.Lock()
+	defer m.Unlock()
+	if vq, ok := m.virtualQueues[queueID]; ok {
+		return vq
+	}
+	m.virtualQueues[queueID] = m.createVirtualQueueFn(nil, queueID)
+	return m.virtualQueues[queueID]
 }
 
 func (m *virtualQueueManagerImpl) UpdateAndGetState() map[int64][]VirtualSliceState {

--- a/service/history/queuev2/virtual_queue_manager_mock.go
+++ b/service/history/queuev2/virtual_queue_manager_mock.go
@@ -51,18 +51,18 @@ func (mr *MockVirtualQueueManagerMockRecorder) AddNewVirtualSliceToRootQueue(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNewVirtualSliceToRootQueue", reflect.TypeOf((*MockVirtualQueueManager)(nil).AddNewVirtualSliceToRootQueue), arg0)
 }
 
-// GetState mocks base method.
-func (m *MockVirtualQueueManager) GetState() map[int64][]VirtualSliceState {
+// GetOrCreateVirtualQueue mocks base method.
+func (m *MockVirtualQueueManager) GetOrCreateVirtualQueue(arg0 int64) VirtualQueue {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetState")
-	ret0, _ := ret[0].(map[int64][]VirtualSliceState)
+	ret := m.ctrl.Call(m, "GetOrCreateVirtualQueue", arg0)
+	ret0, _ := ret[0].(VirtualQueue)
 	return ret0
 }
 
-// GetState indicates an expected call of GetState.
-func (mr *MockVirtualQueueManagerMockRecorder) GetState() *gomock.Call {
+// GetOrCreateVirtualQueue indicates an expected call of GetOrCreateVirtualQueue.
+func (mr *MockVirtualQueueManagerMockRecorder) GetOrCreateVirtualQueue(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockVirtualQueueManager)(nil).GetState))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateVirtualQueue", reflect.TypeOf((*MockVirtualQueueManager)(nil).GetOrCreateVirtualQueue), arg0)
 }
 
 // Start mocks base method.
@@ -101,4 +101,18 @@ func (m *MockVirtualQueueManager) UpdateAndGetState() map[int64][]VirtualSliceSt
 func (mr *MockVirtualQueueManagerMockRecorder) UpdateAndGetState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAndGetState", reflect.TypeOf((*MockVirtualQueueManager)(nil).UpdateAndGetState))
+}
+
+// VirtualQueues mocks base method.
+func (m *MockVirtualQueueManager) VirtualQueues() map[int64]VirtualQueue {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VirtualQueues")
+	ret0, _ := ret[0].(map[int64]VirtualQueue)
+	return ret0
+}
+
+// VirtualQueues indicates an expected call of VirtualQueues.
+func (mr *MockVirtualQueueManagerMockRecorder) VirtualQueues() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualQueues", reflect.TypeOf((*MockVirtualQueueManager)(nil).VirtualQueues))
 }

--- a/service/history/queuev2/virtual_queue_mock.go
+++ b/service/history/queuev2/virtual_queue_mock.go
@@ -11,6 +11,7 @@ package queuev2
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "go.uber.org/mock/gomock"
 )
@@ -91,6 +92,18 @@ func (m *MockVirtualQueue) MergeSlices(arg0 ...VirtualSlice) {
 func (mr *MockVirtualQueueMockRecorder) MergeSlices(arg0 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeSlices", reflect.TypeOf((*MockVirtualQueue)(nil).MergeSlices), arg0...)
+}
+
+// Pause mocks base method.
+func (m *MockVirtualQueue) Pause(arg0 time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Pause", arg0)
+}
+
+// Pause indicates an expected call of Pause.
+func (mr *MockVirtualQueueMockRecorder) Pause(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pause", reflect.TypeOf((*MockVirtualQueue)(nil).Pause), arg0)
 }
 
 // SplitSlices mocks base method.

--- a/service/history/queuev2/virtual_slice.go
+++ b/service/history/queuev2/virtual_slice.go
@@ -38,10 +38,15 @@ type (
 		UpdateAndGetState() VirtualSliceState
 		GetPendingTaskCount() int
 		Clear()
+		PendingTaskStats() PendingTaskStats
 
 		TrySplitByTaskKey(persistence.HistoryTaskKey) (VirtualSlice, VirtualSlice, bool)
 		TrySplitByPredicate(Predicate) (VirtualSlice, VirtualSlice, bool)
 		TryMergeWithVirtualSlice(VirtualSlice) ([]VirtualSlice, bool)
+	}
+
+	PendingTaskStats struct {
+		PendingTaskCountPerDomain map[string]int
 	}
 
 	virtualSliceImpl struct {
@@ -134,6 +139,12 @@ func (s *virtualSliceImpl) GetTasks(ctx context.Context, pageSize int) ([]task.T
 
 func (s *virtualSliceImpl) HasMoreTasks() bool {
 	return len(s.progress) > 0
+}
+
+func (s *virtualSliceImpl) PendingTaskStats() PendingTaskStats {
+	return PendingTaskStats{
+		PendingTaskCountPerDomain: s.pendingTaskTracker.GetPerDomainPendingTaskCount(),
+	}
 }
 
 func (s *virtualSliceImpl) UpdateAndGetState() VirtualSliceState {

--- a/service/history/queuev2/virtual_slice_mock.go
+++ b/service/history/queuev2/virtual_slice_mock.go
@@ -112,6 +112,20 @@ func (mr *MockVirtualSliceMockRecorder) HasMoreTasks() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasMoreTasks", reflect.TypeOf((*MockVirtualSlice)(nil).HasMoreTasks))
 }
 
+// PendingTaskStats mocks base method.
+func (m *MockVirtualSlice) PendingTaskStats() PendingTaskStats {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PendingTaskStats")
+	ret0, _ := ret[0].(PendingTaskStats)
+	return ret0
+}
+
+// PendingTaskStats indicates an expected call of PendingTaskStats.
+func (mr *MockVirtualSliceMockRecorder) PendingTaskStats() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingTaskStats", reflect.TypeOf((*MockVirtualSlice)(nil).PendingTaskStats))
+}
+
 // TryMergeWithVirtualSlice mocks base method.
 func (m *MockVirtualSlice) TryMergeWithVirtualSlice(arg0 VirtualSlice) ([]VirtualSlice, bool) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

***Summary***

This PR implements the logic to handle pending task count alerts in **History Queue V2**.

In History Queue V2, we track the number of pending tasks currently loaded in memory. If the count exceeds a defined threshold, we trigger an alert and proactively clear some tasks to free up memory.

---

***Design Overview***

The core mechanism involves monitoring and managing pending tasks from different virtual slices and domains. The basic idea is as follows:

- **Monitoring**:
  - Track the total number of pending tasks per domain.
  - Track the number of pending tasks per domain within each virtual slice.

- **Mitigation Strategy**:
  - Identify the domain with the highest number of pending tasks.
  - For virtual slices containing tasks from this domain, split each slice into two:
    - One containing only tasks from the high-usage domain.
    - One excluding tasks from that domain.
  - Assign the domain-specific virtual slice to the next virtual queue.

- **Fallback**:
  - If the number of virtual queues has already reached a configured limit, we skip splitting and directly clear the affected virtual slices.

- **Iteration**:
  - Repeat the process until the pending task count falls below the threshold.


<!-- Tell your future self why have you made these changes -->
**Why?**
To implement the virtual queue split feature which prevents too many inflight tasks causing OOM

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests (integration tests should be added but I currently haven't figured out an easy way to do it, will do in a separate PR)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

This feature is behind a feature flag, so no risk. In the worst case that we enable it in production without catching bugs, queue processing may be stuck or we can lose tasks.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
