### PR TITLE
Set up simulation test for history queue v2's pending task alert

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2614,6 +2614,7 @@ const (
 	// Default value: 5s (5*time.Second)
 	// Allowed filters: N/A
 	QueueProcessorPollBackoffInterval
+	VirtualSliceForceAppendInterval
 	// TimerProcessorUpdateAckInterval is update interval for timer processor
 	// KeyName: history.timerProcessorUpdateAckInterval
 	// Value type: Duration
@@ -5128,6 +5129,11 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		KeyName:      "history.queueProcessorPollBackoffInterval",
 		Description:  "QueueProcessorPollBackoffInterval is the backoff duration when queue processor is throttled",
 		DefaultValue: time.Second * 5,
+	},
+	VirtualSliceForceAppendInterval: {
+		KeyName:      "history.virtualSliceForceAppendInterval",
+		Description:  "VirtualSliceForceAppendInterval is the duration forcing a new virtual slice to be appended to the root virtual queue instead of being merged. It has 2 benefits: First, virtual slices won't grow infinitely, task loading for that slice can complete and its scope can be shrinked. Second, when we need to unload a virtual slice to free memory, we won't unload too many tasks.",
+		DefaultValue: time.Minute * 5,
 	},
 	TimerProcessorUpdateAckInterval: {
 		KeyName:      "history.timerProcessorUpdateAckInterval",

--- a/docker/github_actions/docker-compose-local-history-simulation.yml
+++ b/docker/github_actions/docker-compose-local-history-simulation.yml
@@ -49,7 +49,7 @@ services:
       - -e
       - -c
       - >
-        go test -timeout 180s
+        go test -timeout 300s
         -run ^TestHistorySimulation.*$
         -count 1
         -v

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -119,6 +119,7 @@ type Config struct {
 	EnableTransferQueueV2PendingTaskCountAlert dynamicproperties.BoolPropertyFnWithShardIDFilter
 	QueueCriticalPendingTaskCount              dynamicproperties.IntPropertyFn
 	QueueMaxVirtualQueueCount                  dynamicproperties.IntPropertyFn
+	VirtualSliceForceAppendInterval            dynamicproperties.DurationPropertyFn
 
 	// QueueProcessor settings
 	QueueProcessorEnableSplit                          dynamicproperties.BoolPropertyFn
@@ -417,6 +418,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		EnableTransferQueueV2PendingTaskCountAlert: dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTransferQueueV2PendingTaskCountAlert),
 		QueueCriticalPendingTaskCount:              dc.GetIntProperty(dynamicproperties.QueueCriticalPendingTaskCount),
 		QueueMaxVirtualQueueCount:                  dc.GetIntProperty(dynamicproperties.QueueMaxVirtualQueueCount),
+		VirtualSliceForceAppendInterval:            dc.GetDurationProperty(dynamicproperties.VirtualSliceForceAppendInterval),
 
 		QueueProcessorEnableSplit:                          dc.GetBoolProperty(dynamicproperties.QueueProcessorEnableSplit),
 		QueueProcessorSplitMaxLevel:                        dc.GetIntProperty(dynamicproperties.QueueProcessorSplitMaxLevel),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -275,6 +275,7 @@ func TestNewConfig(t *testing.T) {
 		"EnableTransferQueueV2PendingTaskCountAlert":           {dynamicproperties.EnableTransferQueueV2PendingTaskCountAlert, true},
 		"QueueCriticalPendingTaskCount":                        {dynamicproperties.QueueCriticalPendingTaskCount, 100},
 		"QueueMaxVirtualQueueCount":                            {dynamicproperties.QueueMaxVirtualQueueCount, 101},
+		"VirtualSliceForceAppendInterval":                      {dynamicproperties.VirtualSliceForceAppendInterval, time.Second},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/history/queuev2/queue_immediate_test.go
+++ b/service/history/queuev2/queue_immediate_test.go
@@ -78,6 +78,7 @@ func TestImmediateQueue_LifeCycle(t *testing.T) {
 		MaxPollRPS:                           dynamicproperties.GetIntPropertyFn(100),
 		MaxPendingTasksCount:                 dynamicproperties.GetIntPropertyFn(100),
 		CriticalPendingTaskCount:             dynamicproperties.GetIntPropertyFn(90),
+		VirtualSliceForceAppendInterval:      dynamicproperties.GetDurationPropertyFn(time.Second * 10),
 		EnablePendingTaskCountAlert:          func() bool { return true },
 		MaxVirtualQueueCount:                 dynamicproperties.GetIntPropertyFn(2),
 	}

--- a/service/history/queuev2/queue_scheduled_test.go
+++ b/service/history/queuev2/queue_scheduled_test.go
@@ -78,6 +78,7 @@ func TestScheduledQueue_LifeCycle(t *testing.T) {
 		MaxPollRPS:                           dynamicproperties.GetIntPropertyFn(100),
 		MaxPendingTasksCount:                 dynamicproperties.GetIntPropertyFn(100),
 		PollBackoffIntervalJitterCoefficient: dynamicproperties.GetFloatPropertyFn(0.0),
+		VirtualSliceForceAppendInterval:      dynamicproperties.GetDurationPropertyFn(time.Second * 10),
 		CriticalPendingTaskCount:             dynamicproperties.GetIntPropertyFn(90),
 		EnablePendingTaskCountAlert:          func() bool { return true },
 		MaxVirtualQueueCount:                 dynamicproperties.GetIntPropertyFn(2),

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -151,6 +151,7 @@ func (f *timerQueueFactory) createQueuev2(
 			MaxPendingTasksCount:                 config.QueueMaxPendingTaskCount,
 			PollBackoffInterval:                  config.QueueProcessorPollBackoffInterval,
 			PollBackoffIntervalJitterCoefficient: config.QueueProcessorPollBackoffIntervalJitterCoefficient,
+			VirtualSliceForceAppendInterval:      config.VirtualSliceForceAppendInterval,
 			MaxStartJitterInterval:               dynamicproperties.GetDurationPropertyFn(0),
 			RedispatchInterval:                   config.ActiveTaskRedispatchInterval,
 			CriticalPendingTaskCount:             config.QueueCriticalPendingTaskCount,

--- a/service/history/queuev2/transfer_queue_factory.go
+++ b/service/history/queuev2/transfer_queue_factory.go
@@ -158,6 +158,7 @@ func (f *transferQueueFactory) createQueuev2(
 			MaxPendingTasksCount:                 config.QueueMaxPendingTaskCount,
 			PollBackoffInterval:                  config.QueueProcessorPollBackoffInterval,
 			PollBackoffIntervalJitterCoefficient: config.QueueProcessorPollBackoffIntervalJitterCoefficient,
+			VirtualSliceForceAppendInterval:      config.VirtualSliceForceAppendInterval,
 			EnableValidator:                      config.TransferProcessorEnableValidator,
 			ValidationInterval:                   config.TransferProcessorValidationInterval,
 			MaxStartJitterInterval:               dynamicproperties.GetDurationPropertyFn(0),

--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -348,7 +348,7 @@ func (q *virtualQueueImpl) loadAndSubmitTasks() {
 	if q.pauseController.IsPaused() {
 		// emit a metric indicating that the virtual queue is paused
 		q.metricsScope.UpdateGauge(metrics.VirtualQueuePausedGauge, 1.0)
-		q.logger.Debug("virtual queue is paused")
+		q.logger.Debug("virtual queue is paused", tag.PendingTaskCount(pendingTaskCount), tag.MaxTaskCount(maxTaskCount))
 		return
 	}
 

--- a/service/history/queuev2/virtual_queue_manager_test.go
+++ b/service/history/queuev2/virtual_queue_manager_test.go
@@ -2,6 +2,7 @@ package queuev2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -195,15 +196,17 @@ func TestVirtualQueueManager_VirtualQueues(t *testing.T) {
 
 			// Create manager instance
 			manager := &virtualQueueManagerImpl{
-				processor:        mockProcessor,
-				taskInitializer:  mockTaskInitializer,
-				redispatcher:     mockRedispatcher,
-				queueReader:      mockQueueReader,
-				logger:           mockLogger,
-				metricsScope:     mockMetricsScope,
-				rootQueueOptions: &VirtualQueueOptions{},
-				nonRootQueueOptions: &VirtualQueueOptions{
-					PageSize: dynamicproperties.GetIntPropertyFn(100),
+				processor:       mockProcessor,
+				taskInitializer: mockTaskInitializer,
+				redispatcher:    mockRedispatcher,
+				queueReader:     mockQueueReader,
+				logger:          mockLogger,
+				metricsScope:    mockMetricsScope,
+				options: &VirtualQueueManagerOptions{
+					RootQueueOptions: &VirtualQueueOptions{},
+					NonRootQueueOptions: &VirtualQueueOptions{
+						PageSize: dynamicproperties.GetIntPropertyFn(100),
+					},
 				},
 				status:        common.DaemonStatusInitialized,
 				virtualQueues: virtualQueues,
@@ -447,15 +450,17 @@ func TestVirtualQueueManager_UpdateAndGetState(t *testing.T) {
 
 			// Create manager instance
 			manager := &virtualQueueManagerImpl{
-				processor:        mockProcessor,
-				taskInitializer:  mockTaskInitializer,
-				redispatcher:     mockRedispatcher,
-				queueReader:      mockQueueReader,
-				logger:           mockLogger,
-				metricsScope:     mockMetricsScope,
-				rootQueueOptions: &VirtualQueueOptions{},
-				nonRootQueueOptions: &VirtualQueueOptions{
-					MaxPendingTasksCount: dynamicproperties.GetIntPropertyFn(100),
+				processor:       mockProcessor,
+				taskInitializer: mockTaskInitializer,
+				redispatcher:    mockRedispatcher,
+				queueReader:     mockQueueReader,
+				logger:          mockLogger,
+				metricsScope:    mockMetricsScope,
+				options: &VirtualQueueManagerOptions{
+					RootQueueOptions: &VirtualQueueOptions{},
+					NonRootQueueOptions: &VirtualQueueOptions{
+						MaxPendingTasksCount: dynamicproperties.GetIntPropertyFn(100),
+					},
 				},
 				status:        common.DaemonStatusInitialized,
 				virtualQueues: virtualQueues,
@@ -554,6 +559,7 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 			// Set up mock expectations
 			tt.setupMockQueues(mockQueues, mockSlice)
 
+			forceNewSliceDuration := time.Minute
 			// Create manager instance
 			manager := &virtualQueueManagerImpl{
 				processor:       mockProcessor,
@@ -563,11 +569,14 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 				logger:          mockLogger,
 				metricsScope:    mockMetricsScope,
 				timeSource:      mockTimeSource,
-				rootQueueOptions: &VirtualQueueOptions{
-					PageSize: dynamicproperties.GetIntPropertyFn(100),
-				},
-				nonRootQueueOptions: &VirtualQueueOptions{
-					PageSize: dynamicproperties.GetIntPropertyFn(100),
+				options: &VirtualQueueManagerOptions{
+					RootQueueOptions: &VirtualQueueOptions{
+						PageSize: dynamicproperties.GetIntPropertyFn(100),
+					},
+					NonRootQueueOptions: &VirtualQueueOptions{
+						PageSize: dynamicproperties.GetIntPropertyFn(100),
+					},
+					VirtualSliceForceAppendInterval: dynamicproperties.GetDurationPropertyFn(forceNewSliceDuration),
 				},
 				status:        common.DaemonStatusInitialized,
 				virtualQueues: virtualQueues,

--- a/simulation/history/dynamicconfig/queuev2_split.yaml
+++ b/simulation/history/dynamicconfig/queuev2_split.yaml
@@ -1,0 +1,76 @@
+system.workflowDeletionJitterRange:
+- value: 0
+  constraints: {}
+history.enableTimerQueueV2:
+- value: true
+  constraints: {}
+history.enableTransferQueueV2:
+- value: true
+  constraints: {}
+history.timerTaskBatchSize:
+- value: 100
+  constraints: {}
+history.timerProcessorUpdateAckInterval:
+- value: 5s
+  constraints: {}
+history.timerProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.timerProcessorMaxPollRPS:
+- value: 20
+  constraints: {}
+history.transferTaskBatchSize:
+- value: 100
+  constraints: {}
+history.transferProcessorUpdateAckInterval:
+- value: 5s
+  constraints: {}
+history.transferProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.transferProcessorMaxPollRPS:
+- value: 20
+  constraints: {}
+history.shardUpdateMinInterval:
+- value: 3s
+  constraints: {}
+history.queueProcessorPollBackoffInterval:
+- value: 5s
+  constraints: {}
+history.virtualSliceForceAppendInterval:
+- value: 5ms
+  constraints: {}
+# Only Enable 1 level of split, which has been tested manually
+history.queueMaxVirtualQueueCount:
+- value: 2
+  constraints: {}
+# Enable task rate limiter so that the number of pending tasks increases
+history.taskSchedulerEnableRateLimiter:
+- value: true
+  constraints: {}
+history.taskSchedulerEnableRateLimiterShadowMode:
+- value: false
+  constraints: {}
+history.taskSchedulerGlobalDomainRPS:
+- value: 5
+  constraints: {}
+history.enableTransferQueueV2PendingTaskCountAlert:
+- value: false
+  constraints: {}
+- value: true
+  constraints:
+    shardID: 0
+history.enableTimerQueueV2PendingTaskCountAlert:
+- value: false
+  constraints: {}
+- value: true
+  constraints:
+    shardID: 1
+# Set a low number to trigger queue pause with load from tests
+history.queueMaxPendingTaskCount:
+- value: 20
+  constraints: {}
+# Set a low number to trigger queue split with load from tests
+history.queueCriticalPendingTaskCount:
+- value: 18
+  constraints: {}

--- a/simulation/history/history_simulation_test.go
+++ b/simulation/history/history_simulation_test.go
@@ -147,14 +147,14 @@ func (s *HistorySimulationSuite) TearDownSuite() {
 }
 
 func (s *HistorySimulationSuite) TestHistorySimulation() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	var runs []client.WorkflowRun
 	for i := 0; i < 100; i++ {
 		// set a short timeout so that timer tasks can be executed before complete
 		workflowOptions := client.StartWorkflowOptions{
 			TaskList:                        s.taskList,
-			ExecutionStartToCloseTimeout:    5 * time.Second,
+			ExecutionStartToCloseTimeout:    120 * time.Second,
 			DecisionTaskStartToCloseTimeout: 5 * time.Second,
 		}
 		we, err := s.wfClient.ExecuteWorkflow(ctx, workflowOptions, workflow.NoopWorkflow)
@@ -169,5 +169,5 @@ func (s *HistorySimulationSuite) TestHistorySimulation() {
 	for _, we := range runs {
 		s.NoError(we.Get(ctx, nil))
 	}
-	time.Sleep(20 * time.Second)
+	time.Sleep(120 * time.Second)
 }

--- a/simulation/history/testdata/history_simulation_queuev2_split.yaml
+++ b/simulation/history/testdata/history_simulation_queuev2_split.yaml
@@ -1,0 +1,17 @@
+enablearchival: false
+clusterno: 0
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+matchingconfig:
+  nummatchinghosts: 1
+workerconfig:
+  enableasyncwfconsumer: false
+  enablearchiver: false
+  enablereplicator: false
+  enableindexer: false
+dynamicclientconfig:
+  filepath: "dynamicconfig/queuev2_split.yaml"
+  pollInterval: "10s"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Set up simulation test for history queue v2's pending task alert
- Create a new dynamic config property for an existing constant so that I can tune it in simulation and integration tests
- Adjust timeouts of history simulation test to make it pass for the new simulation scenario

<!-- Tell your future self why have you made these changes -->
**Why?**
Simulation test

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
simulation test: `DOCKERFILE_SUFFIX=.local ./simulation/history/run.sh queuev2_split`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

**Appendix**
A snapshot of the summary of a simulation run for the new scenario. All tasks that was created were executed except workflow deletion timers, which was because those timers wasn't expired.
```
---- Simulation Summary ----
Tasks created:
ShardID: 0
  TaskCategory: timer, TaskType: 0, Count: 27
  TaskCategory: timer, TaskType: 3, Count: 27
  TaskCategory: timer, TaskType: 4, Count: 27
  TaskCategory: transfer, TaskType: 0, Count: 27
  TaskCategory: transfer, TaskType: 2, Count: 27
  TaskCategory: transfer, TaskType: 6, Count: 27
ShardID: 1
  TaskCategory: timer, TaskType: 0, Count: 25
  TaskCategory: timer, TaskType: 3, Count: 25
  TaskCategory: timer, TaskType: 4, Count: 25
  TaskCategory: transfer, TaskType: 0, Count: 25
  TaskCategory: transfer, TaskType: 2, Count: 25
  TaskCategory: transfer, TaskType: 6, Count: 25
ShardID: 2
  TaskCategory: timer, TaskType: 0, Count: 22
  TaskCategory: timer, TaskType: 3, Count: 22
  TaskCategory: timer, TaskType: 4, Count: 22
  TaskCategory: transfer, TaskType: 0, Count: 22
  TaskCategory: transfer, TaskType: 2, Count: 22
  TaskCategory: transfer, TaskType: 6, Count: 22
ShardID: 3
  TaskCategory: timer, TaskType: 0, Count: 26
  TaskCategory: timer, TaskType: 3, Count: 26
  TaskCategory: timer, TaskType: 4, Count: 26
  TaskCategory: transfer, TaskType: 0, Count: 26
  TaskCategory: transfer, TaskType: 2, Count: 26
  TaskCategory: transfer, TaskType: 6, Count: 26

Tasks executed:
ShardID: 0
  TaskCategory: timer, TaskType: 0, Count: 27
  TaskCategory: timer, TaskType: 3, Count: 27
  TaskCategory: transfer, TaskType: 0, Count: 27
  TaskCategory: transfer, TaskType: 2, Count: 27
  TaskCategory: transfer, TaskType: 6, Count: 27
ShardID: 1
  TaskCategory: timer, TaskType: 0, Count: 25
  TaskCategory: timer, TaskType: 3, Count: 25
  TaskCategory: transfer, TaskType: 0, Count: 25
  TaskCategory: transfer, TaskType: 2, Count: 25
  TaskCategory: transfer, TaskType: 6, Count: 25
ShardID: 2
  TaskCategory: timer, TaskType: 0, Count: 22
  TaskCategory: timer, TaskType: 3, Count: 22
  TaskCategory: transfer, TaskType: 0, Count: 22
  TaskCategory: transfer, TaskType: 2, Count: 22
  TaskCategory: transfer, TaskType: 6, Count: 22
ShardID: 3
  TaskCategory: timer, TaskType: 0, Count: 26
  TaskCategory: timer, TaskType: 3, Count: 26
  TaskCategory: transfer, TaskType: 0, Count: 26
  TaskCategory: transfer, TaskType: 2, Count: 26
  TaskCategory: transfer, TaskType: 6, Count: 26
```
