### PR TITLE
Test active-active behavior with concurrent SignalWithStart requests

### DIFF
--- a/config/dynamicconfig/replication_simulation_signalwithstart_activeactive_conflict.yml
+++ b/config/dynamicconfig/replication_simulation_signalwithstart_activeactive_conflict.yml
@@ -1,0 +1,23 @@
+# This file is used as dynamicconfig override for "signalwithstart_activeactive_conflict" replication simulation scenario
+# configured via simulation/replication/testdata/replication_simulation_signalwithstart_activeactive_conflict.yaml
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"
+history.replicatorTaskBatchSize:
+  - value: 25
+    constraints: {}
+frontend.failoverCoolDown:
+  - value: 5s
+history.ReplicationTaskProcessorStartWait: # default is 5s. repl task processor sleeps this much before processing received messages.
+  - value: 10ms
+history.standbyTaskMissingEventsResendDelay:
+  - value: 5s
+history.standbyTaskMissingEventsDiscardDelay:
+  - value: 10s
+history.standbyClusterDelay:
+  - value: 10s
+history.enableTransferQueueV2:
+  - value: true
+history.enableTimerQueueV2:
+  - value: true

--- a/simulation/replication/testdata/replication_simulation_activeactive_simultaneous_start.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive_simultaneous_start.yaml
@@ -18,15 +18,6 @@ domains:
       region0: cluster0
       region1: cluster1
 
-# Test scenario: Active-Active domain conflict resolution (non-deterministic)
-# 1. Create workflows with SignalWithStart at t=0 with same workflowID in both clusters
-# 2. Capture each workflow's RunID using runIDKey for later specific validation
-# 3. Use validate_conflict to handle non-deterministic conflict resolution:
-#    - At t=10s: Validate that one workflow is running and one is terminated
-#    - At t=70s: Validate that one workflow completed and one remains terminated
-# 4. Query both RunIDs to validate that each received their respective signals
-# Note: We cannot predict which cluster's workflow will survive the conflict
-
 operations:
   # SignalWithStart workflow with same workflowID in cluster0
   - op: signal_with_start_workflow
@@ -43,7 +34,7 @@ operations:
 
   # SignalWithStart workflow with SAME workflowID in cluster1 - testing conflict resolution
   - op: signal_with_start_workflow
-    at: 0s
+    at: 1s
     workflowID: conflict-wf
     workflowType: timer-activity-loop-workflow
     cluster: cluster1
@@ -54,29 +45,30 @@ operations:
     workflowDuration: 35s
     runIDKey: cluster1-run
 
-  # Validate conflict resolution occurred: one workflow running, one terminated
-  - op: validate_conflict
+  - op: validate
     at: 10s
     workflowID: conflict-wf
+    runIDKey: cluster0-run
     cluster: cluster0
     domain: test-domain-aa-conflict
-    conflictRunIDKeys: ["cluster0-run", "cluster1-run"]
     want:
-      statuses: ["running", "terminated"]
+      status: terminated
+      startedByWorkersInCluster: cluster0
+      completedByWorkersInCluster: cluster0
 
-  # Validate final state: one workflow completed, one terminated
-  - op: validate_conflict
-    at: 70s
+  - op: validate
+    at: 10s
     workflowID: conflict-wf
+    runIDKey: cluster1-run
     cluster: cluster0
     domain: test-domain-aa-conflict
-    conflictRunIDKeys: ["cluster0-run", "cluster1-run"]
     want:
-      statuses: ["completed", "terminated"]
+      status: running
+      startedByWorkersInCluster: cluster1
 
   # Query the cluster0 run to check if signal was received (should have cluster0 signal)
   - op: query_workflow
-    at: 75s
+    at: 15s
     workflowID: conflict-wf
     cluster: cluster0
     domain: test-domain-aa-conflict
@@ -87,7 +79,7 @@ operations:
 
   # Query the cluster1 run to check if signal was received (should have cluster1 signal)
   - op: query_workflow
-    at: 75s
+    at: 15s
     workflowID: conflict-wf
     cluster: cluster1
     domain: test-domain-aa-conflict
@@ -95,3 +87,14 @@ operations:
     runIDKey: cluster1-run
     want:
       queryResult: ["signal-from-cluster1"]
+  
+  - op: validate
+    at: 70s
+    workflowID: conflict-wf
+    runIDKey: cluster1-run
+    cluster: cluster0
+    domain: test-domain-aa-conflict
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster1
+      completedByWorkersInCluster: cluster1

