### PR TITLE
fix(scheduler): honor backfill overlap policy

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -403,6 +403,18 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 // a single activity so that the overlap logic can evolve without introducing
 // nondeterminism in the workflow history.
 func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
+	processScheduleFireWithOverlapPolicy(ctx, logger, input, state, scheduledTime, trigger, input.Policies.OverlapPolicy)
+}
+
+func processScheduleFireWithOverlapPolicy(
+	ctx workflow.Context,
+	logger *zap.Logger,
+	input *SchedulerWorkflowInput,
+	state *SchedulerWorkflowState,
+	scheduledTime time.Time,
+	trigger TriggerSource,
+	overlapPolicy types.ScheduleOverlapPolicy,
+) {
 	state.LastRunTime = scheduledTime
 
 	logger.Info("schedule fired",
@@ -423,7 +435,7 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 		Action:              *input.Action.StartWorkflow,
 		ScheduledTime:       scheduledTime,
 		TriggerSource:       trigger,
-		OverlapPolicy:       input.Policies.OverlapPolicy,
+		OverlapPolicy:       overlapPolicy,
 		LastStartedWorkflow: state.LastStartedWorkflow,
 	}
 
@@ -645,7 +657,7 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, sched cron.Sched
 				)
 				return true
 			}
-			processScheduleFire(ctx, logger, input, state, t, TriggerSourceBackfill)
+			processScheduleFireWithOverlapPolicy(ctx, logger, input, state, t, TriggerSourceBackfill, backfillOverlapPolicy(*bf, input.Policies.OverlapPolicy))
 			fired++
 		}
 
@@ -670,6 +682,13 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, sched cron.Sched
 	}
 
 	return false
+}
+
+func backfillOverlapPolicy(bf BackfillRequest, schedulePolicy types.ScheduleOverlapPolicy) types.ScheduleOverlapPolicy {
+	if bf.OverlapPolicy == types.ScheduleOverlapPolicyInvalid {
+		return schedulePolicy
+	}
+	return bf.OverlapPolicy
 }
 
 // buildScheduleDescription creates a snapshot of the current schedule

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/cadence/testsuite"
 	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common/types"
@@ -772,6 +774,73 @@ func TestProcessBackfillsRespectsPause(t *testing.T) {
 	moreWork := processBackfills(nil, testLogger, sched, input, state)
 	assert.False(t, moreWork, "paused schedule should not process backfills")
 	assert.Len(t, state.PendingBackfills, 1, "pending backfills should be preserved while paused")
+}
+
+func TestSchedulerWorkflowBackfillUsesBackfillOverlapPolicy(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(SchedulerWorkflow)
+
+	backfillTime := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	env.SetStartTime(backfillTime.Add(time.Hour))
+
+	input := SchedulerWorkflowInput{
+		Domain:     "test-domain",
+		ScheduleID: "sched-1",
+		Spec: types.ScheduleSpec{
+			CronExpression: "0 * * * *",
+			EndTime:        backfillTime,
+		},
+		Action: types.ScheduleAction{
+			StartWorkflow: &types.StartWorkflowAction{
+				WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+				TaskList:     &types.TaskList{Name: "my-tasklist"},
+			},
+		},
+		Policies: types.SchedulePolicies{
+			OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+		},
+		State: SchedulerWorkflowState{
+			PendingBackfills: []BackfillRequest{
+				{
+					StartTime:     backfillTime,
+					EndTime:       backfillTime,
+					OverlapPolicy: types.ScheduleOverlapPolicyConcurrent,
+					BackfillID:    "bf-1",
+				},
+			},
+		},
+	}
+
+	env.OnActivity(processScheduleFireActivity, mock.Anything, mock.MatchedBy(func(req ProcessFireRequest) bool {
+		assert.Equal(t, TriggerSourceBackfill, req.TriggerSource)
+		assert.Equal(t, types.ScheduleOverlapPolicyConcurrent, req.OverlapPolicy)
+		assert.Equal(t, backfillTime, req.ScheduledTime)
+		return true
+	})).Return(&ProcessFireResult{TotalDelta: 1}, nil).Once()
+
+	env.ExecuteWorkflow(SchedulerWorkflow, input)
+
+	assert.True(t, env.IsWorkflowCompleted())
+	assert.NoError(t, env.GetWorkflowError())
+	env.AssertExpectations(t)
+}
+
+func TestBackfillOverlapPolicy(t *testing.T) {
+	assert.Equal(t,
+		types.ScheduleOverlapPolicyConcurrent,
+		backfillOverlapPolicy(
+			BackfillRequest{OverlapPolicy: types.ScheduleOverlapPolicyConcurrent},
+			types.ScheduleOverlapPolicySkipNew,
+		),
+	)
+	assert.Equal(t,
+		types.ScheduleOverlapPolicyTerminatePrevious,
+		backfillOverlapPolicy(
+			BackfillRequest{OverlapPolicy: types.ScheduleOverlapPolicyInvalid},
+			types.ScheduleOverlapPolicyTerminatePrevious,
+		),
+	)
 }
 
 func TestBackfillFireComputation(t *testing.T) {


### PR DESCRIPTION
**What changed?**

Backfilled schedule fires now use the overlap policy from the queued backfill request when it is set. Unset backfill policies continue to fall back to the schedule-level policy. Closes #8005.

**Why?**

`BackfillScheduleRequest` and `BackfillSignal` preserve a request-specific `OverlapPolicy`, but `processBackfills` previously called `processScheduleFire`, which always built the fire activity request with `input.Policies.OverlapPolicy`. As a result, a one-off backfill policy override was ignored at execution time.

The fix routes backfilled fires through an overlap-policy-aware helper and keeps the default scheduled-fire path unchanged.

**How did you test it?**

`go test ./service/worker/scheduler -run 'TestSchedulerWorkflowBackfillUsesBackfillOverlapPolicy|TestBackfillOverlapPolicy|TestProcessBackfillsRespectsPause|TestBackfillFireComputation'`\n\n`go test ./service/worker/scheduler`\n\n`make pr GEN_DIR=service/worker/scheduler`\n\n**Potential risks**\n\nLow. This only changes backfill execution when the backfill request supplies an explicit overlap policy. Backfills without an explicit policy retain the prior schedule-policy behavior.\n\n**Release notes**\n\nBackfill schedule requests now honor their requested overlap policy when firing backfilled runs. #8005\n\n**Documentation Changes**\n\nN/A\n