### PR TITLE
Set up integration test for pending task alert of history queue v2

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -133,6 +133,37 @@ jobs:
           name: go-cassandra-running-history-queue-v2-integration-coverage
           path: .build/coverage/*.out
 
+  golang-integration-test-with-cassandra-running-history-queue-v2-alert:
+    name: Golang integration test with running history queue v2 with alert
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.4'
+
+      - name: Run integration profile for cassandra running history queue v2 with alert
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 2
+          timeout_minutes: 30
+          command: |
+            docker compose -f docker/github_actions/docker-compose.yml run integration-test-cassandra-queue-v2-alert bash -c "make .just-build && make cover_integration_profile"
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-cassandra-running-history-queue-v2-alert-integration-coverage
+          path: .build/coverage/*.out
+
 
   golang-integration-test-with-cassandra-and-elasticsearch-v7:
     name: Golang integration test with cassandra and elasticsearch v7

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -156,8 +156,8 @@ func NewTestBaseWithNoSQL(t *testing.T, options *TestBaseOptions) *TestBase {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := TestBaseParams{
 		DefaultTestCluster:    testCluster,
@@ -188,8 +188,8 @@ func NewTestBaseWithSQL(t *testing.T, options *TestBaseOptions) *TestBase {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := TestBaseParams{
 		DefaultTestCluster:    testCluster,

--- a/docker/github_actions/docker-compose-local.yml
+++ b/docker/github_actions/docker-compose-local.yml
@@ -130,6 +130,37 @@ services:
         aliases:
           - integration-test
 
+  integration-test-cassandra-queue-v2-alert:
+    build:
+      context: ../../
+      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    command: make cover_integration_profile
+    environment:
+      - "CASSANDRA_HOST=cassandra"
+      - "CASSANDRA=1"
+      - "CASSANDRA_SEEDS=cassandra"
+      - "ES_SEEDS=elasticsearch"
+      - "KAFKA_SEEDS=kafka"
+      - "TEST_TAG=esintegration"
+      - "ENABLE_QUEUE_V2=true"
+      - "ENABLE_QUEUE_V2_ALERT=true"
+      - "V=1"
+    depends_on:
+      cassandra:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      kafka:
+        condition: service_started
+    volumes:
+      - ../../:/cadence
+      - /cadence/.build/ # ensure we don't mount the build directory
+      - /cadence/.bin/ # ensure we don't mount the bin directory
+    networks:
+      services-network:
+        aliases:
+          - integration-test
+
   integration-test-mysql:
     build:
       context: ../../

--- a/docker/github_actions/docker-compose.yml
+++ b/docker/github_actions/docker-compose.yml
@@ -159,6 +159,32 @@ services:
         aliases:
           - integration-test
 
+  integration-test-cassandra-queue-v2-alert:
+    build:
+      context: ../../
+      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    environment:
+      - "CASSANDRA=1"
+      - "CASSANDRA_SEEDS=cassandra"
+      - "ES_SEEDS=elasticsearch"
+      - "KAFKA_SEEDS=kafka"
+      - "TEST_TAG=esintegration"
+      - "ENABLE_QUEUE_V2=true"
+      - "ENABLE_QUEUE_V2_ALERT=true"
+    depends_on:
+      cassandra:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      kafka:
+        condition: service_started
+    volumes:
+      - ../../:/cadence
+    networks:
+      services-network:
+        aliases:
+          - integration-test
+
   integration-test-mysql:
     build:
       context: ../../

--- a/host/async_wf_test.go
+++ b/host/async_wf_test.go
@@ -99,8 +99,8 @@ func (s *AsyncWFIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -50,8 +50,12 @@ func TestIntegrationSuite(t *testing.T) {
 	flag.Parse()
 
 	configPath := "testdata/integration_test_cluster.yaml"
+	// TODO: remove this logic once we deprecate history queue v1
 	if os.Getenv("ENABLE_QUEUE_V2") == "true" {
 		configPath = "testdata/integration_queuev2_cluster.yaml"
+		if os.Getenv("ENABLE_QUEUE_V2_ALERT") == "true" {
+			configPath = "testdata/integration_queuev2_with_alert_cluster.yaml"
+		}
 	}
 	clusterConfig, err := GetTestClusterConfig(configPath)
 	if err != nil {

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -116,8 +116,8 @@ func (s *IntegrationBase) setupSuite() {
 			EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 			EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 			ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-			ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 			SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+			ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 		}
 		params := pt.TestBaseParams{
 			DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -102,8 +102,8 @@ func (s *NDCIntegrationTestSuite) SetupSuite() {
 		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.defaultTestCluster,

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -114,8 +114,8 @@ func (s *PinotIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/testdata/dynamicconfig/integration_queuev2_with_alert_test.yaml
+++ b/host/testdata/dynamicconfig/integration_queuev2_with_alert_test.yaml
@@ -1,0 +1,59 @@
+frontend.warmupDuration:
+- value: "1s"
+  constraints: {}
+history.enableTimerQueueV2:
+- value: true
+  constraints: {}
+history.enableTransferQueueV2:
+- value: true
+  constraints: {}
+history.shardUpdateMinInterval:
+- value: 3s
+  constraints: {}
+history.timerProcessorUpdateAckInterval:
+- value: 5s
+  constraints: {}
+history.timerProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.transferProcessorUpdateAckInterval:
+- value: 5s
+  constraints: {}
+history.transferProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.queueProcessorPollBackoffInterval:
+- value: 5s
+  constraints: {}
+history.virtualSliceForceAppendInterval:
+- value: 100ms
+  constraints: {}
+# Only Enable 1 level of split, which has been verified in simulation
+history.queueMaxVirtualQueueCount:
+- value: 2
+  constraints: {}
+# Enable task rate limiter so that the number of pending tasks increases
+history.taskSchedulerEnableRateLimiter:
+- value: true
+  constraints: {}
+history.taskSchedulerEnableRateLimiterShadowMode:
+- value: false
+  constraints: {}
+history.taskSchedulerGlobalDomainRPS:
+- value: 30
+  constraints: {}
+# Enable pending task queue alert for integration test
+history.enableTransferQueueV2PendingTaskCountAlert:
+- value: true
+  constraints: {}
+history.enableTimerQueueV2PendingTaskCountAlert:
+- value: true
+  constraints: {}
+# Set a low number to trigger queue pause with load from tests
+history.queueMaxPendingTaskCount:
+- value: 20
+  constraints: {}
+# Set a low number to trigger queue split with load from tests
+history.queueCriticalPendingTaskCount:
+- value: 18
+  constraints: {}

--- a/host/testdata/integration_queuev2_with_alert_cluster.yaml
+++ b/host/testdata/integration_queuev2_with_alert_cluster.yaml
@@ -1,0 +1,16 @@
+enablearchival: true
+clusterno: 0
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+matchingconfig:
+  nummatchinghosts: 1
+workerconfig:
+  enablearchiver: true
+  enablereplicator: true
+  enableindexer: false
+dynamicclientconfig:
+  filepath: "testdata/dynamicconfig/integration_queuev2_with_alert_test.yaml"
+  pollInterval: "10s"

--- a/host/workflowidratelimit_test.go
+++ b/host/workflowidratelimit_test.go
@@ -76,8 +76,8 @@ func (s *WorkflowIDRateLimitIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/host/workflowsidinternalratelimit_test.go
+++ b/host/workflowsidinternalratelimit_test.go
@@ -80,8 +80,8 @@ func (s *WorkflowIDInternalRateLimitIntegrationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,

--- a/service/history/queuev2/virtual_queue_manager_test.go
+++ b/service/history/queuev2/virtual_queue_manager_test.go
@@ -202,7 +202,7 @@ func TestVirtualQueueManager_VirtualQueues(t *testing.T) {
 				queueReader:     mockQueueReader,
 				logger:          mockLogger,
 				metricsScope:    mockMetricsScope,
-				options: &VirtualQueueManagerOptions{
+				queueManagerOptions: &VirtualQueueManagerOptions{
 					RootQueueOptions: &VirtualQueueOptions{},
 					NonRootQueueOptions: &VirtualQueueOptions{
 						PageSize: dynamicproperties.GetIntPropertyFn(100),
@@ -456,7 +456,7 @@ func TestVirtualQueueManager_UpdateAndGetState(t *testing.T) {
 				queueReader:     mockQueueReader,
 				logger:          mockLogger,
 				metricsScope:    mockMetricsScope,
-				options: &VirtualQueueManagerOptions{
+				queueManagerOptions: &VirtualQueueManagerOptions{
 					RootQueueOptions: &VirtualQueueOptions{},
 					NonRootQueueOptions: &VirtualQueueOptions{
 						MaxPendingTasksCount: dynamicproperties.GetIntPropertyFn(100),
@@ -569,7 +569,7 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 				logger:          mockLogger,
 				metricsScope:    mockMetricsScope,
 				timeSource:      mockTimeSource,
-				options: &VirtualQueueManagerOptions{
+				queueManagerOptions: &VirtualQueueManagerOptions{
 					RootQueueOptions: &VirtualQueueOptions{
 						PageSize: dynamicproperties.GetIntPropertyFn(100),
 					},

--- a/simulation/history/history_simulation_test.go
+++ b/simulation/history/history_simulation_test.go
@@ -75,8 +75,8 @@ func (s *HistorySimulationSuite) SetupSuite() {
 		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
 		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
 		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(false),
 		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
 	}
 	params := pt.TestBaseParams{
 		DefaultTestCluster:    s.DefaultTestCluster,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Set up integration test for pending task alert of history queue v2, which is non-blocking currently
- Change the value of ReadNoSQLShardData to true for all integration tests

<!-- Tell your future self why have you made these changes -->
**Why?**
To test virtual queue split feature of history queue v2

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
