### PR TITLE
Run replication simulation scenarios as part of CI

### DIFF
--- a/.github/workflows/replication-simulation.yml
+++ b/.github/workflows/replication-simulation.yml
@@ -1,12 +1,26 @@
+# This workflow runs replication simulaton scenarios via GithubActions matrix strategy.
+# Scenarios are defined in the `simulation/replication/testdata/replication_simulation_<scenario>.yaml` files.
 name: Replication Simulation
 on:
   push:
   pull_request:
 
 jobs:
-  cluster-redirection:
-    name: Cluster Redirection Checks
+  replication-simulation:
+    name: Replication Simulation (${{ matrix.scenario }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - activeactive
+          - activeactive_cron
+          - activeactive_regional_failover
+          - activepassive_to_activeactive
+          - clusterredirection
+          - default
+          - reset
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,38 +38,10 @@ jobs:
           max_attempts: 2
           timeout_minutes: 20
           command: |
-            ./simulation/replication/run.sh clusterredirection
+            ./simulation/replication/run.sh ${{ matrix.scenario }}
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4
         with:
-          name: cluster-redirection-test.log
-          path: ./test.log
-
-  active-active:
-    name: Active-active basic checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.23.4'
-
-      - name: Run simulation
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 2
-          timeout_minutes: 20
-          command: |
-            ./simulation/replication/run.sh activeactive
-
-      - name: Upload test logs
-        uses: actions/upload-artifact@v4
-        with:
-          name: active-active-test.log
+          name: replication-${{ matrix.scenario }}-test.log
           path: ./test.log

--- a/.github/workflows/replication-simulation.yml
+++ b/.github/workflows/replication-simulation.yml
@@ -19,7 +19,6 @@ jobs:
           - activepassive_to_activeactive
           - clusterredirection
           - default
-          - reset
 
     steps:
       - name: Checkout

--- a/simulation/replication/README.md
+++ b/simulation/replication/README.md
@@ -1,0 +1,34 @@
+# Replication Simulation
+
+This folder contains the replication simulation scenarios.
+
+## Running the simulation
+
+```bash
+./simulation/replication/run.sh <scenario>
+```
+
+If you have a custom dockerfile such as Dockerfile.local, you can pass it as an argument:
+
+```bash
+./simulation/replication/run.sh <scenario> newrun "" ".local"
+```
+
+After running the simulation, you can find the test logs in `test.log` file.
+Also check the Cadence UI on localhost:8088 to see the workflow executions.
+
+## Scenario descriptions
+
+- `activeactive`: Active-active basic checks
+- `activeactive_cron`: Active-active with cron workflows
+- `activeactive_regional_failover`: Active-active with regional failover
+- `activepassive_to_activeactive`: Active-passive to active-active migration
+- `clusterredirection`: Cluster redirection checks
+- `default`: Default scenario
+- `reset`: Reset scenario
+
+## Github Actions
+
+Github Actions are used to run the simulation scenarios as part of the CI/CD pipeline.
+
+- `.github/workflows/replication-simulation.yml`: Runs the simulation scenarios via GithubActions matrix strategy.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

We have been adding various multi-cluster setup scenarios to do quick local validation/iteration on new features such as active-active. Now that feature is mostly stable, I'm enabling these in Github Actions.
It will run following scenarios:
- `activeactive`: Active-active basic checks
- `activeactive_cron`: Active-active with cron workflows
- `activeactive_regional_failover`: Active-active with regional failover
- `activepassive_to_activeactive`: Active-passive to active-active migration
- `clusterredirection`: Cluster redirection checks
- `default`: Default scenario

Note: The `reset` scenario is [failing](https://github.com/cadence-workflow/cadence/actions/runs/16915340751/job/47927693387?pr=7158) so it will be enabled once underlying issue is fixed.


<!-- Tell your future self why have you made these changes -->
**Why?**
Detect regressions before change is merged.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Github action jobs running as part of this PR.
