### PR TITLE
fix(BoundedAckCache): also return the number of items freed on Ack

### DIFF
--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -213,7 +213,7 @@ func (m *TaskStore) Ack(cluster string, lastTaskID int64) error {
 		return ErrUnknownCluster
 	}
 
-	_ = cache.Ack(lastTaskID)
+	_, _ = cache.Ack(lastTaskID)
 
 	scope := m.scope.Tagged(metrics.SourceClusterTag(cluster))
 	scope.RecordTimer(metrics.CacheSize, time.Duration(cache.Count()))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Also return the number of items freed on Ack.

<!-- Tell your future self why have you made these changes -->
**Why?**
If an external manager is used to control cache budget, it must know how many items are freed for accounting purposes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
