### PR TITLE
Improve conflict resolution for active-active

### DIFF
--- a/.github/workflows/replication-simulation.yml
+++ b/.github/workflows/replication-simulation.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         scenario:
           - activeactive
+          - activeactive_same_wfid
           - activeactive_cron
           - activeactive_regional_failover
           - activeactive_regional_failover_start_same_wfid

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -2142,6 +2142,20 @@ type ActiveClusterSelectionPolicy struct {
 	ExternalEntityKey  string `json:"externalEntityKey,omitempty"`
 }
 
+func (p *ActiveClusterSelectionPolicy) Equals(other *ActiveClusterSelectionPolicy) bool {
+	if p == nil && other == nil {
+		return true
+	}
+	if p == nil || other == nil {
+		return false
+	}
+
+	return p.GetStrategy() == other.GetStrategy() &&
+		p.StickyRegion == other.StickyRegion &&
+		p.ExternalEntityType == other.ExternalEntityType &&
+		p.ExternalEntityKey == other.ExternalEntityKey
+}
+
 func (p *ActiveClusterSelectionPolicy) GetStrategy() ActiveClusterSelectionStrategy {
 	if p == nil || p.ActiveClusterSelectionStrategy == nil {
 		return ActiveClusterSelectionStrategyRegionSticky

--- a/config/dynamicconfig/replication_simulation_activeactive_same_wfid.yml
+++ b/config/dynamicconfig/replication_simulation_activeactive_same_wfid.yml
@@ -1,0 +1,22 @@
+# This file is used as dynamicconfig override for "activeactive" replication simulation scenario configured via simulation/replication/testdata/replication_simulation_activeactive.yaml
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"
+history.replicatorTaskBatchSize:
+  - value: 25
+    constraints: {}
+frontend.failoverCoolDown:
+  - value: 5s
+history.ReplicationTaskProcessorStartWait: # default is 5s. repl task processor sleeps this much before processing received messages.
+  - value: 5s
+history.standbyTaskMissingEventsResendDelay:
+  - value: 5s
+history.standbyTaskMissingEventsDiscardDelay:
+  - value: 10s
+history.standbyClusterDelay:
+  - value: 10s
+history.enableTransferQueueV2:
+  - value: true
+history.enableTimerQueueV2:
+  - value: true

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -116,6 +116,8 @@ type (
 			persistedHistory events.PersistedBlob,
 			createMode persistence.CreateWorkflowMode,
 			prevRunID string,
+			// TODO(active-active): only passing prevLastWriteVersion might not be enough for active-active workflows, we may consider passing ActiveClusterSelectionPolicy as well
+			// and include ActiveClusterSelectionPolicy in conditional update of current execution record
 			prevLastWriteVersion int64,
 			workflowRequestMode persistence.CreateWorkflowRequestMode,
 		) error

--- a/service/history/execution/workflow.go
+++ b/service/history/execution/workflow.go
@@ -25,6 +25,7 @@ package execution
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/uber/cadence/common/activecluster"
 	"github.com/uber/cadence/common/cluster"
@@ -48,7 +49,7 @@ type (
 		GetContext() Context
 		GetMutableState() MutableState
 		GetReleaseFn() ReleaseFunc
-		GetVectorClock() (int64, int64, error)
+		GetVectorClock() (WorkflowVectorClock, error)
 		HappensAfter(that Workflow) (bool, error)
 		Revive() error
 		SuppressBy(incomingWorkflow Workflow) (TransactionPolicy, error)
@@ -64,6 +65,14 @@ type (
 		context      Context
 		mutableState MutableState
 		releaseFn    ReleaseFunc
+	}
+
+	WorkflowVectorClock struct {
+		ActiveClusterSelectionPolicy *types.ActiveClusterSelectionPolicy
+		LastWriteVersion             int64
+		LastEventTaskID              int64
+		StartTimestamp               time.Time
+		RunID                        string
 	}
 )
 
@@ -101,36 +110,39 @@ func (r *workflowImpl) GetReleaseFn() ReleaseFunc {
 	return r.releaseFn
 }
 
-func (r *workflowImpl) GetVectorClock() (int64, int64, error) {
+func (r *workflowImpl) GetVectorClock() (WorkflowVectorClock, error) {
 
 	lastWriteVersion, err := r.mutableState.GetLastWriteVersion()
 	if err != nil {
-		return 0, 0, err
+		return WorkflowVectorClock{}, err
 	}
 
 	lastEventTaskID := r.mutableState.GetExecutionInfo().LastEventTaskID
-	return lastWriteVersion, lastEventTaskID, nil
+	return WorkflowVectorClock{
+		ActiveClusterSelectionPolicy: r.mutableState.GetExecutionInfo().ActiveClusterSelectionPolicy,
+		LastWriteVersion:             lastWriteVersion,
+		LastEventTaskID:              lastEventTaskID,
+		StartTimestamp:               r.mutableState.GetExecutionInfo().StartTimestamp,
+		RunID:                        r.mutableState.GetExecutionInfo().RunID,
+	}, nil
 }
 
-// TODO(active-active): update this to make it work for active-active domains
 func (r *workflowImpl) HappensAfter(
 	that Workflow,
 ) (bool, error) {
 
-	thisLastWriteVersion, thisLastEventTaskID, err := r.GetVectorClock()
+	thisVectorClock, err := r.GetVectorClock()
 	if err != nil {
 		return false, err
 	}
-	thatLastWriteVersion, thatLastEventTaskID, err := that.GetVectorClock()
+	thatVectorClock, err := that.GetVectorClock()
 	if err != nil {
 		return false, err
 	}
 
 	return workflowHappensAfter(
-		thisLastWriteVersion,
-		thisLastEventTaskID,
-		thatLastWriteVersion,
-		thatLastEventTaskID,
+		thisVectorClock,
+		thatVectorClock,
 	), nil
 }
 
@@ -166,20 +178,19 @@ func (r *workflowImpl) SuppressBy(
 	// if the workflow to be suppressed has last write version being remote active
 	//  then turn this workflow into a zombie
 
-	lastWriteVersion, lastEventTaskID, err := r.GetVectorClock()
+	currentVectorClock, err := r.GetVectorClock()
 	if err != nil {
 		return TransactionPolicyActive, err
 	}
-	incomingLastWriteVersion, incomingLastEventTaskID, err := incomingWorkflow.GetVectorClock()
+	incomingVectorClock, err := incomingWorkflow.GetVectorClock()
 	if err != nil {
 		return TransactionPolicyActive, err
 	}
 
 	if workflowHappensAfter(
-		lastWriteVersion,
-		lastEventTaskID,
-		incomingLastWriteVersion,
-		incomingLastEventTaskID) {
+		currentVectorClock,
+		incomingVectorClock,
+	) {
 		return TransactionPolicyActive, &types.InternalServiceError{
 			Message: "nDCWorkflow cannot suppress workflow by older workflow",
 		}
@@ -190,14 +201,14 @@ func (r *workflowImpl) SuppressBy(
 		return TransactionPolicyPassive, nil
 	}
 
-	lastWriteCluster, err := r.activeClusterManager.ClusterNameForFailoverVersion(lastWriteVersion, r.mutableState.GetExecutionInfo().DomainID)
+	lastWriteCluster, err := r.activeClusterManager.ClusterNameForFailoverVersion(currentVectorClock.LastWriteVersion, r.mutableState.GetExecutionInfo().DomainID)
 	if err != nil {
 		return TransactionPolicyActive, err
 	}
 	currentCluster := r.clusterMetadata.GetCurrentClusterName()
 
 	if currentCluster == lastWriteCluster {
-		return TransactionPolicyActive, r.terminateWorkflow(lastWriteVersion, incomingLastWriteVersion, WorkflowTerminationReason)
+		return TransactionPolicyActive, r.terminateWorkflow(currentVectorClock.LastWriteVersion, incomingVectorClock.LastWriteVersion, WorkflowTerminationReason)
 	}
 	return TransactionPolicyPassive, r.zombiefyWorkflow()
 }
@@ -212,12 +223,12 @@ func (r *workflowImpl) FlushBufferedEvents() error {
 		return nil
 	}
 
-	lastWriteVersion, _, err := r.GetVectorClock()
+	currentVectorClock, err := r.GetVectorClock()
 	if err != nil {
 		return err
 	}
 
-	lastWriteCluster, err := r.activeClusterManager.ClusterNameForFailoverVersion(lastWriteVersion, r.mutableState.GetExecutionInfo().DomainID)
+	lastWriteCluster, err := r.activeClusterManager.ClusterNameForFailoverVersion(currentVectorClock.LastWriteVersion, r.mutableState.GetExecutionInfo().DomainID)
 	if err != nil {
 		// TODO: add a test for this
 		return err
@@ -231,7 +242,7 @@ func (r *workflowImpl) FlushBufferedEvents() error {
 		}
 	}
 
-	return r.failDecision(lastWriteVersion, true)
+	return r.failDecision(currentVectorClock.LastWriteVersion, true)
 }
 
 func (r *workflowImpl) failDecision(
@@ -297,16 +308,20 @@ func (r *workflowImpl) zombiefyWorkflow() error {
 }
 
 func workflowHappensAfter(
-	thisLastWriteVersion int64,
-	thisLastEventTaskID int64,
-	thatLastWriteVersion int64,
-	thatLastEventTaskID int64,
+	thisVectorClock WorkflowVectorClock,
+	thatVectorClock WorkflowVectorClock,
 ) bool {
-
-	if thisLastWriteVersion != thatLastWriteVersion {
-		return thisLastWriteVersion > thatLastWriteVersion
+	if !thisVectorClock.ActiveClusterSelectionPolicy.Equals(thatVectorClock.ActiveClusterSelectionPolicy) {
+		if !thisVectorClock.StartTimestamp.Equal(thatVectorClock.StartTimestamp) {
+			return thatVectorClock.StartTimestamp.Before(thisVectorClock.StartTimestamp)
+		}
+		return thisVectorClock.RunID > thatVectorClock.RunID
 	}
 
-	// thisLastWriteVersion == thatLastWriteVersion
-	return thisLastEventTaskID > thatLastEventTaskID
+	if thisVectorClock.LastWriteVersion != thatVectorClock.LastWriteVersion {
+		return thisVectorClock.LastWriteVersion > thatVectorClock.LastWriteVersion
+	}
+
+	// thisVectorClock.LastWriteVersion == thatVectorClock.LastWriteVersion
+	return thisVectorClock.LastEventTaskID > thatVectorClock.LastEventTaskID
 }

--- a/service/history/execution/workflow_mock.go
+++ b/service/history/execution/workflow_mock.go
@@ -96,13 +96,12 @@ func (mr *MockWorkflowMockRecorder) GetReleaseFn() *gomock.Call {
 }
 
 // GetVectorClock mocks base method.
-func (m *MockWorkflow) GetVectorClock() (int64, int64, error) {
+func (m *MockWorkflow) GetVectorClock() (WorkflowVectorClock, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVectorClock")
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(int64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(WorkflowVectorClock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetVectorClock indicates an expected call of GetVectorClock.

--- a/service/history/execution/workflow_test.go
+++ b/service/history/execution/workflow_test.go
@@ -25,8 +25,10 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -80,12 +82,19 @@ func (s *workflowSuite) TearDownTest() {
 func (s *workflowSuite) TestGetMethods() {
 	lastEventTaskID := int64(144)
 	lastEventVersion := int64(12)
+	startTimestamp := time.Now()
+	activeClusterSelectionPolicy := &types.ActiveClusterSelectionPolicy{
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:                   "region-1",
+	}
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastEventVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
-		DomainID:        s.domainID,
-		WorkflowID:      s.workflowID,
-		RunID:           s.runID,
-		LastEventTaskID: lastEventTaskID,
+		DomainID:                     s.domainID,
+		WorkflowID:                   s.workflowID,
+		RunID:                        s.runID,
+		LastEventTaskID:              lastEventTaskID,
+		StartTimestamp:               startTimestamp,
+		ActiveClusterSelectionPolicy: activeClusterSelectionPolicy,
 	}).AnyTimes()
 
 	nDCWorkflow := NewWorkflow(
@@ -106,66 +115,16 @@ func (s *workflowSuite) TestGetMethods() {
 	expectedReleaseFn := runtime.FuncForPC(reflect.ValueOf(NoopReleaseFn).Pointer()).Name()
 	actualReleaseFn := runtime.FuncForPC(reflect.ValueOf(nDCWorkflow.GetReleaseFn()).Pointer()).Name()
 	s.Equal(expectedReleaseFn, actualReleaseFn)
-	version, taskID, err := nDCWorkflow.GetVectorClock()
+	vectorClock, err := nDCWorkflow.GetVectorClock()
 	s.NoError(err)
-	s.Equal(lastEventVersion, version)
-	s.Equal(lastEventTaskID, taskID)
-}
-
-func (s *workflowSuite) TestHappensAfter_LargerVersion() {
-	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
-	thatLastWriteVersion := thisLastWriteVersion - 1
-	thatLastEventTaskID := int64(123)
-
-	s.True(workflowHappensAfter(
-		thisLastWriteVersion,
-		thisLastEventTaskID,
-		thatLastWriteVersion,
-		thatLastEventTaskID,
-	))
-}
-
-func (s *workflowSuite) TestHappensAfter_SmallerVersion() {
-	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
-	thatLastWriteVersion := thisLastWriteVersion + 1
-	thatLastEventTaskID := int64(23)
-
-	s.False(workflowHappensAfter(
-		thisLastWriteVersion,
-		thisLastEventTaskID,
-		thatLastWriteVersion,
-		thatLastEventTaskID,
-	))
-}
-
-func (s *workflowSuite) TestHappensAfter_SameVersion_SmallerTaskID() {
-	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
-	thatLastWriteVersion := thisLastWriteVersion
-	thatLastEventTaskID := thisLastEventTaskID + 1
-
-	s.False(workflowHappensAfter(
-		thisLastWriteVersion,
-		thisLastEventTaskID,
-		thatLastWriteVersion,
-		thatLastEventTaskID,
-	))
-}
-
-func (s *workflowSuite) TestHappensAfter_SameVersion_LargerTaskID() {
-	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
-	thatLastWriteVersion := thisLastWriteVersion
-	thatLastEventTaskID := thisLastEventTaskID - 1
-
-	s.True(workflowHappensAfter(
-		thisLastWriteVersion,
-		thisLastEventTaskID,
-		thatLastWriteVersion,
-		thatLastEventTaskID,
-	))
+	expectedVectorClock := WorkflowVectorClock{
+		ActiveClusterSelectionPolicy: activeClusterSelectionPolicy,
+		LastWriteVersion:             lastEventVersion,
+		LastEventTaskID:              lastEventTaskID,
+		StartTimestamp:               startTimestamp,
+		RunID:                        s.runID,
+	}
+	s.Equal(expectedVectorClock, vectorClock)
 }
 
 func (s *workflowSuite) TestSuppressWorkflowBy_Error() {
@@ -523,4 +482,89 @@ func (s *workflowSuite) newTestActiveClusterManager(clusterMetadata cluster.Meta
 		s.T().Fatalf("failed to create active cluster manager, error: %v", err)
 	}
 	return activeClusterMgr
+}
+
+func TestWorkflowHappensAfter(t *testing.T) {
+	baseTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.FixedZone("UTC-8", -8*60*60))
+	utcBaseTime := baseTime.UTC()
+	laterTime := baseTime.Add(time.Hour)
+
+	// Helper function to create ActiveClusterSelectionPolicy
+	createPolicy := func(strategy types.ActiveClusterSelectionStrategy, region string) *types.ActiveClusterSelectionPolicy {
+		return &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: &strategy,
+			StickyRegion:                   region,
+		}
+	}
+
+	// Helper function to create WorkflowVectorClock
+	createVectorClock := func(policy *types.ActiveClusterSelectionPolicy, lastWriteVersion, lastEventTaskID int64, startTime time.Time, runID string) WorkflowVectorClock {
+		return WorkflowVectorClock{
+			ActiveClusterSelectionPolicy: policy,
+			LastWriteVersion:             lastWriteVersion,
+			LastEventTaskID:              lastEventTaskID,
+			StartTimestamp:               startTime,
+			RunID:                        runID,
+		}
+	}
+
+	policy1 := createPolicy(types.ActiveClusterSelectionStrategyRegionSticky, "region-1")
+	policy2 := createPolicy(types.ActiveClusterSelectionStrategyRegionSticky, "region-2")
+
+	tests := []struct {
+		name            string
+		thisVectorClock WorkflowVectorClock
+		thatVectorClock WorkflowVectorClock
+		expected        bool
+	}{
+		{
+			name:            "Different policies - this happens after based on start timestamp",
+			thisVectorClock: createVectorClock(policy1, 100, 10, laterTime, "run-1"),
+			thatVectorClock: createVectorClock(policy2, 200, 20, baseTime, "run-2"),
+			expected:        true,
+		},
+		{
+			name:            "Different policies - same start timestamp - this happens after based on RunID",
+			thisVectorClock: createVectorClock(policy1, 100, 10, baseTime, "run-z"),
+			thatVectorClock: createVectorClock(policy2, 200, 20, baseTime, "run-a"),
+			expected:        true,
+		},
+		{
+			name:            "Different policies - same start timestamp in different time zone - this happens after based on RunID",
+			thisVectorClock: createVectorClock(policy1, 100, 10, baseTime, "run-z"),
+			thatVectorClock: createVectorClock(policy2, 200, 20, utcBaseTime, "run-a"),
+			expected:        true,
+		},
+		{
+			name:            "Same policies - this happens after based on LastWriteVersion",
+			thisVectorClock: createVectorClock(policy1, 200, 10, baseTime, "run-1"),
+			thatVectorClock: createVectorClock(policy1, 100, 20, baseTime, "run-2"),
+			expected:        true,
+		},
+		{
+			name:            "Same policies and LastWriteVersion - this happens after based on LastEventTaskID",
+			thisVectorClock: createVectorClock(policy1, 100, 20, baseTime, "run-1"),
+			thatVectorClock: createVectorClock(policy1, 100, 10, baseTime, "run-2"),
+			expected:        true,
+		},
+		{
+			name:            "Nil policies - this happens after based on LastWriteVersion",
+			thisVectorClock: createVectorClock(nil, 200, 10, laterTime, "run-1"),
+			thatVectorClock: createVectorClock(nil, 100, 20, baseTime, "run-2"),
+			expected:        true,
+		},
+		{
+			name:            "One nil policy, one non-nil - this happens after based on start timestamp",
+			thisVectorClock: createVectorClock(nil, 100, 10, laterTime, "run-1"),
+			thatVectorClock: createVectorClock(policy1, 200, 20, baseTime, "run-2"),
+			expected:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := workflowHappensAfter(tt.thisVectorClock, tt.thatVectorClock)
+			assert.Equal(t, tt.expected, result, "workflowHappensAfter result mismatch for test case: %s", tt.name)
+		})
+	}
 }

--- a/service/history/ndc/new_workflow_transaction_manager.go
+++ b/service/history/ndc/new_workflow_transaction_manager.go
@@ -185,7 +185,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 		// current workflow exists, need to do compare and swap
 		createMode := persistence.CreateWorkflowModeWorkflowIDReuse
 		prevRunID := currentWorkflow.GetMutableState().GetExecutionInfo().RunID
-		prevLastWriteVersion, _, err := currentWorkflow.GetVectorClock()
+		prevVectorClock, err := currentWorkflow.GetVectorClock()
 		if err != nil {
 			return err
 		}
@@ -195,7 +195,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 			targetWorkflowHistoryBlob,
 			createMode,
 			prevRunID,
-			prevLastWriteVersion,
+			prevVectorClock.LastWriteVersion,
 			persistence.CreateWorkflowRequestModeReplicated,
 		)
 	}

--- a/service/history/ndc/new_workflow_transaction_manager_test.go
+++ b/service/history/ndc/new_workflow_transaction_manager_test.go
@@ -213,7 +213,9 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 		WorkflowID: workflowID,
 		RunID:      currentRunID,
 	}).AnyTimes()
-	currentWorkflow.EXPECT().GetVectorClock().Return(currentLastWriteVersion, int64(0), nil)
+	currentWorkflow.EXPECT().GetVectorClock().Return(execution.WorkflowVectorClock{
+		LastWriteVersion: currentLastWriteVersion,
+	}, nil)
 
 	targetContext.EXPECT().PersistNonStartWorkflowBatchEvents(
 		gomock.Any(),

--- a/simulation/replication/replication_simulation_test.go
+++ b/simulation/replication/replication_simulation_test.go
@@ -83,19 +83,20 @@ func TestReplicationSimulation(t *testing.T) {
 
 	startTime := time.Now().UTC()
 	simTypes.Logf(t, "Simulation start time: %v", startTime)
+	runIDMap := make(map[string]string)
 	for i, op := range simCfg.Operations {
 		op := op
 		waitForOpTime(t, op, startTime)
 		var err error
 		switch op.Type {
 		case simTypes.ReplicationSimulationOperationStartWorkflow:
-			err = startWorkflow(t, op, simCfg)
+			err = startWorkflow(t, op, simCfg, runIDMap)
 		case simTypes.ReplicationSimulationOperationResetWorkflow:
 			err = resetWorkflow(t, op, simCfg)
 		case simTypes.ReplicationSimulationOperationChangeActiveClusters:
 			err = changeActiveClusters(t, op, simCfg)
 		case simTypes.ReplicationSimulationOperationValidate:
-			err = validate(t, op, simCfg)
+			err = validate(t, op, simCfg, runIDMap)
 		case simTypes.ReplicationSimulationOperationQueryWorkflow:
 			err = queryWorkflow(t, op, simCfg)
 		case simTypes.ReplicationSimulationOperationSignalWithStartWorkflow:
@@ -127,6 +128,7 @@ func startWorkflow(
 	t *testing.T,
 	op *simTypes.Operation,
 	simCfg *simTypes.ReplicationSimulationConfig,
+	runIDMap map[string]string,
 ) error {
 	t.Helper()
 
@@ -166,6 +168,9 @@ func startWorkflow(
 	}
 
 	simTypes.Logf(t, "Started workflow: %s on domain: %s on cluster: %s. RunID: %s", op.WorkflowID, op.Domain, op.Cluster, resp.GetRunID())
+	if len(op.ID) > 0 {
+		runIDMap[op.ID] = resp.RunID
+	}
 
 	return nil
 }
@@ -398,11 +403,16 @@ func validate(
 	t *testing.T,
 	op *simTypes.Operation,
 	simCfg *simTypes.ReplicationSimulationConfig,
+	runIDMap map[string]string,
 ) error {
 	t.Helper()
 
 	simTypes.Logf(t, "Validating workflow: %s on cluster: %s", op.WorkflowID, op.Cluster)
 
+	runID := ""
+	if len(op.RunIDFromOp) > 0 {
+		runID = runIDMap[op.RunIDFromOp]
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	resp, err := simCfg.MustGetFrontendClient(t, op.Cluster).DescribeWorkflowExecution(ctx,
@@ -410,6 +420,7 @@ func validate(
 			Domain: op.Domain,
 			Execution: &types.WorkflowExecution{
 				WorkflowID: op.WorkflowID,
+				RunID:      runID,
 			},
 		})
 	if err != nil {

--- a/simulation/replication/testdata/replication_simulation_activeactive_same_wfid.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive_same_wfid.yaml
@@ -1,0 +1,63 @@
+# This file is a replication simulation scenario spec.
+# It is parsed into ReplicationSimulationConfig struct.
+# Replication simulation for this file can be run via ./simulation/replication/run.sh activeactive_same_wfid
+# Dynamic config overrides can be set via config/dynamicconfig/replication_simulation_activeactive_same_wfid.yml
+clusters:
+  cluster0:
+    grpcEndpoint: "cadence-cluster0:7833"
+  cluster1:
+    grpcEndpoint: "cadence-cluster1:7833"
+
+# primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
+primaryCluster: "cluster0"
+
+domains:
+  test-domain-aa:
+    activeClustersByRegion:
+      region0: cluster0
+      region1: cluster1
+
+operations:
+  # start workflow in cluster0
+  - id: 0
+    op: start_workflow
+    at: 0s
+    workflowID: wf1
+    workflowType: timer-activity-loop-workflow
+    cluster: cluster0
+    domain: test-domain-aa
+    workflowExecutionStartToCloseTimeout: 65s
+    workflowDuration: 35s
+
+  # start workflow in cluster1
+  - op: 1
+    op: start_workflow
+    at: 2s
+    workflowID: wf1
+    workflowType: timer-activity-loop-workflow
+    cluster: cluster1
+    domain: test-domain-aa
+    workflowExecutionStartToCloseTimeout: 65s
+    workflowDuration: 35s
+
+  # validate that wf1 is started in cluster0 and terminated
+  - op: validate
+    at: 70s
+    workflowID: wf1
+    cluster: cluster0
+    domain: test-domain-aa
+    runIDFromOp: 0
+    want:
+      status: terminated
+
+  # validate that wf2 is started and completed in cluster1
+  - op: validate
+    at: 70s
+    workflowID: wf1
+    cluster: cluster1
+    domain: test-domain-aa
+    runIDFromOp: 1
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster1
+      completedByWorkersInCluster: cluster1

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -73,6 +73,7 @@ type ReplicationDomainConfig struct {
 }
 
 type Operation struct {
+	ID            string                         `yaml:"id"`
 	Type          ReplicationSimulationOperation `yaml:"op"`
 	At            time.Duration                  `yaml:"at"`
 	Cluster       string                         `yaml:"cluster"`
@@ -81,6 +82,7 @@ type Operation struct {
 
 	WorkflowType                         string        `yaml:"workflowType"`
 	WorkflowID                           string        `yaml:"workflowID"`
+	RunIDFromOp                          string        `yaml:"runIDFromOp"`
 	WorkflowExecutionStartToCloseTimeout time.Duration `yaml:"workflowExecutionStartToCloseTimeout"`
 	WorkflowDuration                     time.Duration `yaml:"workflowDuration"`
 	ActivityCount                        int           `yaml:"activityCount"`


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Improve conflict resolution for active-active and add a new simulation test to verify it

The simulation test starts 2 workflows in different clusters with the same id concurrently. We expect the one started earlier to be terminated and the other one to complete.

<!-- Tell your future self why have you made these changes -->
**Why?**
For workflows from an active-active domain's conflict resolution, we cannot simply compare their failover version to determine which one is newer if they have different active selection policies (failover groups), because the failover version is associated with an active selection policy (failover group).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests & simulation tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
