### PR TITLE
Retry standby tasks immediately on failover

### DIFF
--- a/common/task/fifo_task_scheduler.go
+++ b/common/task/fifo_task_scheduler.go
@@ -151,7 +151,7 @@ func (f *fifoTaskSchedulerImpl) dispatcher() {
 		case task := <-f.taskCh:
 			if err := f.processor.Submit(task); err != nil {
 				f.logger.Error("failed to submit task to processor", tag.Error(err))
-				task.Nack()
+				task.Nack(err)
 			}
 		case <-f.shutdownCh:
 			return
@@ -167,7 +167,7 @@ func (f *fifoTaskSchedulerImpl) drainAndNackTasks() {
 	for {
 		select {
 		case task := <-f.taskCh:
-			task.Nack()
+			task.Nack(nil)
 		default:
 			return
 		}

--- a/common/task/interface.go
+++ b/common/task/interface.go
@@ -57,7 +57,7 @@ type (
 		// Ack marks the task as successful completed
 		Ack()
 		// Nack marks the task as unsuccessful completed
-		Nack()
+		Nack(err error)
 		// Cancel marks the task as canceled
 		Cancel()
 		// State returns the current task state

--- a/common/task/interface_mock.go
+++ b/common/task/interface_mock.go
@@ -231,15 +231,15 @@ func (mr *MockTaskMockRecorder) HandleErr(err any) *gomock.Call {
 }
 
 // Nack mocks base method.
-func (m *MockTask) Nack() {
+func (m *MockTask) Nack(err error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Nack")
+	m.ctrl.Call(m, "Nack", err)
 }
 
 // Nack indicates an expected call of Nack.
-func (mr *MockTaskMockRecorder) Nack() *gomock.Call {
+func (mr *MockTaskMockRecorder) Nack(err any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockTask)(nil).Nack))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockTask)(nil).Nack), err)
 }
 
 // RetryErr mocks base method.
@@ -347,15 +347,15 @@ func (mr *MockPriorityTaskMockRecorder) HandleErr(err any) *gomock.Call {
 }
 
 // Nack mocks base method.
-func (m *MockPriorityTask) Nack() {
+func (m *MockPriorityTask) Nack(err error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Nack")
+	m.ctrl.Call(m, "Nack", err)
 }
 
 // Nack indicates an expected call of Nack.
-func (mr *MockPriorityTaskMockRecorder) Nack() *gomock.Call {
+func (mr *MockPriorityTaskMockRecorder) Nack(err any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockPriorityTask)(nil).Nack))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockPriorityTask)(nil).Nack), err)
 }
 
 // Priority mocks base method.

--- a/common/task/parallel_task_processor.go
+++ b/common/task/parallel_task_processor.go
@@ -158,7 +158,7 @@ func (p *parallelTaskProcessorImpl) executeTask(task Task, shutdownCh chan struc
 		if r := recover(); r != nil {
 			p.logger.Error("recovered panic in task execution", tag.Dynamic("recovered-panic", r))
 			task.HandleErr(fmt.Errorf("recovered panic: %v", r))
-			task.Nack()
+			task.Nack(nil)
 		}
 	}()
 