--- a/simulation/replication/testdata/replication_simulation_activeactive_simultaneous_start.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive_simultaneous_start.yaml
@@ -1,0 +1,97 @@
+# This file is a replication simulation scenario spec.
+# It is parsed into ReplicationSimulationConfig struct.
+# Replication simulation for this file can be run via ./simulation/replication/run.sh signalwithstart_activeactive_conflict
+# Dynamic config overrides can be set via config/dynamicconfig/replication_simulation_signalwithstart_activeactive_conflict.yml
+
+clusters:
+  cluster0:
+    grpcEndpoint: "cadence-cluster0:7833"
+  cluster1:
+    grpcEndpoint: "cadence-cluster1:7833"
+
+# primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
+primaryCluster: "cluster0"
+
+domains:
+  test-domain-aa-conflict:
+    activeClustersByRegion:
+      region0: cluster0
+      region1: cluster1
+
+# Test scenario: Active-Active domain conflict resolution (non-deterministic)
+# 1. Create workflows with SignalWithStart at t=0 with same workflowID in both clusters
+# 2. Capture each workflow's RunID using runIDKey for later specific validation
+# 3. Use validate_conflict to handle non-deterministic conflict resolution:
+#    - At t=10s: Validate that one workflow is running and one is terminated
+#    - At t=70s: Validate that one workflow completed and one remains terminated
+# 4. Query both RunIDs to validate that each received their respective signals
+# Note: We cannot predict which cluster's workflow will survive the conflict
+
+operations:
+  # SignalWithStart workflow with same workflowID in cluster0
+  - op: signal_with_start_workflow
+    at: 0s
+    workflowID: conflict-wf
+    workflowType: timer-activity-loop-workflow
+    cluster: cluster0
+    domain: test-domain-aa-conflict
+    signalName: signal-from-cluster0
+    signalInput: "cluster0-signal-data"
+    workflowExecutionStartToCloseTimeout: 65s
+    workflowDuration: 35s
+    runIDKey: cluster0-run
+
+  # SignalWithStart workflow with SAME workflowID in cluster1 - testing conflict resolution
+  - op: signal_with_start_workflow
+    at: 0s
+    workflowID: conflict-wf
+    workflowType: timer-activity-loop-workflow
+    cluster: cluster1
+    domain: test-domain-aa-conflict
+    signalName: signal-from-cluster1
+    signalInput: "cluster1-signal-data"
+    workflowExecutionStartToCloseTimeout: 65s
+    workflowDuration: 35s
+    runIDKey: cluster1-run
+
+  # Validate conflict resolution occurred: one workflow running, one terminated
+  - op: validate_conflict
+    at: 10s
+    workflowID: conflict-wf
+    cluster: cluster0
+    domain: test-domain-aa-conflict
+    conflictRunIDKeys: ["cluster0-run", "cluster1-run"]
+    want:
+      statuses: ["running", "terminated"]
+
+  # Validate final state: one workflow completed, one terminated
+  - op: validate_conflict
+    at: 70s
+    workflowID: conflict-wf
+    cluster: cluster0
+    domain: test-domain-aa-conflict
+    conflictRunIDKeys: ["cluster0-run", "cluster1-run"]
+    want:
+      statuses: ["completed", "terminated"]
+
+  # Query the cluster0 run to check if signal was received (should have cluster0 signal)
+  - op: query_workflow
+    at: 75s
+    workflowID: conflict-wf
+    cluster: cluster0
+    domain: test-domain-aa-conflict
+    query: "get_signals_received"
+    runIDKey: cluster0-run
+    want:
+      queryResult: ["signal-from-cluster0"]
+
+  # Query the cluster1 run to check if signal was received (should have cluster1 signal)
+  - op: query_workflow
+    at: 75s
+    workflowID: conflict-wf
+    cluster: cluster1
+    domain: test-domain-aa-conflict
+    query: "get_signals_received"
+    runIDKey: cluster1-run
+    want:
+      queryResult: ["signal-from-cluster1"]

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -52,6 +52,7 @@ const (
 	ReplicationSimulationOperationSignalWithStartWorkflow     ReplicationSimulationOperation = "signal_with_start_workflow"
 	ReplicationSimulationOperationMigrateDomainToActiveActive ReplicationSimulationOperation = "migrate_domain_to_active_active"
 	ReplicationSimulationOperationValidateWorkflowReplication ReplicationSimulationOperation = "validate_workflow_replication"
+	ReplicationSimulationOperationValidateConflict            ReplicationSimulationOperation = "validate_conflict"
 )
 
 type ReplicationSimulationConfig struct {
@@ -64,6 +65,10 @@ type ReplicationSimulationConfig struct {
 	Domains map[string]ReplicationDomainConfig `yaml:"domains"`
 
 	Operations []*Operation `yaml:"operations"`
+
+	// RunIDRegistry stores captured RunIDs for later reference
+	// It should never be set as part of the configuration
+	RunIDRegistry map[string]string
 }
 
 type ReplicationDomainConfig struct {
@@ -100,15 +105,24 @@ type Operation struct {
 	NewActiveClustersByRegion map[string]string `yaml:"newActiveClustersByRegion"`
 	FailoverTimeout           *int32            `yaml:"failoverTimeoutSec"`
 
+	// RunIDKey specifies a key to store/retrieve RunID for this operation
+	RunIDKey string `yaml:"runIDKey"`
+
+	// ConflictRunIDKeys specifies two RunID keys to compare for conflict validation
+	ConflictRunIDKeys []string `yaml:"conflictRunIDKeys"`
+
 	Want Validation `yaml:"want"`
 }
 
 type Validation struct {
-	Status                      string `yaml:"status"`
-	StartedByWorkersInCluster   string `yaml:"startedByWorkersInCluster"`
-	CompletedByWorkersInCluster string `yaml:"completedByWorkersInCluster"`
-	Error                       string `yaml:"error"`
-	QueryResult                 any    `yaml:"queryResult"`
+	Status                      string   `yaml:"status"`
+	StartedByWorkersInCluster   string   `yaml:"startedByWorkersInCluster"`
+	CompletedByWorkersInCluster string   `yaml:"completedByWorkersInCluster"`
+	Error                       string   `yaml:"error"`
+	QueryResult                 any      `yaml:"queryResult"`
+
+	// Statuses array for conflict validation - contains expected workflow statuses
+	Statuses []string `yaml:"statuses"`
 }
 
 type Cluster struct {
@@ -133,6 +147,9 @@ func LoadConfig() (*ReplicationSimulationConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
+
+	// Initialize RunIDRegistry
+	cfg.RunIDRegistry = make(map[string]string)
 
 	fmt.Printf("Loaded config from path: %s\n", path)
 	return &cfg, nil
@@ -177,6 +194,22 @@ func (s *ReplicationSimulationConfig) MustInitClientsFor(t *testing.T, clusterNa
 
 func (s *ReplicationSimulationConfig) IsActiveActiveDomain(domainName string) bool {
 	return len(s.Domains[domainName].ActiveClustersByRegion) > 0
+}
+
+// StoreRunID stores a RunID with the given key for later reference
+func (s *ReplicationSimulationConfig) StoreRunID(key, runID string) {
+	if s.RunIDRegistry == nil {
+		s.RunIDRegistry = make(map[string]string)
+	}
+	s.RunIDRegistry[key] = runID
+}
+
+// GetRunID retrieves a stored RunID by key, returns empty string if not found
+func (s *ReplicationSimulationConfig) GetRunID(key string) string {
+	if s.RunIDRegistry == nil {
+		return ""
+	}
+	return s.RunIDRegistry[key]
 }
 
 func (s *ReplicationSimulationConfig) MustRegisterDomain(t *testing.T, domainName string, domainCfg ReplicationDomainConfig) {

--- a/simulation/replication/types/types.go
+++ b/simulation/replication/types/types.go
@@ -33,6 +33,8 @@ const (
 	TimerInterval = 5 * time.Second
 )
 
+type OperationFunction func(t *testing.T, op *Operation, simCfg *ReplicationSimulationConfig) error
+
 type WorkflowInput struct {
 	Duration      time.Duration
 	ActivityCount int
@@ -40,6 +42,31 @@ type WorkflowInput struct {
 
 type WorkflowOutput struct {
 	Count int
+}
+
+type ReplicationSimulation struct {
+	RunIDRegistry map[string]string
+}
+
+func NewReplicationSimulation() *ReplicationSimulation {
+	return &ReplicationSimulation{
+		RunIDRegistry: make(map[string]string),
+	}
+}
+
+func (s *ReplicationSimulation) StoreRunID(key, runID string) error {
+	if s.RunIDRegistry == nil {
+		return fmt.Errorf("runIDRegistry is nil")
+	}
+	s.RunIDRegistry[key] = runID
+	return nil
+}
+
+func (s *ReplicationSimulation) GetRunID(key string) (string, error) {
+	if s.RunIDRegistry == nil {
+		return "", fmt.Errorf("runIDRegistry is nil")
+	}
+	return s.RunIDRegistry[key], nil
 }
 
 func WorkerIdentityFor(clusterName string, domainName string) string {


### PR DESCRIPTION
⚠️ Should not be merged until https://github.com/cadence-workflow/cadence/pull/7265 has been merged and pulled in ⚠️ 

<!-- Describe what has changed in this PR -->
**What changed?**

Tests conflict resolution when the same workflowID is used to create workflows in two different clusters with an Active-Active setup in the domain. 

<!-- Tell your future self why have you made these changes -->
**Why?**

Cadence does not support two workflows existing with the same workflow ID. When a domain is configured active-active it can be possible for a user to make two simultaneous requests to two different clusters with the same workflow ID. When this happens, both workflows will run temporarily until the clusters have replicated their data to the other, at which point the conflict will have to be resolved. 

This test is a follow up to https://github.com/cadence-workflow/cadence/pull/7265, testing the scenario when SignalWithStart is used (rather than StartWorkflow).  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Locally + against dev canary domains. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

N/A