### PR TITLE
feat(invariants): add history invalid and mismatched records

### DIFF
--- a/common/reconciliation/invariant/history_invalid.go
+++ b/common/reconciliation/invariant/history_invalid.go
@@ -1,0 +1,183 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package invariant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+
+	c "github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/constants"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/reconciliation/entity"
+	"github.com/uber/cadence/common/types"
+)
+
+type historyInvalid struct {
+	pr persistence.Retryer
+	dc cache.DomainCache
+}
+
+// NewHistoryInvalid returns a new history invalid invariant that checks
+// whether the full history is readable and not corrupted.
+func NewHistoryInvalid(
+	pr persistence.Retryer, dc cache.DomainCache,
+) Invariant {
+	return &historyInvalid{
+		pr: pr,
+		dc: dc,
+	}
+}
+
+func (h *historyInvalid) Check(
+	ctx context.Context,
+	execution interface{},
+) CheckResult {
+	if checkResult := validateCheckContext(ctx, h.Name()); checkResult != nil {
+		return *checkResult
+	}
+
+	concreteExecution, ok := execution.(*entity.ConcreteExecution)
+	if !ok {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   h.Name(),
+			Info:            "failed to check: expected concrete execution",
+		}
+	}
+
+	domainID := concreteExecution.GetDomainID()
+	domainName, err := h.dc.GetDomainName(domainID)
+	if err != nil {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   h.Name(),
+			Info:            "failed to check: expected DomainName",
+			InfoDetails:     err.Error(),
+		}
+	}
+
+	var nextPageToken []byte
+	var lastEventID int64
+
+	for {
+		resp, readErr := h.pr.ReadHistoryBranch(ctx, &persistence.ReadHistoryBranchRequest{
+			BranchToken:   concreteExecution.BranchToken,
+			MinEventID:    constants.FirstEventID,
+			MaxEventID:    math.MaxInt64,
+			PageSize:      100,
+			NextPageToken: nextPageToken,
+			ShardID:       c.IntPtr(concreteExecution.ShardID),
+			DomainName:    domainName,
+		})
+		if readErr != nil {
+			if errors.Is(readErr, persistence.ErrCorruptedHistory) {
+				return CheckResult{
+					CheckResultType: CheckResultTypeCorrupted,
+					InvariantName:   h.Name(),
+					Info:            "corrupt history",
+					InfoDetails:     readErr.Error(),
+				}
+			}
+			return CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   h.Name(),
+				Info:            "failed to read history",
+				InfoDetails:     readErr.Error(),
+			}
+		}
+		if len(resp.HistoryEvents) > 0 {
+			lastEventID = resp.HistoryEvents[len(resp.HistoryEvents)-1].ID
+		}
+		if resp.NextPageToken == nil {
+			break
+		}
+		nextPageToken = resp.NextPageToken
+	}
+
+	if lastEventID == 0 {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   h.Name(),
+			Info:            "empty history",
+			InfoDetails:     "no history events found for workflow",
+		}
+	}
+
+	wfResp, wfErr := h.pr.GetWorkflowExecution(ctx, &persistence.GetWorkflowExecutionRequest{
+		DomainID: domainID,
+		Execution: types.WorkflowExecution{
+			WorkflowID: concreteExecution.WorkflowID,
+			RunID:      concreteExecution.RunID,
+		},
+		DomainName: domainName,
+	})
+	if wfErr != nil {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   h.Name(),
+			Info:            "failed to get workflow execution",
+			InfoDetails:     wfErr.Error(),
+		}
+	}
+
+	expectedLastEventID := wfResp.State.ExecutionInfo.NextEventID - 1
+	if lastEventID != expectedLastEventID {
+		return CheckResult{
+			CheckResultType: CheckResultTypeCorrupted,
+			InvariantName:   h.Name(),
+			Info:            "event count mismatch",
+			InfoDetails:     fmt.Sprintf("history has last event ID %d but execution record expects %d", lastEventID, expectedLastEventID),
+		}
+	}
+
+	return CheckResult{
+		CheckResultType: CheckResultTypeHealthy,
+		InvariantName:   h.Name(),
+	}
+}
+
+func (h *historyInvalid) Fix(
+	ctx context.Context,
+	execution interface{},
+) FixResult {
+	if fixResult := validateFixContext(ctx, h.Name()); fixResult != nil {
+		return *fixResult
+	}
+
+	fixResult, checkResult := checkBeforeFix(ctx, h, execution)
+	if fixResult != nil {
+		return *fixResult
+	}
+	fixResult = DeleteExecution(ctx, execution, h.pr, h.dc)
+	fixResult.CheckResult = *checkResult
+	fixResult.InvariantName = h.Name()
+	return *fixResult
+}
+
+func (h *historyInvalid) Name() Name {
+	return HistoryInvalid
+}

