### PR TITLE
chore: Replace bitnamilegacy/kafka with soldevelo/kafka (actively maintained fork)

### DIFF
--- a/docker/dev/cassandra-esv7-kafka.yml
+++ b/docker/dev/cassandra-esv7-kafka.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/dev/cassandra-opensearch-kafka-migration.yml
+++ b/docker/dev/cassandra-opensearch-kafka-migration.yml
@@ -35,7 +35,7 @@ services:
     environment:
       OPENSEARCH_HOSTS: '["https://opensearch:9200"]' # Define the OpenSearch nodes that OpenSearch Dashboards will query
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/dev/cassandra-opensearch-kafka.yml
+++ b/docker/dev/cassandra-opensearch-kafka.yml
@@ -29,7 +29,7 @@ services:
     environment:
       OPENSEARCH_HOSTS: '["http://opensearch:9200"]' # Define the OpenSearch nodes that OpenSearch Dashboards will query
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/dev/cassandra-pinot-kafka.yml
+++ b/docker/dev/cassandra-pinot-kafka.yml
@@ -49,7 +49,7 @@ services:
     depends_on:
       - pinot-broker
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     restart: unless-stopped
     container_name: "kafka"
     ports:

--- a/docker/dev/mongo-esv7-kafka.yml
+++ b/docker/dev/mongo-esv7-kafka.yml
@@ -25,7 +25,7 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/dev/mysql-esv7-kafka.yml
+++ b/docker/dev/mysql-esv7-kafka.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/docker-compose-async-wf-kafka.yml
+++ b/docker/docker-compose-async-wf-kafka.yml
@@ -72,7 +72,7 @@ services:
     ports:
       - '3000:3000'
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/docker-compose-multiclusters-cass-mysql-es.yaml
+++ b/docker/docker-compose-multiclusters-cass-mysql-es.yaml
@@ -27,7 +27,7 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/github_actions/docker-compose-es7.yml
+++ b/docker/github_actions/docker-compose-es7.yml
@@ -15,7 +15,7 @@ services:
       retries: 10
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/github_actions/docker-compose-local-async-wf.yml
+++ b/docker/github_actions/docker-compose-local-async-wf.yml
@@ -17,7 +17,7 @@ services:
       retries: 10
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/github_actions/docker-compose-local-es7.yml
+++ b/docker/github_actions/docker-compose-local-es7.yml
@@ -17,7 +17,7 @@ services:
       retries: 10
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/github_actions/docker-compose-local-pinot.yml
+++ b/docker/github_actions/docker-compose-local-pinot.yml
@@ -29,7 +29,7 @@ services:
       - '9090:9090'
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     restart: unless-stopped
     container_name: "kafka"
     ports:

--- a/docker/github_actions/docker-compose-local.yml
+++ b/docker/github_actions/docker-compose-local.yml
@@ -43,7 +43,7 @@ services:
           - postgres
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/github_actions/docker-compose-opensearch2.yml
+++ b/docker/github_actions/docker-compose-opensearch2.yml
@@ -15,7 +15,7 @@ services:
       retries: 10
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:

--- a/docker/github_actions/docker-compose-pinot.yml
+++ b/docker/github_actions/docker-compose-pinot.yml
@@ -29,7 +29,7 @@ services:
       - '9090:9090'
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     restart: unless-stopped
     container_name: "kafka"
     ports:

--- a/docker/github_actions/docker-compose.yml
+++ b/docker/github_actions/docker-compose.yml
@@ -35,7 +35,7 @@ services:
           - postgres
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replaced `bitnamilegacy/kafka:3.7` with `soldevelo/kafka:3.7` in the Docker configuration. The Soldevelo image is a fully compatible, actively maintained fork. 
https://hub.docker.com/r/soldevelo/kafka/ 
https://github.com/SolDevelo/containers


<!-- Tell your future self why have you made these changes -->
**Why?**
The Bitnami legacy Kafka image is outdated and no longer maintained. Soldevelo provides a drop-in replacement that remains open-source, actively supported, and avoids the limitations of the legacy image. This follows the earlier note that Bitnami Legacy was only a temporary workaround until an open-source alternative was selected.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally via Docker Compose to confirm compatibility with the previous Bitnami image.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks expected. The Kafka version remains the same and the image is a drop-in replacement.


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No updates required.


<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
None required; configuration remains unchanged.