### PR TITLE
Fixing flaky-tests in matching

### DIFF
--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -157,7 +157,7 @@ func NewEngine(
 	}
 
 	e.shutdownCompletion.Add(1)
-	go e.subscribeToMembershipChanges()
+	go e.runMembershipChangeLoop()
 
 	return e
 }

--- a/service/matching/handler/membership.go
+++ b/service/matching/handler/membership.go
@@ -44,7 +44,7 @@ const subscriptionBufferSize = 1000
 // which host is the real owner of the tasklist.
 //
 // This is not the main shutdown process, its just an optimization.
-func (e *matchingEngineImpl) subscribeToMembershipChanges() {
+func (e *matchingEngineImpl) runMembershipChangeLoop() {
 	defer func() {
 		if r := recover(); r != nil {
 			e.logger.Error("matching membership watcher changes caused a panic, recovering", tag.Dynamic("recovered-panic", r))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Multiple tests in matching were flaky because of race-condition:
 - we had to wait for engine.Stop() to finish since it calls finilizers
   we're checking with mocks
 - but we were calling it in goroutine w/o waiting

Instead, it is closer now to how code runs it -
runMembershipChangeLoop() is in goroutine, .Stop is called
synchronously.

Also renamed `subscribeToMembershipChanges` to `runMembershipChangeLoop`
to emphasize it is blocking a loop, not just "subscription".

In addition, removed time.Sleep - so now tests run for few ms, instead
of 3+ seconds.

Removed `TestMembershipSubscriptionShutdown` since it was 1:1 copying
`TestSubscriptionAndShutdown`.


<!-- Tell your future self why have you made these changes -->
**Why?**
Flaky tests are slowing us down, and we often hit matching' tests.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit-tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
