### PR TITLE
[Wf-Diagnostics] Reduce number of issues per type returned in diagnostics

### DIFF
--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -65,7 +65,8 @@ func (w *dw) identifyIssues(ctx context.Context, info identifyIssuesParams) ([]i
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, issues...)
+		topIssues := pickTopIssues(issues)
+		result = append(result, topIssues...)
 	}
 
 	return result, nil
@@ -153,4 +154,12 @@ func (w *dw) emit(ctx context.Context, info analytics.WfDiagnosticsUsageData, cl
 		Producer: producer,
 	})
 	return emitter.EmitUsageData(ctx, info)
+}
+
+// pickTopIssues limits the number of issues to 10 to avoid overwhelming the result with too many issues.
+func pickTopIssues(issues []invariant.InvariantCheckResult) []invariant.InvariantCheckResult {
+	if len(issues) > 10 {
+		return issues[:10]
+	}
+	return issues
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Diagnostics workflow used to return all the issues it identified in a workflow and this could be a huge if it is a very big workflow with lot of events especially when the workflow is configured with duplicate options like invalid retry policy. Now it limits them to 10 per invariant

<!-- Tell your future self why have you made these changes -->
**Why?**
The problem was identified when activity response was exceeding blob size limits but also on a practical note, it doesnt make sense to dump a huge list of issues so limiting them makes sense. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