--- a/common/reconciliation/invariant/history_invalid.go
+++ b/common/reconciliation/invariant/history_invalid.go
@@ -120,7 +120,7 @@ func (h *historyInvalid) Check(
 
 	if lastEventID == 0 {
 		return CheckResult{
-			CheckResultType: CheckResultTypeFailed,
+			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   h.Name(),
 			Info:            "empty history",
 			InfoDetails:     "no history events found for workflow",
@@ -145,7 +145,7 @@ func (h *historyInvalid) Check(
 	}
 
 	expectedLastEventID := wfResp.State.ExecutionInfo.NextEventID - 1
-	if lastEventID != expectedLastEventID {
+	if !Open(wfResp.State.ExecutionInfo.State) && lastEventID != expectedLastEventID {
 		return CheckResult{
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   h.Name(),

--- a/common/reconciliation/invariant/history_invalid.go
+++ b/common/reconciliation/invariant/history_invalid.go
@@ -94,7 +94,8 @@ func (h *historyInvalid) Check(
 			DomainName:    domainName,
 		})
 		if readErr != nil {
-			if errors.Is(readErr, persistence.ErrCorruptedHistory) {
+			var inconsistencyErr *types.InternalDataInconsistencyError
+			if errors.As(readErr, &inconsistencyErr) {
 				return CheckResult{
 					CheckResultType: CheckResultTypeCorrupted,
 					InvariantName:   h.Name(),

--- a/common/reconciliation/invariant/history_invalid_test.go
+++ b/common/reconciliation/invariant/history_invalid_test.go
@@ -71,8 +71,8 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			},
 		},
 		{
-			name:      "corrupted history",
-			execution: getOpenConcreteExecution(),
+			name:         "corrupted history",
+			execution:    getOpenConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
 			historyErrs:  []error{persistence.ErrCorruptedHistory},
 			expectedResult: CheckResult{
@@ -83,8 +83,8 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			},
 		},
 		{
-			name:      "read error",
-			execution: getOpenConcreteExecution(),
+			name:         "read error",
+			execution:    getOpenConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
 			historyErrs:  []error{errors.New("db connection failed")},
 			expectedResult: CheckResult{
@@ -298,8 +298,8 @@ func TestHistoryInvalid_Fix(t *testing.T) {
 			},
 		},
 		{
-			name:      "fix succeeds for corrupted history",
-			execution: getOpenConcreteExecution(),
+			name:         "fix succeeds for corrupted history",
+			execution:    getOpenConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
 			historyErrs:  []error{persistence.ErrCorruptedHistory},
 			expectedResult: FixResult{
@@ -340,10 +340,10 @@ func TestHistoryInvalid_Fix(t *testing.T) {
 			},
 		},
 		{
-			name:      "fix fails on delete error",
-			execution: getOpenConcreteExecution(),
-			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
-			historyErrs:  []error{persistence.ErrCorruptedHistory},
+			name:          "fix fails on delete error",
+			execution:     getOpenConcreteExecution(),
+			historyResps:  []*persistence.ReadHistoryBranchResponse{nil},
+			historyErrs:   []error{persistence.ErrCorruptedHistory},
 			deleteExecErr: errors.New("delete failed"),
 			expectedResult: FixResult{
 				FixResultType: FixResultTypeFailed,

--- a/common/reconciliation/invariant/history_invalid_test.go
+++ b/common/reconciliation/invariant/history_invalid_test.go
@@ -1,0 +1,363 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package invariant
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/mock/gomock"
+
+	c "github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/mocks"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/reconciliation/entity"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestHistoryInvalid_Check(t *testing.T) {
+	testCases := []struct {
+		name           string
+		execution      interface{}
+		domainErr      error
+		historyResps   []*persistence.ReadHistoryBranchResponse
+		historyErrs    []error
+		wfExecResp     *persistence.GetWorkflowExecutionResponse
+		wfExecErr      error
+		expectedResult CheckResult
+	}{
+		{
+			name:      "not a concrete execution",
+			execution: "not-an-execution",
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   HistoryInvalid,
+				Info:            "failed to check: expected concrete execution",
+			},
+		},
+		{
+			name:      "domain cache error",
+			execution: getOpenConcreteExecution(),
+			domainErr: errors.New("domain not found"),
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   HistoryInvalid,
+				Info:            "failed to check: expected DomainName",
+				InfoDetails:     "domain not found",
+			},
+		},
+		{
+			name:      "corrupted history",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
+			historyErrs:  []error{persistence.ErrCorruptedHistory},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   HistoryInvalid,
+				Info:            "corrupt history",
+				InfoDetails:     persistence.ErrCorruptedHistory.Error(),
+			},
+		},
+		{
+			name:      "read error",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
+			historyErrs:  []error{errors.New("db connection failed")},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   HistoryInvalid,
+				Info:            "failed to read history",
+				InfoDetails:     "db connection failed",
+			},
+		},
+		{
+			name:      "empty history",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{HistoryEvents: []*types.HistoryEvent{}, NextPageToken: nil},
+			},
+			historyErrs: []error{nil},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   HistoryInvalid,
+				Info:            "empty history",
+				InfoDetails:     "no history events found for workflow",
+			},
+		},
+		{
+			name:      "get workflow execution error",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{HistoryEvents: []*types.HistoryEvent{{ID: 1}}},
+			},
+			historyErrs: []error{nil},
+			wfExecErr:   errors.New("db error"),
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   HistoryInvalid,
+				Info:            "failed to get workflow execution",
+				InfoDetails:     "db error",
+			},
+		},
+		{
+			name:      "event count mismatch",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{HistoryEvents: []*types.HistoryEvent{{ID: 1}, {ID: 2}}},
+			},
+			historyErrs: []error{nil},
+			wfExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						NextEventID: 10,
+					},
+				},
+			},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   HistoryInvalid,
+				Info:            "event count mismatch",
+				InfoDetails:     "history has last event ID 2 but execution record expects 9",
+			},
+		},
+		{
+			name:      "healthy single page",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{HistoryEvents: []*types.HistoryEvent{{ID: 1}}},
+			},
+			historyErrs: []error{nil},
+			wfExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						NextEventID: 2,
+					},
+				},
+			},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeHealthy,
+				InvariantName:   HistoryInvalid,
+			},
+		},
+		{
+			name:      "healthy multi page",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{
+					HistoryEvents: []*types.HistoryEvent{{ID: 1}},
+					NextPageToken: []byte("next"),
+				},
+				{
+					HistoryEvents: []*types.HistoryEvent{{ID: 2}, {ID: 3}},
+					NextPageToken: nil,
+				},
+			},
+			historyErrs: []error{nil, nil},
+			wfExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						NextEventID: 4,
+					},
+				},
+			},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeHealthy,
+				InvariantName:   HistoryInvalid,
+			},
+		},
+		{
+			name:      "corruption on second page",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{
+					HistoryEvents: []*types.HistoryEvent{{ID: 1}},
+					NextPageToken: []byte("next"),
+				},
+				nil,
+			},
+			historyErrs: []error{nil, persistence.ErrCorruptedHistory},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   HistoryInvalid,
+				Info:            "corrupt history",
+				InfoDetails:     persistence.ErrCorruptedHistory.Error(),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+
+			if _, ok := tc.execution.(*entity.ConcreteExecution); ok {
+				mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, tc.domainErr).MaxTimes(1)
+			}
+
+			historyManager := &mocks.HistoryV2Manager{}
+			for i := range tc.historyResps {
+				historyManager.On("ReadHistoryBranch", mock.Anything, mock.Anything).Return(tc.historyResps[i], tc.historyErrs[i]).Once()
+			}
+
+			execManager := &mocks.ExecutionManager{}
+			execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.wfExecResp, tc.wfExecErr)
+
+			inv := NewHistoryInvalid(
+				persistence.NewPersistenceRetryer(execManager, historyManager, c.CreatePersistenceRetryPolicy()),
+				mockDomainCache,
+			)
+
+			result := inv.Check(context.Background(), tc.execution)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestHistoryInvalid_Fix(t *testing.T) {
+	testCases := []struct {
+		name             string
+		execution        interface{}
+		historyResps     []*persistence.ReadHistoryBranchResponse
+		historyErrs      []error
+		wfExecResp       *persistence.GetWorkflowExecutionResponse
+		wfExecErr        error
+		deleteExecErr    error
+		deleteCurrentErr error
+		expectedResult   FixResult
+	}{
+		{
+			name:      "fix skipped because healthy",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{HistoryEvents: []*types.HistoryEvent{{ID: 1}}},
+			},
+			historyErrs: []error{nil},
+			wfExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						NextEventID: 2,
+					},
+				},
+			},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeSkipped,
+				InvariantName: HistoryInvalid,
+				Info:          "skipped fix because execution was healthy",
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeHealthy,
+					InvariantName:   HistoryInvalid,
+				},
+			},
+		},
+		{
+			name:      "fix succeeds for corrupted history",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
+			historyErrs:  []error{persistence.ErrCorruptedHistory},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFixed,
+				InvariantName: HistoryInvalid,
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeCorrupted,
+					InvariantName:   HistoryInvalid,
+					Info:            "corrupt history",
+					InfoDetails:     persistence.ErrCorruptedHistory.Error(),
+				},
+			},
+		},
+		{
+			name:      "fix succeeds for event count mismatch",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{HistoryEvents: []*types.HistoryEvent{{ID: 1}, {ID: 2}}},
+			},
+			historyErrs: []error{nil},
+			wfExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						NextEventID: 10,
+					},
+				},
+			},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFixed,
+				InvariantName: HistoryInvalid,
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeCorrupted,
+					InvariantName:   HistoryInvalid,
+					Info:            "event count mismatch",
+					InfoDetails:     "history has last event ID 2 but execution record expects 9",
+				},
+			},
+		},
+		{
+			name:      "fix fails on delete error",
+			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
+			historyErrs:  []error{persistence.ErrCorruptedHistory},
+			deleteExecErr: errors.New("delete failed"),
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFailed,
+				InvariantName: HistoryInvalid,
+				Info:          "failed to delete concrete workflow execution",
+				InfoDetails:   "delete failed",
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeCorrupted,
+					InvariantName:   HistoryInvalid,
+					Info:            "corrupt history",
+					InfoDetails:     persistence.ErrCorruptedHistory.Error(),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+			mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
+
+			historyManager := &mocks.HistoryV2Manager{}
+			for i := range tc.historyResps {
+				historyManager.On("ReadHistoryBranch", mock.Anything, mock.Anything).Return(tc.historyResps[i], tc.historyErrs[i]).Once()
+			}
+
+			execManager := &mocks.ExecutionManager{}
+			execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.wfExecResp, tc.wfExecErr)
+			execManager.On("DeleteWorkflowExecution", mock.Anything, mock.Anything).Return(tc.deleteExecErr)
+			execManager.On("DeleteCurrentWorkflowExecution", mock.Anything, mock.Anything).Return(tc.deleteCurrentErr)
+
+			inv := NewHistoryInvalid(
+				persistence.NewPersistenceRetryer(execManager, historyManager, c.CreatePersistenceRetryPolicy()),
+				mockDomainCache,
+			)
+
+			result := inv.Fix(context.Background(), tc.execution)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/common/reconciliation/invariant/history_invalid_test.go
+++ b/common/reconciliation/invariant/history_invalid_test.go
@@ -102,7 +102,7 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			},
 			historyErrs: []error{nil},
 			expectedResult: CheckResult{
-				CheckResultType: CheckResultTypeFailed,
+				CheckResultType: CheckResultTypeCorrupted,
 				InvariantName:   HistoryInvalid,
 				Info:            "empty history",
 				InfoDetails:     "no history events found for workflow",
@@ -124,8 +124,8 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			},
 		},
 		{
-			name:      "event count mismatch",
-			execution: getOpenConcreteExecution(),
+			name:      "event count mismatch on closed workflow",
+			execution: getClosedConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{
 				{HistoryEvents: []*types.HistoryEvent{{ID: 1}, {ID: 2}}},
 			},
@@ -133,6 +133,7 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			wfExecResp: &persistence.GetWorkflowExecutionResponse{
 				State: &persistence.WorkflowMutableState{
 					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State:       closedState,
 						NextEventID: 10,
 					},
 				},
@@ -145,8 +146,28 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			},
 		},
 		{
-			name:      "healthy single page",
+			name:      "open workflow skips event count check",
 			execution: getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{
+				{HistoryEvents: []*types.HistoryEvent{{ID: 1}, {ID: 2}}},
+			},
+			historyErrs: []error{nil},
+			wfExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State:       openState,
+						NextEventID: 10,
+					},
+				},
+			},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeHealthy,
+				InvariantName:   HistoryInvalid,
+			},
+		},
+		{
+			name:      "healthy single page",
+			execution: getClosedConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{
 				{HistoryEvents: []*types.HistoryEvent{{ID: 1}}},
 			},
@@ -154,6 +175,7 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			wfExecResp: &persistence.GetWorkflowExecutionResponse{
 				State: &persistence.WorkflowMutableState{
 					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State:       closedState,
 						NextEventID: 2,
 					},
 				},
@@ -165,7 +187,7 @@ func TestHistoryInvalid_Check(t *testing.T) {
 		},
 		{
 			name:      "healthy multi page",
-			execution: getOpenConcreteExecution(),
+			execution: getClosedConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{
 				{
 					HistoryEvents: []*types.HistoryEvent{{ID: 1}},
@@ -180,6 +202,7 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			wfExecResp: &persistence.GetWorkflowExecutionResponse{
 				State: &persistence.WorkflowMutableState{
 					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State:       closedState,
 						NextEventID: 4,
 					},
 				},
@@ -251,7 +274,7 @@ func TestHistoryInvalid_Fix(t *testing.T) {
 	}{
 		{
 			name:      "fix skipped because healthy",
-			execution: getOpenConcreteExecution(),
+			execution: getClosedConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{
 				{HistoryEvents: []*types.HistoryEvent{{ID: 1}}},
 			},
@@ -259,6 +282,7 @@ func TestHistoryInvalid_Fix(t *testing.T) {
 			wfExecResp: &persistence.GetWorkflowExecutionResponse{
 				State: &persistence.WorkflowMutableState{
 					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State:       closedState,
 						NextEventID: 2,
 					},
 				},
@@ -291,7 +315,7 @@ func TestHistoryInvalid_Fix(t *testing.T) {
 		},
 		{
 			name:      "fix succeeds for event count mismatch",
-			execution: getOpenConcreteExecution(),
+			execution: getClosedConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{
 				{HistoryEvents: []*types.HistoryEvent{{ID: 1}, {ID: 2}}},
 			},
@@ -299,6 +323,7 @@ func TestHistoryInvalid_Fix(t *testing.T) {
 			wfExecResp: &persistence.GetWorkflowExecutionResponse{
 				State: &persistence.WorkflowMutableState{
 					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State:       closedState,
 						NextEventID: 10,
 					},
 				},

--- a/common/reconciliation/invariant/history_invalid_test.go
+++ b/common/reconciliation/invariant/history_invalid_test.go
@@ -71,7 +71,7 @@ func TestHistoryInvalid_Check(t *testing.T) {
 			},
 		},
 		{
-			name:         "corrupted history",
+			name:         "corrupted history - sentinel error",
 			execution:    getOpenConcreteExecution(),
 			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
 			historyErrs:  []error{persistence.ErrCorruptedHistory},
@@ -80,6 +80,18 @@ func TestHistoryInvalid_Check(t *testing.T) {
 				InvariantName:   HistoryInvalid,
 				Info:            "corrupt history",
 				InfoDetails:     persistence.ErrCorruptedHistory.Error(),
+			},
+		},
+		{
+			name:         "corrupted history - inline inconsistency error",
+			execution:    getOpenConcreteExecution(),
+			historyResps: []*persistence.ReadHistoryBranchResponse{nil},
+			historyErrs:  []error{&types.InternalDataInconsistencyError{Message: "corrupted event batch, empty events"}},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   HistoryInvalid,
+				Info:            "corrupt history",
+				InfoDetails:     "corrupted event batch, empty events",
 			},
 		},
 		{

--- a/common/reconciliation/invariant/mismatched_records.go
+++ b/common/reconciliation/invariant/mismatched_records.go
@@ -107,6 +107,13 @@ func (m *mismatchedRecords) Check(
 		}
 	}
 
+	if currentExec.RunID != concreteExecution.RunID {
+		return CheckResult{
+			CheckResultType: CheckResultTypeHealthy,
+			InvariantName:   m.Name(),
+		}
+	}
+
 	if concreteWorkflow.State.ExecutionInfo.CloseStatus != currentExec.CloseStatus {
 		return CheckResult{
 			CheckResultType: CheckResultTypeCorrupted,

--- a/common/reconciliation/invariant/mismatched_records.go
+++ b/common/reconciliation/invariant/mismatched_records.go
@@ -1,0 +1,145 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package invariant
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/reconciliation/entity"
+	"github.com/uber/cadence/common/types"
+)
+
+type mismatchedRecords struct {
+	pr persistence.Retryer
+	dc cache.DomainCache
+}
+
+// NewMismatchedRecords returns a new invariant that checks whether
+// current and concrete execution records agree on close status.
+func NewMismatchedRecords(
+	pr persistence.Retryer, dc cache.DomainCache,
+) Invariant {
+	return &mismatchedRecords{
+		pr: pr,
+		dc: dc,
+	}
+}
+
+func (m *mismatchedRecords) Check(
+	ctx context.Context,
+	execution interface{},
+) CheckResult {
+	if checkResult := validateCheckContext(ctx, m.Name()); checkResult != nil {
+		return *checkResult
+	}
+
+	concreteExecution, ok := execution.(*entity.ConcreteExecution)
+	if !ok {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   m.Name(),
+			Info:            "failed to check: expected concrete execution",
+		}
+	}
+
+	domainID := concreteExecution.GetDomainID()
+	domainName, err := m.dc.GetDomainName(domainID)
+	if err != nil {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   m.Name(),
+			Info:            "failed to check: expected DomainName",
+			InfoDetails:     err.Error(),
+		}
+	}
+
+	currentExec, err := m.pr.GetCurrentExecution(ctx, &persistence.GetCurrentExecutionRequest{
+		DomainID:   domainID,
+		WorkflowID: concreteExecution.WorkflowID,
+		DomainName: domainName,
+	})
+	if err != nil {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   m.Name(),
+			Info:            "failed to get current execution record",
+			InfoDetails:     err.Error(),
+		}
+	}
+
+	concreteWorkflow, err := m.pr.GetWorkflowExecution(ctx, &persistence.GetWorkflowExecutionRequest{
+		DomainID: domainID,
+		Execution: types.WorkflowExecution{
+			WorkflowID: concreteExecution.WorkflowID,
+			RunID:      concreteExecution.RunID,
+		},
+		DomainName: domainName,
+	})
+	if err != nil {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   m.Name(),
+			Info:            "failed to get workflow execution",
+			InfoDetails:     err.Error(),
+		}
+	}
+
+	if concreteWorkflow.State.ExecutionInfo.CloseStatus != currentExec.CloseStatus {
+		return CheckResult{
+			CheckResultType: CheckResultTypeCorrupted,
+			InvariantName:   m.Name(),
+			Info:            "current record does not agree with concrete record about workflow being closed",
+			InfoDetails:     fmt.Sprintf("current: %d concrete: %d", currentExec.CloseStatus, concreteWorkflow.State.ExecutionInfo.CloseStatus),
+		}
+	}
+
+	return CheckResult{
+		CheckResultType: CheckResultTypeHealthy,
+		InvariantName:   m.Name(),
+	}
+}
+
+func (m *mismatchedRecords) Fix(
+	ctx context.Context,
+	execution interface{},
+) FixResult {
+	if fixResult := validateFixContext(ctx, m.Name()); fixResult != nil {
+		return *fixResult
+	}
+
+	fixResult, checkResult := checkBeforeFix(ctx, m, execution)
+	if fixResult != nil {
+		return *fixResult
+	}
+	fixResult = DeleteExecution(ctx, execution, m.pr, m.dc)
+	fixResult.CheckResult = *checkResult
+	fixResult.InvariantName = m.Name()
+	return *fixResult
+}
+
+func (m *mismatchedRecords) Name() Name {
+	return MismatchedRecords
+}

--- a/common/reconciliation/invariant/mismatched_records_test.go
+++ b/common/reconciliation/invariant/mismatched_records_test.go
@@ -1,0 +1,266 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package invariant
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/mocks"
+	"github.com/uber/cadence/common/persistence"
+)
+
+func TestMismatchedRecords_Check(t *testing.T) {
+	testCases := []struct {
+		name             string
+		execution        interface{}
+		domainErr        error
+		currentExecResp  *persistence.GetCurrentExecutionResponse
+		currentExecErr   error
+		workflowExecResp *persistence.GetWorkflowExecutionResponse
+		workflowExecErr  error
+		expectedResult   CheckResult
+	}{
+		{
+			name:      "not a concrete execution",
+			execution: "not-an-execution",
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   MismatchedRecords,
+				Info:            "failed to check: expected concrete execution",
+			},
+		},
+		{
+			name:      "domain cache error",
+			execution: getClosedConcreteExecution(),
+			domainErr: errors.New("domain not found"),
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   MismatchedRecords,
+				Info:            "failed to check: expected DomainName",
+				InfoDetails:     "domain not found",
+			},
+		},
+		{
+			name:           "get current execution error",
+			execution:      getClosedConcreteExecution(),
+			currentExecErr: errors.New("db error"),
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   MismatchedRecords,
+				Info:            "failed to get current execution record",
+				InfoDetails:     "db error",
+			},
+		},
+		{
+			name:      "get workflow execution error",
+			execution: getClosedConcreteExecution(),
+			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				CloseStatus: persistence.WorkflowCloseStatusCompleted,
+			},
+			workflowExecErr: errors.New("db error"),
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   MismatchedRecords,
+				Info:            "failed to get workflow execution",
+				InfoDetails:     "db error",
+			},
+		},
+		{
+			name:      "mismatched close status",
+			execution: getClosedConcreteExecution(),
+			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				CloseStatus: persistence.WorkflowCloseStatusCompleted,
+			},
+			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						CloseStatus: persistence.WorkflowCloseStatusTerminated,
+					},
+				},
+			},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   MismatchedRecords,
+				Info:            "current record does not agree with concrete record about workflow being closed",
+				InfoDetails:     "current: 1 concrete: 4",
+			},
+		},
+		{
+			name:      "matching close status",
+			execution: getClosedConcreteExecution(),
+			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				CloseStatus: persistence.WorkflowCloseStatusCompleted,
+			},
+			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						CloseStatus: persistence.WorkflowCloseStatusCompleted,
+					},
+				},
+			},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeHealthy,
+				InvariantName:   MismatchedRecords,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+			mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, tc.domainErr).MaxTimes(1)
+
+			execManager := &mocks.ExecutionManager{}
+			execManager.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(tc.currentExecResp, tc.currentExecErr)
+			execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.workflowExecResp, tc.workflowExecErr)
+
+			inv := NewMismatchedRecords(
+				persistence.NewPersistenceRetryer(execManager, nil, common.CreatePersistenceRetryPolicy()),
+				mockDomainCache,
+			)
+
+			result := inv.Check(context.Background(), tc.execution)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestMismatchedRecords_Fix(t *testing.T) {
+	testCases := []struct {
+		name             string
+		execution        interface{}
+		currentExecResp  *persistence.GetCurrentExecutionResponse
+		currentExecErr   error
+		workflowExecResp *persistence.GetWorkflowExecutionResponse
+		workflowExecErr  error
+		deleteExecErr    error
+		deleteCurrentErr error
+		expectedResult   FixResult
+	}{
+		{
+			name:      "fix skipped because healthy",
+			execution: getClosedConcreteExecution(),
+			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				CloseStatus: persistence.WorkflowCloseStatusCompleted,
+			},
+			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						CloseStatus: persistence.WorkflowCloseStatusCompleted,
+					},
+				},
+			},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeSkipped,
+				InvariantName: MismatchedRecords,
+				Info:          "skipped fix because execution was healthy",
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeHealthy,
+					InvariantName:   MismatchedRecords,
+				},
+			},
+		},
+		{
+			name:      "fix succeeds for mismatched records",
+			execution: getClosedConcreteExecution(),
+			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				CloseStatus: persistence.WorkflowCloseStatusCompleted,
+			},
+			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						CloseStatus: persistence.WorkflowCloseStatusTerminated,
+					},
+				},
+			},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFixed,
+				InvariantName: MismatchedRecords,
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeCorrupted,
+					InvariantName:   MismatchedRecords,
+					Info:            "current record does not agree with concrete record about workflow being closed",
+					InfoDetails:     "current: 1 concrete: 4",
+				},
+			},
+		},
+		{
+			name:      "fix fails on delete error",
+			execution: getClosedConcreteExecution(),
+			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				CloseStatus: persistence.WorkflowCloseStatusCompleted,
+			},
+			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						CloseStatus: persistence.WorkflowCloseStatusTerminated,
+					},
+				},
+			},
+			deleteExecErr: errors.New("delete failed"),
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFailed,
+				InvariantName: MismatchedRecords,
+				Info:          "failed to delete concrete workflow execution",
+				InfoDetails:   "delete failed",
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeCorrupted,
+					InvariantName:   MismatchedRecords,
+					Info:            "current record does not agree with concrete record about workflow being closed",
+					InfoDetails:     "current: 1 concrete: 4",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockDomainCache := cache.NewMockDomainCache(ctrl)
+			mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
+
+			execManager := &mocks.ExecutionManager{}
+			execManager.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(tc.currentExecResp, tc.currentExecErr)
+			execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.workflowExecResp, tc.workflowExecErr)
+			execManager.On("DeleteWorkflowExecution", mock.Anything, mock.Anything).Return(tc.deleteExecErr)
+			execManager.On("DeleteCurrentWorkflowExecution", mock.Anything, mock.Anything).Return(tc.deleteCurrentErr)
+
+			inv := NewMismatchedRecords(
+				persistence.NewPersistenceRetryer(execManager, nil, common.CreatePersistenceRetryPolicy()),
+				mockDomainCache,
+			)
+
+			result := inv.Fix(context.Background(), tc.execution)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/common/reconciliation/invariant/mismatched_records_test.go
+++ b/common/reconciliation/invariant/mismatched_records_test.go
@@ -94,9 +94,29 @@ func TestMismatchedRecords_Check(t *testing.T) {
 			},
 		},
 		{
+			name:      "different run ID is healthy",
+			execution: getClosedConcreteExecution(),
+			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				RunID:       "different-run-id",
+				CloseStatus: persistence.WorkflowCloseStatusCompleted,
+			},
+			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						CloseStatus: persistence.WorkflowCloseStatusTerminated,
+					},
+				},
+			},
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeHealthy,
+				InvariantName:   MismatchedRecords,
+			},
+		},
+		{
 			name:      "mismatched close status",
 			execution: getClosedConcreteExecution(),
 			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				RunID:       runID,
 				CloseStatus: persistence.WorkflowCloseStatusCompleted,
 			},
 			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
