### PR TITLE
Update the default value of history.readNoSQLHistoryTaskFromDataBlob to true

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -4610,7 +4610,7 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	ReadNoSQLShardFromDataBlob: {
 		KeyName:      "history.readNoSQLShardFromDataBlob",
 		Description:  "ReadNoSQLShardFromDataBlob is to read shards from data blob",
-		DefaultValue: false,
+		DefaultValue: true,
 	},
 	EnableSizeBasedHistoryExecutionCache: {
 		KeyName:      "history.enableSizeBasedHistoryExecutionCache",

--- a/docs/migration/cassandra-shard-info.md
+++ b/docs/migration/cassandra-shard-info.md
@@ -1,0 +1,20 @@
+# What?
+
+The [`shard`](https://github.com/cadence-workflow/cadence/blob/v1.3.3/schema/cassandra/cadence/schema.cql#L1) Cassandra data type and [`shard`](https://github.com/cadence-workflow/cadence/blob/v1.3.3/schema/cassandra/cadence/schema.cql#L368) column in Cassandra [`executions`](https://github.com/cadence-workflow/cadence/blob/v1.3.3/schema/cassandra/cadence/schema.cql#L357) table is deprecated in favor of [`data`](https://github.com/cadence-workflow/cadence/blob/v1.3.3/schema/cassandra/cadence/schema.cql#L366C3-L366C7) and [`data_encoding`](https://github.com/cadence-workflow/cadence/blob/v1.3.3/schema/cassandra/cadence/schema.cql#L367) field.
+
+# Why?
+
+The process to introduce new field to existing data type is quite tedious because we need to update the corresponding Cassandra data type.
+
+# How?
+1. Update server to v1.3.1 or a newer version
+2. Set this dynamic configuration value to true
+    - [`history.readNoSQLShardFromDataBlob`](https://github.com/cadence-workflow/cadence/blob/v1.3.3/common/dynamicconfig/dynamicproperties/constants.go#L4578C18-L4578C52)
+3. Check the metrics with these tags:
+    - operation: getshard
+    - name: nosql_shard_store_read_from_original_column OR nosql_shard_store_read_from_data_blob
+
+    These metrics are only emitted during service start time, and after migration you should only see metrics with `name:nosql_shard_store_read_from_data_blob` tag.
+
+# Status
+Starting from 1.3.4, the default value of [`history.readNoSQLShardFromDataBlob`](https://github.com/cadence-workflow/cadence/blob/v1.3.3/common/dynamicconfig/dynamicproperties/constants.go#L4578C18-L4578C52) is set to `true`. And we're planning to remove this dynamic config in later version.


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
- Change default value of a dynamic config
- Add document for migration

<!-- Tell your future self why have you made these changes -->
**Why?**
See document in this PR

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
