### PR TITLE
Determinized the shard assignments

### DIFF
--- a/service/sharddistributor/leader/process/processor.go
+++ b/service/sharddistributor/leader/process/processor.go
@@ -402,14 +402,14 @@ func assignShardsToEmptyExecutors(currentAssignments map[string][]string) bool {
 	executorsWithShards := make([]string, 0)
 	minShardsCurrentlyAssigned := 0
 
-	// Sort the executors so the distribution is deterministic.
-	sortedExecutors := make([]string, 0, len(currentAssignments))
+	// Ensure the iteration is deterministic.
+	executors := make([]string, 0, len(currentAssignments))
 	for executorID := range currentAssignments {
-		sortedExecutors = append(sortedExecutors, executorID)
+		executors = append(executors, executorID)
 	}
-	slices.Sort(sortedExecutors)
+	slices.Sort(executors)
 
-	for _, executorID := range sortedExecutors {
+	for _, executorID := range executors {
 		if len(currentAssignments[executorID]) == 0 {
 			emptyExecutors = append(emptyExecutors, executorID)
 		} else {

--- a/service/sharddistributor/leader/process/processor.go
+++ b/service/sharddistributor/leader/process/processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sort"
 	"strconv"
 	"sync"
@@ -401,7 +402,14 @@ func assignShardsToEmptyExecutors(currentAssignments map[string][]string) bool {
 	executorsWithShards := make([]string, 0)
 	minShardsCurrentlyAssigned := 0
 
+	// Sort the executors so the distribution is deterministic.
+	sortedExecutors := make([]string, 0, len(currentAssignments))
 	for executorID := range currentAssignments {
+		sortedExecutors = append(sortedExecutors, executorID)
+	}
+	slices.Sort(sortedExecutors)
+
+	for _, executorID := range sortedExecutors {
 		if len(currentAssignments[executorID]) == 0 {
 			emptyExecutors = append(emptyExecutors, executorID)
 		} else {

--- a/service/sharddistributor/leader/process/processor_test.go
+++ b/service/sharddistributor/leader/process/processor_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"context"
 	"errors"
-	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -399,7 +398,6 @@ func TestGetShards_Utility(t *testing.T) {
 }
 
 func TestAssignShardsToEmptyExecutors(t *testing.T) {
-	t.Skip("Skipping this test for now because it's flaky")
 	cases := []struct {
 		name                       string
 		inputAssignments           map[string][]string
@@ -468,18 +466,8 @@ func TestAssignShardsToEmptyExecutors(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			actualDistributionChanged := assignShardsToEmptyExecutors(c.inputAssignments)
 
-			// Sort the assignments, so the test is stable
-			sortAssignments(c.expectedAssignments)
-			sortAssignments(c.inputAssignments)
-
 			assert.Equal(t, c.expectedAssignments, c.inputAssignments)
 			assert.Equal(t, c.expectedDistributonChanged, actualDistributionChanged)
 		})
-	}
-}
-
-func sortAssignments(assignments map[string][]string) {
-	for _, assignment := range assignments {
-		slices.Sort(assignment)
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now sort the executors before we process the shard assignement.


<!-- Tell your future self why have you made these changes -->
**Why?**
We don't want to rely on map ordering since it's random in Go. This made tests flaky, and also would make debugging harder. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
