### PR TITLE
[admin-auth]Make ListDomainEndpoint accessible for customers

### DIFF
--- a/service/frontend/templates/accesscontrolled.tmpl
+++ b/service/frontend/templates/accesscontrolled.tmpl
@@ -20,7 +20,6 @@ import (
 {{$permissionMap = set $permissionMap "GetWorkflowExecutionHistory" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "ListArchivedWorkflowExecutions" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "ListClosedWorkflowExecutions" "PermissionRead"}}
-{{$permissionMap = set $permissionMap "ListDomains" "PermissionAdmin"}}
 {{$permissionMap = set $permissionMap "ListOpenWorkflowExecutions" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "ListWorkflowExecutions" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "PollForActivityTask" "PermissionProcess"}}
@@ -46,7 +45,7 @@ import (
 {{$adminPermissionMap := dict }}
 {{$adminPermissionMap = set $adminPermissionMap "DescribeCluster" "PermissionRead"}}
 
-{{$nonDomainAuthAPIs := list "RegisterDomain" "DescribeDomain" "UpdateDomain" "DeprecateDomain" "DeleteDomain" "ListDomains" "GetSearchAttributes" "GetClusterInfo" "RecordActivityTaskHeartbeat" "RespondActivityTaskCanceled" "RespondActivityTaskCompleted" "RespondActivityTaskFailed" "RespondDecisionTaskCompleted" "RespondDecisionTaskFailed" "RespondQueryTaskCompleted"}}
+{{$nonDomainAuthAPIs := list "RegisterDomain" "DescribeDomain" "UpdateDomain" "DeprecateDomain" "DeleteDomain" "GetSearchAttributes" "GetClusterInfo" "RecordActivityTaskHeartbeat" "RespondActivityTaskCanceled" "RespondActivityTaskCompleted" "RespondActivityTaskFailed" "RespondDecisionTaskCompleted" "RespondDecisionTaskFailed" "RespondQueryTaskCompleted"}}
 {{$taskListAuthAPIs := list "PollForActivityTask" "PollForDecisionTask"}}
 {{$workflowTypeAuthAPIs := list "SignalWithStartWorkflowExecution" "StartWorkflowExecution" "SignalWithStartWorkflowExecutionAsync" "StartWorkflowExecutionAsync"}}
 

--- a/service/frontend/wrappers/accesscontrolled/api_generated.go
+++ b/service/frontend/wrappers/accesscontrolled/api_generated.go
@@ -234,19 +234,6 @@ func (a *apiHandler) ListClosedWorkflowExecutions(ctx context.Context, lp1 *type
 }
 
 func (a *apiHandler) ListDomains(ctx context.Context, lp1 *types.ListDomainsRequest) (lp2 *types.ListDomainsResponse, err error) {
-	scope := a.GetMetricsClient().Scope(metrics.FrontendListDomainsScope)
-	attr := &authorization.Attributes{
-		APIName:     "ListDomains",
-		Permission:  authorization.PermissionAdmin,
-		RequestBody: authorization.NewFilteredRequestBody(lp1),
-	}
-	isAuthorized, err := a.isAuthorized(ctx, attr, scope)
-	if err != nil {
-		return nil, err
-	}
-	if !isAuthorized {
-		return nil, errUnauthorized
-	}
 	return a.handler.ListDomains(ctx, lp1)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removing PermissionAdmin access control from ListDomains to allow unrestricted access for all users. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Project - Enforcing admin permissions will prevent customers from searching for their domains in the cadence UI.
Previously, these admin checks were bypassed. So removing the admin restrictions from ListDomains allow users to access their domain from the UI.
Later, we will implement domain-scoped permissions. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
ListDomains now accessible to all users