### PR TITLE
[active-active] Use simple lru cache for workflow cluster selection policies

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -880,6 +880,9 @@ const (
 	// ActiveClusterManager is the scope used by active cluster manager
 	ActiveClusterManager
 
+	// ActiveClusterManagerWorkflowCacheScope is the scope used by active cluster manager's workflow cache
+	ActiveClusterManagerWorkflowCacheScope
+
 	NumCommonScopes
 )
 
@@ -1836,7 +1839,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 
 		LoadBalancerScope: {operation: "RRLoadBalancer"},
 
-		ActiveClusterManager: {operation: "ActiveClusterManager"},
+		ActiveClusterManager:                   {operation: "ActiveClusterManager"},
+		ActiveClusterManagerWorkflowCacheScope: {operation: "ActiveClusterManagerWorkflowCache"},
 	},
 	// Frontend Scope Names
 	Frontend: {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Currently workflow active cluster is look up always goes to DB. Most of the time the same handler (task or rpc) will keep asking about this information so caching these per-workflow policies for a brief period would help reduce DB load and avoid unnecessary latency.

For now adding a basic lru cache with 1k item limit and 10s ttl. After analyzing cache hit/miss metrics we may consider adding byte size based limit and change ttl.

<!-- Tell your future self why have you made these changes -->
**Why?**
Better processing latency and less DB calls.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- unit test
