### PR TITLE
Support for creating ephemeral shards

### DIFF
--- a/service/sharddistributor/store/etcd/etcdstore.go
+++ b/service/sharddistributor/store/etcd/etcdstore.go
@@ -465,44 +465,15 @@ func (s *Store) AssignShard(ctx context.Context, namespace, shardID, executorID 
 	}
 }
 
+// DeleteExecutors deletes the given executors from the store. It does not delete the shards owned by the executors, this
+// should be handled by the namespace processor loop as we want to reassign, not delete the shards.
 func (s *Store) DeleteExecutors(ctx context.Context, namespace string, executorIDs []string, guard store.GuardFunc) error {
 	if len(executorIDs) == 0 {
 		return nil
 	}
 	var ops []clientv3.Op
 
-	// For each executor, find all shards it owns and create conditional deletion operations.
 	for _, executorID := range executorIDs {
-		// 1. Find the shards currently assigned to this executor.
-		assignedStateKey := s.buildExecutorKey(namespace, executorID, executorAssignedStateKey)
-		resp, err := s.client.Get(ctx, assignedStateKey)
-		if err != nil {
-			return fmt.Errorf("get assigned state for executor %s: %w", executorID, err)
-		}
-
-		if len(resp.Kvs) > 0 {
-			var state store.AssignedState
-			if err := json.Unmarshal(resp.Kvs[0].Value, &state); err != nil {
-				return fmt.Errorf("unmarshal assigned state for executor %s: %w", executorID, err)
-			}
-
-			// 2. For each shard, create a nested transaction to conditionally delete it.
-			for shardID := range state.AssignedShards {
-				shardOwnerKey := s.buildShardKey(namespace, shardID, shardAssignedKey)
-
-				// This is an atomic check-and-delete operation for a single shard.
-				// IF the shard owner is still the executor being deleted,
-				// THEN delete the shard ownership key.
-				conditionalDelete := clientv3.OpTxn(
-					[]clientv3.Cmp{clientv3.Compare(clientv3.Value(shardOwnerKey), "=", executorID)}, // IF condition
-					[]clientv3.Op{clientv3.OpDelete(shardOwnerKey)},                                  // THEN operations
-					nil, // ELSE do nothing
-				)
-				ops = append(ops, conditionalDelete)
-			}
-		}
-
-		// 3. Add the unconditional deletion for the executor's entire record.
 		executorPrefix := s.buildExecutorKey(namespace, executorID, "")
 		ops = append(ops, clientv3.OpDelete(executorPrefix, clientv3.WithPrefix()))
 	}


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
We now support ephemeral shards
- Shards are created if they do not already exist.
- An executors shards are no longer deleted when the executor disappears 
- We now load the set of shards from the database for ephemeral shards 

Future PRs will:
- Support removing shards when they are no longer needed
- Support the executor library to heartbeat immediately if an unknown shard is requested (so we do not have to wait for the next heartbeat to process shard requests)

<!-- Tell your future self why have you made these changes -->
**Why?**
We need to support ephemeral shards for use cases where the set of shard is changing (e.g. Cadence Matching)


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
