### PR TITLE
feat(history): add MinCronInterval config to restrict high-frequency cron

### DIFF
--- a/common/backoff/cron.go
+++ b/common/backoff/cron.go
@@ -121,3 +121,36 @@ func GetBackoffForNextScheduleInSeconds(
 	}
 	return int32(math.Ceil(backoffDuration.Seconds())), nil
 }
+
+// minIntervalProbeCount is the number of consecutive firings to sample when
+// computing the minimum interval of a cron schedule. Sampling more than two
+// firings lets us handle schedules whose gaps are not uniform (e.g.
+// "0 9,17 * * *"), while still bounding the cost of the probe.
+const minIntervalProbeCount = 10
+
+// MinScheduleInterval returns the smallest gap between any two consecutive
+// firings within the next minIntervalProbeCount firings after startTime. It
+// returns (0, nil) if the schedule has fewer than two future firings (this
+// should not normally happen for a schedule that has passed ValidateSchedule).
+func MinScheduleInterval(sched cron.Schedule, startTime time.Time) (time.Duration, error) {
+	if sched == nil {
+		return 0, fmt.Errorf("nil cron schedule")
+	}
+	prev := sched.Next(startTime.In(time.UTC))
+	if prev.IsZero() {
+		return 0, fmt.Errorf("invalid CronSchedule, no next firing time found")
+	}
+	minInterval := time.Duration(0)
+	for i := 0; i < minIntervalProbeCount; i++ {
+		next := sched.Next(prev)
+		if next.IsZero() {
+			break
+		}
+		interval := next.Sub(prev)
+		if i == 0 || interval < minInterval {
+			minInterval = interval
+		}
+		prev = next
+	}
+	return minInterval, nil
+}

--- a/common/backoff/cron_test.go
+++ b/common/backoff/cron_test.go
@@ -254,3 +254,60 @@ func TestCronWithBufferOneCronWorkflow(t *testing.T) {
 		})
 	}
 }
