### PR TITLE
Add support for multiple wildcard queries joined by OR

### DIFF
--- a/common/persistence/elasticsearch/es_visibility_store.go
+++ b/common/persistence/elasticsearch/es_visibility_store.go
@@ -1054,7 +1054,7 @@ func extractLikeClauses(sql string) ([]likeClause, string) {
 		})
 		// Remove LIKE clause from SQL
 		// Replace LIKE with a dummy expression that elasticsql can parse
-		replacement := fmt.Sprintf(`__dummy_field__ = '__dummy_value__'`)
+		replacement := `__dummy_field__ = '__dummy_value__'`
 		strippedSQL = strings.Replace(strippedSQL, match[0], replacement, 1)
 	}
 	return clauses, strippedSQL
@@ -1075,10 +1075,20 @@ func injectWildcardQueries(dsl *fastjson.Value, likes []likeClause) error {
 		return fmt.Errorf("missing 'bool' query")
 	}
 
-	mustArr := boolObj.GetArray("must")
-	if mustArr == nil {
-		// if must doesn't exist, create it
-		mustArr = []*fastjson.Value{}
+	// Check if we have a 'should' array (for OR queries) or 'must' array (for AND queries)
+	var targetArray []*fastjson.Value
+	var arrayKey string
+
+	if shouldArr := boolObj.GetArray("should"); shouldArr != nil {
+		targetArray = shouldArr
+		arrayKey = "should"
+	} else if mustArr := boolObj.GetArray("must"); mustArr != nil {
+		targetArray = mustArr
+		arrayKey = "must"
+	} else {
+		// if neither exists, create a must array
+		targetArray = []*fastjson.Value{}
+		arrayKey = "must"
 	}
 
 	for _, clause := range likes {
@@ -1090,11 +1100,11 @@ func injectWildcardQueries(dsl *fastjson.Value, likes []likeClause) error {
 		if err != nil {
 			return err
 		}
-		mustArr = append(mustArr, v)
+		targetArray = append(targetArray, v)
 	}
 
-	// Inject updated must array
-	boolObj.Set("must", fastjson.MustParse(fmt.Sprintf("[%s]", joinFastjson(mustArr, ","))))
+	// Inject updated array
+	boolObj.Set(arrayKey, fastjson.MustParse(fmt.Sprintf("[%s]", joinFastjson(targetArray, ","))))
 	return nil
 }
 

--- a/common/persistence/elasticsearch/es_visibility_store.go
+++ b/common/persistence/elasticsearch/es_visibility_store.go
@@ -1095,7 +1095,7 @@ func injectWildcardQueries(dsl *fastjson.Value, likes []likeClause) error {
 		wildcardValue := strings.ReplaceAll(clause.Pattern, "%", "*")
 		wildcardValue = strings.ReplaceAll(wildcardValue, "_", "?")
 
-		wildcard := fmt.Sprintf(`{"wildcard": {"%s": {"value": "%s*"}}}`, clause.Field, wildcardValue)
+		wildcard := fmt.Sprintf(`{"wildcard": {"%s": {"value": "%s*", "case_insensitive": true}}}`, clause.Field, wildcardValue)
 		v, err := fastjson.Parse(wildcard)
 		if err != nil {
 			return err

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -824,7 +824,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 
 func (s *ESVisibilitySuite) TestListWorkflowExecutionsWithLike() {
 	s.mockESClient.On("SearchByQuery", mock.Anything, mock.MatchedBy(func(input *es.SearchByQueryRequest) bool {
-		s.True(strings.Contains(input.Query, `{"wildcard":{"WorkflowID":{"value":"wid*"}}}`))
+		s.True(strings.Contains(input.Query, `{"wildcard":{"WorkflowID":{"value":"wid*","case_insensitive":true}}}`))
 		s.Equal(esIndexMaxResultWindow, input.MaxResultWindow)
 		return true
 	})).Return(testSearchResult, nil).Once()
@@ -1137,12 +1137,12 @@ func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
 	sql := "select * from dummy where WorkflowID like 'wid' LIMIT 100"
 	dsl, err := getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
-	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}}]}}]}},"from":0,"size":100}`, dsl.String())
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*","case_insensitive":true}}}]}}]}},"from":0,"size":100}`, dsl.String())
 
 	sql = "select * from dummy where Attr.CustomizedKeywordField like 'test'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
-	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*","case_insensitive":true}}}]}}]}},"from":0,"size":1}`, dsl.String())
 
 	sql = "select * from dummy where WorkflowID = 'wid'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
@@ -1157,17 +1157,17 @@ func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
 	sql = "select * from dummy where WorkflowID like 'wid' and Attr.CustomizedKeywordField = 'test'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
-	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"test"}}},{"wildcard":{"WorkflowID":{"value":"wid*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"test"}}},{"wildcard":{"WorkflowID":{"value":"wid*","case_insensitive":true}}}]}}]}},"from":0,"size":1}`, dsl.String())
 
 	sql = "select * from dummy where WorkflowID like 'like' and Attr.CustomizedKeywordField = 'like'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
-	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"like"}}},{"wildcard":{"WorkflowID":{"value":"like*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"match_phrase":{"Attr.CustomizedKeywordField":{"query":"like"}}},{"wildcard":{"WorkflowID":{"value":"like*","case_insensitive":true}}}]}}]}},"from":0,"size":1}`, dsl.String())
 
 	sql = "select * from dummy where WorkflowID like 'wid' and Attr.CustomizedKeywordField like 'test'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
-	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*","case_insensitive":true}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*","case_insensitive":true}}}]}}]}},"from":0,"size":1}`, dsl.String())
 
 	sql = "select * from dummy where WorkflowID = 'wid' OR RunID = 'runid'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
@@ -1177,5 +1177,5 @@ func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
 	sql = "select * from dummy where WorkflowID like 'wid' OR Attr.CustomizedKeywordField like 'test'"
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
-	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"should":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"should":[{"wildcard":{"WorkflowID":{"value":"wid*","case_insensitive":true}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*","case_insensitive":true}}}]}}]}},"from":0,"size":1}`, dsl.String())
 }

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -1168,4 +1168,14 @@ func (s *ESVisibilitySuite) TestGetCustomizedDSLFromSQL() {
 	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
 	s.NoError(err)
 	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+
+	sql = "select * from dummy where WorkflowID = 'wid' OR RunID = 'runid'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"should":[{"match_phrase":{"WorkflowID":{"query":"wid"}}},{"match_phrase":{"RunID":{"query":"runid"}}}]}}]}},"from":0,"size":1}`, dsl.String())
+
+	sql = "select * from dummy where WorkflowID like 'wid' OR Attr.CustomizedKeywordField like 'test'"
+	dsl, err = getCustomizedDSLFromSQL(sql, testDomainID)
+	s.NoError(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"should":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`, dsl.String())
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
It is not supported when there are multiple wildcard queries joined, it should be one query with should condition.

<!-- Tell your future self why have you made these changes -->
**Why?**
`select * from dummy where WorkflowID like 'wid' OR Attr.CustomizedKeywordField like 'test'

=>

{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"should":[{"wildcard":{"WorkflowID":{"value":"wid*"}}},{"wildcard":{"Attr.CustomizedKeywordField":{"value":"test*"}}}]}}]}},"from":0,"size":1}`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
