### PR TITLE
Reset update queue state timer on failure

### DIFF
--- a/service/history/queuev2/queue_base.go
+++ b/service/history/queuev2/queue_base.go
@@ -313,6 +313,10 @@ func (q *queueBase) updateQueueState(ctx context.Context) {
 			})
 			if err != nil {
 				q.logger.Error("Failed to range complete history tasks", tag.Error(err))
+				q.updateQueueStateTimer.Reset(backoff.JitDuration(
+					q.options.UpdateAckInterval(),
+					q.options.UpdateAckIntervalJitterCoefficient(),
+				))
 				return
 			}
 			if !persistence.HasMoreRowsToDelete(resp.TasksCompleted, pageSize) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Reset update queue state timer on failure

<!-- Tell your future self why have you made these changes -->
**Why?**
This is necessary. Otherwise, we won't be able to clear acknowledged tasks from memory and persist queue state.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
