### PR TITLE
Remove version constraint for es v6 and v7 bulk delete requests

### DIFF
--- a/common/elasticsearch/client/v6/client_bulk.go
+++ b/common/elasticsearch/client/v6/client_bulk.go
@@ -68,9 +68,7 @@ func (v *v6BulkProcessor) Add(request *bulk.GenericBulkableAddRequest) {
 		req = elastic.NewBulkDeleteRequest().
 			Index(request.Index).
 			Type(request.Type).
-			Id(request.ID).
-			VersionType(request.VersionType).
-			Version(request.Version)
+			Id(request.ID)
 	case bulk.BulkableIndexRequest:
 		req = elastic.NewBulkIndexRequest().
 			Index(request.Index).

--- a/common/elasticsearch/client/v7/client_bulk.go
+++ b/common/elasticsearch/client/v7/client_bulk.go
@@ -65,9 +65,7 @@ func (v *v7BulkProcessor) Add(request *bulk.GenericBulkableAddRequest) {
 	case bulk.BulkableDeleteRequest:
 		req = elastic.NewBulkDeleteRequest().
 			Index(request.Index).
-			Id(request.ID).
-			VersionType(request.VersionType).
-			Version(request.Version)
+			Id(request.ID)
 	case bulk.BulkableIndexRequest:
 		req = elastic.NewBulkIndexRequest().
 			Index(request.Index).


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
There are cases closed workflow execution taskID is higher than delete task ID, this caused delete requests failed and records can never be deleted

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
