### PR TITLE
feat [shard-distributor]: Removed custom storage registration logic

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -45,7 +45,7 @@ import (
 	"github.com/uber/cadence/common/service"
 	shardDistributorCfg "github.com/uber/cadence/service/sharddistributor/config"
 	"github.com/uber/cadence/service/sharddistributor/sharddistributorfx"
-	"github.com/uber/cadence/service/sharddistributor/store"
+	"github.com/uber/cadence/service/sharddistributor/store/etcd"
 	"github.com/uber/cadence/tools/cassandra"
 	"github.com/uber/cadence/tools/sql"
 )
@@ -73,8 +73,9 @@ func Module(serviceName string) fx.Option {
 			fx.Decorate(func(z *zap.Logger, l log.Logger) (*zap.Logger, log.Logger) {
 				return z.With(zap.String("service", service.ShardDistributor)), l.WithTags(tag.Service(service.ShardDistributor))
 			}),
-			store.LeaderModule("etcd"),
-			store.Module("etcd"),
+
+			fx.Provide(etcd.NewStore),
+			fx.Provide(etcd.NewLeaderStore),
 
 			rpcfx.Module,
 			sharddistributorfx.Module)

--- a/service/sharddistributor/store/etcd/etcdleaderstore.go
+++ b/service/sharddistributor/store/etcd/etcdleaderstore.go
@@ -13,10 +13,6 @@ import (
 	"github.com/uber/cadence/service/sharddistributor/store"
 )
 
-func init() {
-	store.RegisterLeaderStore("etcd", fx.Provide(NewLeaderStore))
-}
-
 type LeaderStore struct {
 	client         *clientv3.Client
 	electionConfig etcdCfg

--- a/service/sharddistributor/store/etcd/etcdstore.go
+++ b/service/sharddistributor/store/etcd/etcdstore.go
@@ -16,10 +16,6 @@ import (
 	"github.com/uber/cadence/service/sharddistributor/store"
 )
 
-func init() {
-	store.Register("etcd", fx.Provide(NewStore))
-}
-
 const (
 	executorHeartbeatKey      = "heartbeat"
 	executorStatusKey         = "status"

--- a/service/sharddistributor/store/leaderstore.go
+++ b/service/sharddistributor/store/leaderstore.go
@@ -2,9 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
-
-	"go.uber.org/fx"
 )
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination=leaderstore_mock.go Elector,Election
@@ -28,23 +25,4 @@ type Election interface {
 	// Guard returns a transaction guard representing the current leadership term.
 	// This guard can be passed to the generic store to perform leader-protected writes.
 	Guard() GuardFunc
-}
-
-var (
-	leaderStoreRegistry = make(map[string]Impl)
-)
-
-// RegisterLeaderStore registers store implementation in the registry.
-func RegisterLeaderStore(name string, factory Impl) {
-	leaderStoreRegistry[name] = factory
-}
-
-// LeaderModule returns registered a leader store fx.Option from the configuration.
-// This can introduce extra dependency requirements to the fx application.
-func LeaderModule(name string) fx.Option {
-	factory, ok := leaderStoreRegistry[name]
-	if !ok {
-		panic(fmt.Sprintf("no leader store registered with name %s", name))
-	}
-	return factory
 }

--- a/service/sharddistributor/store/store.go
+++ b/service/sharddistributor/store/store.go
@@ -3,8 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-
-	"go.uber.org/fx"
 )
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination=store_mock.go Store
@@ -63,27 +61,4 @@ type Store interface {
 
 	GetHeartbeat(ctx context.Context, namespace string, executorID string) (*HeartbeatState, *AssignedState, error)
 	RecordHeartbeat(ctx context.Context, namespace, executorID string, state HeartbeatState) error
-}
-
-// Impl could be used to build an implementation in the registry.
-// We use registry based approach to avoid introduction of global etcd dependency.
-type Impl fx.Option
-
-var (
-	storeRegistry = make(map[string]Impl)
-)
-
-// Register registers store implementation in the registry.
-func Register(name string, factory Impl) {
-	storeRegistry[name] = factory
-}
-
-// Module returns registered a leader store fx.Option from the configuration.
-// This can introduce extra dependency requirements to the fx application.
-func Module(name string) fx.Option {
-	factory, ok := storeRegistry[name]
-	if !ok {
-		panic(fmt.Sprintf("no store registered with name %s", name))
-	}
-	return factory
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed custom logic to store and discover storage backends, and moved to using fx


<!-- Tell your future self why have you made these changes -->
**Why?**
The logic was not nessesary and didn't acheive the goal of avoiding a dependencty. 
We want to be able to add things to the storage fx modules which was not possible with this solution.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
