### PR TITLE
Force creating new virtual slice every 5 mins

### DIFF
--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -50,6 +50,8 @@ type (
 		UpdateAndGetState() []VirtualSliceState
 		// MergeSlices merge the incoming slices into the virtual queue
 		MergeSlices(...VirtualSlice)
+		// AppendSlices append the incoming slices to the virtual queue
+		AppendSlices(...VirtualSlice)
 		// IterateSlices iterate over the slices in the virtual queue
 		IterateSlices(func(VirtualSlice))
 		// ClearSlices calls the Clear method of the slices that satisfy the predicate function
@@ -195,6 +197,10 @@ func (q *virtualQueueImpl) UpdateAndGetState() []VirtualSliceState {
 }
 
 func (q *virtualQueueImpl) MergeSlices(incomingSlices ...VirtualSlice) {
+	if len(incomingSlices) == 0 {
+		return
+	}
+
 	q.Lock()
 	defer q.Unlock()
 
@@ -224,6 +230,21 @@ func (q *virtualQueueImpl) MergeSlices(incomingSlices ...VirtualSlice) {
 
 	q.virtualSlices.Init()
 	q.virtualSlices = mergedSlices
+	q.resetNextReadSliceLocked()
+}
+
+func (q *virtualQueueImpl) AppendSlices(incomingSlices ...VirtualSlice) {
+	if len(incomingSlices) == 0 {
+		return
+	}
+
+	q.Lock()
+	defer q.Unlock()
+
+	for _, slice := range incomingSlices {
+		q.virtualSlices.PushBack(slice)
+	}
+
 	q.resetNextReadSliceLocked()
 }
 

--- a/service/history/queuev2/virtual_queue_mock.go
+++ b/service/history/queuev2/virtual_queue_mock.go
@@ -40,6 +40,22 @@ func (m *MockVirtualQueue) EXPECT() *MockVirtualQueueMockRecorder {
 	return m.recorder
 }
 
+// AppendSlices mocks base method.
+func (m *MockVirtualQueue) AppendSlices(arg0 ...VirtualSlice) {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "AppendSlices", varargs...)
+}
+
+// AppendSlices indicates an expected call of AppendSlices.
+func (mr *MockVirtualQueueMockRecorder) AppendSlices(arg0 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendSlices", reflect.TypeOf((*MockVirtualQueue)(nil).AppendSlices), arg0...)
+}
+
 // ClearSlices mocks base method.
 func (m *MockVirtualQueue) ClearSlices(arg0 func(VirtualSlice) bool) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Partially cherry pick https://github.com/temporalio/temporal/pull/3291 from temporal

- Force creating new virtual slice in root queue every 5 mins

<!-- Tell your future self why have you made these changes -->
**Why?**
Force creating new virtual slice also means that the virtual slice in root queue won't expand infinitely. Assuming that there is one domain having a lot of tasks and the critical pending task alert is triggered, by forcing creating new virtual slice, we don't need to unload all tasks from that domain, because we're applying the split and unload operation at virtual slice level.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
