### PR TITLE
Explain differe btw. terminate/cancel

### DIFF
--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -77,9 +77,16 @@ func newWorkflowCommands() []*cli.Command {
 			Action: RunWorkflow,
 		},
 		{
+			Name:    "terminate",
+			Aliases: []string{"term"},
+			Usage:   "force-stop a workflow execution (no cleanup)",
+			Flags:   getFlagsForTerminate(),
+			Action:  TerminateWorkflow,
+		},
+		{
 			Name:    "cancel",
 			Aliases: []string{"c"},
-			Usage:   "cancel a workflow execution",
+			Usage:   "gracefully stop a workflow execution (similar to terminate, but allows to cleanup)",
 			Flags:   getFlagsForCancel(),
 			Action:  CancelWorkflow,
 		},
@@ -95,13 +102,6 @@ func newWorkflowCommands() []*cli.Command {
 			Usage:  "signal the current open workflow if exists, or attempt to start a new run based on IDResuePolicy and signals it",
 			Flags:  getFlagsForSignalWithStart(),
 			Action: SignalWithStartWorkflowExecution,
-		},
-		{
-			Name:    "terminate",
-			Aliases: []string{"term"},
-			Usage:   "terminate a new workflow execution",
-			Flags:   getFlagsForTerminate(),
-			Action:  TerminateWorkflow,
 		},
 		{
 			Name:        "list",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Highlighted the difference btw. terminate/cancel commands in the cadence CLI.


<!-- Tell your future self why have you made these changes -->
**Why?**
Otherwise we just tell terminate terminates workflow, and cancel
cancels it, which doesn't highlight the difference.
We have this question often in support channels, and the answer we give
is basically will be in `--help` now.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
