### PR TITLE
Fix thrift decode test flakyness

### DIFF
--- a/simulation/replication/README.md
+++ b/simulation/replication/README.md
@@ -1,6 +1,23 @@
 # Replication Simulation
 
-This folder contains the replication simulation scenarios.
+This folder contains the replication simulation framework and scenarios.
+
+
+## Scenario descriptions
+
+- `activeactive`: Active-active basic checks
+- `activeactive_cron`: Active-active with cron workflows
+- `activeactive_regional_failover`: Active-active with regional failover
+- `activepassive_to_activeactive`: Active-passive to active-active migration
+- `clusterredirection`: Cluster redirection checks
+- `default`: Default scenario
+- `reset`: Reset scenario
+
+## Conventions
+
+Scenario files are placed in `testdata/replication_simulation_<scenario>.yaml`.
+Scenario file is a YAML file that contains the simulation configuration that is parsed into `ReplicationSimulationConfig` struct.
+There should be a corresponding `config/dynamicconfig/replication_simulation_<scenario>.yml` file that contains the dynamic config overrides.
 
 ## Running the simulation
 
@@ -17,18 +34,9 @@ If you have a custom dockerfile such as Dockerfile.local, you can pass it as an 
 After running the simulation, you can find the test logs in `test.log` file.
 Also check the Cadence UI on localhost:8088 to see the workflow executions.
 
-## Scenario descriptions
-
-- `activeactive`: Active-active basic checks
-- `activeactive_cron`: Active-active with cron workflows
-- `activeactive_regional_failover`: Active-active with regional failover
-- `activepassive_to_activeactive`: Active-passive to active-active migration
-- `clusterredirection`: Cluster redirection checks
-- `default`: Default scenario
-- `reset`: Reset scenario
 
 ## Github Actions
 
 Github Actions are used to run the simulation scenarios as part of the CI/CD pipeline.
-
-- `.github/workflows/replication-simulation.yml`: Runs the simulation scenarios via GithubActions matrix strategy.
+Configuration is in `.github/workflows/replication-simulation.yml`.
+If you add a new scenario (following the conventions above), also add it to the Github Actions matrix in `.github/workflows/replication-simulation.yml` once the test is passing.

--- a/tools/cli/admin_db_decode_thrift_test.go
+++ b/tools/cli/admin_db_decode_thrift_test.go
@@ -104,7 +104,7 @@ func TestThriftDecodeHelper(t *testing.T) {
 		},
 		{
 			desc:      "Active clusters config",
-			input:     "590d000a0b0c0000000200000007726567696f6e300b000a00000008636c7573746572310a001400000000000000020000000007726567696f6e310b000a00000008636c7573746572310a001400000000000000000000",
+			input:     "590d000a0b0c0000000100000007726567696f6e300b000a00000008636c7573746572310a001400000000000000020000",
 			encoding:  "hex",
 			wantObjFn: generateTestActiveClustersConfig,
 		},
@@ -275,10 +275,6 @@ func generateTestActiveClustersConfig(t *testing.T) codec.ThriftObject {
 			"region0": {
 				ActiveClusterName: common.StringPtr("cluster1"),
 				FailoverVersion:   common.Int64Ptr(2),
-			},
-			"region1": {
-				ActiveClusterName: common.StringPtr("cluster1"),
-				FailoverVersion:   common.Int64Ptr(0),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

`TestThriftDecodeHelper` has been flaky. The way the payload validation is done requires re-encoded payload to match exactly with the input byte array. This doesn't work for maps. One of the test cases have multiple items in the map and it was failing this validation randomly and annoying developers.

Quick fix: replace that test case to use single item map so its byte representation is deterministic.

Misc change: minor readme updates for replication simulation.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go test -timeout 60s -run ^TestThriftDecodeHelper$ github.com/uber/cadence/tools/cli -v -count=100 >> test.log
```
