### PR TITLE
exposes constructor for tooling use

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/db.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/db.go
@@ -51,8 +51,8 @@ func dbWithClient(client gocql.Client) cassandraDBOption {
 	}
 }
 
-// newCassandraDBFromSession returns a DB from a session
-func newCassandraDBFromSession(
+// NewCassandraDBFromSession returns a DB from a session
+func NewCassandraDBFromSession(
 	cfg *config.NoSQL,
 	session gocql.Session,
 	logger log.Logger,

--- a/common/persistence/nosql/nosqlplugin/cassandra/db_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/db_test.go
@@ -41,7 +41,7 @@ func TestCDBBasics(t *testing.T) {
 	logger := testlogger.New(t)
 	dc := &persistence.DynamicConfiguration{}
 
-	db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+	db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 	if db.PluginName() != PluginName {
 		t.Errorf("got plugin name: %v but want %v", db.PluginName(), PluginName)
@@ -174,7 +174,7 @@ func TestExecuteWithConsistencyAll(t *testing.T) {
 				tc.clientMockPrep(client)
 			}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.executeWithConsistencyAll(query)
 			if (err != nil) != tc.wantErr {
@@ -277,7 +277,7 @@ func TestExecuteBatchWithConsistencyAll(t *testing.T) {
 				tc.clientMockPrep(client)
 			}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.executeBatchWithConsistencyAll(batch)
 			if (err != nil) != tc.wantErr {

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain_test.go
@@ -248,7 +248,7 @@ func TestInsertDomain(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertDomain(context.Background(), tc.row)
 
@@ -381,7 +381,7 @@ func TestUpdateDomain(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateDomain(context.Background(), tc.row)
 
@@ -506,7 +506,7 @@ func TestSelectDomain(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotRow, err := db.SelectDomain(context.Background(), tc.domainID, tc.domainName)
 
@@ -655,7 +655,7 @@ func TestSelectAllDomains(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			gotRows, _, err := db.SelectAllDomains(context.Background(), tc.pageSize, tc.pagetoken)
 
@@ -753,7 +753,7 @@ func TestSelectDomainMetadata(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotNtfVer, err := db.SelectDomainMetadata(context.Background())
 
@@ -928,7 +928,7 @@ func TestDeleteDomain(t *testing.T) {
 				},
 			}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.DeleteDomain(context.Background(), tc.domainID, tc.domainName)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
@@ -78,7 +78,7 @@ func (p *plugin) doCreateDB(cfg *config.NoSQL, logger log.Logger, dc *persistenc
 	if err != nil {
 		return nil, err
 	}
-	db := newCassandraDBFromSession(cfg, session, logger, dc)
+	db := NewCassandraDBFromSession(cfg, session, logger, dc)
 	return db, nil
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
@@ -94,7 +94,7 @@ func TestInsertIntoQueue(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertIntoQueue(context.Background(), tc.row)
 
@@ -161,7 +161,7 @@ func TestSelectLastEnqueuedMessageID(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotMsgID, err := db.SelectLastEnqueuedMessageID(context.Background(), tc.queueType)
 
@@ -263,7 +263,7 @@ func TestSelectQueueMetadata(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotRow, err := db.SelectQueueMetadata(context.Background(), tc.queueType)
 
@@ -334,7 +334,7 @@ func TestGetQueueSize(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotCount, err := db.GetQueueSize(context.Background(), tc.queueType)
 
@@ -434,7 +434,7 @@ func TestSelectMessagesFrom(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			gotRows, err := db.SelectMessagesFrom(context.Background(), tc.queueType, tc.exclusiveBeginMessageID, tc.maxRows)
 
@@ -562,7 +562,7 @@ func TestSelectMessagesBetween(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			gotResp, err := db.SelectMessagesBetween(context.Background(), tc.request)
 
@@ -633,7 +633,7 @@ func TestDeleteMessagesBefore(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			err := db.DeleteMessagesBefore(context.Background(), tc.queueType, tc.exclusiveBeginMessageID)
 
@@ -699,7 +699,7 @@ func TestDeleteMessagesInRange(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			err := db.DeleteMessagesInRange(context.Background(), tc.queueType, tc.exclusiveBeginMessageID, tc.inclusiveEndMsgID)
 
@@ -762,7 +762,7 @@ func TestDeleteMessage(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			err := db.DeleteMessage(context.Background(), tc.queueType, tc.msgID)
 
@@ -826,7 +826,7 @@ func TestInsertQueueMetadata(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			row := nosqlplugin.QueueMetadataRow{
 				QueueType:        tc.queueType,
@@ -915,7 +915,7 @@ func TestUpdateQueueMetadataCas(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateQueueMetadataCas(context.Background(), tc.row)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
@@ -112,7 +112,7 @@ func TestInsertShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertShard(context.Background(), tc.row)
 
@@ -265,7 +265,7 @@ func TestSelectShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotRangeID, gotShardInfo, err := db.SelectShard(context.Background(), tc.shardID, tc.cluster)
 
@@ -366,7 +366,7 @@ func TestUpdateRangeID(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateRangeID(context.Background(), tc.shardID, tc.rangeID, tc.prevRangeID)
 
@@ -482,7 +482,7 @@ func TestUpdateShard(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateShard(context.Background(), tc.row, tc.prevRangeID)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
@@ -186,7 +186,7 @@ func TestSelectTaskList(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotRow, err := db.SelectTaskList(context.Background(), tc.filter)
 
@@ -338,7 +338,7 @@ func TestInsertTaskList(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertTaskList(context.Background(), tc.row)
 
@@ -450,7 +450,7 @@ func TestUpdateTaskList(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateTaskList(context.Background(), tc.row, tc.prevRangeID)
 
@@ -551,7 +551,7 @@ func TestUpdateTaskListWithTTL(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 			err := db.UpdateTaskListWithTTL(context.Background(), tc.ttlSeconds, tc.row, tc.prevRangeID)
 
 			if (err != nil) != tc.wantErr {
@@ -576,7 +576,7 @@ func TestListTaskList(t *testing.T) {
 	logger := testlogger.New(t)
 	dc := &persistence.DynamicConfiguration{}
 	session := &fakeSession{}
-	db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+	db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 	_, err := db.ListTaskList(context.Background(), 10, nil)
 	var want *types.InternalServiceError
@@ -719,7 +719,7 @@ func TestDeleteTaskList(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.DeleteTaskList(context.Background(), tc.filter, tc.prevRangeID)
 
@@ -830,7 +830,7 @@ func TestInsertTasks(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertTasks(context.Background(), tc.tasksToInsert, tc.tasklistCond)
 
@@ -915,7 +915,7 @@ func TestGetTasksCount(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			queueSize, err := db.GetTasksCount(context.Background(), tc.filter)
 
@@ -1093,7 +1093,7 @@ func TestSelectTasks(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			gotRows, err := db.SelectTasks(context.Background(), tc.filter)
 
@@ -1179,7 +1179,7 @@ func TestRangeDeleteTasks(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, dbWithClient(client))
 
 			rowsDeleted, err := db.RangeDeleteTasks(context.Background(), tc.filter)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/visibility_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/visibility_test.go
@@ -89,7 +89,7 @@ func TestInsertVisibility(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertVisibility(context.Background(), test.ttlSeconds, test.row)
 			if test.wantErr {
@@ -159,7 +159,7 @@ func TestUpdateVisibility(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 			err := db.UpdateVisibility(context.Background(), test.ttlSeconds, test.row)
 			if test.wantErr {
 				assert.Error(t, err)
@@ -258,7 +258,7 @@ func TestSelectOneClosedWorkflow(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 			result, err := db.SelectOneClosedWorkflow(context.Background(), test.domainID, test.workflowID, test.runID)
 			if test.wantError {
 				assert.Error(t, err)
@@ -488,7 +488,7 @@ func TestDeleteVisibility(t *testing.T) {
 			}
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(cfg, session, logger, test.dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, test.dc, dbWithClient(client))
 			err := db.DeleteVisibility(test.context, test.domainID, test.workflowID, test.runID)
 			if test.wantError {
 				assert.Error(t, err)
@@ -884,7 +884,7 @@ func TestSelectVisibility(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 			result, err := db.SelectVisibility(context.Background(), test.filter)
 			if test.wantError {
 				assert.Error(t, err)

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
@@ -153,7 +153,7 @@ func TestInsertWorkflowExecutionWithTasks(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.InsertWorkflowExecutionWithTasks(
 				context.Background(),
@@ -278,7 +278,7 @@ func TestSelectCurrentWorkflow(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			row, err := db.SelectCurrentWorkflow(context.Background(), tc.shardID, tc.domainID, tc.workflowID)
 
@@ -488,7 +488,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			err := db.UpdateWorkflowExecutionWithTasks(
 				context.Background(),
@@ -615,7 +615,7 @@ func TestSelectWorkflowExecution(t *testing.T) {
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
 
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			got, err := db.SelectWorkflowExecution(
 				context.Background(),
@@ -687,7 +687,7 @@ func TestDeleteCurrentWorkflow(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.DeleteCurrentWorkflow(context.Background(), tc.shardID, tc.domainID, tc.workflowID, tc.currentRunIDCondition)
 
@@ -745,7 +745,7 @@ func TestDeleteWorkflowExecution(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.DeleteWorkflowExecution(context.Background(), tc.shardID, tc.domainID, tc.workflowID, tc.runID)
 
@@ -854,7 +854,7 @@ func TestSelectAllCurrentWorkflows(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotExecutions, gotPageToken, err := db.SelectAllCurrentWorkflows(context.Background(), tc.shardID, tc.pageToken, tc.pageSize)
 			if (err != nil) != tc.wantErr {
@@ -976,7 +976,7 @@ func TestSelectAllWorkflowExecutions(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotExecutions, gotPageToken, err := db.SelectAllWorkflowExecutions(context.Background(), tc.shardID, tc.pageToken, tc.pageSize)
 			if (err != nil) != tc.wantErr {
@@ -1063,7 +1063,7 @@ func TestIsWorkflowExecutionExists(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			got, err := db.IsWorkflowExecutionExists(context.Background(), 1, "domain1", "wfi", "run1")
 			if (err != nil) != tc.wantErr {
@@ -1183,7 +1183,7 @@ func TestSelectTransferTasksOrderByTaskID(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotTasks, gotPageToken, err := db.SelectTransferTasksOrderByTaskID(context.Background(), tc.shardID, tc.pageSize, tc.pageToken, tc.inclusiveMinTaskID, tc.exclusiveMaxTaskID)
 			if (err != nil) != tc.wantErr {
@@ -1250,7 +1250,7 @@ func TestDeleteTransferTask(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.DeleteTransferTask(context.Background(), tc.shardID, tc.taskID)
 
@@ -1305,7 +1305,7 @@ func TestRangeDeleteTransferTasks(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.RangeDeleteTransferTasks(context.Background(), tc.shardID, tc.inclusiveBeginTaskID, tc.exclusiveEndTaskID)
 
@@ -1425,7 +1425,7 @@ func TestSelectTimerTasksOrderByVisibilityTime(t *testing.T) {
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
 			dc := &persistence.DynamicConfiguration{}
-			db := newCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
+			db := NewCassandraDBFromSession(cfg, session, logger, dc, dbWithClient(client))
 
 			gotTasks, gotPageToken, err := db.SelectTimerTasksOrderByVisibilityTime(context.Background(), tc.shardID, tc.pageSize, tc.pageToken, tc.inclusiveMinTime, tc.exclusiveMaxTime)
 			if (err != nil) != tc.wantErr {
@@ -1497,7 +1497,7 @@ func TestDeleteTimerTask(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.DeleteTimerTask(context.Background(), tc.shardID, tc.taskID, tc.visibilityTimestamp)
 
@@ -1553,7 +1553,7 @@ func TestRangeDeleteTimerTasks(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.RangeDeleteTimerTasks(context.Background(), tc.shardID, tc.inclusiveMinTime, tc.exclusiveMaxTime)
 
@@ -1667,7 +1667,7 @@ func TestSelectReplicationTasksOrderByTaskID(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			gotTasks, _, err := db.SelectReplicationTasksOrderByTaskID(context.Background(), tc.shardID, tc.pageSize, tc.pageToken, tc.inclusiveMinTaskID, tc.exclusiveMaxTaskID)
 
@@ -1727,7 +1727,7 @@ func TestDeleteReplicationTask(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.DeleteReplicationTask(context.Background(), tc.shardID, tc.taskID)
 
@@ -1779,7 +1779,7 @@ func TestRangeDeleteReplicationTasks(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.RangeDeleteReplicationTasks(context.Background(), tc.shardID, tc.exclusiveEndTaskID)
 
@@ -1834,7 +1834,7 @@ func TestDeleteCrossClusterTask(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.DeleteCrossClusterTask(context.Background(), tc.shardID, tc.targetCluster, tc.taskID)
 
@@ -1907,7 +1907,7 @@ func TestInsertReplicationDLQTask(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.InsertReplicationDLQTask(context.Background(), tc.shardID, tc.sourceCluster, tc.task)
 
@@ -2021,7 +2021,7 @@ func TestSelectReplicationDLQTasksOrderByTaskID(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			gotTasks, _, err := db.SelectReplicationDLQTasksOrderByTaskID(context.Background(), tc.shardID, "src-cluster", tc.pageSize, tc.pageToken, tc.inclusiveMinTaskID, tc.exclusiveMaxTaskID)
 
@@ -2081,7 +2081,7 @@ func TestSelectReplicationDLQTasksCount(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			gotCount, err := db.SelectReplicationDLQTasksCount(context.Background(), tc.shardID, "src-cluster")
 
@@ -2143,7 +2143,7 @@ func TestDeleteReplicationDLQTask(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.DeleteReplicationDLQTask(context.Background(), tc.shardID, tc.sourceCluster, tc.taskID)
 
@@ -2200,7 +2200,7 @@ func TestRangeDeleteReplicationDLQTasks(t *testing.T) {
 				query: query,
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.RangeDeleteReplicationDLQTasks(context.Background(), tc.shardID, tc.sourceCluster, tc.exclusiveBeginTaskID, tc.inclusiveEndTaskID)
 
@@ -2400,7 +2400,7 @@ func TestInsertReplicationTask(t *testing.T) {
 				iter:                      &fakeIter{},
 			}
 			logger := testlogger.New(t)
-			db := newCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
+			db := NewCassandraDBFromSession(nil, session, logger, nil, dbWithClient(gocql.NewMockClient(ctrl)))
 
 			err := db.InsertReplicationTask(context.Background(), tc.tasks, tc.shardCondition)
 
@@ -2511,7 +2511,7 @@ func TestSelectActiveClusterSelectionPolicy(t *testing.T) {
 			logger := testlogger.New(t)
 			cl := gocql.NewMockClient(ctrl)
 
-			db := newCassandraDBFromSession(nil, tc.session, logger, nil, dbWithClient(cl))
+			db := NewCassandraDBFromSession(nil, tc.session, logger, nil, dbWithClient(cl))
 
 			if tc.mockFn != nil {
 				tc.mockFn(cl)
@@ -2589,7 +2589,7 @@ func TestDeleteActiveClusterSelectionPolicy(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			logger := testlogger.New(t)
 			cl := gocql.NewMockClient(ctrl)
-			db := newCassandraDBFromSession(nil, tc.session, logger, nil, dbWithClient(cl))
+			db := NewCassandraDBFromSession(nil, tc.session, logger, nil, dbWithClient(cl))
 			err := db.DeleteActiveClusterSelectionPolicy(context.Background(), tc.shardID, tc.domainID, tc.wfID, tc.rID)
 
 			if (err != nil) != tc.wantErr {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

It's useful to be able to instantiate a Cassandra persistence DB object with passing in a preexisting  an existing GoCQL connection for tooling and external work which uses the persistence layer. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
