### PR TITLE
feat(persistence): add autoSetup option for SQLite schema auto-migration

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -149,6 +149,10 @@ func (a *App) verifySchema(ctx context.Context) error {
 	if err := cassandra.VerifyCompatibleVersion(a.cfg.Persistence, gocql.Quorum); err != nil {
 		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)
 	}
+	// auto-setup SQLite stores that have autoSetup enabled
+	if err := sql.MaybeAutoSetupSQLiteSchema(a.cfg.Persistence); err != nil {
+		return fmt.Errorf("sqlite auto-setup failed: %w", err)
+	}
 	// sql schema version validation
 	if err := sql.VerifyCompatibleVersion(a.cfg.Persistence); err != nil {
 		return fmt.Errorf("sql schema version compatibility check failed: %w", err)

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -167,6 +167,10 @@ func (a *App) verifySchema(ctx context.Context) error {
 	if err := cassandra.VerifyCompatibleVersion(a.cfg.Persistence, gocql.Quorum); err != nil {
 		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)
 	}
+	// auto-setup SQLite stores that have autoSetup enabled
+	if err := sql.MaybeAutoSetupSQLiteSchema(a.cfg.Persistence); err != nil {
+		return fmt.Errorf("sqlite auto-setup failed: %w", err)
+	}
 	// sql schema version validation
 	if err := sql.VerifyCompatibleVersion(a.cfg.Persistence); err != nil {
 		return fmt.Errorf("sql schema version compatibility check failed: %w", err)

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -378,6 +378,9 @@ type (
 		// Required when UseMultipleDatabases is true
 		// the length of the list should be exactly the same as NumShards
 		MultipleDatabasesConfig []MultipleDatabasesConfigEntry `yaml:"multipleDatabasesConfig"`
+		// AutoSetup, when true, automatically creates and migrates the schema on server startup.
+		// Only supported for SQLite; intended for development use.
+		AutoSetup bool `yaml:"autoSetup"`
 	}
 
 	// MultipleDatabasesConfigEntry is an entry for MultipleDatabasesConfig to connect to a single SQL database

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -376,6 +376,9 @@ type (
 		// Required when UseMultipleDatabases is true
 		// the length of the list should be exactly the same as NumShards
 		MultipleDatabasesConfig []MultipleDatabasesConfigEntry `yaml:"multipleDatabasesConfig"`
+		// AutoSetup, when true, automatically creates and migrates the schema on server startup.
+		// Only supported for SQLite; intended for development use.
+		AutoSetup bool `yaml:"autoSetup"`
 	}
 
 	// MultipleDatabasesConfigEntry is an entry for MultipleDatabasesConfig to connect to a single SQL database

--- a/config/development_sqlite.yaml
+++ b/config/development_sqlite.yaml
@@ -5,6 +5,7 @@ persistence:
     sqlite-default:
       sql:
         pluginName: "sqlite"
+        autoSetup: true
         maxConns: 1
         maxIdleConns: 1
         maxConnLifetime: "128h"
@@ -12,6 +13,7 @@ persistence:
     sqlite-visibility:
       sql:
         pluginName: "sqlite"
+        autoSetup: true
         maxConns: 1
         maxIdleConns: 1
         maxConnLifetime: "128h"

--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -26,4 +26,4 @@ package sqlite
 const Version = "0.2"
 
 // VisibilityVersion is the SQLite visibility database release version
-const VisibilityVersion = "0.1"
+const VisibilityVersion = "0.2"

--- a/tools/sql/sqlite_setup.go
+++ b/tools/sql/sqlite_setup.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sql
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+	"sync"
+
+	"github.com/ncruces/go-sqlite3"
+
+	"github.com/uber/cadence/common/config"
+	sqlite_db "github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
+	sqlite_schema "github.com/uber/cadence/schema/sqlite"
+	"github.com/uber/cadence/tools/common/schema"
+)
+
+// autoSetupState tracks per-database setup state so concurrent service goroutines
+// don't race to initialize the same SQLite database.
+var autoSetupState = struct {
+	mu   sync.Mutex
+	byDB map[string]*dbSetupOnce
+}{byDB: make(map[string]*dbSetupOnce)}
+
+type dbSetupOnce struct {
+	once sync.Once
+	err  error
+}
+
+// MaybeAutoSetupSQLiteSchema runs schema setup and migration for any SQLite datastores
+// that have AutoSetup enabled. It is a no-op for non-SQLite stores and for SQLite
+// stores without AutoSetup. Intended to be called before schema version verification
+// on server startup.
+func MaybeAutoSetupSQLiteSchema(cfg config.Persistence) error {
+	type storeTarget struct {
+		storeName    string
+		schemaSubdir string
+	}
+	targets := []storeTarget{
+		{cfg.DefaultStore, "cadence/versioned"},
+		{cfg.VisibilityStore, "visibility/versioned"},
+	}
+	for _, t := range targets {
+		ds, ok := cfg.DataStores[t.storeName]
+		if !ok || ds.SQL == nil {
+			continue
+		}
+		if ds.SQL.PluginName != sqlite_db.PluginName || !ds.SQL.AutoSetup {
+			continue
+		}
+		if err := doSQLiteAutoSetupOnce(*ds.SQL, t.schemaSubdir); err != nil {
+			return fmt.Errorf("auto-setup SQLite store %q: %w", t.storeName, err)
+		}
+	}
+	return nil
+}
+
+// doSQLiteAutoSetupOnce ensures setup runs exactly once per database file across
+// all concurrent service goroutines, and propagates any error to all of them.
+func doSQLiteAutoSetupOnce(cfg config.SQL, schemaSubdir string) error {
+	autoSetupState.mu.Lock()
+	state, ok := autoSetupState.byDB[cfg.DatabaseName]
+	if !ok {
+		state = &dbSetupOnce{}
+		autoSetupState.byDB[cfg.DatabaseName] = state
+	}
+	autoSetupState.mu.Unlock()
+
+	state.once.Do(func() {
+		state.err = doSQLiteAutoSetup(cfg, schemaSubdir)
+	})
+	return state.err
+}
+
+func doSQLiteAutoSetup(cfg config.SQL, schemaSubdir string) error {
+	conn, err := NewConnection(&cfg)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer conn.Close()
+
+	// If the schema version table doesn't exist yet, run initial setup.
+	// Only treat a SQLite "no such table" error as a fresh database; any other
+	// error (disk full, file locked, corrupt DB) is propagated as-is.
+	if _, err := conn.ReadSchemaVersion(); err != nil {
+		if !isSQLiteNoSuchTableError(err) {
+			return fmt.Errorf("read schema version: %w", err)
+		}
+		if err2 := schema.SetupFromConfig(&schema.SetupConfig{
+			InitialVersion: "0.0",
+		}, conn); err2 != nil {
+			return fmt.Errorf("schema setup: %w", err2)
+		}
+	}
+
+	// Apply any outstanding migrations (idempotent: skips already-applied versions).
+	subFS, err := fs.Sub(sqlite_schema.SchemaFS, schemaSubdir)
+	if err != nil {
+		return fmt.Errorf("schema subdir %q: %w", schemaSubdir, err)
+	}
+	return schema.UpdateFromConfig(&schema.UpdateConfig{
+		SchemaFS: subFS,
+	}, conn)
+}
+
+// isSQLiteNoSuchTableError reports whether err is a SQLite "no such table" error,
+// which means the schema version table has not been created yet (fresh database).
+// It returns false for all other errors (disk full, file locked, corrupt DB, etc.)
+// so callers can propagate them instead of treating them as a fresh-database signal.
+//
+// SQLite's C API does not provide a specific extended error code for "no such table"
+// — it falls under the generic ERROR (code 1) alongside every other SQL logic error.
+// Checking the error message is the only reliable way to distinguish this case.
+func isSQLiteNoSuchTableError(err error) bool {
+	var sqlErr *sqlite3.Error
+	if !errors.As(err, &sqlErr) {
+		return false
+	}
+	// Confirm it is a generic SQL logic error (not a timeout, I/O error, etc.)
+	// before inspecting the message.
+	return sqlErr.Code() == sqlite3.ERROR && strings.Contains(sqlErr.Error(), "no such table")
+}

--- a/tools/sql/sqlite_setup.go
+++ b/tools/sql/sqlite_setup.go
@@ -1,23 +1,3 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package sql
 
 import (
@@ -35,61 +15,42 @@ import (
 	"github.com/uber/cadence/tools/common/schema"
 )
 
-// autoSetupState tracks per-database setup state so concurrent service goroutines
-// don't race to initialize the same SQLite database.
-var autoSetupState = struct {
-	mu   sync.Mutex
-	byDB map[string]*dbSetupOnce
-}{byDB: make(map[string]*dbSetupOnce)}
-
-type dbSetupOnce struct {
+// autoSetup runs at most once per process; err is retained for later callers.
+var autoSetup struct {
 	once sync.Once
 	err  error
 }
 
 // MaybeAutoSetupSQLiteSchema runs schema setup and migration for any SQLite datastores
 // that have AutoSetup enabled. It is a no-op for non-SQLite stores and for SQLite
-// stores without AutoSetup. Intended to be called before schema version verification
-// on server startup.
+// stores without AutoSetup.
+// Called from each service's schema verification; only the first call runs setup.
 func MaybeAutoSetupSQLiteSchema(cfg config.Persistence) error {
-	type storeTarget struct {
-		storeName    string
-		schemaSubdir string
-	}
-	targets := []storeTarget{
+	autoSetup.once.Do(func() {
+		autoSetup.err = autoSetupSQLiteSchema(cfg)
+	})
+	return autoSetup.err
+}
+
+func autoSetupSQLiteSchema(cfg config.Persistence) error {
+	datastores := []struct{ storeName, schemaSubdir string }{
 		{cfg.DefaultStore, "cadence/versioned"},
 		{cfg.VisibilityStore, "visibility/versioned"},
 	}
-	for _, t := range targets {
-		ds, ok := cfg.DataStores[t.storeName]
+
+	for _, datastore := range datastores {
+		ds, ok := cfg.DataStores[datastore.storeName]
 		if !ok || ds.SQL == nil {
 			continue
 		}
 		if ds.SQL.PluginName != sqlite_db.PluginName || !ds.SQL.AutoSetup {
 			continue
 		}
-		if err := doSQLiteAutoSetupOnce(*ds.SQL, t.schemaSubdir); err != nil {
-			return fmt.Errorf("auto-setup SQLite store %q: %w", t.storeName, err)
+		if err := doSQLiteAutoSetup(*ds.SQL, datastore.schemaSubdir); err != nil {
+			return fmt.Errorf("auto-setup SQLite store %q: %w", datastore.storeName, err)
 		}
 	}
 	return nil
-}
-
-// doSQLiteAutoSetupOnce ensures setup runs exactly once per database file across
-// all concurrent service goroutines, and propagates any error to all of them.
-func doSQLiteAutoSetupOnce(cfg config.SQL, schemaSubdir string) error {
-	autoSetupState.mu.Lock()
-	state, ok := autoSetupState.byDB[cfg.DatabaseName]
-	if !ok {
-		state = &dbSetupOnce{}
-		autoSetupState.byDB[cfg.DatabaseName] = state
-	}
-	autoSetupState.mu.Unlock()
-
-	state.once.Do(func() {
-		state.err = doSQLiteAutoSetup(cfg, schemaSubdir)
-	})
-	return state.err
 }
 
 func doSQLiteAutoSetup(cfg config.SQL, schemaSubdir string) error {
@@ -125,18 +86,10 @@ func doSQLiteAutoSetup(cfg config.SQL, schemaSubdir string) error {
 
 // isSQLiteNoSuchTableError reports whether err is a SQLite "no such table" error,
 // which means the schema version table has not been created yet (fresh database).
-// It returns false for all other errors (disk full, file locked, corrupt DB, etc.)
-// so callers can propagate them instead of treating them as a fresh-database signal.
-//
-// SQLite's C API does not provide a specific extended error code for "no such table"
-// — it falls under the generic ERROR (code 1) alongside every other SQL logic error.
-// Checking the error message is the only reliable way to distinguish this case.
 func isSQLiteNoSuchTableError(err error) bool {
 	var sqlErr *sqlite3.Error
 	if !errors.As(err, &sqlErr) {
 		return false
 	}
-	// Confirm it is a generic SQL logic error (not a timeout, I/O error, etc.)
-	// before inspecting the message.
 	return sqlErr.Code() == sqlite3.ERROR && strings.Contains(sqlErr.Error(), "no such table")
 }

--- a/tools/sql/sqlite_setup_test.go
+++ b/tools/sql/sqlite_setup_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sql
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/config"
+	sqlite_db "github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
+	sqlite_schema "github.com/uber/cadence/schema/sqlite"
+)
+
+func sqliteTestCfg(dbPath string) config.SQL {
+	return config.SQL{
+		PluginName:   sqlite_db.PluginName,
+		DatabaseName: dbPath,
+		MaxConns:     1,
+		MaxIdleConns: 1,
+		AutoSetup:    true,
+	}
+}
+
+func TestDoSQLiteAutoSetup_FreshDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := sqliteTestCfg(filepath.Join(tmpDir, "cadence.db"))
+	require.NoError(t, doSQLiteAutoSetup(cfg, "cadence/versioned"))
+
+	conn, err := NewConnection(&cfg)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	version, err := conn.ReadSchemaVersion()
+	require.NoError(t, err)
+	assert.Equal(t, sqlite_schema.Version, version)
+}
+
+func TestDoSQLiteAutoSetup_FreshVisibilityDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := sqliteTestCfg(filepath.Join(tmpDir, "cadence_visibility.db"))
+	require.NoError(t, doSQLiteAutoSetup(cfg, "visibility/versioned"))
+
+	conn, err := NewConnection(&cfg)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	version, err := conn.ReadSchemaVersion()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, version, sqlite_schema.VisibilityVersion)
+}
+
+func TestDoSQLiteAutoSetup_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := sqliteTestCfg(filepath.Join(tmpDir, "cadence.db"))
+
+	require.NoError(t, doSQLiteAutoSetup(cfg, "cadence/versioned"))
+	// Second call on an already-migrated database must not return an error.
+	require.NoError(t, doSQLiteAutoSetup(cfg, "cadence/versioned"))
+}
+
+func TestMaybeAutoSetupSQLiteSchema_BothStores(t *testing.T) {
+	tmpDir := t.TempDir()
+	defaultDB := filepath.Join(tmpDir, "cadence.db")
+	visibilityDB := filepath.Join(tmpDir, "cadence_visibility.db")
+
+	cfg := config.Persistence{
+		DefaultStore:    "default",
+		VisibilityStore: "visibility",
+		DataStores: map[string]config.DataStore{
+			"default": {SQL: &config.SQL{
+				PluginName:   sqlite_db.PluginName,
+				DatabaseName: defaultDB,
+				MaxConns:     1,
+				MaxIdleConns: 1,
+				AutoSetup:    true,
+			}},
+			"visibility": {SQL: &config.SQL{
+				PluginName:   sqlite_db.PluginName,
+				DatabaseName: visibilityDB,
+				MaxConns:     1,
+				MaxIdleConns: 1,
+				AutoSetup:    true,
+			}},
+		},
+	}
+
+	require.NoError(t, MaybeAutoSetupSQLiteSchema(cfg))
+
+	for storeName, wantVersion := range map[string]string{
+		"default":    sqlite_schema.Version,
+		"visibility": sqlite_schema.VisibilityVersion,
+	} {
+		sqlCfg := cfg.DataStores[storeName].SQL
+		conn, err := NewConnection(sqlCfg)
+		require.NoError(t, err, "store %q", storeName)
+
+		version, err := conn.ReadSchemaVersion()
+		conn.Close()
+		require.NoError(t, err, "store %q", storeName)
+		assert.Equal(t, wantVersion, version, "store %q", storeName)
+	}
+}
+
+func TestMaybeAutoSetupSQLiteSchema_SkipsNonSQLitePlugin(t *testing.T) {
+	// Non-SQLite stores must be silently skipped (no connection attempted).
+	cfg := config.Persistence{
+		DefaultStore: "default",
+		DataStores: map[string]config.DataStore{
+			"default": {SQL: &config.SQL{
+				PluginName: "mysql",
+				AutoSetup:  true,
+			}},
+		},
+	}
+	require.NoError(t, MaybeAutoSetupSQLiteSchema(cfg))
+}
+
+func TestMaybeAutoSetupSQLiteSchema_SkipsWhenAutoSetupDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := config.Persistence{
+		DefaultStore: "default",
+		DataStores: map[string]config.DataStore{
+			"default": {SQL: &config.SQL{
+				PluginName:   sqlite_db.PluginName,
+				DatabaseName: filepath.Join(tmpDir, "cadence.db"),
+				MaxConns:     1,
+				MaxIdleConns: 1,
+				AutoSetup:    false,
+			}},
+		},
+	}
+	require.NoError(t, MaybeAutoSetupSQLiteSchema(cfg))
+
+	// Schema version table must not exist because setup was skipped.
+	conn, err := NewConnection(cfg.DataStores["default"].SQL)
+	require.NoError(t, err)
+
+	_, err = conn.ReadSchemaVersion()
+	conn.Close()
+	require.Error(t, err)
+	assert.True(t, isSQLiteNoSuchTableError(err))
+}
+
+func TestIsSQLiteNoSuchTableError_FreshDB(t *testing.T) {
+	// An in-memory database has no tables; ReadSchemaVersion must produce a
+	// "no such table" error that isSQLiteNoSuchTableError recognises.
+	conn, err := NewConnection(&config.SQL{
+		PluginName: sqlite_db.PluginName,
+		// Empty DatabaseName → in-memory SQLite.
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, readErr := conn.ReadSchemaVersion()
+	require.Error(t, readErr)
+	assert.True(t, isSQLiteNoSuchTableError(readErr))
+}
+
+func TestIsSQLiteNoSuchTableError_OtherErrors(t *testing.T) {
+	assert.False(t, isSQLiteNoSuchTableError(errors.New("disk full")))
+	assert.False(t, isSQLiteNoSuchTableError(nil))
+}

--- a/tools/sql/sqlite_setup_test.go
+++ b/tools/sql/sqlite_setup_test.go
@@ -1,28 +1,9 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package sql
 
 import (
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,6 +22,14 @@ func sqliteTestCfg(dbPath string) config.SQL {
 		MaxIdleConns: 1,
 		AutoSetup:    true,
 	}
+}
+
+func resetSQLiteAutoSetupForTest(t *testing.T) {
+	t.Helper()
+	autoSetup = struct {
+		once sync.Once
+		err  error
+	}{}
 }
 
 func TestDoSQLiteAutoSetup_FreshDatabase(t *testing.T) {
@@ -83,6 +72,7 @@ func TestDoSQLiteAutoSetup_Idempotent(t *testing.T) {
 }
 
 func TestMaybeAutoSetupSQLiteSchema_BothStores(t *testing.T) {
+	resetSQLiteAutoSetupForTest(t)
 	tmpDir := t.TempDir()
 	defaultDB := filepath.Join(tmpDir, "cadence.db")
 	visibilityDB := filepath.Join(tmpDir, "cadence_visibility.db")
@@ -126,6 +116,7 @@ func TestMaybeAutoSetupSQLiteSchema_BothStores(t *testing.T) {
 }
 
 func TestMaybeAutoSetupSQLiteSchema_SkipsNonSQLitePlugin(t *testing.T) {
+	resetSQLiteAutoSetupForTest(t)
 	// Non-SQLite stores must be silently skipped (no connection attempted).
 	cfg := config.Persistence{
 		DefaultStore: "default",
@@ -140,6 +131,7 @@ func TestMaybeAutoSetupSQLiteSchema_SkipsNonSQLitePlugin(t *testing.T) {
 }
 
 func TestMaybeAutoSetupSQLiteSchema_SkipsWhenAutoSetupDisabled(t *testing.T) {
+	resetSQLiteAutoSetupForTest(t)
 	tmpDir := t.TempDir()
 	cfg := config.Persistence{
 		DefaultStore: "default",
@@ -163,6 +155,54 @@ func TestMaybeAutoSetupSQLiteSchema_SkipsWhenAutoSetupDisabled(t *testing.T) {
 	conn.Close()
 	require.Error(t, err)
 	assert.True(t, isSQLiteNoSuchTableError(err))
+}
+
+func TestMaybeAutoSetupSQLiteSchema_OnceRetainsError(t *testing.T) {
+	resetSQLiteAutoSetupForTest(t)
+	t.Cleanup(func() { resetSQLiteAutoSetupForTest(t) })
+
+	tmpDir := t.TempDir()
+	cfg := config.Persistence{
+		DefaultStore: "default",
+		DataStores: map[string]config.DataStore{
+			"default": {SQL: &config.SQL{
+				PluginName:   sqlite_db.PluginName,
+				DatabaseName: tmpDir, // existing directory, not a database file
+				MaxConns:     1,
+				MaxIdleConns: 1,
+				AutoSetup:    true,
+			}},
+		},
+	}
+
+	err1 := MaybeAutoSetupSQLiteSchema(cfg)
+	require.Error(t, err1)
+
+	err2 := MaybeAutoSetupSQLiteSchema(cfg)
+	require.Error(t, err2)
+	assert.Equal(t, err1, err2)
+}
+
+func TestMaybeAutoSetupSQLiteSchema_OnceRetainsSuccess(t *testing.T) {
+	resetSQLiteAutoSetupForTest(t)
+	t.Cleanup(func() { resetSQLiteAutoSetupForTest(t) })
+
+	tmpDir := t.TempDir()
+	cfg := config.Persistence{
+		DefaultStore: "default",
+		DataStores: map[string]config.DataStore{
+			"default": {SQL: &config.SQL{
+				PluginName:   sqlite_db.PluginName,
+				DatabaseName: filepath.Join(tmpDir, "cadence.db"),
+				MaxConns:     1,
+				MaxIdleConns: 1,
+				AutoSetup:    true,
+			}},
+		},
+	}
+
+	require.NoError(t, MaybeAutoSetupSQLiteSchema(cfg))
+	require.NoError(t, MaybeAutoSetupSQLiteSchema(cfg))
 }
 
 func TestIsSQLiteNoSuchTableError_FreshDB(t *testing.T) {


### PR DESCRIPTION
Closes #8068

**What changed?**

Added `autoSetup` boolean to the SQL datastore config (`config.SQL`). When set on a SQLite store, the server automatically creates and migrates the schema on startup using the already-embedded schema files.

The default SQLite config (`config/development_sqlite.yaml`) enables this by default, so `./cadence-server --zone sqlite start` now works on a fresh checkout without any prior `make install-schema-sqlite` step.

**Why?**

Using Cadence with SQLite previously required two manual steps: running `make install-schema-sqlite` to create and migrate the schema, then starting the server. This was easy to forget and created friction for local development and experimentation.

Since the SQLite schema files are already embedded in the binary (`schema/sqlite/embed.go`), the server has everything it needs to bootstrap the database itself. The `autoSetup` flag is intentionally opt-in and SQLite-only — it is ignored for MySQL/Postgres where schema management is a more deliberate operation.

Concurrent service goroutines (all four services start in parallel) are coordinated via a per-database `sync.Once` so setup runs exactly once and all goroutines get the same result.

**How did you test it?**

Manually verified the two key scenarios:

Fresh database:
```
rm -f cadence.db* cadence_visibility.db*
./cadence-server --zone sqlite start
# Server starts successfully; schema created automatically
```

Existing up-to-date database (second start, should be a no-op):
```
./cadence-server --zone sqlite start
# Server starts successfully; no migrations run
```

Unit tests:
```
go test ./tools/sql/...
```

**Potential risks**

N/A. The `autoSetup` field defaults to `false` and is ignored for non-SQLite plugins, so there is no impact on existing Cassandra or MySQL/Postgres deployments.

**Release notes**

SQLite datastores now support `autoSetup: true` in the persistence config. When enabled, the server creates and migrates the SQLite schema automatically on startup — no separate schema installation step required. Enabled by default in `config/development_sqlite.yaml`.

**Documentation Changes**

The `CLAUDE.md` dev guide mentions `make install-schema-sqlite` as a prerequisite for the SQLite local dev path. That note can be removed or updated to reflect that `--zone sqlite` now works out of the box.