+
+func TestMinScheduleInterval(t *testing.T) {
+	start, err := time.Parse(time.RFC3339, "2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		cron     string
+		expected time.Duration
+	}{
+		{
+			name:     "every minute star syntax",
+			cron:     "* * * * *",
+			expected: time.Minute,
+		},
+		{
+			name:     "every 10 minutes",
+			cron:     "*/10 * * * *",
+			expected: 10 * time.Minute,
+		},
+		{
+			name:     "hourly",
+			cron:     "0 * * * *",
+			expected: time.Hour,
+		},
+		{
+			name:     "every 5 seconds via @every",
+			cron:     "@every 5s",
+			expected: 5 * time.Second,
+		},
+		{
+			name:     "daily at 10am",
+			cron:     "0 10 * * *",
+			expected: 24 * time.Hour,
+		},
+		{
+			// fires at 9:00 and 17:00 daily; minimum gap is 8h (17->9 next day is 16h)
+			name:     "non-uniform intervals take the smallest gap",
+			cron:     "0 9,17 * * *",
+			expected: 8 * time.Hour,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched, err := ValidateSchedule(tt.cron)
+			require.NoError(t, err)
+			got, err := MinScheduleInterval(sched, start)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestMinScheduleIntervalNilSchedule(t *testing.T) {
+	_, err := MinScheduleInterval(nil, time.Now())
+	assert.Error(t, err)
+}

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2371,6 +2371,14 @@ const (
 	// Allowed filters: DomainName
 	EnableTaskListAwareTaskSchedulerByDomain
 
+	// EnforceMinCronInterval controls whether cron schedules with an interval below
+	// MinCronInterval are rejected. When false, violating schedules are only logged.
+	// KeyName: history.enforceMinCronInterval
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	EnforceMinCronInterval
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -3281,6 +3289,16 @@ const (
 	// Default value: 30m (30 * time.Minute)
 	// Allowed filters: ShardID
 	HistoryTaskDLQProcessorInterval
+
+	// MinCronInterval is the minimum allowed interval between cron firings. Start
+	// workflow requests whose cron schedule fires more frequently than this are
+	// logged, and rejected when EnforceMinCronInterval is also true. A value of 0
+	// disables the check entirely.
+	// KeyName: history.minCronInterval
+	// Value type: Duration
+	// Default value: 0 (disabled)
+	// Allowed filters: DomainName
+	MinCronInterval
 
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
@@ -5121,6 +5139,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		Filters:      []Filter{DomainName},
 		DefaultValue: false,
 	},
+	EnforceMinCronInterval: {
+		KeyName:      "history.enforceMinCronInterval",
+		Filters:      []Filter{DomainName},
+		Description:  "EnforceMinCronInterval controls whether cron schedules below MinCronInterval are rejected. When false, violating schedules are only logged.",
+		DefaultValue: false,
+	},
 }
 
 var FloatKeys = map[FloatKey]DynamicFloat{
@@ -5914,6 +5938,12 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		Filters:      []Filter{ShardID},
 		Description:  "HistoryTaskDLQProcessorInterval is the interval for background processing of the History Task DLQ",
 		DefaultValue: time.Minute * 30,
+	},
+	MinCronInterval: {
+		KeyName:      "history.minCronInterval",
+		Filters:      []Filter{DomainName},
+		Description:  "MinCronInterval is the minimum allowed interval between cron firings. A value of 0 disables the check entirely.",
+		DefaultValue: time.Duration(0),
 	},
 }
 

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -263,6 +263,13 @@ type Config struct {
 	NormalDecisionScheduleToStartMaxAttempts dynamicproperties.IntPropertyFnWithDomainFilter
 	NormalDecisionScheduleToStartTimeout     dynamicproperties.DurationPropertyFnWithDomainFilter
 
+	// MinCronInterval is the minimum allowed interval between cron firings. When a
+	// StartWorkflow request has a cron schedule that fires more frequently than
+	// this, it is logged and, if EnforceMinCronInterval is true, rejected.
+	// A zero value disables the check.
+	MinCronInterval        dynamicproperties.DurationPropertyFnWithDomainFilter
+	EnforceMinCronInterval dynamicproperties.BoolPropertyFnWithDomainFilter
+
 	// The following is used by the new RPC replication stack
 	ReplicationTaskFetcherParallelism                    dynamicproperties.IntPropertyFn
 	ReplicationTaskFetcherAggregationInterval            dynamicproperties.DurationPropertyFn
@@ -544,6 +551,9 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		EnforceDecisionTaskAttempts:              dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnforceDecisionTaskAttempts),
 		NormalDecisionScheduleToStartMaxAttempts: dc.GetIntPropertyFilteredByDomain(dynamicproperties.NormalDecisionScheduleToStartMaxAttempts),
 		NormalDecisionScheduleToStartTimeout:     dc.GetDurationPropertyFilteredByDomain(dynamicproperties.NormalDecisionScheduleToStartTimeout),
+
+		MinCronInterval:        dc.GetDurationPropertyFilteredByDomain(dynamicproperties.MinCronInterval),
+		EnforceMinCronInterval: dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnforceMinCronInterval),
 
 		ReplicationTaskFetcherParallelism:                    dc.GetIntProperty(dynamicproperties.ReplicationTaskFetcherParallelism),
 		ReplicationTaskFetcherAggregationInterval:            dc.GetDurationProperty(dynamicproperties.ReplicationTaskFetcherAggregationInterval),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -209,6 +209,8 @@ func TestNewConfig(t *testing.T) {
 		"EnforceDecisionTaskAttempts":                          {dynamicproperties.EnforceDecisionTaskAttempts, true},
 		"NormalDecisionScheduleToStartMaxAttempts":             {dynamicproperties.NormalDecisionScheduleToStartMaxAttempts, 84},
 		"NormalDecisionScheduleToStartTimeout":                 {dynamicproperties.NormalDecisionScheduleToStartTimeout, time.Second},
+		"MinCronInterval":                                      {dynamicproperties.MinCronInterval, time.Second},
+		"EnforceMinCronInterval":                               {dynamicproperties.EnforceMinCronInterval, true},
 		"ReplicationTaskFetcherParallelism":                    {dynamicproperties.ReplicationTaskFetcherParallelism, 85},
 		"ReplicationTaskFetcherAggregationInterval":            {dynamicproperties.ReplicationTaskFetcherAggregationInterval, time.Second},
 		"ReplicationTaskFetcherTimerJitterCoefficient":         {dynamicproperties.ReplicationTaskFetcherTimerJitterCoefficient, 9.0},

--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/activecluster"
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -739,7 +740,60 @@ func (e *historyEngineImpl) validateStartWorkflowExecutionRequest(request *types
 		return &types.BadRequestError{Message: "WorkflowType exceeds length limit."}
 	}
 
+	if err := e.validateCronSchedule(request); err != nil {
+		return err
+	}
+
 	return common.ValidateRetryPolicy(request.RetryPolicy)
+}
+
+// validateCronSchedule enforces the MinCronInterval policy for a StartWorkflow
+// request. When the request has a cron schedule whose minimum firing interval
+// is below the configured minimum, the violation is always logged with the
+// domain name. If EnforceMinCronInterval is true for the domain, the request
+// is rejected with a BadRequestError.
+func (e *historyEngineImpl) validateCronSchedule(request *types.StartWorkflowExecutionRequest) error {
+	cronSchedule := request.GetCronSchedule()
+	if cronSchedule == "" {
+		return nil
+	}
+	domainName := request.GetDomain()
+	minAllowed := e.config.MinCronInterval(domainName)
+	if minAllowed <= 0 {
+		return nil
+	}
+	sched, err := backoff.ValidateSchedule(cronSchedule)
+	if err != nil {
+		// Invalid schedules are caught by the existing validator paths; treat
+		// them as not-a-cron-restriction issue here and let downstream code
+		// surface the original parse error.
+		return nil
+	}
+	minInterval, err := backoff.MinScheduleInterval(sched, time.Now())
+	if err != nil || minInterval <= 0 {
+		return nil
+	}
+	if minInterval >= minAllowed {
+		return nil
+	}
+	e.logger.Warn(
+		"Cron schedule fires more frequently than the configured minimum interval",
+		tag.WorkflowDomainName(domainName),
+		tag.WorkflowID(request.GetWorkflowID()),
+		tag.WorkflowType(request.WorkflowType.GetName()),
+		tag.WorkflowCronSchedule(cronSchedule),
+		tag.Dynamic("cron-min-interval", minInterval.String()),
+		tag.Dynamic("cron-min-interval-allowed", minAllowed.String()),
+	)
+	if e.config.EnforceMinCronInterval(domainName) {
+		return &types.BadRequestError{
+			Message: fmt.Sprintf(
+				"CronSchedule %q fires every %s, which is below the minimum allowed interval of %s for this domain.",
+				cronSchedule, minInterval, minAllowed,
+			),
+		}
+	}
+	return nil
 }
 
 func (e *historyEngineImpl) overrideTaskStartToCloseTimeoutSeconds(

--- a/service/history/engine/engineimpl/validate_cron_schedule_test.go
+++ b/service/history/engine/engineimpl/validate_cron_schedule_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2017-2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package engineimpl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/config"
+)
+
+func TestValidateCronSchedule(t *testing.T) {
+	const testDomain = "test-domain"
+
+	type configOverride struct {
+		minInterval time.Duration
+		enforce     bool
+	}
+
+	tests := []struct {
+		name         string
+		cronSchedule string
+		cfg          configOverride
+		wantErr      bool
+		wantErrMsg   string
+	}{
+		{
+			name:         "no cron schedule is allowed",
+			cronSchedule: "",
+			cfg:          configOverride{minInterval: time.Hour, enforce: true},
+		},
+		{
+			name:         "min interval disabled accepts any schedule",
+			cronSchedule: "* * * * *",
+			cfg:          configOverride{minInterval: 0, enforce: true},
+		},
+		{
+			name:         "schedule meeting the minimum is accepted",
+			cronSchedule: "0 * * * *", // hourly
+			cfg:          configOverride{minInterval: time.Hour, enforce: true},
+		},
+		{
+			name:         "schedule above the minimum is accepted",
+			cronSchedule: "0 */6 * * *", // every 6 hours
+			cfg:          configOverride{minInterval: time.Hour, enforce: true},
+		},
+		{
+			name:         "violation with enforcement rejects the request",
+			cronSchedule: "* * * * *", // every minute
+			cfg:          configOverride{minInterval: time.Hour, enforce: true},
+			wantErr:      true,
+			wantErrMsg:   "below the minimum allowed interval",
+		},
+		{
+			name:         "violation without enforcement logs but accepts",
+			cronSchedule: "* * * * *",
+			cfg:          configOverride{minInterval: time.Hour, enforce: false},
+		},
+		{
+			name:         "non-uniform interval caught by min gap",
+			cronSchedule: "0 9,17 * * *", // gaps of 8h and 16h
+			cfg:          configOverride{minInterval: 12 * time.Hour, enforce: true},
+			wantErr:      true,
+			wantErrMsg:   "below the minimum allowed interval",
+		},
+		{
+			name:         "every 30 seconds violates 1 minute minimum",
+			cronSchedule: "@every 30s",
+			cfg:          configOverride{minInterval: time.Minute, enforce: true},
+			wantErr:      true,
+		},
+		{
+			name:         "invalid cron schedule is not rejected by this validator",
+			cronSchedule: "not-a-cron",
+			cfg:          configOverride{minInterval: time.Hour, enforce: true},
+			// The existing pipeline validates the schedule via backoff.ValidateSchedule
+			// elsewhere; this validator only applies when the schedule can be parsed,
+			// so it must not double-surface parse errors.
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			override := tt.cfg
+			cfg := &config.Config{
+				MinCronInterval: func(domain string) time.Duration {
+					require.Equal(t, testDomain, domain)
+					return override.minInterval
+				},
+				EnforceMinCronInterval: func(domain string) bool {
+					require.Equal(t, testDomain, domain)
+					return override.enforce
+				},
+			}
+			e := &historyEngineImpl{
+				config: cfg,
+				logger: testlogger.New(t),
+			}
+			request := &types.StartWorkflowExecutionRequest{
+				Domain:       testDomain,
+				WorkflowID:   "test-workflow",
+				WorkflowType: &types.WorkflowType{Name: "test-workflow-type"},
+				CronSchedule: tt.cronSchedule,
+			}
+
+			err := e.validateCronSchedule(request)
+			if tt.wantErr {
+				require.Error(t, err)
+				var badRequest *types.BadRequestError
+				require.ErrorAs(t, err, &badRequest)
+				if tt.wantErrMsg != "" {
+					assert.Contains(t, err.Error(), tt.wantErrMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What changed?**

Adds two new domain-filtered dynamic configs to the history service that let operators cap how frequently a cron schedule can fire for new start-workflow requests. Fixes #7598.

- `history.minCronInterval` (Duration, default `0` = disabled) — the smallest allowed gap between consecutive cron firings.
- `history.enforceMinCronInterval` (Bool, default `false`) — when `true`, violating requests are rejected; when `false`, they are only logged.

The check runs inside `historyEngineImpl.validateStartWorkflowExecutionRequest` so it covers both `StartWorkflowExecution` and `SignalWithStartWorkflowExecution`. The minimum interval of the schedule is computed by sampling the next 10 firings of the schedule and taking the smallest gap, via a new `backoff.MinScheduleInterval` helper. Sampling several firings correctly handles schedules with non-uniform gaps such as `0 9,17 * * *` (where the 8-hour gap would be missed if only the first interval were checked).

Violations always log the domain name, workflow id, workflow type, the cron spec, the computed minimum interval, and the configured limit, which lets operators identify offenders before enabling enforcement. Existing cron workflows that continue-as-new are not affected — only new start-workflow requests go through this validator — matching the behaviour requested in the issue.

**Why?**

Users sometimes start workflows with a CronSchedule that fires more often than a long-running activity can complete (for example `* * * * *` on a workflow that takes a couple of minutes). These schedules rarely do what the user intends and can place substantial, avoidable load on the cluster because every missed firing still costs a history event, a transfer task, and a decision task. There was previously no way for a cluster operator to set a lower bound on cron frequency, so operators had to chase these workflows down by hand. The issue author requested a per-domain dynamic config that can start in warn-only mode for observability and then be flipped to enforcement once the offending workflows are cleaned up; this PR implements exactly that shape.

**How did you test it?**

Unit tests:

```
go test -race ./common/backoff/... -run TestMinScheduleInterval
go test -race ./service/history/engine/engineimpl/... -run TestValidateCronSchedule
go test -race ./service/history/config/...
go test -race ./common/backoff/...
go test -race ./common/dynamicconfig/...
```

All pass locally. The new `TestMinScheduleInterval` in `common/backoff/cron_test.go` covers uniform schedules (`* * * * *`, `*/10 * * * *`, hourly, `@every 5s`, daily at 10am) and a non-uniform schedule (`0 9,17 * * *`) to verify the sampler picks the smallest gap. The new `TestValidateCronSchedule` in `service/history/engine/engineimpl/validate_cron_schedule_test.go` exercises the full validator in both enforce-on and enforce-off modes, including empty cron, disabled min-interval, schedules meeting or exceeding the minimum, schedules violating it, the non-uniform case, and an unparseable spec (which this validator must not double-surface because the existing pipeline already reports that error).

The existing `TestStartWorkflowExecution` suite continues to pass unchanged because the default `MinCronInterval` of `0` disables the check entirely.

Compile-check: `go build ./...` from the repo root passes after the change.

**Potential risks**

Low. The feature is off by default (`MinCronInterval = 0` disables the check entirely), and only new start-workflow requests are affected. Even when `MinCronInterval` is non-zero, the default `EnforceMinCronInterval = false` means operators will only see warn-level logs until they explicitly opt in. The check adds a bounded cron sampling step (≤10 `sched.Next` calls) on the StartWorkflow hot path; this is negligible compared to the existing cron validation performed in the frontend handler.

No IDL, API, or schema changes. No feature-flag reuse. No changes to any task processing logic beyond adding one validation step before the existing retry policy validation.

**Release notes**

Adds two optional dynamic configs — `history.minCronInterval` (duration, default disabled) and `history.enforceMinCronInterval` (bool, default false) — that let operators cap the minimum allowed cron firing interval per domain. When a new StartWorkflow or SignalWithStartWorkflow request specifies a cron schedule whose smallest firing gap is below the configured minimum, the violation is logged with the domain name; if enforcement is on, the request is rejected with a `BadRequestError`. Existing running cron workflows are unaffected. Closes #7598.

**Documentation Changes**

No public API or configuration file changes beyond the dynamic config registry, which is self-documenting via `common/dynamicconfig/dynamicproperties/constants.go`. The two new keys follow the same comment structure as the surrounding entries and include `KeyName`, `Value type`, `Default value`, and `Allowed filters`. No docs-repo update needed.