### PR TITLE
test: fix fail test cases in common/asyncworkflow/queue/kafka/queue_test.go

### DIFF
--- a/common/asyncworkflow/queue/kafka/queue_test.go
+++ b/common/asyncworkflow/queue/kafka/queue_test.go
@@ -135,7 +135,7 @@ func TestCreateConsumer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockBroker := sarama.NewMockBroker(t, 0)
+			mockBroker := sarama.NewMockBrokerAddr(t, 0, "127.0.0.1:0")
 			defer mockBroker.Close()
 			mockBroker.SetHandlerByMap(map[string]sarama.MockResponse{
 				"MetadataRequest": sarama.NewMockMetadataResponse(t).
@@ -205,7 +205,7 @@ func TestCreateProducer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockBroker := sarama.NewMockBroker(t, 0)
+			mockBroker := sarama.NewMockBrokerAddr(t, 0, "127.0.0.1:0")
 			defer mockBroker.Close()
 			mockBroker.SetHandlerByMap(map[string]sarama.MockResponse{
 				"MetadataRequest": sarama.NewMockMetadataResponse(t).


### PR DESCRIPTION
<!-- Tell your future self why have you made these changes -->
**Why?**
- Running `go test ./common/asyncworkflow/queue/kafka` always fails.
- Reason:
  - A mock broker is initialized by calling `sarama.NewMockBroker(t, 0)`.
  - This is a convenience constructor that creates a `sarama.MockBroker` listening on a kernel-selected port using the host string `"localhost:0"`.
  - Internally, it effectively does `net.Listen("tcp", "localhost:0")` (so the OS resolves "localhost").
  - The behavior depends on how "localhost" resolves on the machine (could be `127.0.0.1` or `::1`). If name resolution for "localhost" is broken, it can fail.

<!-- Describe what has changed in this PR -->
**What changed?**
- Call `sarama.NewMockBrokerAddr(t, 0, "127.0.0.1:0")` to create the mock broker instead of `sarama.NewMockBroker(t, 0)` which is equivalent to `sarama.NewMockBrokerAddr(t, 0, "localhost:0")`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Ran `go test ./common/asyncworkflow/queue/kafka`.
- Ran `make test`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
N/A