### PR TITLE
Extract replication config updates into separate method

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -77,6 +77,10 @@ type (
 			ctx context.Context,
 			updateRequest *types.UpdateDomainRequest,
 		) (*types.UpdateDomainResponse, error)
+		UpdateDomainReplicationConfig(
+			ctx context.Context,
+			updateReplicationRequest *types.UpdateDomainReplicationConfigRequest,
+		) (*types.UpdateDomainReplicationConfigResponse, error)
 		UpdateIsolationGroups(
 			ctx context.Context,
 			updateRequest types.UpdateDomainIsolationGroupsRequest,
@@ -700,6 +704,258 @@ func (d *handlerImpl) UpdateDomain(
 		tag.WorkflowDomainID(info.ID),
 	)
 	return response, nil
+}
+
+// UpdateDomainReplicationConfig handles replication configuration updates for the domain
+func (d *handlerImpl) UpdateDomainReplicationConfig(
+	ctx context.Context,
+	updateReplicationRequest *types.UpdateDomainReplicationConfigRequest,
+) (*types.UpdateDomainReplicationConfigResponse, error) {
+
+	// must get the metadata (notificationVersion) first
+	// this version can be regarded as the lock on the v2 domain table
+	// and since we do not know which table will return the domain afterwards
+	// this call has to be made
+	metadata, err := d.domainManager.GetMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+	notificationVersion := metadata.NotificationVersion
+	getResponse, err := d.domainManager.GetDomain(ctx, &persistence.GetDomainRequest{Name: updateReplicationRequest.GetName()})
+	if err != nil {
+		return nil, err
+	}
+
+	info := getResponse.Info
+	config := getResponse.Config
+	replicationConfig := getResponse.ReplicationConfig
+	wasActiveActive := replicationConfig.IsActiveActive()
+	configVersion := getResponse.ConfigVersion
+	failoverVersion := getResponse.FailoverVersion
+	failoverNotificationVersion := getResponse.FailoverNotificationVersion
+	isGlobalDomain := getResponse.IsGlobalDomain
+	gracefulFailoverEndTime := getResponse.FailoverEndTime
+	currentActiveCluster := replicationConfig.ActiveClusterName
+	currentActiveClusters := replicationConfig.ActiveClusters
+	previousFailoverVersion := getResponse.PreviousFailoverVersion
+	lastUpdatedTime := time.Unix(0, getResponse.LastUpdatedTime)
+
+	updateRequest := &types.UpdateDomainRequest{
+		Name:                     updateReplicationRequest.Name,
+		ActiveClusterName:        updateReplicationRequest.ActiveClusterName,
+		ActiveClusters:           updateReplicationRequest.ActiveClusters,
+		Clusters:                 updateReplicationRequest.Clusters,
+		FailoverTimeoutInSeconds: updateReplicationRequest.FailoverTimeoutInSeconds,
+	}
+
+	// Update replication config
+	replicationConfig, replicationConfigChanged, activeClusterChanged, err := d.updateReplicationConfig(
+		getResponse.Info.Name,
+		replicationConfig,
+		updateRequest,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle graceful failover request
+	if updateRequest.FailoverTimeoutInSeconds != nil {
+		gracefulFailoverEndTime, previousFailoverVersion, err = d.handleGracefulFailover(
+			updateRequest,
+			replicationConfig,
+			currentActiveCluster,
+			gracefulFailoverEndTime,
+			failoverVersion,
+			activeClusterChanged,
+			isGlobalDomain,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = d.validateDomainReplicationConfigForUpdateDomain(replicationConfig, isGlobalDomain, replicationConfigChanged, activeClusterChanged)
+	if err != nil {
+		return nil, err
+	}
+
+	now := d.timeSource.Now()
+	// Check the failover cool down time
+	if lastUpdatedTime.Add(d.config.FailoverCoolDown(info.Name)).After(now) {
+		d.logger.Debugf("Domain was last updated at %v, failoverCoolDown: %v, current time: %v.", lastUpdatedTime, d.config.FailoverCoolDown(info.Name), now)
+		return nil, errDomainUpdateTooFrequent
+	}
+
+	// set the version
+	if replicationConfigChanged {
+		configVersion++
+	}
+
+	if activeClusterChanged && isGlobalDomain {
+		var failoverType constants.FailoverType = constants.FailoverTypeGrace
+
+		// Force failover cleans graceful failover state
+		if updateRequest.FailoverTimeoutInSeconds == nil {
+			failoverType = constants.FailoverTypeForce
+			gracefulFailoverEndTime = nil
+			previousFailoverVersion = constants.InitialPreviousFailoverVersion
+		}
+
+		// Cases:
+		// 1. active-passive domain's ActiveClusterName is changed
+		// 2. active-passive domain is being migrated to active-active
+		// 3. active-active domain's ActiveClusters is changed
+		isActiveActive := replicationConfig.IsActiveActive()
+
+		// case 1. active-passive domain's ActiveClusterName is changed
+		if !wasActiveActive && !isActiveActive {
+			failoverVersion = d.clusterMetadata.GetNextFailoverVersion(
+				replicationConfig.ActiveClusterName,
+				failoverVersion,
+				updateRequest.Name,
+			)
+
+			d.logger.Debug("active-passive domain failover",
+				tag.WorkflowDomainName(info.Name),
+				tag.Dynamic("failover-version", failoverVersion),
+				tag.Dynamic("failover-type", failoverType),
+			)
+
+			err = updateFailoverHistory(info, d.config, NewFailoverEvent(
+				now,
+				failoverType,
+				&currentActiveCluster,
+				updateRequest.ActiveClusterName,
+				nil,
+				nil,
+			))
+			if err != nil {
+				d.logger.Warn("failed to update failover history", tag.Error(err))
+			}
+		}
+
+		// case 2. active-passive domain is being migrated to active-active
+		if !wasActiveActive && isActiveActive {
+			// for active-passive to active-active migration,
+			// we increment failover version so top level failoverVersion is updated and domain data is replicated.
+			failoverVersion = d.clusterMetadata.GetNextFailoverVersion(
+				replicationConfig.ActiveClusterName,
+				failoverVersion+1,
+				updateRequest.Name,
+			)
+
+			// we also use the new failover version belonging to currentActiveCluster for the corresponding ActiveClustersByRegion map entry
+			for region, clusterInfo := range replicationConfig.ActiveClusters.ActiveClustersByRegion {
+				if clusterInfo.ActiveClusterName == currentActiveCluster {
+					clusterInfo.FailoverVersion = failoverVersion
+					replicationConfig.ActiveClusters.ActiveClustersByRegion[region] = clusterInfo
+				}
+			}
+
+			d.logger.Debug("active-passive domain is being migrated to active-active",
+				tag.WorkflowDomainName(info.Name),
+				tag.Dynamic("failover-version", failoverVersion),
+				tag.Dynamic("failover-type", failoverType),
+			)
+
+			err = updateFailoverHistory(info, d.config, NewFailoverEvent(
+				now,
+				failoverType,
+				&currentActiveCluster,
+				updateRequest.ActiveClusterName,
+				nil,
+				replicationConfig.ActiveClusters,
+			))
+			if err != nil {
+				d.logger.Warn("failed to update failover history", tag.Error(err))
+			}
+		}
+
+		// case 3. active-active domain's ActiveClusters is changed
+		if wasActiveActive && isActiveActive {
+			// top level failover version is not used for task versions for active-active domains but we still increment it
+			// to indicate there was a change in replication config
+			failoverVersion = d.clusterMetadata.GetNextFailoverVersion(
+				d.clusterMetadata.GetCurrentClusterName(),
+				failoverVersion+1,
+				updateRequest.Name,
+			)
+
+			d.logger.Debug("active-active domain failover",
+				tag.WorkflowDomainName(info.Name),
+				tag.Dynamic("failover-version", failoverVersion),
+				tag.Dynamic("failover-type", failoverType),
+			)
+
+			err = updateFailoverHistory(info, d.config, NewFailoverEvent(
+				now,
+				failoverType,
+				&currentActiveCluster,
+				nil,
+				currentActiveClusters,
+				replicationConfig.ActiveClusters,
+			))
+			if err != nil {
+				d.logger.Warn("failed to update failover history", tag.Error(err))
+			}
+		}
+
+		failoverNotificationVersion = notificationVersion
+	}
+
+	lastUpdatedTime = now
+
+	updateReq := createUpdateRequest(
+		info,
+		config,
+		replicationConfig,
+		configVersion,
+		failoverVersion,
+		failoverNotificationVersion,
+		gracefulFailoverEndTime,
+		previousFailoverVersion,
+		lastUpdatedTime,
+		notificationVersion,
+	)
+
+	err = d.domainManager.UpdateDomain(ctx, &updateReq)
+	if err != nil {
+		d.logger.Info("Update domain's replication configs failed",
+			tag.WorkflowDomainName(info.Name),
+			tag.WorkflowDomainID(info.ID),
+		)
+		return nil, err
+	}
+
+	if isGlobalDomain {
+		if err = d.domainReplicator.HandleTransmissionTask(
+			ctx,
+			types.DomainOperationUpdate,
+			info,
+			config,
+			replicationConfig,
+			configVersion,
+			failoverVersion,
+			previousFailoverVersion,
+			isGlobalDomain,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	domainInfo, configuration, replicationConfiguration := d.createResponse(info, config, replicationConfig)
+
+	d.logger.Info("Update domain's replication configs succeeded",
+		tag.WorkflowDomainName(info.Name),
+		tag.WorkflowDomainID(info.ID),
+	)
+	return &types.UpdateDomainReplicationConfigResponse{
+		DomainInfo:               domainInfo,
+		Configuration:            configuration,
+		ReplicationConfiguration: replicationConfiguration,
+		FailoverVersion:          failoverVersion,
+		IsGlobalDomain:           isGlobalDomain,
+	}, nil
 }
 
 // DeleteDomain deletes a domain

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -744,7 +744,6 @@ func (d *handlerImpl) UpdateDomainReplicationConfig(
 		Name:                     updateReplicationRequest.Name,
 		ActiveClusterName:        updateReplicationRequest.ActiveClusterName,
 		ActiveClusters:           updateReplicationRequest.ActiveClusters,
-		Clusters:                 updateReplicationRequest.Clusters,
 		FailoverTimeoutInSeconds: updateReplicationRequest.FailoverTimeoutInSeconds,
 	}
 

--- a/common/domain/handler_mock.go
+++ b/common/domain/handler_mock.go
@@ -143,6 +143,21 @@ func (mr *MockHandlerMockRecorder) UpdateDomain(ctx, updateRequest any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockHandler)(nil).UpdateDomain), ctx, updateRequest)
 }
 
+// UpdateDomainReplicationConfig mocks base method.
+func (m *MockHandler) UpdateDomainReplicationConfig(ctx context.Context, updateReplicationRequest *types.UpdateDomainReplicationConfigRequest) (*types.UpdateDomainReplicationConfigResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDomainReplicationConfig", ctx, updateReplicationRequest)
+	ret0, _ := ret[0].(*types.UpdateDomainReplicationConfigResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateDomainReplicationConfig indicates an expected call of UpdateDomainReplicationConfig.
+func (mr *MockHandlerMockRecorder) UpdateDomainReplicationConfig(ctx, updateReplicationRequest any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomainReplicationConfig", reflect.TypeOf((*MockHandler)(nil).UpdateDomainReplicationConfig), ctx, updateReplicationRequest)
+}
+
 // UpdateIsolationGroups mocks base method.
 func (m *MockHandler) UpdateIsolationGroups(ctx context.Context, updateRequest types.UpdateDomainIsolationGroupsRequest) error {
 	m.ctrl.T.Helper()

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -7405,11 +7405,10 @@ func (v *UpdateDomainResponse) GetIsGlobalDomain() (o bool) {
 
 // UpdateDomainReplicationConfigRequest is the request for domain replication update operations
 type UpdateDomainReplicationConfigRequest struct {
-	Name                     string                             `json:"name,omitempty"`
-	ActiveClusterName        *string                            `json:"activeClusterName,omitempty"`
-	ActiveClusters           *ActiveClusters                    `json:"activeClusters,omitempty"`
-	Clusters                 []*ClusterReplicationConfiguration `json:"clusters,omitempty"`
-	FailoverTimeoutInSeconds *int32                             `json:"failoverTimeoutInSeconds,omitempty"`
+	Name                     string          `json:"name,omitempty"`
+	ActiveClusterName        *string         `json:"activeClusterName,omitempty"`
+	ActiveClusters           *ActiveClusters `json:"activeClusters,omitempty"`
+	FailoverTimeoutInSeconds *int32          `json:"failoverTimeoutInSeconds,omitempty"`
 }
 
 // UpdateDomainReplicationConfigResponse is the response for domain replication update operations

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -7403,16 +7403,14 @@ func (v *UpdateDomainResponse) GetIsGlobalDomain() (o bool) {
 	return
 }
 
-// UpdateDomainReplicationConfigRequest is the request for domain replication update operations
-type UpdateDomainReplicationConfigRequest struct {
-	Name                     string          `json:"name,omitempty"`
-	ActiveClusterName        *string         `json:"activeClusterName,omitempty"`
-	ActiveClusters           *ActiveClusters `json:"activeClusters,omitempty"`
-	FailoverTimeoutInSeconds *int32          `json:"failoverTimeoutInSeconds,omitempty"`
+// FailoverDomainRequest is the request for domain failover
+type FailoverDomainRequest struct {
+	Name           string          `json:"name,omitempty"`
+	ActiveClusters *ActiveClusters `json:"activeClusters,omitempty"`
 }
 
-// UpdateDomainReplicationConfigResponse is the response for domain replication update operations
-type UpdateDomainReplicationConfigResponse struct {
+// FailoverDomainResponse is the response for domain failover
+type FailoverDomainResponse struct {
 	DomainInfo               *DomainInfo                     `json:"domainInfo,omitempty"`
 	Configuration            *DomainConfiguration            `json:"configuration,omitempty"`
 	ReplicationConfiguration *DomainReplicationConfiguration `json:"replicationConfiguration,omitempty"`
@@ -7421,17 +7419,9 @@ type UpdateDomainReplicationConfigResponse struct {
 }
 
 // GetName is an internal getter (TBD...)
-func (v *UpdateDomainReplicationConfigRequest) GetName() (o string) {
+func (v *FailoverDomainRequest) GetName() (o string) {
 	if v != nil {
 		return v.Name
-	}
-	return
-}
-
-// GetFailoverTimeoutInSeconds is an internal getter (TBD...)
-func (v *UpdateDomainReplicationConfigRequest) GetFailoverTimeoutInSeconds() (o int32) {
-	if v != nil && v.FailoverTimeoutInSeconds != nil {
-		return *v.FailoverTimeoutInSeconds
 	}
 	return
 }

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -7403,6 +7403,40 @@ func (v *UpdateDomainResponse) GetIsGlobalDomain() (o bool) {
 	return
 }
 
+// UpdateDomainReplicationConfigRequest is the request for domain replication update operations
+type UpdateDomainReplicationConfigRequest struct {
+	Name                     string                             `json:"name,omitempty"`
+	ActiveClusterName        *string                            `json:"activeClusterName,omitempty"`
+	ActiveClusters           *ActiveClusters                    `json:"activeClusters,omitempty"`
+	Clusters                 []*ClusterReplicationConfiguration `json:"clusters,omitempty"`
+	FailoverTimeoutInSeconds *int32                             `json:"failoverTimeoutInSeconds,omitempty"`
+}
+
+// UpdateDomainReplicationConfigResponse is the response for domain replication update operations
+type UpdateDomainReplicationConfigResponse struct {
+	DomainInfo               *DomainInfo                     `json:"domainInfo,omitempty"`
+	Configuration            *DomainConfiguration            `json:"configuration,omitempty"`
+	ReplicationConfiguration *DomainReplicationConfiguration `json:"replicationConfiguration,omitempty"`
+	FailoverVersion          int64                           `json:"failoverVersion,omitempty"`
+	IsGlobalDomain           bool                            `json:"isGlobalDomain,omitempty"`
+}
+
+// GetName is an internal getter (TBD...)
+func (v *UpdateDomainReplicationConfigRequest) GetName() (o string) {
+	if v != nil {
+		return v.Name
+	}
+	return
+}
+
+// GetFailoverTimeoutInSeconds is an internal getter (TBD...)
+func (v *UpdateDomainReplicationConfigRequest) GetFailoverTimeoutInSeconds() (o int32) {
+	if v != nil && v.FailoverTimeoutInSeconds != nil {
+		return *v.FailoverTimeoutInSeconds
+	}
+	return
+}
+
 // UpsertWorkflowSearchAttributesDecisionAttributes is an internal type (TBD...)
 type UpsertWorkflowSearchAttributesDecisionAttributes struct {
 	SearchAttributes *SearchAttributes `json:"searchAttributes,omitempty"`


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Extracted domain replication config updates into a separate method from UpdateDomain() method. All the logic was copied from UpdateDomain() and the UpdateDomain() was not changed at all.

<!-- Tell your future self why have you made these changes -->
**Why?**
In an ongoing effort to introduce admin authorization only users with admin permissions can perform domain-related operations. But the failover operation needs to be accessible by all users. Thus extracting the specific logic into separate endpoint.
This is the first part of introducing an API - UpdateDomainReplicationConfig

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local testing & unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Since the original endpoint was not changed, no risks

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
