### PR TITLE
Changing one of cli tests to be more explicit

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -29,12 +29,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flynn/go-shlex"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olivere/elastic"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
@@ -44,6 +42,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/tools/cli/clitest"
 )
 
 type (
@@ -159,10 +158,7 @@ func (s *cliAppSuite) runTestCase(tt testcase) {
 		tt.mock()
 	}
 
-	args, err := shlex.Split(tt.command)
-	require.NoError(s.T(), err)
-	err = s.app.Run(args)
-
+	err := clitest.RunCommandLine(s.T(), s.app, tt.command)
 	if tt.err != "" {
 		assert.ErrorContains(s.T(), err, tt.err)
 	} else {

--- a/tools/cli/clitest/runner.go
+++ b/tools/cli/clitest/runner.go
@@ -1,0 +1,18 @@
+package clitest
+
+import (
+	"testing"
+
+	"github.com/flynn/go-shlex"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// RunCommandLine runs cmdline (a whole line like you'd type it in Shell)
+func RunCommandLine(t *testing.T, app *cli.App, cmdline string) error {
+	t.Helper()
+
+	args, err := shlex.Split(cmdline)
+	require.NoError(t, err)
+	return app.Run(args)
+}

--- a/tools/cli/clitest/runner_test.go
+++ b/tools/cli/clitest/runner_test.go
@@ -1,0 +1,48 @@
+package clitest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestRunCommandLine(t *testing.T) {
+	var output string
+
+	testApp := &cli.App{
+		Name: "devmngr",
+		Commands: []*cli.Command{
+			{
+				Name: "upgrade",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "device"},
+					&cli.BoolFlag{Name: "enabled"},
+					&cli.StringFlag{Name: "reason"},
+				},
+				Action: func(c *cli.Context) error {
+					output = fmt.Sprintf(
+						"upgrading device: \"%s\"; enabled: %v; reason: \"%s\"",
+						c.String("device"),
+						c.Bool("enabled"),
+						c.String("reason"),
+					)
+					return nil
+				},
+			},
+		},
+	}
+
+	err := RunCommandLine(
+		t,
+		testApp,
+		"devmngr upgrade --device video-card --enabled --reason \"Doom: The Dark Ages is released\"",
+	)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"upgrading device: \"video-card\"; enabled: true; reason: \"Doom: The Dark Ages is released\"",
+		output,
+	)
+}


### PR DESCRIPTION
In order to migrate to urfave v3 tests should call .Run explicitely -
with command line arguments. There is no cli.NewContext() anymore.

I think it is even better to have a whole command-line instead of []string -
then one can easily take this usage.

<!-- Describe what has changed in this PR -->
**What changed?**
Migrating from cli.NewContext() to app.Run()


<!-- Tell your future self why have you made these changes -->
**Why?**
This is required to migrate to urfave3 and also brings clarity on how the correponding command is called.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit-tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
