### PR TITLE
fix: update the incorrect UI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Try out the sample recipes for [Go](https://github.com/cadence-workflow/cadence-
 
 3. Visit UI
 
-Visit http://localhost:8080 to check workflow histories and detailed traces.
+Visit http://localhost:8088 to check workflow histories and detailed traces.
 
 
 ### Client Libraries


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix the incorrect UI URL in README.md.

<!-- Tell your future self why have you made these changes -->
**Why?**
- The default UI URL is http://localhost:8088, not http://localhost:8080.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
