### PR TITLE
Remove version constraint for OpenSearch bulk delete requests

### DIFF
--- a/common/elasticsearch/client/os2/client_bulk.go
+++ b/common/elasticsearch/client/os2/client_bulk.go
@@ -67,13 +67,9 @@ func (v *bulkProcessor) Add(request *bulk.GenericBulkableAddRequest) {
 	switch request.RequestType {
 	case bulk.BulkableDeleteRequest:
 		req.Action = "delete"
-		req.Version = &request.Version
-		req.VersionType = &request.VersionType
 		callBackRequest = bulk.NewBulkDeleteRequest().
 			ID(request.ID).
-			Index(request.Index).
-			Version(request.Version).
-			VersionType(request.VersionType)
+			Index(request.Index)
 	case bulk.BulkableIndexRequest:
 		body, err := json.Marshal(request.Doc)
 		if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
There are cases visibility record has higher version (taskID) than the delete request which should not happen, this caused delete requests failed and records can never be deleted

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
