### PR TITLE
Set default active cluster selection policy at Frontend

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -1000,6 +1000,7 @@ func (entry *DomainCacheEntry) IsSampledForLongerRetention(
 	return false
 }
 
+// TODO(active-active): This function should accept active cluster selection policy as a parameter
 func GetActiveDomainByID(cache DomainCache, currentCluster string, domainID string) (*DomainCacheEntry, error) {
 	if err := common.ValidateDomainUUID(domainID); err != nil {
 		return nil, err

--- a/service/frontend/templates/clusterredirection.tmpl
+++ b/service/frontend/templates/clusterredirection.tmpl
@@ -111,6 +111,14 @@ func (handler *clusterRedirectionHandler) {{$method.Declaration}} {
 	var actClSelPolicyForNewWF *types.ActiveClusterSelectionPolicy
 	var workflowExecution *types.WorkflowExecution
 	{{- if has $method.Name $startWFAPIs}}
+	if {{(index $method.Params 1).Name}}.ActiveClusterSelectionPolicy == nil {
+		{{(index $method.Params 1).Name}}.ActiveClusterSelectionPolicy = &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+			StickyRegion:                   handler.GetActiveClusterManager().CurrentRegion(),
+		}
+	} else if {{(index $method.Params 1).Name}}.ActiveClusterSelectionPolicy.GetStrategy() == types.ActiveClusterSelectionStrategyRegionSticky {
+		{{(index $method.Params 1).Name}}.ActiveClusterSelectionPolicy.StickyRegion = handler.GetActiveClusterManager().CurrentRegion()
+	}
 	actClSelPolicyForNewWF = {{(index $method.Params 1).Name}}.ActiveClusterSelectionPolicy
 	{{- else if has $method.Name $nonstartWFAPIs}}
 	workflowExecution = {{(index $method.Params 1).Name}}.GetWorkflowExecution()

--- a/service/frontend/wrappers/clusterredirection/api_generated.go
+++ b/service/frontend/wrappers/clusterredirection/api_generated.go
@@ -1343,6 +1343,14 @@ func (handler *clusterRedirectionHandler) SignalWithStartWorkflowExecution(ctx c
 
 	var actClSelPolicyForNewWF *types.ActiveClusterSelectionPolicy
 	var workflowExecution *types.WorkflowExecution
+	if sp1.ActiveClusterSelectionPolicy == nil {
+		sp1.ActiveClusterSelectionPolicy = &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+			StickyRegion:                   handler.GetActiveClusterManager().CurrentRegion(),
+		}
+	} else if sp1.ActiveClusterSelectionPolicy.GetStrategy() == types.ActiveClusterSelectionStrategyRegionSticky {
+		sp1.ActiveClusterSelectionPolicy.StickyRegion = handler.GetActiveClusterManager().CurrentRegion()
+	}
 	actClSelPolicyForNewWF = sp1.ActiveClusterSelectionPolicy
 
 	err = handler.redirectionPolicy.Redirect(ctx, domainEntry, workflowExecution, actClSelPolicyForNewWF, apiName, requestedConsistencyLevel, func(targetDC string) error {
@@ -1383,6 +1391,14 @@ func (handler *clusterRedirectionHandler) SignalWithStartWorkflowExecutionAsync(
 
 	var actClSelPolicyForNewWF *types.ActiveClusterSelectionPolicy
 	var workflowExecution *types.WorkflowExecution
+	if sp1.ActiveClusterSelectionPolicy == nil {
+		sp1.ActiveClusterSelectionPolicy = &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+			StickyRegion:                   handler.GetActiveClusterManager().CurrentRegion(),
+		}
+	} else if sp1.ActiveClusterSelectionPolicy.GetStrategy() == types.ActiveClusterSelectionStrategyRegionSticky {
+		sp1.ActiveClusterSelectionPolicy.StickyRegion = handler.GetActiveClusterManager().CurrentRegion()
+	}
 	actClSelPolicyForNewWF = sp1.ActiveClusterSelectionPolicy
 
 	err = handler.redirectionPolicy.Redirect(ctx, domainEntry, workflowExecution, actClSelPolicyForNewWF, apiName, requestedConsistencyLevel, func(targetDC string) error {
@@ -1463,6 +1479,14 @@ func (handler *clusterRedirectionHandler) StartWorkflowExecution(ctx context.Con
 
 	var actClSelPolicyForNewWF *types.ActiveClusterSelectionPolicy
 	var workflowExecution *types.WorkflowExecution
+	if sp1.ActiveClusterSelectionPolicy == nil {
+		sp1.ActiveClusterSelectionPolicy = &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+			StickyRegion:                   handler.GetActiveClusterManager().CurrentRegion(),
+		}
+	} else if sp1.ActiveClusterSelectionPolicy.GetStrategy() == types.ActiveClusterSelectionStrategyRegionSticky {
+		sp1.ActiveClusterSelectionPolicy.StickyRegion = handler.GetActiveClusterManager().CurrentRegion()
+	}
 	actClSelPolicyForNewWF = sp1.ActiveClusterSelectionPolicy
 
 	err = handler.redirectionPolicy.Redirect(ctx, domainEntry, workflowExecution, actClSelPolicyForNewWF, apiName, requestedConsistencyLevel, func(targetDC string) error {
@@ -1503,6 +1527,14 @@ func (handler *clusterRedirectionHandler) StartWorkflowExecutionAsync(ctx contex
 
 	var actClSelPolicyForNewWF *types.ActiveClusterSelectionPolicy
 	var workflowExecution *types.WorkflowExecution
+	if sp1.ActiveClusterSelectionPolicy == nil {
+		sp1.ActiveClusterSelectionPolicy = &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+			StickyRegion:                   handler.GetActiveClusterManager().CurrentRegion(),
+		}
+	} else if sp1.ActiveClusterSelectionPolicy.GetStrategy() == types.ActiveClusterSelectionStrategyRegionSticky {
+		sp1.ActiveClusterSelectionPolicy.StickyRegion = handler.GetActiveClusterManager().CurrentRegion()
+	}
 	actClSelPolicyForNewWF = sp1.ActiveClusterSelectionPolicy
 
 	err = handler.redirectionPolicy.Redirect(ctx, domainEntry, workflowExecution, actClSelPolicyForNewWF, apiName, requestedConsistencyLevel, func(targetDC string) error {

--- a/service/frontend/wrappers/clusterredirection/api_test.go
+++ b/service/frontend/wrappers/clusterredirection/api_test.go
@@ -915,6 +915,7 @@ func (s *clusterRedirectionHandlerSuite) TestSignalWithStartWorkflowExecution() 
 		},
 	}
 
+	s.mockResource.ActiveClusterMgr.EXPECT().CurrentRegion().Return("region-a").Times(1)
 	s.mockClusterRedirectionPolicy.EXPECT().Redirect(ctx, s.domainCacheEntry, nil, req.ActiveClusterSelectionPolicy, apiName, types.QueryConsistencyLevelEventual, gomock.Any()).
 		DoAndReturn(func(ctx context.Context, domainCacheEntry *cache.DomainCacheEntry, wfExec *types.WorkflowExecution, selPlcy *types.ActiveClusterSelectionPolicy, apiName string, consistencyLevel types.QueryConsistencyLevel, callFn func(targetDC string) error) error {
 			// validate callFn logic
@@ -974,6 +975,7 @@ func (s *clusterRedirectionHandlerSuite) TestStartWorkflowExecution() {
 		},
 	}
 
+	s.mockResource.ActiveClusterMgr.EXPECT().CurrentRegion().Return("region-a").Times(1)
 	s.mockClusterRedirectionPolicy.EXPECT().Redirect(ctx, s.domainCacheEntry, nil, req.ActiveClusterSelectionPolicy, apiName, types.QueryConsistencyLevelEventual, gomock.Any()).
 		DoAndReturn(func(ctx context.Context, domainCacheEntry *cache.DomainCacheEntry, wfExec *types.WorkflowExecution, selPlcy *types.ActiveClusterSelectionPolicy, apiName string, consistencyLevel types.QueryConsistencyLevel, callFn func(targetDC string) error) error {
 			// validate callFn logic

--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -438,44 +438,23 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) activeClusterForActi
 		policy.logger.Debug("Active cluster selection policy for new workflow", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.OperationName(apiName), tag.Dynamic("policy", actClSelPolicyForNewWF))
 		lookupRes, err := policy.activeClusterManager.LookupNewWorkflow(ctx, domainEntry.GetInfo().ID, actClSelPolicyForNewWF)
 		if err != nil {
-			policy.logger.Error("Failed to lookup active cluster of new workflow, using active cluster in the same region", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.OperationName(apiName), tag.Error(err))
-			return policy.activeClusterInSameRegion(ctx, domainEntry, policy.currentClusterName)
+			policy.logger.Error("Failed to lookup active cluster of new workflow, using current cluster", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.OperationName(apiName), tag.Error(err))
+			return policy.currentClusterName
 		}
 		return lookupRes.ClusterName
 	}
 
-	if workflowExecution == nil {
-		policy.logger.Debug("Workflow execution is nil, using active cluster in the same region", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.OperationName(apiName))
-		return policy.activeClusterInSameRegion(ctx, domainEntry, policy.currentClusterName)
-	}
-	if workflowExecution.RunID == "" {
-		policy.logger.Debug("Workflow execution run id is empty, using active cluster in the same region", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.OperationName(apiName))
-		return policy.activeClusterInSameRegion(ctx, domainEntry, policy.currentClusterName)
+	if workflowExecution == nil || workflowExecution.WorkflowID == "" || workflowExecution.RunID == "" {
+		policy.logger.Debug("Workflow execution is nil or workflow id or run id is empty, using current cluster", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.OperationName(apiName))
+		return policy.currentClusterName
 	}
 
 	lookupRes, err := policy.activeClusterManager.LookupWorkflow(ctx, domainEntry.GetInfo().ID, workflowExecution.WorkflowID, workflowExecution.RunID)
 	if err != nil {
-		policy.logger.Error("Failed to lookup active cluster of workflow, using active cluster in the same region", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.WorkflowID(workflowExecution.WorkflowID), tag.WorkflowRunID(workflowExecution.RunID), tag.OperationName(apiName), tag.Error(err))
-		return policy.activeClusterInSameRegion(ctx, domainEntry, policy.currentClusterName)
+		policy.logger.Error("Failed to lookup active cluster of workflow, using current cluster", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.WorkflowID(workflowExecution.WorkflowID), tag.WorkflowRunID(workflowExecution.RunID), tag.OperationName(apiName), tag.Error(err))
+		return policy.currentClusterName
 	}
 
 	policy.logger.Debug("Lookup workflow result for active-active domain request", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.WorkflowID(workflowExecution.WorkflowID), tag.WorkflowRunID(workflowExecution.RunID), tag.OperationName(apiName), tag.ActiveClusterName(lookupRes.ClusterName))
-	return lookupRes.ClusterName
-}
-
-// activeClusterInSameRegion returns the active cluster in the same region as the given cluster name
-// If the lookup fails, it returns current cluster name as fallback
-// In that case, if current cluster is not the active cluster the caller will return an not-active error
-// TODO(active-active): Revisit this logic for strong-consistency requests and potentially reject them instead of serving them from the current cluster
-func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) activeClusterInSameRegion(
-	ctx context.Context,
-	domainEntry *cache.DomainCacheEntry,
-	clusterName string,
-) string {
-	lookupRes, err := policy.activeClusterManager.LookupCluster(ctx, domainEntry.GetInfo().ID, clusterName)
-	if err != nil {
-		policy.logger.Error("Failed to lookup active cluster in same region", tag.WorkflowDomainName(domainEntry.GetInfo().Name), tag.ClusterName(clusterName), tag.Error(err))
-		return policy.currentClusterName
-	}
 	return lookupRes.ClusterName
 }

--- a/service/frontend/wrappers/clusterredirection/policy_test.go
+++ b/service/frontend/wrappers/clusterredirection/policy_test.go
@@ -634,11 +634,6 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestActiveClusterForActiv
 			actClSelPolicyForNewWF: usEastStickyPlcy,
 			mockFn: func(activeClusterManager *activecluster.MockManager) {
 				activeClusterManager.EXPECT().LookupNewWorkflow(gomock.Any(), domainEntry.GetInfo().ID, usEastStickyPlcy).Return(nil, errors.New("lookup failed"))
-				activeClusterManager.EXPECT().LookupCluster(gomock.Any(), domainEntry.GetInfo().ID, s.currentClusterName).Return(&activecluster.LookupResult{
-					Region:          "us-east",
-					ClusterName:     s.currentClusterName,
-					FailoverVersion: 1,
-				}, nil)
 			},
 			want: s.currentClusterName,
 		},
@@ -646,11 +641,16 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestActiveClusterForActiv
 			name:        "existing workflow - missing workflow execution",
 			domainEntry: domainEntry,
 			mockFn: func(activeClusterManager *activecluster.MockManager) {
-				activeClusterManager.EXPECT().LookupCluster(gomock.Any(), domainEntry.GetInfo().ID, s.currentClusterName).Return(&activecluster.LookupResult{
-					Region:          "us-east",
-					ClusterName:     s.currentClusterName,
-					FailoverVersion: 1,
-				}, nil)
+			},
+			want: s.currentClusterName,
+		},
+		{
+			name:        "existing workflow - missing workflow id",
+			domainEntry: domainEntry,
+			workflowExecution: &types.WorkflowExecution{
+				RunID: "run1",
+			},
+			mockFn: func(activeClusterManager *activecluster.MockManager) {
 			},
 			want: s.currentClusterName,
 		},
@@ -661,11 +661,6 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestActiveClusterForActiv
 				WorkflowID: "wf1",
 			},
 			mockFn: func(activeClusterManager *activecluster.MockManager) {
-				activeClusterManager.EXPECT().LookupCluster(gomock.Any(), domainEntry.GetInfo().ID, s.currentClusterName).Return(&activecluster.LookupResult{
-					Region:          "us-east",
-					ClusterName:     s.currentClusterName,
-					FailoverVersion: 1,
-				}, nil)
 			},
 			want: s.currentClusterName,
 		},
@@ -678,11 +673,6 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestActiveClusterForActiv
 			},
 			mockFn: func(activeClusterManager *activecluster.MockManager) {
 				activeClusterManager.EXPECT().LookupWorkflow(gomock.Any(), domainEntry.GetInfo().ID, "wf1", "run1").Return(nil, errors.New("lookup failed"))
-				activeClusterManager.EXPECT().LookupCluster(gomock.Any(), domainEntry.GetInfo().ID, s.currentClusterName).Return(&activecluster.LookupResult{
-					Region:          "us-east",
-					ClusterName:     s.currentClusterName,
-					FailoverVersion: 1,
-				}, nil)
 			},
 			want: s.currentClusterName,
 		},

--- a/service/history/engine/engineimpl/start_workflow_execution_test.go
+++ b/service/history/engine/engineimpl/start_workflow_execution_test.go
@@ -232,6 +232,35 @@ func TestStartWorkflowExecution(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "active-active domain - active cluster selection policy is required",
+			request: &types.HistoryStartWorkflowExecutionRequest{
+				DomainUUID: "36047120-fe32-40d6-a242-f14864fc302c",
+				StartRequest: &types.StartWorkflowExecutionRequest{
+					Domain:                              constants.TestDomainName,
+					WorkflowID:                          "workflow-id",
+					WorkflowType:                        &types.WorkflowType{Name: "workflow-type"},
+					TaskList:                            &types.TaskList{Name: "default-task-list"},
+					ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600), // 1 hour
+					TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(10),   // 10 seconds
+					Identity:                            "workflow-starter",
+					RequestID:                           "request-id-for-start",
+					WorkflowIDReusePolicy:               types.WorkflowIDReusePolicyRejectDuplicate.Ptr(),
+				},
+			},
+			setupMocks: func(t *testing.T, eft *testdata.EngineForTest) {
+				domainEntry := getDomainCacheEntry(-1, &types.ActiveClusters{
+					ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+						"region0": {
+							ActiveClusterName: "active",
+							FailoverVersion:   35,
+						},
+					},
+				})
+				eft.ShardCtx.Resource.DomainCache.EXPECT().GetDomainByID("36047120-fe32-40d6-a242-f14864fc302c").Return(domainEntry, nil).AnyTimes()
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -387,6 +416,35 @@ func TestSignalWithStartWorkflowExecution(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "active-active domain - active cluster selection policy is required",
+			request: &types.HistorySignalWithStartWorkflowExecutionRequest{
+				DomainUUID: "36047120-fe32-40d6-a242-f14864fc302c",
+				SignalWithStartRequest: &types.SignalWithStartWorkflowExecutionRequest{
+					Domain:                              constants.TestDomainName,
+					WorkflowID:                          "workflow-id",
+					WorkflowType:                        &types.WorkflowType{Name: "workflow-type"},
+					TaskList:                            &types.TaskList{Name: "default-task-list"},
+					ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600), // 1 hour
+					TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(10),   // 10 seconds
+					Identity:                            "workflow-starter",
+					RequestID:                           "request-id-for-start",
+					WorkflowIDReusePolicy:               types.WorkflowIDReusePolicyRejectDuplicate.Ptr(),
+				},
+			},
+			setupMocks: func(t *testing.T, eft *testdata.EngineForTest) {
+				domainEntry := getDomainCacheEntry(-1, &types.ActiveClusters{
+					ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+						"region0": {
+							ActiveClusterName: "active",
+							FailoverVersion:   35,
+						},
+					},
+				})
+				eft.ShardCtx.Resource.DomainCache.EXPECT().GetDomainByID("36047120-fe32-40d6-a242-f14864fc302c").Return(domainEntry, nil).AnyTimes()
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -523,124 +581,4 @@ func getDomainCacheEntry(domainFailoverVersion int64, cfg *types.ActiveClusters)
 		1,
 		1,
 	)
-}
-
-func TestOverrideActiveClusterSelectionPolicy(t *testing.T) {
-	invalidStrategy := types.ActiveClusterSelectionStrategy(-1) // not supported
-
-	tests := []struct {
-		name        string
-		domainEntry *cache.DomainCacheEntry
-		request     *types.StartWorkflowExecutionRequest
-		mockFn      func(acm *activecluster.MockManager)
-		want        *types.ActiveClusterSelectionPolicy
-		wantErr     bool
-	}{
-		{
-			name:        "local domain - override policy with nil",
-			domainEntry: constants.TestLocalDomainEntry,
-			request: &types.StartWorkflowExecutionRequest{
-				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
-					StickyRegion:                   "region1",
-				},
-			},
-			want: nil,
-		},
-		{
-			name:        "active-passive domain - override policy with nil",
-			domainEntry: constants.TestGlobalDomainEntry,
-			request: &types.StartWorkflowExecutionRequest{
-				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
-					StickyRegion:                   "region1",
-				},
-			},
-			want: nil,
-		},
-		{
-			name:        "active-active domain - region sticky policy overriden with current region",
-			domainEntry: constants.TestActiveActiveDomainEntry,
-			request: &types.StartWorkflowExecutionRequest{
-				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
-					StickyRegion:                   "user-provided-region-to-be-replaced",
-				},
-			},
-			mockFn: func(acm *activecluster.MockManager) {
-				acm.EXPECT().CurrentRegion().Return("region1").AnyTimes()
-			},
-			want: &types.ActiveClusterSelectionPolicy{
-				ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
-				StickyRegion:                   "region1",
-			},
-		},
-		{
-			name:        "active-active domain - attributes with external entity policy but entity type not supported",
-			domainEntry: constants.TestActiveActiveDomainEntry,
-			request: &types.StartWorkflowExecutionRequest{
-				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyExternalEntity.Ptr(),
-					ExternalEntityType:             "city", // not supported
-				},
-			},
-			mockFn: func(acm *activecluster.MockManager) {
-				acm.EXPECT().SupportedExternalEntityType(gomock.Any()).Return(false)
-			},
-			wantErr: true,
-		},
-		{
-			name:        "active-active domain - attributes with external entity policy",
-			domainEntry: constants.TestActiveActiveDomainEntry,
-			request: &types.StartWorkflowExecutionRequest{
-				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyExternalEntity.Ptr(),
-					ExternalEntityType:             "city",
-					ExternalEntityKey:              "city-1",
-				},
-			},
-			mockFn: func(acm *activecluster.MockManager) {
-				acm.EXPECT().SupportedExternalEntityType(gomock.Any()).Return(true)
-			},
-			want: &types.ActiveClusterSelectionPolicy{
-				ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyExternalEntity.Ptr(),
-				ExternalEntityType:             "city",
-				ExternalEntityKey:              "city-1",
-			},
-		},
-		{
-			name:        "active-active domain - not supported strategy",
-			domainEntry: constants.TestActiveActiveDomainEntry,
-			request: &types.StartWorkflowExecutionRequest{
-				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ActiveClusterSelectionStrategy: &invalidStrategy,
-				},
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			eft := testdata.NewEngineForTest(t, NewEngineWithShardContext)
-			eft.Engine.Start()
-			defer eft.Engine.Stop()
-
-			if test.mockFn != nil {
-				test.mockFn(eft.ShardCtx.Resource.ActiveClusterMgr)
-			}
-
-			eng := eft.Engine.(*historyEngineImpl)
-			err := eng.overrideActiveClusterSelectionPolicy(test.domainEntry, test.request)
-			if test.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-			if err != nil {
-				return
-			}
-			assert.Equal(t, test.want, test.request.ActiveClusterSelectionPolicy)
-		})
-	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set default active cluster selection policy at Frontend instead of History

<!-- Tell your future self why have you made these changes -->
**Why?**
This will remove the topology couple between region and cluster and simplify the implementation. The active cluster lookup will always be one hop and we don't need restriction on failover topology to prevent loops in lookup.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and simulation tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
