### PR TITLE
refactor: refactor the domain / cli commands for active-active's cluster-attr

### DIFF
--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -1710,6 +1710,13 @@ type DescribeDomainResponse struct {
 	FailoverInfo             *FailoverInfo                   `json:"failoverInfo,omitempty"`
 }
 
+func (v *DomainReplicationConfiguration) GetActiveClusters() (o *ActiveClusters) {
+	if v != nil && v.ActiveClusters != nil {
+		return v.ActiveClusters
+	}
+	return
+}
+
 // GetDomainInfo is an internal getter (TBD...)
 func (v *DescribeDomainResponse) GetDomainInfo() (o *DomainInfo) {
 	if v != nil && v.DomainInfo != nil {
@@ -2253,6 +2260,20 @@ type DomainReplicationConfiguration struct {
 	ActiveClusters    *ActiveClusters                    `json:"activeClusters,omitempty"`
 }
 
+func (v *DomainReplicationConfiguration) IsActiveActiveDomain() bool {
+	if v == nil || v.ActiveClusters == nil {
+		return false
+	}
+	if v.ActiveClusters.AttributeScopes != nil && len(v.ActiveClusters.AttributeScopes) > 0 {
+		return true
+	}
+	// todo (david.porter) remove this once we have fully migrated to AttributeScopes
+	if v.ActiveClusters.ActiveClustersByRegion != nil && len(v.ActiveClusters.ActiveClustersByRegion) > 0 {
+		return true
+	}
+	return false
+}
+
 // GetActiveClusterName is an internal getter (TBD...)
 func (v *DomainReplicationConfiguration) GetActiveClusterName() (o string) {
 	if v != nil {
@@ -2265,13 +2286,6 @@ func (v *DomainReplicationConfiguration) GetActiveClusterName() (o string) {
 func (v *DomainReplicationConfiguration) GetClusters() (o []*ClusterReplicationConfiguration) {
 	if v != nil && v.Clusters != nil {
 		return v.Clusters
-	}
-	return
-}
-
-func (v *DomainReplicationConfiguration) GetActiveClusters() (o *ActiveClusters) {
-	if v != nil && v.ActiveClusters != nil {
-		return v.ActiveClusters
 	}
 	return
 }

--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -142,11 +143,6 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) error {
 		activeClusterName = c.String(FlagActiveClusterName)
 	}
 
-	activeClustersByRegion, err := parseActiveClustersByRegion(c, isActiveActiveDomain)
-	if err != nil {
-		return err
-	}
-
 	var clusters []*types.ClusterReplicationConfiguration
 	if c.IsSet(FlagClusters) {
 		for _, clusterStr := range c.StringSlice(FlagClusters) {
@@ -165,6 +161,15 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) error {
 		return fmt.Errorf("failed to parse %s flag: %w", FlagVisibilityArchivalStatus, err)
 	}
 
+	var activeClusters *types.ActiveClusters
+	if c.IsSet(FlagActiveClusters) {
+		ac, err := parseActiveClustersByClusterAttribute(c.String(FlagActiveClusters))
+		if err != nil {
+			return err
+		}
+		activeClusters = &ac
+	}
+
 	request := &types.RegisterDomainRequest{
 		Name:                                   domainName,
 		Description:                            description,
@@ -173,7 +178,7 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) error {
 		WorkflowExecutionRetentionPeriodInDays: int32(retentionDays),
 		Clusters:                               clusters,
 		ActiveClusterName:                      activeClusterName,
-		ActiveClustersByRegion:                 activeClustersByRegion,
+		ActiveClusters:                         activeClusters,
 		SecurityToken:                          securityToken,
 		HistoryArchivalStatus:                  has,
 		HistoryArchivalURI:                     c.String(FlagHistoryArchivalURI),
@@ -225,23 +230,16 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) error {
 			ActiveClusterName:        common.StringPtr(activeCluster),
 			FailoverTimeoutInSeconds: failoverTimeout,
 		}
-	} else if c.IsSet(FlagActiveClustersByRegion) { // active-active domain failover
-		activeClustersByRegion, err := parseActiveClustersByRegion(c, true)
+	} else if c.IsSet(FlagActiveClusters) { // active-active domain failover
+		activeClusters, err := parseActiveClustersByClusterAttribute(c.String(FlagActiveClusters))
 		if err != nil {
 			return err
-		}
-
-		acbr := make(map[string]types.ActiveClusterInfo)
-		for region, cluster := range activeClustersByRegion {
-			acbr[region] = types.ActiveClusterInfo{
-				ActiveClusterName: cluster,
-			}
 		}
 
 		updateRequest = &types.UpdateDomainRequest{
 			Name: domainName,
 			ActiveClusters: &types.ActiveClusters{
-				ActiveClustersByRegion: acbr,
+				AttributeScopes: activeClusters.AttributeScopes,
 			},
 		}
 	} else {
@@ -634,26 +632,27 @@ type ActiveClusterInfoRow struct {
 }
 
 type DomainRow struct {
-	Name                     string `header:"Name"`
-	UUID                     string `header:"UUID"`
-	Description              string
-	OwnerEmail               string
-	DomainData               map[string]string  `header:"Domain Data"`
-	Status                   types.DomainStatus `header:"Status"`
-	IsGlobal                 bool               `header:"Is Global Domain"`
-	ActiveCluster            string             `header:"Active Cluster"`
-	Clusters                 []string           `header:"Clusters"`
-	RetentionDays            int32              `header:"Retention Days"`
-	EmitMetrics              bool
-	HistoryArchivalStatus    types.ArchivalStatus `header:"History Archival Status"`
-	HistoryArchivalURI       string               `header:"History Archival URI"`
-	VisibilityArchivalStatus types.ArchivalStatus `header:"Visibility Archival Status"`
-	VisibilityArchivalURI    string               `header:"Visibility Archival URI"`
-	BadBinaries              []BadBinaryRow
-	FailoverInfo             *FailoverInfoRow
-	LongRunningWorkFlowNum   *int
-	IsActiveActiveDomain     bool
-	ActiveClustersByRegion   []ActiveClusterInfoRow
+	Name                             string `header:"Name"`
+	UUID                             string `header:"UUID"`
+	Description                      string
+	OwnerEmail                       string
+	DomainData                       map[string]string  `header:"Domain Data"`
+	Status                           types.DomainStatus `header:"Status"`
+	IsGlobal                         bool               `header:"Is Global Domain"`
+	ActiveCluster                    string             `header:"Active Cluster"`
+	Clusters                         []string           `header:"Clusters"`
+	RetentionDays                    int32              `header:"Retention Days"`
+	EmitMetrics                      bool
+	HistoryArchivalStatus            types.ArchivalStatus `header:"History Archival Status"`
+	HistoryArchivalURI               string               `header:"History Archival URI"`
+	VisibilityArchivalStatus         types.ArchivalStatus `header:"Visibility Archival Status"`
+	VisibilityArchivalURI            string               `header:"Visibility Archival URI"`
+	BadBinaries                      []BadBinaryRow
+	FailoverInfo                     *FailoverInfoRow
+	LongRunningWorkFlowNum           *int
+	IsActiveActiveDomain             bool
+	ActiveClustersByRegion           []ActiveClusterInfoRow // todo (david.porter) remove this as it's not in use
+	ActiveClustersByClusterAttribute []ActiveClusterInfoRow
 }
 
 type DomainMigrationRow struct {
@@ -925,27 +924,30 @@ func clustersToStrings(clusters []*types.ClusterReplicationConfiguration) []stri
 	return res
 }
 
-func parseActiveClustersByRegion(c *cli.Context, isActiveActiveDomain bool) (map[string]string, error) {
-	var activeClustersByRegion map[string]string
-	if c.IsSet(FlagActiveClustersByRegion) {
-		if !isActiveActiveDomain {
-			return nil, commoncli.Problem("Option --active_clusters_by_region is only supported for active-active domain. Use --active_cluster instead.", nil)
-		}
+func parseActiveClustersByClusterAttribute(clusters string) (types.ActiveClusters, error) {
+	split := regexp.MustCompile(`(?P<attribute>[a-zA-Z0-9_]+).(?P<scope>[a-zA-Z0-9_]+):(?P<name>[a-zA-Z0-9_]+)`)
+	matches := split.FindAllStringSubmatch(clusters, -1)
+	if len(matches) == 0 {
+		return types.ActiveClusters{}, fmt.Errorf("Option %s format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx'", FlagActiveClusters)
+	}
 
-		activeClustersByRegion = make(map[string]string)
-		for _, regionCluster := range c.StringSlice(FlagActiveClustersByRegion) {
-			splitted := strings.Split(regionCluster, ":")
-			if len(splitted) != 2 {
-				return nil, commoncli.Problem(fmt.Sprintf("Option --%s format is invalid. Expected format is 'region1:cluster1,region2:cluster2'", FlagActiveClustersByRegion), nil)
+	out := types.ActiveClusters{
+		AttributeScopes: map[string]types.ClusterAttributeScope{},
+	}
+
+	for _, match := range matches {
+		attribute := match[1]
+		scope := match[2]
+		name := match[3]
+
+		if _, ok := out.AttributeScopes[attribute]; !ok {
+			out.AttributeScopes[attribute] = types.ClusterAttributeScope{
+				ClusterAttributes: map[string]types.ActiveClusterInfo{},
 			}
-			region, cluster := strings.TrimSpace(splitted[0]), strings.TrimSpace(splitted[1])
-			activeClustersByRegion[region] = cluster
 		}
+
+		out.AttributeScopes[attribute].ClusterAttributes[scope] = types.ActiveClusterInfo{ActiveClusterName: name}
 	}
 
-	if isActiveActiveDomain && len(activeClustersByRegion) == 0 {
-		return nil, commoncli.Problem("Option --active_clusters_by_region is required for active-active domain.", nil)
-	}
-
-	return activeClustersByRegion, nil
+	return out, nil
 }

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -84,7 +84,7 @@ func (s *cliAppSuite) TestDomainRegister() {
 		{
 			"active-active domain with invalid active clusters by region",
 			"cadence --do test-domain domain register --active_clusters region1=cluster1",
-			"Option active_clusters format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx'",
+			"option active_clusters format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx",
 			nil,
 		},
 		{

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -425,9 +425,31 @@ func TestParseActiveClustersByClusterAttribute(t *testing.T) {
 				},
 			},
 		},
+		"valid active clusters by cluster attribute with multiple scopes": {
+			clusters: "region.newyork:cluster0,location.brussels:cluster2,region.madrid:cluster1",
+			expected: types.ActiveClusters{
+				AttributeScopes: map[string]types.ClusterAttributeScope{
+					"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"newyork": {ActiveClusterName: "cluster0"},
+						"madrid":  {ActiveClusterName: "cluster1"},
+					}},
+					"location": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"brussels": {ActiveClusterName: "cluster2"},
+					}},
+				},
+			},
+		},
+		"duplicate keys consistutes an error in parsing and shouldn't be allowed": {
+			clusters:      "region.newyork:cluster0,region.newyork:cluster1",
+			expectedError: fmt.Errorf(`option active_clusters format is invalid. the key "newyork" was duplicated. This can only map to a single active cluster`),
+		},
 		"Some invalid input": {
 			clusters:      "bad-data",
-			expectedError: fmt.Errorf("Option active_clusters format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx'"),
+			expectedError: fmt.Errorf("option active_clusters format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx'"),
+		},
+		"empty input": {
+			clusters:      "",
+			expectedError: fmt.Errorf("option active_clusters format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx'"),
 		},
 	}
 

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -61,7 +61,7 @@ func (s *cliAppSuite) TestDomainRegister() {
 		},
 		{
 			"active-active domain",
-			"cadence --do test-domain domain register --active_active_domain true --active_clusters region.region1:cluster1,region.region2:cluster2",
+			"cadence --do test-domain domain register --active_clusters region.region1:cluster1,region.region2:cluster2",
 			"",
 			func() {
 				s.serverFrontendClient.EXPECT().RegisterDomain(gomock.Any(), &types.RegisterDomainRequest{
@@ -83,21 +83,9 @@ func (s *cliAppSuite) TestDomainRegister() {
 		},
 		{
 			"active-active domain with invalid active clusters by region",
-			"cadence --do test-domain domain register --active_active_domain true --active_clusters region1=cluster1",
+			"cadence --do test-domain domain register --active_clusters region1=cluster1",
 			"Option active_clusters format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx'",
 			nil,
-		},
-		{
-			"active-active domain with no active clusters by region",
-			"cadence --do test-domain domain register --active_active_domain true",
-			"",
-			func() {
-				s.serverFrontendClient.EXPECT().RegisterDomain(gomock.Any(), &types.RegisterDomainRequest{
-					Name:                                   "test-domain",
-					WorkflowExecutionRetentionPeriodInDays: 3,
-					IsGlobalDomain:                         true,
-				}).Return(nil)
-			},
 		},
 		{
 			"domain with other options",

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -143,6 +143,11 @@ var (
 			Usage:   "Active cluster name",
 		},
 		&cli.StringSliceFlag{
+			Name:    FlagActiveClusters,
+			Aliases: []string{"acs"},
+			Usage:   "Active clusters by cluster attribute in the format '<cluster-attr>.<scope>:<name> ie: region.manilla:cluster0,region.newyork:cluster1'",
+		},
+		&cli.StringSliceFlag{
 			Name:    FlagClusters,
 			Aliases: []string{"cl"},
 			Usage:   FlagClustersUsage,

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -73,9 +73,9 @@ var (
 			Usage:   "Active cluster name",
 		},
 		&cli.StringSliceFlag{
-			Name:    FlagActiveClustersByRegion,
-			Aliases: []string{"acbr"},
-			Usage:   "Active clusters by region in the format 'region1:cluster1,region2:cluster2'",
+			Name:    FlagActiveClusters,
+			Aliases: []string{"acs"},
+			Usage:   "Active clusters by cluster attribute in the format '<cluster-attr>.<scope>:<name> ie: region.manilla:cluster0,region.newyork:cluster1'",
 		},
 		&cli.StringSliceFlag{
 			Name:    FlagClusters,
@@ -149,9 +149,9 @@ var (
 			Usage:   "Active cluster name",
 		},
 		&cli.StringSliceFlag{
-			Name:    FlagActiveClustersByRegion,
-			Aliases: []string{"acbr"},
-			Usage:   "Active clusters by region in the format 'region1:cluster1,region2:cluster2'",
+			Name:    FlagActiveClusters,
+			Aliases: []string{"acbca"},
+			Usage:   "Active clusters by cluster attribute in the format '<cluster-attr>.<scope>:<name> ie: region.manilla:cluster0,region.newyork:cluster1'",
 		},
 		&cli.StringSliceFlag{
 			Name:    FlagClusters,

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -88,12 +88,6 @@ var (
 			Usage:   "Flag to indicate whether domain is a global domain (active-passive domain). Default to true. Local domain is now legacy.",
 			Value:   "true",
 		},
-		&cli.StringFlag{
-			Name:    FlagIsActiveActiveDomain,
-			Aliases: []string{"aad"},
-			Usage:   "Flag to indicate whether domain is an active-active domain. Default to false.",
-			Value:   "false",
-		},
 		&cli.GenericFlag{
 			Name:    FlagDomainData,
 			Aliases: []string{"dmd"},
@@ -147,11 +141,6 @@ var (
 			Name:    FlagActiveClusterName,
 			Aliases: []string{"ac"},
 			Usage:   "Active cluster name",
-		},
-		&cli.StringSliceFlag{
-			Name:    FlagActiveClusters,
-			Aliases: []string{"acbca"},
-			Usage:   "Active clusters by cluster attribute in the format '<cluster-attr>.<scope>:<name> ie: region.manilla:cluster0,region.newyork:cluster1'",
 		},
 		&cli.StringSliceFlag{
 			Name:    FlagClusters,

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -125,7 +125,7 @@ const (
 	FlagQueryConsistencyLevel          = "query_consistency_level"
 	FlagShowDetail                     = "show_detail"
 	FlagActiveClusterName              = "active_cluster"
-	FlagActiveClustersByRegion         = "active_clusters_by_region"
+	FlagActiveClusters                 = "active_clusters"
 	FlagClusters                       = "clusters"
 	FlagIsGlobalDomain                 = "global_domain"        // active-passive domain
 	FlagIsActiveActiveDomain           = "active_active_domain" // active-active domain

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -127,8 +127,7 @@ const (
 	FlagActiveClusterName              = "active_cluster"
 	FlagActiveClusters                 = "active_clusters"
 	FlagClusters                       = "clusters"
-	FlagIsGlobalDomain                 = "global_domain"        // active-passive domain
-	FlagIsActiveActiveDomain           = "active_active_domain" // active-active domain
+	FlagIsGlobalDomain                 = "global_domain" // active-passive domain
 	FlagDomainData                     = "domain_data"
 	FlagEventID                        = "event_id"
 	FlagActivityID                     = "activity_id"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This is changing the cli to update the cluster-attributes for active/active clusters. This allows domains to update the domain by passing in the format `<cluster-attr>.<scope>:<name>` ie: `region.manilla:cluster0,region.newyork:cluster1'` 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
