### PR TITLE
Improve domain failover for history queue v2

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2419,6 +2419,7 @@ const (
 	TaskRequestsOldScheduler
 	TaskRequestsNewScheduler
 	PendingTaskGauge
+	ReschedulerTaskCountGauge
 
 	TaskRequestsPerDomain
 	TaskLatencyPerDomain
@@ -3194,6 +3195,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskRequestsOldScheduler:                      {metricName: "task_requests_old_scheduler", metricType: Counter},
 		TaskRequestsNewScheduler:                      {metricName: "task_requests_new_scheduler", metricType: Counter},
 		PendingTaskGauge:                              {metricName: "pending_task_gauge", metricType: Gauge},
+		ReschedulerTaskCountGauge:                     {metricName: "rescheduler_task_count", metricType: Gauge},
 
 		// per domain task metrics
 

--- a/service/history/queuev2/queue_base.go
+++ b/service/history/queuev2/queue_base.go
@@ -114,12 +114,9 @@ func newQueueBase(
 	queueState := FromPersistenceQueueState(persistenceQueueState)
 	exclusiveAckLevel, _ := getExclusiveAckLevelAndMaxQueueIDFromQueueState(queueState)
 
-	redispatcher := task.NewRedispatcher(
+	redispatcher := task.NewRescheduler(
 		taskProcessor,
 		timeSource,
-		&task.RedispatcherOptions{
-			TaskRedispatchInterval: options.RedispatchInterval,
-		},
 		logger,
 		metricsScope,
 	)
@@ -246,7 +243,9 @@ func (q *queueBase) Category() persistence.HistoryTaskCategory {
 	return q.category
 }
 
-func (q *queueBase) FailoverDomain(domainIDs map[string]struct{}) {}
+func (q *queueBase) FailoverDomain(domainIDs map[string]struct{}) {
+	q.redispatcher.RescheduleDomains(domainIDs)
+}
 
 func (q *queueBase) HandleAction(ctx context.Context, clusterName string, action *queue.Action) (*queue.ActionResult, error) {
 	return nil, nil

--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -41,6 +41,10 @@ import (
 	"github.com/uber/cadence/service/history/task"
 )
 
+var (
+	taskSchedulerThrottleBackoffInterval = time.Second * 5
+)
+
 type (
 	VirtualQueue interface {
 		common.Daemon
@@ -402,7 +406,7 @@ func (q *virtualQueueImpl) loadAndSubmitTasks() {
 		}
 		if !submitted {
 			q.metricsScope.IncCounter(metrics.ProcessingQueueThrottledCounter)
-			q.redispatcher.AddTask(task)
+			q.redispatcher.RedispatchTask(task, q.timeSource.Now().Add(taskSchedulerThrottleBackoffInterval))
 		}
 	}
 

--- a/service/history/queuev2/virtual_queue_manager.go
+++ b/service/history/queuev2/virtual_queue_manager.go
@@ -61,7 +61,7 @@ type (
 	virtualQueueManagerImpl struct {
 		processor           task.Processor
 		taskInitializer     task.Initializer
-		redispatcher        task.Redispatcher
+		rescheduler         task.Rescheduler
 		queueReader         QueueReader
 		logger              log.Logger
 		metricsScope        metrics.Scope
@@ -81,7 +81,7 @@ type (
 
 func NewVirtualQueueManager(
 	processor task.Processor,
-	redispatcher task.Redispatcher,
+	rescheduler task.Rescheduler,
 	taskInitializer task.Initializer,
 	queueReader QueueReader,
 	logger log.Logger,
@@ -104,13 +104,13 @@ func NewVirtualQueueManager(
 		} else {
 			opts = queueManagerOptions.NonRootQueueOptions
 		}
-		virtualQueues[queueID] = NewVirtualQueue(processor, redispatcher, logger.WithTags(tag.VirtualQueueID(queueID)), metricsScope, timeSource, taskLoadRateLimiter, monitor, virtualSlices, opts)
+		virtualQueues[queueID] = NewVirtualQueue(processor, rescheduler, logger.WithTags(tag.VirtualQueueID(queueID)), metricsScope, timeSource, taskLoadRateLimiter, monitor, virtualSlices, opts)
 	}
 	return &virtualQueueManagerImpl{
 		processor:           processor,
 		taskInitializer:     taskInitializer,
 		queueReader:         queueReader,
-		redispatcher:        redispatcher,
+		rescheduler:         rescheduler,
 		logger:              logger,
 		metricsScope:        metricsScope,
 		timeSource:          timeSource,
@@ -126,7 +126,7 @@ func NewVirtualQueueManager(
 			} else {
 				opts = queueManagerOptions.NonRootQueueOptions
 			}
-			return NewVirtualQueue(processor, redispatcher, logger.WithTags(tag.VirtualQueueID(queueID)), metricsScope, timeSource, taskLoadRateLimiter, monitor, s, opts)
+			return NewVirtualQueue(processor, rescheduler, logger.WithTags(tag.VirtualQueueID(queueID)), metricsScope, timeSource, taskLoadRateLimiter, monitor, s, opts)
 		},
 	}
 }

--- a/service/history/queuev2/virtual_queue_manager_test.go
+++ b/service/history/queuev2/virtual_queue_manager_test.go
@@ -172,7 +172,7 @@ func TestVirtualQueueManager_VirtualQueues(t *testing.T) {
 
 			// Create mock dependencies
 			mockProcessor := task.NewMockProcessor(ctrl)
-			mockRedispatcher := task.NewMockRedispatcher(ctrl)
+			mockRescheduler := task.NewMockRescheduler(ctrl)
 			mockTaskInitializer := func(t persistence.Task) task.Task {
 				mockTask := task.NewMockTask(ctrl)
 				mockTask.EXPECT().GetTaskID().Return(t.GetTaskID())
@@ -198,7 +198,7 @@ func TestVirtualQueueManager_VirtualQueues(t *testing.T) {
 			manager := &virtualQueueManagerImpl{
 				processor:       mockProcessor,
 				taskInitializer: mockTaskInitializer,
-				redispatcher:    mockRedispatcher,
+				rescheduler:     mockRescheduler,
 				queueReader:     mockQueueReader,
 				logger:          mockLogger,
 				metricsScope:    mockMetricsScope,
@@ -426,7 +426,7 @@ func TestVirtualQueueManager_UpdateAndGetState(t *testing.T) {
 
 			// Create mock dependencies
 			mockProcessor := task.NewMockProcessor(ctrl)
-			mockRedispatcher := task.NewMockRedispatcher(ctrl)
+			mockRescheduler := task.NewMockRescheduler(ctrl)
 			mockTaskInitializer := func(t persistence.Task) task.Task {
 				mockTask := task.NewMockTask(ctrl)
 				mockTask.EXPECT().GetTaskID().Return(t.GetTaskID())
@@ -452,7 +452,7 @@ func TestVirtualQueueManager_UpdateAndGetState(t *testing.T) {
 			manager := &virtualQueueManagerImpl{
 				processor:       mockProcessor,
 				taskInitializer: mockTaskInitializer,
-				redispatcher:    mockRedispatcher,
+				rescheduler:     mockRescheduler,
 				queueReader:     mockQueueReader,
 				logger:          mockLogger,
 				metricsScope:    mockMetricsScope,
@@ -533,7 +533,7 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 
 			// Create mock dependencies
 			mockProcessor := task.NewMockProcessor(ctrl)
-			mockRedispatcher := task.NewMockRedispatcher(ctrl)
+			mockRescheduler := task.NewMockRescheduler(ctrl)
 			mockTaskInitializer := func(t persistence.Task) task.Task {
 				mockTask := task.NewMockTask(ctrl)
 				mockTask.EXPECT().GetTaskID().Return(t.GetTaskID())
@@ -564,7 +564,7 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 			manager := &virtualQueueManagerImpl{
 				processor:       mockProcessor,
 				taskInitializer: mockTaskInitializer,
-				redispatcher:    mockRedispatcher,
+				rescheduler:     mockRescheduler,
 				queueReader:     mockQueueReader,
 				logger:          mockLogger,
 				metricsScope:    mockMetricsScope,

--- a/service/history/queuev2/virtual_queue_test.go
+++ b/service/history/queuev2/virtual_queue_test.go
@@ -669,7 +669,7 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 
 	mockProcessor.EXPECT().TrySubmit(mockTask1).Return(true, nil)
 	mockRedispatcher.EXPECT().RedispatchTask(mockTask2, mockTimeSource.Now().Add(time.Second*1))
-	mockRedispatcher.EXPECT().AddTask(mockTask3)
+	mockRedispatcher.EXPECT().RedispatchTask(mockTask3, mockTimeSource.Now().Add(taskSchedulerThrottleBackoffInterval))
 
 	queue := NewVirtualQueue(
 		mockProcessor,

--- a/service/history/queuev2/virtual_queue_test.go
+++ b/service/history/queuev2/virtual_queue_test.go
@@ -23,7 +23,7 @@ func TestVirtualQueueImpl_GetState(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -57,7 +57,7 @@ func TestVirtualQueueImpl_GetState(t *testing.T) {
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -96,7 +96,7 @@ func TestVirtualQueueImpl_UpdateAndGetState(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -134,7 +134,7 @@ func TestVirtualQueueImpl_UpdateAndGetState(t *testing.T) {
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -348,7 +348,7 @@ func TestVirtualQueue_MergeSlices(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockProcessor := task.NewMockProcessor(ctrl)
-			mockRedispatcher := task.NewMockRedispatcher(ctrl)
+			mockRescheduler := task.NewMockRescheduler(ctrl)
 			mockLogger := testlogger.New(t)
 			mockMetricsScope := metrics.NoopScope
 			mockTimeSource := clock.NewMockedTimeSource()
@@ -358,7 +358,7 @@ func TestVirtualQueue_MergeSlices(t *testing.T) {
 
 			queue := NewVirtualQueue(
 				mockProcessor,
-				mockRedispatcher,
+				mockRescheduler,
 				mockLogger,
 				mockMetricsScope,
 				mockTimeSource,
@@ -614,7 +614,7 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -668,12 +668,12 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	mockProcessor.EXPECT().TrySubmit(mockTask3).Return(false, nil)
 
 	mockProcessor.EXPECT().TrySubmit(mockTask1).Return(true, nil)
-	mockRedispatcher.EXPECT().RedispatchTask(mockTask2, mockTimeSource.Now().Add(time.Second*1))
-	mockRedispatcher.EXPECT().RedispatchTask(mockTask3, mockTimeSource.Now().Add(taskSchedulerThrottleBackoffInterval))
+	mockRescheduler.EXPECT().RescheduleTask(mockTask2, mockTimeSource.Now().Add(time.Second*1))
+	mockRescheduler.EXPECT().RescheduleTask(mockTask3, mockTimeSource.Now().Add(taskSchedulerThrottleBackoffInterval))
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -702,7 +702,7 @@ func TestVirtualQueue_LifeCycle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -731,7 +731,7 @@ func TestVirtualQueue_LifeCycle(t *testing.T) {
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -757,7 +757,7 @@ func TestVirtualQueue_LifeCycle_Pause(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -773,7 +773,7 @@ func TestVirtualQueue_LifeCycle_Pause(t *testing.T) {
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -814,7 +814,7 @@ func TestVirtualQueue_IterateSlices(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -848,7 +848,7 @@ func TestVirtualQueue_IterateSlices(t *testing.T) {
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -891,7 +891,7 @@ func TestVirtualQueue_ClearSlices(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -933,7 +933,7 @@ func TestVirtualQueue_ClearSlices(t *testing.T) {
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -977,7 +977,7 @@ func TestVirtualQueue_SplitSlices(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockProcessor := task.NewMockProcessor(ctrl)
-	mockRedispatcher := task.NewMockRedispatcher(ctrl)
+	mockRescheduler := task.NewMockRescheduler(ctrl)
 	mockLogger := testlogger.New(t)
 	mockMetricsScope := metrics.NoopScope
 	mockPageSize := dynamicproperties.GetIntPropertyFn(10)
@@ -1016,7 +1016,7 @@ func TestVirtualQueue_SplitSlices(t *testing.T) {
 
 	queue := NewVirtualQueue(
 		mockProcessor,
-		mockRedispatcher,
+		mockRescheduler,
 		mockLogger,
 		mockMetricsScope,
 		mockTimeSource,
@@ -1341,7 +1341,7 @@ func TestVirtualQueue_AppendSlices(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			mockProcessor := task.NewMockProcessor(ctrl)
-			mockRedispatcher := task.NewMockRedispatcher(ctrl)
+			mockRescheduler := task.NewMockRescheduler(ctrl)
 			mockLogger := testlogger.New(t)
 			mockMetricsScope := metrics.NoopScope
 			mockTimeSource := clock.NewMockedTimeSource()
@@ -1351,7 +1351,7 @@ func TestVirtualQueue_AppendSlices(t *testing.T) {
 
 			queue := NewVirtualQueue(
 				mockProcessor,
-				mockRedispatcher,
+				mockRescheduler,
 				mockLogger,
 				mockMetricsScope,
 				mockTimeSource,

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -92,10 +92,15 @@ type (
 		AddTask(Task)
 		Redispatch(targetSize int)
 		RedispatchTask(Task, time.Time)
-		RescheduleDomains(domainIDs map[string]struct{})
 		Size() int
 	}
 
+	Rescheduler interface {
+		common.Daemon
+		RescheduleTask(Task, time.Time)
+		RescheduleDomains(domainIDs map[string]struct{})
+		Size() int
+	}
 	// Fetcher is a host level component for aggregating task fetch requests
 	// from all shards on the host and perform one fetching operation for
 	// aggregated requests.

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -90,8 +90,9 @@ type (
 	Redispatcher interface {
 		common.Daemon
 		AddTask(Task)
-		RedispatchTask(Task, time.Time)
 		Redispatch(targetSize int)
+		RedispatchTask(Task, time.Time)
+		RescheduleDomains(domainIDs map[string]struct{})
 		Size() int
 	}
 

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -1205,6 +1205,18 @@ func (mr *MockRedispatcherMockRecorder) RedispatchTask(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedispatchTask", reflect.TypeOf((*MockRedispatcher)(nil).RedispatchTask), arg0, arg1)
 }
 
+// RescheduleDomains mocks base method.
+func (m *MockRedispatcher) RescheduleDomains(domainIDs map[string]struct{}) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RescheduleDomains", domainIDs)
+}
+
+// RescheduleDomains indicates an expected call of RescheduleDomains.
+func (mr *MockRedispatcherMockRecorder) RescheduleDomains(domainIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RescheduleDomains", reflect.TypeOf((*MockRedispatcher)(nil).RescheduleDomains), domainIDs)
+}
+
 // Size mocks base method.
 func (m *MockRedispatcher) Size() int {
 	m.ctrl.T.Helper()

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -1205,18 +1205,6 @@ func (mr *MockRedispatcherMockRecorder) RedispatchTask(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedispatchTask", reflect.TypeOf((*MockRedispatcher)(nil).RedispatchTask), arg0, arg1)
 }
 
-// RescheduleDomains mocks base method.
-func (m *MockRedispatcher) RescheduleDomains(domainIDs map[string]struct{}) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RescheduleDomains", domainIDs)
-}
-
-// RescheduleDomains indicates an expected call of RescheduleDomains.
-func (mr *MockRedispatcherMockRecorder) RescheduleDomains(domainIDs any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RescheduleDomains", reflect.TypeOf((*MockRedispatcher)(nil).RescheduleDomains), domainIDs)
-}
-
 // Size mocks base method.
 func (m *MockRedispatcher) Size() int {
 	m.ctrl.T.Helper()
@@ -1253,6 +1241,92 @@ func (m *MockRedispatcher) Stop() {
 func (mr *MockRedispatcherMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockRedispatcher)(nil).Stop))
+}
+
+// MockRescheduler is a mock of Rescheduler interface.
+type MockRescheduler struct {
+	ctrl     *gomock.Controller
+	recorder *MockReschedulerMockRecorder
+	isgomock struct{}
+}
+
+// MockReschedulerMockRecorder is the mock recorder for MockRescheduler.
+type MockReschedulerMockRecorder struct {
+	mock *MockRescheduler
+}
+
+// NewMockRescheduler creates a new mock instance.
+func NewMockRescheduler(ctrl *gomock.Controller) *MockRescheduler {
+	mock := &MockRescheduler{ctrl: ctrl}
+	mock.recorder = &MockReschedulerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRescheduler) EXPECT() *MockReschedulerMockRecorder {
+	return m.recorder
+}
+
+// RescheduleDomains mocks base method.
+func (m *MockRescheduler) RescheduleDomains(domainIDs map[string]struct{}) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RescheduleDomains", domainIDs)
+}
+
+// RescheduleDomains indicates an expected call of RescheduleDomains.
+func (mr *MockReschedulerMockRecorder) RescheduleDomains(domainIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RescheduleDomains", reflect.TypeOf((*MockRescheduler)(nil).RescheduleDomains), domainIDs)
+}
+
+// RescheduleTask mocks base method.
+func (m *MockRescheduler) RescheduleTask(arg0 Task, arg1 time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RescheduleTask", arg0, arg1)
+}
+
+// RescheduleTask indicates an expected call of RescheduleTask.
+func (mr *MockReschedulerMockRecorder) RescheduleTask(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RescheduleTask", reflect.TypeOf((*MockRescheduler)(nil).RescheduleTask), arg0, arg1)
+}
+
+// Size mocks base method.
+func (m *MockRescheduler) Size() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockReschedulerMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockRescheduler)(nil).Size))
+}
+
+// Start mocks base method.
+func (m *MockRescheduler) Start() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockReschedulerMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockRescheduler)(nil).Start))
+}
+
+// Stop mocks base method.
+func (m *MockRescheduler) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockReschedulerMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockRescheduler)(nil).Stop))
 }
 
 // MockFetcher is a mock of Fetcher interface.

--- a/service/history/task/redispatcher.go
+++ b/service/history/task/redispatcher.go
@@ -157,10 +157,6 @@ func (r *redispatcherImpl) RedispatchTask(task Task, t time.Time) {
 	r.timerGate.Update(t)
 }
 
-func (r *redispatcherImpl) RescheduleDomains(domainIDs map[string]struct{}) {
-	// no need to implement this method for now
-}
-
 // TODO: review this method, it doesn't seem to redispatch the tasks immediately
 func (r *redispatcherImpl) Redispatch(targetSize int) {
 	doneCh := make(chan struct{})

--- a/service/history/task/redispatcher.go
+++ b/service/history/task/redispatcher.go
@@ -157,6 +157,10 @@ func (r *redispatcherImpl) RedispatchTask(task Task, t time.Time) {
 	r.timerGate.Update(t)
 }
 
+func (r *redispatcherImpl) RescheduleDomains(domainIDs map[string]struct{}) {
+	// no need to implement this method for now
+}
+
 // TODO: review this method, it doesn't seem to redispatch the tasks immediately
 func (r *redispatcherImpl) Redispatch(targetSize int) {
 	doneCh := make(chan struct{})

--- a/service/history/task/rescheduler.go
+++ b/service/history/task/rescheduler.go
@@ -1,0 +1,298 @@
+package task
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/collection"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
+	ctask "github.com/uber/cadence/common/task"
+)
+
+const (
+	taskChanFullBackoff                  = 2 * time.Second
+	taskChanFullBackoffJitterCoefficient = 0.5
+
+	reschedulerPQCleanupDuration          = 3 * time.Minute
+	reschedulerPQCleanupJitterCoefficient = 0.15
+)
+
+type (
+	rescheduledTask struct {
+		task           Task
+		rescheduleTime time.Time
+	}
+
+	reschedulerImpl struct {
+		scheduler    Processor
+		timeSource   clock.TimeSource
+		logger       log.Logger
+		metricsScope metrics.Scope
+
+		status     int32
+		ctx        context.Context
+		cancel     context.CancelFunc
+		shutdownWG sync.WaitGroup
+
+		timerGate clock.TimerGate
+
+		sync.Mutex
+		pqMap          map[DomainPriorityKey]collection.Queue[rescheduledTask]
+		numExecutables int
+	}
+)
+
+func NewRescheduler(
+	scheduler Processor,
+	timeSource clock.TimeSource,
+	logger log.Logger,
+	metricsScope metrics.Scope,
+) Redispatcher {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &reschedulerImpl{
+		scheduler:    scheduler,
+		timeSource:   timeSource,
+		logger:       logger,
+		metricsScope: metricsScope,
+
+		status: common.DaemonStatusInitialized,
+		ctx:    ctx,
+		cancel: cancel,
+
+		timerGate: clock.NewTimerGate(timeSource),
+
+		pqMap: make(map[DomainPriorityKey]collection.Queue[rescheduledTask]),
+	}
+}
+
+func (r *reschedulerImpl) Start() {
+	if !atomic.CompareAndSwapInt32(&r.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+
+	r.shutdownWG.Add(1)
+	go r.rescheduleLoop()
+
+	r.logger.Info("Task rescheduler started.", tag.LifeCycleStarted)
+}
+
+func (r *reschedulerImpl) Stop() {
+	if !atomic.CompareAndSwapInt32(&r.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+
+	r.cancel()
+	r.timerGate.Stop()
+
+	if success := common.AwaitWaitGroup(&r.shutdownWG, time.Minute); !success {
+		r.logger.Warn("Task rescheduler timedout on shutdown.", tag.LifeCycleStopTimedout)
+	}
+
+	r.logger.Info("Task rescheduler stopped.", tag.LifeCycleStopped)
+}
+
+func (r *reschedulerImpl) RedispatchTask(
+	task Task,
+	rescheduleTime time.Time,
+) {
+	r.Lock()
+	pq := r.getOrCreatePQLocked(DomainPriorityKey{
+		DomainID: task.GetDomainID(),
+		Priority: task.Priority(),
+	})
+	pq.Add(rescheduledTask{
+		task:           task,
+		rescheduleTime: rescheduleTime,
+	})
+	r.numExecutables++
+	r.Unlock()
+	r.timerGate.Update(rescheduleTime)
+
+	if r.isStopped() {
+		r.drain()
+	}
+}
+
+func (r *reschedulerImpl) RescheduleDomains(
+	domainIDs map[string]struct{},
+) {
+	r.Lock()
+	defer r.Unlock()
+
+	now := r.timeSource.Now()
+	updatedRescheduleTime := false
+	for key, pq := range r.pqMap {
+		if _, ok := domainIDs[key.DomainID]; !ok {
+			continue
+		}
+
+		updatedRescheduleTime = true
+		// set reschedule time for all tasks in this pq to be now
+		items := make([]rescheduledTask, 0, pq.Len())
+		for !pq.IsEmpty() {
+			rescheduled, _ := pq.Remove()
+			// scheduled queue pre-fetches tasks,
+			// so we need to make sure the reschedule time is not before the task scheduled time
+			scheduleTime := rescheduled.task.GetTaskKey().GetScheduledTime()
+			if now.Before(scheduleTime) {
+				rescheduled.rescheduleTime = scheduleTime
+			} else {
+				rescheduled.rescheduleTime = now
+			}
+			items = append(items, rescheduled)
+		}
+		r.pqMap[key] = r.newPriorityQueue(items)
+	}
+
+	// then update timer gate to trigger the actual reschedule
+	if updatedRescheduleTime {
+		r.timerGate.Update(now)
+	}
+}
+
+func (r *reschedulerImpl) Size() int {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.numExecutables
+}
+
+func (r *reschedulerImpl) AddTask(task Task) {
+}
+
+func (r *reschedulerImpl) Redispatch(targetSize int) {
+}
+
+func (r *reschedulerImpl) rescheduleLoop() {
+	defer r.shutdownWG.Done()
+
+	cleanupTimer := r.timeSource.NewTimer(backoff.JitDuration(
+		reschedulerPQCleanupDuration,
+		reschedulerPQCleanupJitterCoefficient,
+	))
+	defer cleanupTimer.Stop()
+
+	for {
+		select {
+		case <-r.ctx.Done():
+			r.drain()
+			return
+		case <-r.timerGate.Chan():
+			r.reschedule()
+		case <-cleanupTimer.Chan():
+			r.cleanupPQ()
+			cleanupTimer.Reset(backoff.JitDuration(
+				reschedulerPQCleanupDuration,
+				reschedulerPQCleanupJitterCoefficient,
+			))
+		}
+	}
+
+}
+
+func (r *reschedulerImpl) reschedule() {
+	r.Lock()
+	defer r.Unlock()
+
+	r.metricsScope.RecordTimer(metrics.TaskRedispatchQueuePendingTasksTimer, time.Duration(r.numExecutables))
+	now := r.timeSource.Now()
+	for _, pq := range r.pqMap {
+		for !pq.IsEmpty() {
+			rescheduled, _ := pq.Peek()
+
+			if rescheduleTime := rescheduled.rescheduleTime; now.Before(rescheduleTime) {
+				r.timerGate.Update(rescheduleTime)
+				break
+			}
+
+			task := rescheduled.task
+			if task.State() != ctask.TaskStatePending {
+				pq.Remove()
+				r.numExecutables--
+				continue
+			}
+
+			if task.GetAttempt() == 0 {
+				task.SetInitialSubmitTime(now)
+			}
+			submitted, err := r.scheduler.TrySubmit(task)
+			if err != nil {
+				if r.isStopped() {
+					// if error is due to shard shutdown
+					break
+				}
+				// otherwise it might be error from domain cache etc, add
+				// the task to reschedule queue so that it can be retried
+				r.logger.Error("Failed to reschedule task", tag.Error(err))
+			}
+			if !submitted {
+				r.timerGate.Update(now.Add(backoff.JitDuration(taskChanFullBackoff, taskChanFullBackoffJitterCoefficient)))
+				break
+			}
+
+			pq.Remove()
+			r.numExecutables--
+		}
+	}
+}
+
+func (r *reschedulerImpl) cleanupPQ() {
+	r.Lock()
+	defer r.Unlock()
+
+	for key, pq := range r.pqMap {
+		if pq.IsEmpty() {
+			delete(r.pqMap, key)
+		}
+	}
+}
+
+func (r *reschedulerImpl) drain() {
+	r.Lock()
+	defer r.Unlock()
+
+	for key, pq := range r.pqMap {
+		for !pq.IsEmpty() {
+			pq.Remove()
+		}
+		delete(r.pqMap, key)
+	}
+
+	r.numExecutables = 0
+}
+
+func (r *reschedulerImpl) isStopped() bool {
+	return atomic.LoadInt32(&r.status) == common.DaemonStatusStopped
+}
+
+func (r *reschedulerImpl) getOrCreatePQLocked(
+	key DomainPriorityKey,
+) collection.Queue[rescheduledTask] {
+	if pq, ok := r.pqMap[key]; ok {
+		return pq
+	}
+
+	pq := r.newPriorityQueue(nil)
+	r.pqMap[key] = pq
+	return pq
+}
+
+func (r *reschedulerImpl) newPriorityQueue(
+	items []rescheduledTask,
+) collection.Queue[rescheduledTask] {
+	return collection.NewPriorityQueue(rescheduledTaskCompareLess, items...)
+}
+
+func rescheduledTaskCompareLess(
+	this rescheduledTask,
+	that rescheduledTask,
+) bool {
+	return this.rescheduleTime.Before(that.rescheduleTime)
+}

--- a/service/history/task/rescheduler_test.go
+++ b/service/history/task/rescheduler_test.go
@@ -1,0 +1,237 @@
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	ctask "github.com/uber/cadence/common/task"
+)
+
+func newNoopTransferTaskFromDomainID(domainID string) *noopTask {
+	return &noopTask{
+		Task: &persistence.DecisionTask{
+			WorkflowIdentifier: persistence.WorkflowIdentifier{
+				DomainID: domainID,
+			},
+		},
+		state: ctask.TaskStatePending,
+	}
+}
+
+func newNoopTimerTaskFromDomainID(domainID string, scheduledTime time.Time) *noopTask {
+	return &noopTask{
+		Task: &persistence.UserTimerTask{
+			WorkflowIdentifier: persistence.WorkflowIdentifier{
+				DomainID: domainID,
+			},
+			TaskData: persistence.TaskData{
+				VisibilityTimestamp: scheduledTime,
+			},
+		},
+		state: ctask.TaskStatePending,
+	}
+}
+
+func TestReschedulerLifeCycle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockScheduler := NewMockProcessor(ctrl)
+	mockTimeSource := clock.NewMockedTimeSource()
+	logger := testlogger.New(t)
+	scope := metrics.NoopScope
+	now := mockTimeSource.Now()
+
+	rescheduler := NewRescheduler(mockScheduler, mockTimeSource, logger, scope)
+
+	rescheduler.Start()
+
+	for i := 0; i < 10; i++ {
+		var task Task
+		if i%2 == 0 {
+			task = newNoopTransferTaskFromDomainID("domainID")
+		} else {
+			task = newNoopTimerTaskFromDomainID("domainID", now)
+		}
+		rescheduler.RedispatchTask(task, now.Add(time.Second*time.Duration(i+1)))
+		assert.Equal(t, rescheduler.Size(), i+1)
+	}
+
+	taskCh := make(chan Task, 10)
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(task Task) (bool, error) {
+		taskCh <- task
+		return true, nil
+	}).Times(1)
+	mockTimeSource.Advance(time.Second)
+	<-taskCh
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(task Task) (bool, error) {
+		taskCh <- task
+		return true, nil
+	}).Times(4)
+	mockTimeSource.Advance(time.Second * 4)
+	for i := 0; i < 4; i++ {
+		<-taskCh
+	}
+
+	assert.Equal(t, 5, rescheduler.Size())
+	rescheduler.Stop()
+	assert.Equal(t, 0, rescheduler.Size())
+}
+
+func TestReschedulerRescheduleDomains(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockScheduler := NewMockProcessor(ctrl)
+	mockTimeSource := clock.NewMockedTimeSource()
+	logger := testlogger.New(t)
+	scope := metrics.NoopScope
+	now := mockTimeSource.Now()
+
+	rescheduler := NewRescheduler(mockScheduler, mockTimeSource, logger, scope)
+
+	rescheduler.Start()
+
+	for i := 0; i < 10; i++ {
+		var task Task
+		task = newNoopTransferTaskFromDomainID("X")
+		rescheduler.RedispatchTask(task, now.Add(time.Second*time.Duration(i+1)))
+		assert.Equal(t, rescheduler.Size(), i+1)
+	}
+
+	for i := 0; i < 10; i++ {
+		var task Task
+		task = newNoopTransferTaskFromDomainID("Y")
+		rescheduler.RedispatchTask(task, now.Add(time.Second*100))
+		assert.Equal(t, rescheduler.Size(), i+11)
+	}
+
+	for i := 0; i < 10; i++ {
+		var scheduledTime time.Time
+		if i%2 == 0 {
+			scheduledTime = now.Add(time.Second * 1000)
+		} else {
+			scheduledTime = now
+		}
+		task := newNoopTimerTaskFromDomainID("Z", scheduledTime)
+		rescheduler.RedispatchTask(task, now.Add(time.Second*1000))
+		assert.Equal(t, rescheduler.Size(), i+21)
+	}
+
+	taskCh := make(chan Task, 30)
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(task Task) (bool, error) {
+		taskCh <- task
+		return true, nil
+	}).Times(10)
+	// advance time to reschedule tasks from domain X
+	mockTimeSource.Advance(time.Second * 10)
+	for i := 0; i < 10; i++ {
+		task := <-taskCh
+		assert.Equal(t, "X", task.GetDomainID())
+	}
+	assert.Equal(t, 20, rescheduler.Size())
+
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(task Task) (bool, error) {
+		taskCh <- task
+		return true, nil
+	}).Times(10)
+	// reschedule tasks from domain Y immediately even though their reschedule time is 100s in the future
+	rescheduler.RescheduleDomains(map[string]struct{}{"Y": {}})
+	for i := 0; i < 10; i++ {
+		task := <-taskCh
+		assert.Equal(t, "Y", task.GetDomainID())
+	}
+	assert.Equal(t, 10, rescheduler.Size())
+
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(task Task) (bool, error) {
+		taskCh <- task
+		return true, nil
+	}).Times(5)
+	// reschedule tasks from domain Z immediately and verify that tasks with scheduled time in the future are not rescheduled
+	rescheduler.RescheduleDomains(map[string]struct{}{"Z": {}})
+	for i := 0; i < 5; i++ {
+		task := <-taskCh
+		assert.Equal(t, "Z", task.GetDomainID())
+		assert.False(t, now.After(task.GetTaskKey().GetScheduledTime()))
+	}
+	assert.Equal(t, 5, rescheduler.Size())
+	rescheduler.Stop()
+	assert.Equal(t, 0, rescheduler.Size())
+}
+
+func TestReschedulerIgnoreTaskWithStateNotPending(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockScheduler := NewMockProcessor(ctrl)
+	mockTimeSource := clock.NewMockedTimeSource()
+	logger := testlogger.New(t)
+	scope := metrics.NoopScope
+	now := mockTimeSource.Now()
+	rescheduler := NewRescheduler(mockScheduler, mockTimeSource, logger, scope)
+
+	rescheduler.Start()
+
+	for i := 0; i < 10; i++ {
+		var task *noopTask
+		if i%2 == 0 {
+			task = newNoopTransferTaskFromDomainID("domainID")
+		} else {
+			task = newNoopTransferTaskFromDomainID("domainID")
+			task.state = ctask.TaskStateCanceled
+		}
+		rescheduler.RedispatchTask(task, now.Add(time.Second))
+		assert.Equal(t, rescheduler.Size(), i+1)
+	}
+
+	taskCh := make(chan Task, 5)
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(task Task) (bool, error) {
+		taskCh <- task
+		return true, nil
+	}).Times(5)
+	mockTimeSource.Advance(time.Second)
+	for i := 0; i < 5; i++ {
+		task := <-taskCh
+		assert.Equal(t, ctask.TaskStatePending, task.State())
+	}
+	assert.Equal(t, 0, rescheduler.Size())
+	rescheduler.Stop()
+}
+
+func TestReschedulerProcessorThrottled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockScheduler := NewMockProcessor(ctrl)
+	mockTimeSource := clock.NewMockedTimeSource()
+	logger := testlogger.New(t)
+	scope := metrics.NoopScope
+	now := mockTimeSource.Now()
+
+	rescheduler := NewRescheduler(mockScheduler, mockTimeSource, logger, scope)
+
+	rescheduler.Start()
+
+	for i := 0; i < 10; i++ {
+		task := newNoopTransferTaskFromDomainID("domainID")
+		rescheduler.RedispatchTask(task, now.Add(time.Second))
+		assert.Equal(t, rescheduler.Size(), i+1)
+	}
+
+	taskCh := make(chan Task, 10)
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(task Task) (bool, error) {
+		taskCh <- task
+		return true, nil
+	}).Times(4)
+	mockScheduler.EXPECT().TrySubmit(gomock.Any()).Return(false, nil).Times(1)
+	mockTimeSource.Advance(time.Second)
+	for i := 0; i < 4; i++ {
+		<-taskCh
+	}
+	assert.Equal(t, 6, rescheduler.Size())
+	rescheduler.Stop()
+	assert.Equal(t, 0, rescheduler.Size())
+}

--- a/service/history/task/rescheduler_test.go
+++ b/service/history/task/rescheduler_test.go
@@ -59,7 +59,7 @@ func TestReschedulerLifeCycle(t *testing.T) {
 		} else {
 			task = newNoopTimerTaskFromDomainID("domainID", now)
 		}
-		rescheduler.RedispatchTask(task, now.Add(time.Second*time.Duration(i+1)))
+		rescheduler.RescheduleTask(task, now.Add(time.Second*time.Duration(i+1)))
 		assert.Equal(t, rescheduler.Size(), i+1)
 	}
 
@@ -100,14 +100,14 @@ func TestReschedulerRescheduleDomains(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		var task Task
 		task = newNoopTransferTaskFromDomainID("X")
-		rescheduler.RedispatchTask(task, now.Add(time.Second*time.Duration(i+1)))
+		rescheduler.RescheduleTask(task, now.Add(time.Second*time.Duration(i+1)))
 		assert.Equal(t, rescheduler.Size(), i+1)
 	}
 
 	for i := 0; i < 10; i++ {
 		var task Task
 		task = newNoopTransferTaskFromDomainID("Y")
-		rescheduler.RedispatchTask(task, now.Add(time.Second*100))
+		rescheduler.RescheduleTask(task, now.Add(time.Second*100))
 		assert.Equal(t, rescheduler.Size(), i+11)
 	}
 
@@ -119,7 +119,7 @@ func TestReschedulerRescheduleDomains(t *testing.T) {
 			scheduledTime = now
 		}
 		task := newNoopTimerTaskFromDomainID("Z", scheduledTime)
-		rescheduler.RedispatchTask(task, now.Add(time.Second*1000))
+		rescheduler.RescheduleTask(task, now.Add(time.Second*1000))
 		assert.Equal(t, rescheduler.Size(), i+21)
 	}
 
@@ -184,7 +184,7 @@ func TestReschedulerIgnoreTaskWithStateNotPending(t *testing.T) {
 			task = newNoopTransferTaskFromDomainID("domainID")
 			task.state = ctask.TaskStateCanceled
 		}
-		rescheduler.RedispatchTask(task, now.Add(time.Second))
+		rescheduler.RescheduleTask(task, now.Add(time.Second))
 		assert.Equal(t, rescheduler.Size(), i+1)
 	}
 
@@ -217,7 +217,7 @@ func TestReschedulerProcessorThrottled(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		task := newNoopTransferTaskFromDomainID("domainID")
-		rescheduler.RedispatchTask(task, now.Add(time.Second))
+		rescheduler.RescheduleTask(task, now.Add(time.Second))
 		assert.Equal(t, rescheduler.Size(), i+1)
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR picks these commits from Temporal:
- https://github.com/temporalio/temporal/pull/3279
- https://github.com/temporalio/temporal/pull/3266

The intention is to improve the current implementation of `Redispatcher` interface with these commits from Temporal. However, we still have history queue v1 code not deleted. Instead of modifying the current implementation, I create a new implementation in this PR to adopt the changes from Temporal.

This only changes the behavior of history queue v2.

<!-- Tell your future self why have you made these changes -->
**Why?**
We observed that when a domain failover happens, the task processing latency around that time increases to around 30s. We pick these commits from Temporal to improve the latency.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, integration test with history queue v2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Task retry flow might be broken for history queue v2. In that case, we have to rollback to queue v1.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
