### PR TITLE
Fix a bug that cause non-default virtual queue to be orphaned

### DIFF
--- a/service/history/queuev2/virtual_queue_test.go
+++ b/service/history/queuev2/virtual_queue_test.go
@@ -118,6 +118,7 @@ func TestVirtualQueueImpl_UpdateAndGetState(t *testing.T) {
 		Predicate: NewUniversalPredicate(),
 	})
 	mockVirtualSlice1.EXPECT().GetPendingTaskCount().Return(1)
+	mockVirtualSlice1.EXPECT().IsEmpty().Return(false)
 	mockMonitor.EXPECT().SetSlicePendingTaskCount(mockVirtualSlice1, 1)
 
 	mockVirtualSlice2.EXPECT().UpdateAndGetState().Return(VirtualSliceState{
@@ -127,6 +128,7 @@ func TestVirtualQueueImpl_UpdateAndGetState(t *testing.T) {
 		},
 		Predicate: NewUniversalPredicate(),
 	})
+	mockVirtualSlice2.EXPECT().IsEmpty().Return(true)
 	mockMonitor.EXPECT().RemoveSlice(mockVirtualSlice2)
 
 	mockTimeSource := clock.NewMockedTimeSource()

--- a/service/history/queuev2/virtual_slice_mock.go
+++ b/service/history/queuev2/virtual_slice_mock.go
@@ -112,6 +112,20 @@ func (mr *MockVirtualSliceMockRecorder) HasMoreTasks() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasMoreTasks", reflect.TypeOf((*MockVirtualSlice)(nil).HasMoreTasks))
 }
 
+// IsEmpty mocks base method.
+func (m *MockVirtualSlice) IsEmpty() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEmpty")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEmpty indicates an expected call of IsEmpty.
+func (mr *MockVirtualSliceMockRecorder) IsEmpty() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEmpty", reflect.TypeOf((*MockVirtualSlice)(nil).IsEmpty))
+}
+
 // PendingTaskStats mocks base method.
 func (m *MockVirtualSlice) PendingTaskStats() PendingTaskStats {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix a bug that cause non-default virtual queue to be orphaned

<!-- Tell your future self why have you made these changes -->
**Why?**
When virtual_queue component's UpdateAndGetState method is called, it can remove a slice pointed by sliceToRead Pointer. This is not expected, but what happens is that in that virtual slice component, the nextTaskKey is equals to the ExclusiveMaxTaskKey of that range, but nextPageToken is not empty. So HasMoreTasks method still returns true, but UpdateAndGetState method of virtual slice component updates InclusiveMinTaskKey to be the same as nextTaskKey which is the same as ExclusiveMaxTaskKey.

This doesn't affect root virtual queue, because when new virtual slices are merged into root queue, sliceToRead pointer is reset to be non-nil.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests and load tests in dev2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
