### PR TITLE
[active-active] Fix lookup workflow by domain id

### DIFF
--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -367,7 +367,7 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) activeClusterForActi
 		return policy.activeClusterInSameRegion(ctx, domainEntry, policy.currentClusterName)
 	}
 
-	lookupRes, err := policy.activeClusterManager.LookupWorkflow(ctx, domainEntry.GetInfo().Name, workflowExecution.WorkflowID, workflowExecution.RunID)
+	lookupRes, err := policy.activeClusterManager.LookupWorkflow(ctx, domainEntry.GetInfo().ID, workflowExecution.WorkflowID, workflowExecution.RunID)
 	if err != nil {
 		policy.logger.Error("Failed to lookup active cluster of workflow, using active cluster in the same region", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.WorkflowID(workflowExecution.WorkflowID), tag.WorkflowRunID(workflowExecution.RunID), tag.OperationName(apiName), tag.Error(err))
 		return policy.activeClusterInSameRegion(ctx, domainEntry, policy.currentClusterName)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Cluster redirection layer was calling `LookupWorkflow` with domain name instead of domain id which fails to find correct policy and defaults to current cluster. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
TODO: Unit tests