@@ -185,7 +185,7 @@ func (p *parallelTaskProcessorImpl) executeTask(task Task, shutdownCh chan struc
 
 	if err := throttleRetry.Do(context.Background(), op); err != nil {
 		// non-retryable error or exhausted all retries or worker shutdown
-		task.Nack()
+		task.Nack(err)
 		return
 	}
 
@@ -245,7 +245,7 @@ func (p *parallelTaskProcessorImpl) drainAndNackTasks() {
 	for {
 		select {
 		case task := <-p.tasksCh:
-			task.Nack()
+			task.Nack(nil)
 		default:
 			return
 		}

--- a/common/task/parallel_task_processor_test.go
+++ b/common/task/parallel_task_processor_test.go
@@ -146,7 +146,7 @@ func (s *parallelTaskProcessorSuite) TestExecuteTask_NonRetryableError() {
 		mockTask.EXPECT().Execute().Return(errNonRetryable),
 		mockTask.EXPECT().HandleErr(errNonRetryable).Return(errNonRetryable),
 		mockTask.EXPECT().RetryErr(errNonRetryable).Return(false).AnyTimes(),
-		mockTask.EXPECT().Nack(),
+		mockTask.EXPECT().Nack(gomock.Any()),
 	)
 
 	s.processor.executeTask(mockTask, make(chan struct{}))
@@ -157,7 +157,7 @@ func (s *parallelTaskProcessorSuite) TestExecuteTask_WorkerStopped() {
 	mockTask.EXPECT().Execute().Return(errRetryable).AnyTimes()
 	mockTask.EXPECT().HandleErr(errRetryable).Return(errRetryable).AnyTimes()
 	mockTask.EXPECT().RetryErr(errRetryable).Return(true).AnyTimes()
-	mockTask.EXPECT().Nack().Times(1)
+	mockTask.EXPECT().Nack(gomock.Any()).Times(1)
 
 	done := make(chan struct{})
 	workerShutdownCh := make(chan struct{})
@@ -265,7 +265,7 @@ func (s *parallelTaskProcessorSuite) TestProcessorContract() {
 			taskStatus[mockTask] = TaskStateAcked
 			taskWG.Done()
 		}).MaxTimes(1)
-		mockTask.EXPECT().Nack().Do(func() {
+		mockTask.EXPECT().Nack(gomock.Any()).Do(func(err error) {
 			taskStatusLock.Lock()
 			defer taskStatusLock.Unlock()
 
@@ -315,7 +315,7 @@ func (s *parallelTaskProcessorSuite) TestExecuteTask_PanicHandling() {
 		panic("A panic occurred")
 	})
 	mockTask.EXPECT().HandleErr(gomock.Any()).Return(errRetryable).AnyTimes()
-	mockTask.EXPECT().Nack().Times(1)
+	mockTask.EXPECT().Nack(gomock.Any()).Times(1)
 	done := make(chan struct{})
 	workerShutdownCh := make(chan struct{})
 	go func() {

--- a/common/task/sequential_task_processor.go
+++ b/common/task/sequential_task_processor.go
@@ -185,7 +185,7 @@ func (t *sequentialTaskProcessorImpl) processTaskOnce(taskqueue SequentialTaskQu
 			taskqueue.Add(task)
 		} else {
 			t.logger.Error("Unable to process task", tag.Error(err))
-			task.Nack()
+			task.Nack(err)
 		}
 	} else {
 		task.Ack()

--- a/common/task/sequential_task_processor_test.go
+++ b/common/task/sequential_task_processor_test.go
@@ -276,7 +276,7 @@ func (t *testSequentialTaskImpl) NumAcked() int {
 	return t.acked
 }
 
-func (t *testSequentialTaskImpl) Nack() {
+func (t *testSequentialTaskImpl) Nack(err error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 

--- a/common/task/weighted_round_robin_task_scheduler.go
+++ b/common/task/weighted_round_robin_task_scheduler.go
@@ -191,7 +191,7 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) dispatchTasks() {
 				hasTask = true
 				if err := w.processor.Submit(task); err != nil {
 					w.logger.Error("fail to submit task to processor", tag.Error(err))
-					task.Nack()
+					task.Nack(err)
 				}
 			case <-w.shutdownCh:
 				return
@@ -218,7 +218,7 @@ func drainAndNackPriorityTask(taskCh <-chan PriorityTask) {
 	for {
 		select {
 		case task := <-taskCh:
-			task.Nack()
+			task.Nack(nil)
 		default:
 			return
 		}

--- a/common/task/weighted_round_robin_task_scheduler_test.go
+++ b/common/task/weighted_round_robin_task_scheduler_test.go
@@ -227,7 +227,7 @@ func (s *weightedRoundRobinTaskSchedulerSuite) TestDispatcher_SubmitWithNoError(
 func (s *weightedRoundRobinTaskSchedulerSuite) TestDispatcher_FailToSubmit() {
 	mockTask := NewMockPriorityTask(s.controller)
 	mockTask.EXPECT().Priority().Return(0)
-	mockTask.EXPECT().Nack()
+	mockTask.EXPECT().Nack(gomock.Any())
 
 	var taskWG sync.WaitGroup
 	s.scheduler.Submit(mockTask)
@@ -328,7 +328,7 @@ func testSchedulerContract(
 			taskStatus[mockTask] = TaskStateAcked
 			taskWG.Done()
 		}).MaxTimes(1)
-		mockTask.EXPECT().Nack().Do(func() {
+		mockTask.EXPECT().Nack(gomock.Any()).Do(func(err error) {
 			taskStatusLock.Lock()
 			defer taskStatusLock.Unlock()
 

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -295,15 +295,15 @@ func (mr *MockTaskMockRecorder) HandleErr(err any) *gomock.Call {
 }
 
 // Nack mocks base method.
-func (m *MockTask) Nack() {
+func (m *MockTask) Nack(err error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Nack")
+	m.ctrl.Call(m, "Nack", err)
 }
 
 // Nack indicates an expected call of Nack.
-func (mr *MockTaskMockRecorder) Nack() *gomock.Call {
+func (mr *MockTaskMockRecorder) Nack(err any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockTask)(nil).Nack))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockTask)(nil).Nack), err)
 }
 
 // Priority mocks base method.
@@ -769,15 +769,15 @@ func (mr *MockCrossClusterTaskMockRecorder) IsValid() *gomock.Call {
 }
 
 // Nack mocks base method.
-func (m *MockCrossClusterTask) Nack() {
+func (m *MockCrossClusterTask) Nack(err error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Nack")
+	m.ctrl.Call(m, "Nack", err)
 }
 
 // Nack indicates an expected call of Nack.
-func (mr *MockCrossClusterTaskMockRecorder) Nack() *gomock.Call {
+func (mr *MockCrossClusterTaskMockRecorder) Nack(err any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockCrossClusterTask)(nil).Nack))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockCrossClusterTask)(nil).Nack), err)
 }
 
 // Priority mocks base method.

--- a/service/history/task/standby_task_util.go
+++ b/service/history/task/standby_task_util.go
@@ -43,6 +43,10 @@ type (
 	standbyCurrentTimeFn func(persistence.Task) (time.Time, error)
 )
 
+var (
+	errDomainBecomesActive = errors.New("domain becomes active when processing task as standby")
+)
+
 func standbyTaskPostActionNoOp(
 	ctx context.Context,
 	taskInfo persistence.Task,
@@ -222,7 +226,7 @@ func getRemoteClusterName(
 		}
 		if resp.ClusterName == currentCluster {
 			// domain has turned active, retry the task
-			return "", errors.New("domain becomes active when processing task as standby")
+			return "", errDomainBecomesActive
 		}
 		return resp.ClusterName, nil
 	}
@@ -230,7 +234,7 @@ func getRemoteClusterName(
 	remoteClusterName := domainEntry.GetReplicationConfig().ActiveClusterName
 	if remoteClusterName == currentCluster {
 		// domain has turned active, retry the task
-		return "", errors.New("domain becomes active when processing task as standby")
+		return "", errDomainBecomesActive
 	}
 	return remoteClusterName, nil
 }

--- a/service/history/task/task_rate_limiter_test.go
+++ b/service/history/task/task_rate_limiter_test.go
@@ -78,7 +78,7 @@ func (s *noopTask) Ack() {
 	s.state = ctask.TaskStateAcked
 }
 
-func (s *noopTask) Nack() {
+func (s *noopTask) Nack(err error) {
 	s.Lock()
 	defer s.Unlock()
 	if s.state != ctask.TaskStatePending {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update Nack method of task to accept an error as parameter
- Retry standby history tasks immediately on failover

<!-- Tell your future self why have you made these changes -->
**Why?**
We standby tasks becomes active, we should retry immediately to reduce the task processing latency.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
