### PR TITLE
test(mapper): add thrift error and helper fuzz tests

### DIFF
--- a/common/types/mapper/thrift/errors_test.go
+++ b/common/types/mapper/thrift/errors_test.go
@@ -24,10 +24,14 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
+	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/yarpcerrors"
 
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/testutils"
 	"github.com/uber/cadence/common/types/testdata"
 )
 
@@ -54,4 +58,41 @@ func TestFromUnknownErrorMapsToItself(t *testing.T) {
 func TestToUnknownErrorMapsToItself(t *testing.T) {
 	err := yarpcerrors.DeadlineExceededErrorf("timeout")
 	assert.Equal(t, err, ToError(err))
+}
+
+func RetryTaskV2ErrorFuzzer(e *types.RetryTaskV2Error, c fuzz.Continue) {
+	c.FuzzNoCustom(e)
+	if e.StartEventID == nil || e.StartEventVersion == nil {
+		e.StartEventID = nil
+		e.StartEventVersion = nil
+	}
+	if e.EndEventID == nil || e.EndEventVersion == nil {
+		e.EndEventID = nil
+		e.EndEventVersion = nil
+	}
+}
+
+func TestErrorsFuzz(t *testing.T) {
+	seed := time.Now().UnixNano()
+	defer func() {
+		if t.Failed() {
+			t.Logf("fuzz seed: %v", seed)
+		}
+	}()
+
+	for _, errTemplate := range testdata.Errors {
+		errType := reflect.TypeOf(errTemplate).Elem()
+		t.Run(errType.Name(), func(t *testing.T) {
+			var customFuncs []interface{}
+			if _, ok := errTemplate.(*types.RetryTaskV2Error); ok {
+				customFuncs = []interface{}{RetryTaskV2ErrorFuzzer}
+			}
+			f := fuzz.NewWithSeed(seed).Funcs(customFuncs...)
+			for i := 0; i < testutils.DefaultIterations; i++ {
+				newErr := reflect.New(errType).Interface()
+				f.Fuzz(newErr)
+				assert.Equal(t, newErr, ToError(FromError(newErr.(error))), "iteration %d", i)
+			}
+		})
+	}
 }

--- a/common/types/mapper/thrift/helpers_test.go
+++ b/common/types/mapper/thrift/helpers_test.go
@@ -24,7 +24,10 @@ import (
 	"testing"
 	"time"
 
+	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/types/mapper/testutils"
 )
 
 func TestTimeToNano(t *testing.T) {
@@ -90,4 +93,24 @@ func TestSecondsI32ToDuration(t *testing.T) {
 func TestSecondsI32ToDurationNil(t *testing.T) {
 	result := secondsToDuration(nil)
 	assert.Equal(t, time.Duration(0), result)
+}
+
+func SafeNanoFuzzer(n *int64, c fuzz.Continue) {
+	*n = c.Int63n(int64(testutils.MaxSafeTimestampSeconds) * int64(testutils.NanosecondsPerSecond))
+}
+
+func LocalTimeFuzzer(t *time.Time, c fuzz.Continue) {
+	*t = time.Unix(c.Int63n(testutils.MaxSafeTimestampSeconds), c.Int63n(int64(testutils.NanosecondsPerSecond)))
+}
+
+func TestTimeToNanoFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, timeToNano, nanoToTime,
+		testutils.WithCustomFuncs(LocalTimeFuzzer),
+	)
+}
+
+func TestNanoToTimeFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, nanoToTime, timeToNano,
+		testutils.WithCustomFuncs(SafeNanoFuzzer),
+	)
 }


### PR DESCRIPTION
**What changed?**

Added gofuzz-based round-trip tests for thrift error mappers and thrift helper time/nanosecond conversions. Refs #7611.

**Why?**

The mapper fuzz test tracking issue lists errors and helpers as remaining coverage areas. These tests exercise randomized mapper inputs, preserve nil edge cases, and constrain time/error values where the existing conversions require paired fields or safe timestamp ranges.

**How did you test it?**

- `go test ./common/types/mapper/thrift -run 'Test(ErrorsFuzz|TimeToNanoFuzz|NanoToTimeFuzz|Errors|NilMapsToNil|FromUnknownErrorMapsToItself|ToUnknownErrorMapsToItself)$' -count=1`
- `go test ./common/types/mapper/thrift -count=1`
- `go test ./common/types/mapper/... -count=1`
- `git diff --check`

**Potential risks**

Low. This is test-only and does not change mapper behavior.

**Release notes**

N/A. Test-only change for #7611.

**Documentation Changes**

N/A.
