### PR TITLE
refactor: Require ActiveClusterName for active-active domains

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -113,9 +113,9 @@ func NewMetadata(
 	return m
 }
 
-// GetNextFailoverVersion return the next failover version based on input
-func (m Metadata) GetNextFailoverVersion(cluster string, currentFailoverVersion int64, domainName string) int64 {
-	initialFailoverVersion := m.getInitialFailoverVersion(cluster, domainName)
+// GetNextFailoverVersion returns the next valid FailoverVersion for a domain
+func (m Metadata) GetNextFailoverVersion(targetClusterName string, currentFailoverVersion int64, domainName string) int64 {
+	initialFailoverVersion := m.getInitialFailoverVersion(targetClusterName, domainName)
 	failoverVersion := currentFailoverVersion/m.failoverVersionIncrement*m.failoverVersionIncrement + initialFailoverVersion
 	if failoverVersion < currentFailoverVersion {
 		return failoverVersion + m.failoverVersionIncrement

--- a/common/cluster/metadata_test.go
+++ b/common/cluster/metadata_test.go
@@ -42,6 +42,8 @@ func TestMetadataBehaviour(t *testing.T) {
 	const initialFailoverVersionC1 = 0
 	const clusterName2 = "c2"
 	const initialFailoverVersionC2 = 2
+	const clusterName3 = "c3"
+	const initialFailoverVersionC3 = 4
 
 	const failoverVersionIncrement = 100
 
@@ -60,12 +62,17 @@ func TestMetadataBehaviour(t *testing.T) {
 			currentVersion:  0,
 			expectedOut:     2,
 		},
-		"a subsequent failover back": {
+		"a failover to c3 should set the failover version to be based on c3": {
+			failoverCluster: clusterName3,
+			currentVersion:  2,
+			expectedOut:     4,
+		},
+		"a subsequent failover back to c1 should increment the failover version by failoverVersionIncrement": {
 			failoverCluster: clusterName1,
 			currentVersion:  2,
 			expectedOut:     100,
 		},
-		"and a duplicate": {
+		"when the current failover version matches the target cluster it should not increment the failover version": {
 			failoverCluster: clusterName1,
 			currentVersion:  100,
 			expectedOut:     100,
@@ -74,6 +81,11 @@ func TestMetadataBehaviour(t *testing.T) {
 			failoverCluster: clusterName2,
 			currentVersion:  100,
 			expectedOut:     102,
+		},
+		"and a subsequent fail back over to c1 should skip over c3": {
+			failoverCluster: clusterName1,
+			currentVersion:  102,
+			expectedOut:     200,
 		},
 	}
 
@@ -88,10 +100,14 @@ func TestMetadataBehaviour(t *testing.T) {
 					clusterName2: {
 						InitialFailoverVersion: initialFailoverVersionC2,
 					},
+					clusterName3: {
+						InitialFailoverVersion: initialFailoverVersionC3,
+					},
 				},
 				versionToClusterName: map[int64]string{
 					initialFailoverVersionC1: clusterName1,
 					initialFailoverVersionC2: clusterName2,
+					initialFailoverVersionC3: clusterName3,
 				},
 				useNewFailoverVersionOverride: func(domain string) bool { return false },
 				metrics:                       metrics.NewNoopMetricsClient().Scope(0),

--- a/common/domain/attrValidator.go
+++ b/common/domain/attrValidator.go
@@ -101,8 +101,6 @@ func (d *AttrValidatorImpl) validateDomainReplicationConfigForGlobalDomain(
 	clusters := replicationConfig.Clusters
 	activeClusters := replicationConfig.ActiveClusters
 
-	// ActiveClusterName is required for all global domains (both active-passive and active-active)
-	// to serve as a fallback when there are issues with active-active configuration
 	if activeCluster == "" {
 		return errActiveClusterNameRequired
 	}
@@ -122,7 +120,6 @@ func (d *AttrValidatorImpl) validateDomainReplicationConfigForGlobalDomain(
 		return false
 	}
 
-	// Validate ActiveClusterName is in the clusters list
 	if err := d.validateClusterName(activeCluster); err != nil {
 		return err
 	}

--- a/common/domain/attrValidator_test.go
+++ b/common/domain/attrValidator_test.go
@@ -238,7 +238,7 @@ func (s *attrValidatorSuite) TestValidateDomainReplicationConfigForGlobalDomain(
 	)
 	s.NoError(err)
 
-	// Test missing ActiveClusterName for global domain (should fail)
+	// When ActiveClusterName is not provided, and ActiveClusters are not provided, it should return an error
 	err = s.validator.validateDomainReplicationConfigForGlobalDomain(
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: "",
@@ -250,7 +250,7 @@ func (s *attrValidatorSuite) TestValidateDomainReplicationConfigForGlobalDomain(
 	s.Error(err)
 	s.IsType(&types.BadRequestError{}, err)
 
-	// Test active-active domain with valid ActiveClusterName
+	// When ActiveClusterName and ActiveClusters are provided, it should not return an error
 	err = s.validator.validateDomainReplicationConfigForGlobalDomain(
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestCurrentClusterName,
@@ -268,7 +268,7 @@ func (s *attrValidatorSuite) TestValidateDomainReplicationConfigForGlobalDomain(
 	)
 	s.NoError(err)
 
-	// Test active-active domain with missing ActiveClusterName (should fail)
+	// When ActiveClusterName is not provided, and ActiveClusters are provided, it should return an error
 	err = s.validator.validateDomainReplicationConfigForGlobalDomain(
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: "",

--- a/common/domain/attrValidator_test.go
+++ b/common/domain/attrValidator_test.go
@@ -237,6 +237,55 @@ func (s *attrValidatorSuite) TestValidateDomainReplicationConfigForGlobalDomain(
 		},
 	)
 	s.NoError(err)
+
+	// Test missing ActiveClusterName for global domain (should fail)
+	err = s.validator.validateDomainReplicationConfigForGlobalDomain(
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: "",
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+			},
+		},
+	)
+	s.Error(err)
+	s.IsType(&types.BadRequestError{}, err)
+
+	// Test active-active domain with valid ActiveClusterName
+	err = s.validator.validateDomainReplicationConfigForGlobalDomain(
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+			ActiveClusters: &types.ActiveClusters{
+				ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+					cluster.TestRegion1: {ActiveClusterName: cluster.TestCurrentClusterName},
+					cluster.TestRegion2: {ActiveClusterName: cluster.TestAlternativeClusterName},
+				},
+			},
+		},
+	)
+	s.NoError(err)
+
+	// Test active-active domain with missing ActiveClusterName (should fail)
+	err = s.validator.validateDomainReplicationConfigForGlobalDomain(
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: "",
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+			ActiveClusters: &types.ActiveClusters{
+				ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
+					cluster.TestRegion1: {ActiveClusterName: cluster.TestCurrentClusterName},
+					cluster.TestRegion2: {ActiveClusterName: cluster.TestAlternativeClusterName},
+				},
+			},
+		},
+	)
+	s.Error(err)
+	s.IsType(&types.BadRequestError{}, err)
 }
 
 func (s *attrValidatorSuite) TestValidateDomainReplicationConfigClustersDoesNotRemove() {

--- a/common/domain/errors.go
+++ b/common/domain/errors.go
@@ -32,6 +32,7 @@ var (
 	errGracefulFailoverInActiveCluster     = &types.BadRequestError{Message: "Cannot start the graceful failover from an active cluster to an active cluster."}
 	errOngoingGracefulFailover             = &types.BadRequestError{Message: "Cannot start concurrent graceful failover."}
 	errInvalidGracefulFailover             = &types.BadRequestError{Message: "Cannot start graceful failover without updating active cluster or in local domain."}
+	errActiveClusterNameRequired           = &types.BadRequestError{Message: "ActiveClusterName is required for all global domains."}
 
 	errInvalidRetentionPeriod = &types.BadRequestError{Message: "A valid retention period is not set on request."}
 	errInvalidArchivalConfig  = &types.BadRequestError{Message: "Invalid to enable archival without specifying a uri."}

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -268,12 +268,6 @@ func (d *handlerImpl) RegisterDomain(
 		return err
 	}
 
-	if activeClusters != nil {
-		// TODO: Leave a default activeClusterName for active-active domains
-		// active-active domain, activeClusterName is not used
-		activeClusterName = ""
-	}
-
 	replicationConfig := &persistence.DomainReplicationConfig{
 		ActiveClusterName: activeClusterName,
 		Clusters:          clusters,

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -293,8 +293,7 @@ func (d *handlerImpl) RegisterDomain(
 	}
 
 	failoverVersion := constants.EmptyVersion
-	if registerRequest.GetIsGlobalDomain() && !replicationConfig.IsActiveActive() {
-		// assign failover version for active-passive domain
+	if registerRequest.GetIsGlobalDomain() {
 		failoverVersion = d.clusterMetadata.GetNextFailoverVersion(activeClusterName, 0, registerRequest.Name)
 	}
 
@@ -588,10 +587,12 @@ func (d *handlerImpl) UpdateDomain(
 				// we increment failover version so top level failoverVersion is updated and domain data is replicated.
 				failoverVersion = d.clusterMetadata.GetNextFailoverVersion(
 					replicationConfig.ActiveClusterName,
+					// TODO(active-active): This should be incremented in the same way as an active-passive domain
 					failoverVersion+1,
 					updateRequest.Name,
 				)
 
+				// TODO(active-active): Increment all ClusterAttributes that have changed
 				// we also use the new failover version belonging to currentActiveCluster for the corresponding ActiveClustersByRegion map entry
 				for region, clusterInfo := range replicationConfig.ActiveClusters.ActiveClustersByRegion {
 					if clusterInfo.ActiveClusterName == currentActiveCluster {
@@ -625,6 +626,7 @@ func (d *handlerImpl) UpdateDomain(
 				// to indicate there was a change in replication config
 				failoverVersion = d.clusterMetadata.GetNextFailoverVersion(
 					d.clusterMetadata.GetCurrentClusterName(),
+					// TODO(active-active): If the domain level ActiveCluster has changed this should be incremented in the same way as an active-passive domain
 					failoverVersion+1,
 					updateRequest.Name,
 				)
@@ -639,7 +641,7 @@ func (d *handlerImpl) UpdateDomain(
 					now,
 					failoverType,
 					&currentActiveCluster,
-					nil,
+					updateRequest.ActiveClusterName,
 					currentActiveClusters,
 					replicationConfig.ActiveClusters,
 				))

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -1664,6 +1664,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 			setupMock: func(domainManager *persistence.MockDomainManager, updateRequest *types.UpdateDomainRequest, archivalMetadata *archiver.MockArchivalMetadata, timeSource clock.MockedTimeSource, domainReplicator *MockReplicator) {
 				domainResponse := &persistence.GetDomainResponse{
 					ReplicationConfig: &persistence.DomainReplicationConfig{
+						ActiveClusterName: cluster.TestCurrentClusterName,
 						Clusters: []*persistence.ClusterReplicationConfig{
 							{ClusterName: cluster.TestCurrentClusterName},
 							{ClusterName: cluster.TestAlternativeClusterName},
@@ -1716,6 +1717,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 					Info:   domainResponse.Info,
 					Config: domainResponse.Config,
 					ReplicationConfig: &persistence.DomainReplicationConfig{
+						ActiveClusterName: cluster.TestCurrentClusterName,
 						Clusters: []*persistence.ClusterReplicationConfig{
 							{ClusterName: cluster.TestCurrentClusterName},
 							{ClusterName: cluster.TestAlternativeClusterName},
@@ -1771,6 +1773,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 			response: func(timeSource clock.MockedTimeSource) *types.UpdateDomainResponse {
 				data, _ := json.Marshal([]FailoverEvent{{
 					EventTime:    timeSource.Now(),
+					FromCluster:  cluster.TestCurrentClusterName,
 					FailoverType: commonconstants.FailoverType(commonconstants.FailoverTypeForce).String(),
 					FromActiveClusters: types.ActiveClusters{
 						ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
@@ -1816,6 +1819,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 						AsyncWorkflowConfig:                    &types.AsyncWorkflowConfiguration{Enabled: true},
 					},
 					ReplicationConfiguration: &types.DomainReplicationConfiguration{
+						ActiveClusterName: cluster.TestCurrentClusterName,
 						Clusters: []*types.ClusterReplicationConfiguration{
 							{ClusterName: cluster.TestCurrentClusterName},
 							{ClusterName: cluster.TestAlternativeClusterName},

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1148,12 +1148,14 @@ type (
 		Clusters []*ClusterReplicationConfig
 
 		// ActiveClusterName is the name of the cluster that the domain is active in.
-		// Applicable for active-passive domains.
+		// Required for all global domains (both active-passive and active-active).
+		// For active-passive domains, this is the single active cluster.
+		// For active-active domains this is the default cluster whenever a ClusterAttribute is not provided
 		ActiveClusterName string
 
-		// TODO(c-warren): Update documentation once ActiveClusterName is the default for active-active domains.
 		// ActiveClusters is only applicable for active-active domains.
-		// If this is set, ActiveClusterName is ignored.
+		// When this is set, the domain is considered active-active and workflows are routed
+		// based on their ClusterAttributes.
 		ActiveClusters *types.ActiveClusters
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Requires ActiveClusterName to be set for active-active domains

<!-- Tell your future self why have you made these changes -->
**Why?**

Active-Active domains will use the ActiveClusterName as the "default" ActiveCluster for any workflows that do not specify a valid `scope:name` ClusterAttribute. This makes migration simple (existing domains can just start adding ClusterAttributes to divide work). 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit tests + simulations. 
Canary to come. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

The existing Canary or Simulation tests may start to fail. I plan on validating that they do not prior to merging. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

Active-Active domains now require an ActiveClusterName. 

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

N/A