### PR TITLE
Bypass failover drills for active-active domains

### DIFF
--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -381,6 +381,14 @@ func shouldFailover(domain *types.DescribeDomainResponse, sourceCluster string) 
 	if !domain.GetIsGlobalDomain() {
 		return false
 	}
+
+	// TODO(active-active): Remove this check once failover drills are supported for
+	// active-active workflows
+	if domain.ReplicationConfiguration.ActiveClusters != nil &&
+		len(domain.ReplicationConfiguration.ActiveClusters.ActiveClustersByRegion) > 0 {
+		return false
+	}
+
 	currentActiveCluster := domain.ReplicationConfiguration.GetActiveClusterName()
 	isDomainTarget := currentActiveCluster == sourceCluster
 	return isDomainTarget && isDomainFailoverManagedByCadence(domain)

--- a/service/worker/failovermanager/workflow_test.go
+++ b/service/worker/failovermanager/workflow_test.go
@@ -320,6 +320,48 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 			sourceCluster: "c2",
 			expected:      true,
 		},
+		{
+			domain: &types.DescribeDomainResponse{
+				IsGlobalDomain: true,
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusterName: "c2",
+					Clusters:          clusters,
+					ActiveClusters: &types.ActiveClusters{
+						ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+							"c1": {
+								ActiveClusterName: "c1",
+							},
+						},
+					},
+				},
+				DomainInfo: &types.DomainInfo{
+					Data: map[string]string{
+						constants.DomainDataKeyForManagedFailover: "true",
+					},
+				},
+			},
+			sourceCluster: "c2",
+			expected:      false,
+		},
+		{
+			domain: &types.DescribeDomainResponse{
+				IsGlobalDomain: true,
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusterName: "c2",
+					Clusters:          clusters,
+					ActiveClusters: &types.ActiveClusters{
+						ActiveClustersByRegion: map[string]types.ActiveClusterInfo{},
+					},
+				},
+				DomainInfo: &types.DomainInfo{
+					Data: map[string]string{
+						constants.DomainDataKeyForManagedFailover: "true",
+					},
+				},
+			},
+			sourceCluster: "c2",
+			expected:      true,
+		},
 	}
 	for _, t := range tests {
 		s.Equal(t.expected, shouldFailover(t.domain, t.sourceCluster))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added a bypass for `active-active` domains in the failover drill workflow. 

<!-- Tell your future self why have you made these changes -->
**Why?**

Failover drills can be performed via the cadence client. Using the client instantiates a FailoverWorkflow within the cadence worker service, which fetches domains and calls `UpdateDomain` for each domain that should be failed over (all non-local domains).  

Currently, the `UpdateDomainRequest` passes an intended ActiveClusterName.
This is insufficient for an active-active domain to determine which region should have its region<>cluster mapping updated. 
Until a full story is determined we're choosing to disable active-active domains rather than having unexpected failover behavior. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit tests. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Only `active-active` domains should have an `ActiveClustersByRegion` mapping. However, if a domain has been misconfigured we may not failover some domains unexpectedly. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

N/A