@@ -117,6 +137,7 @@ func TestMismatchedRecords_Check(t *testing.T) {
 			name:      "matching close status",
 			execution: getClosedConcreteExecution(),
 			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				RunID:       runID,
 				CloseStatus: persistence.WorkflowCloseStatusCompleted,
 			},
 			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
@@ -170,6 +191,7 @@ func TestMismatchedRecords_Fix(t *testing.T) {
 			name:      "fix skipped because healthy",
 			execution: getClosedConcreteExecution(),
 			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				RunID:       runID,
 				CloseStatus: persistence.WorkflowCloseStatusCompleted,
 			},
 			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
@@ -193,6 +215,7 @@ func TestMismatchedRecords_Fix(t *testing.T) {
 			name:      "fix succeeds for mismatched records",
 			execution: getClosedConcreteExecution(),
 			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				RunID:       runID,
 				CloseStatus: persistence.WorkflowCloseStatusCompleted,
 			},
 			workflowExecResp: &persistence.GetWorkflowExecutionResponse{
@@ -217,6 +240,7 @@ func TestMismatchedRecords_Fix(t *testing.T) {
 			name:      "fix fails on delete error",
 			execution: getClosedConcreteExecution(),
 			currentExecResp: &persistence.GetCurrentExecutionResponse{
+				RunID:       runID,
 				CloseStatus: persistence.WorkflowCloseStatusCompleted,
 			},
 			workflowExecResp: &persistence.GetWorkflowExecutionResponse{


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added history invalid and mismatched records invariants. The fix maintain the same pattern as other invariant fixes.

https://github.com/cadence-workflow/cadence/issues/8031

**Why?**
As part of the work to scan, detect and repair corruptions, we are introducing invariants to check for history corruption and corruption between concrete and current execution record statuses. This will increase coverage for detection and repair of corrupted workflows.

**How did you test it?**
Created new unit tests for each one of the new invariants

go test -race -run "TestHistoryInvalid" ./common/reconciliation/invariant/...
go test -race -run "TestMismatchedRecords" ./common/reconciliation/invariant/...

**Potential risks**
There is a potential risk because the fixes delete execution records. The implementation attempts to guard any possible edge case, and it has been used internally for a while without issues. These are just being defined and not registered yet to be used by the scanners or implemented anywhere else.

**Release notes**
Added invariants to improve detection of history and execution record corruption

**Documentation Changes**
N/A
