### PR TITLE
fix(schedules): reject CreateSchedule when scheduler worker is not enabled for domain

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -163,6 +163,12 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if domainName == "" {
 		return nil, validate.ErrDomainNotSet
 	}
+	if !wh.config.EnableScheduler(domainName) {
+		return nil, &types.BadRequestError{Message: fmt.Sprintf(
+			"Schedules are not enabled for domain %q. Set dynamic config worker.enableScheduler=true for this domain to enable them.",
+			domainName,
+		)}
+	}
 	scheduleID := request.GetScheduleID()
 	if scheduleID == "" {
 		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -76,6 +76,7 @@ func newScheduleTestFixture(t *testing.T) *scheduleTestFixture {
 		10, false, "hostname", mockResource.Logger,
 	)
 	config.EmitSignalNameMetricsTag = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
+	config.EnableScheduler = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
 
 	handler := NewWorkflowHandler(mockResource, config, versionChecker, nil)
 
@@ -123,6 +124,13 @@ func TestCreateSchedule(t *testing.T) {
 		"empty domain": {
 			request: &types.CreateScheduleRequest{},
 			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"scheduler not enabled for domain": {
+			request: &types.CreateScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.handler.config.EnableScheduler = dynamicproperties.GetBoolPropertyFnFilteredByDomain(false)
+			},
 			wantErr: true,
 		},
 		"empty schedule ID": {

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -127,6 +127,10 @@ type Config struct {
 	// Emit signal related metrics with signal name tag. Be aware of cardinality.
 	EmitSignalNameMetricsTag dynamicproperties.BoolPropertyFnWithDomainFilter
 
+	// EnableScheduler mirrors the worker-side flag so the frontend can reject
+	// CreateSchedule early when no scheduler worker will run for the domain.
+	EnableScheduler dynamicproperties.BoolPropertyFnWithDomainFilter
+
 	// HostName for machine running the service
 	HostName string
 }
@@ -206,6 +210,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		Lockdown:                                          dc.GetBoolPropertyFilteredByDomain(dynamicproperties.Lockdown),
 		EnableTasklistIsolation:                           dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableTasklistIsolation),
 		EnableDomainAuditLogging:                          dc.GetBoolProperty(dynamicproperties.EnableDomainAuditLogging),
+		EnableScheduler:                                   dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableScheduler),
 		DomainConfig: domain.Config{
 			MaxBadBinaryCount:           dc.GetIntPropertyFilteredByDomain(dynamicproperties.FrontendMaxBadBinaries),
 			MinRetentionDays:            dc.GetIntProperty(dynamicproperties.MinRetentionDays),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -105,6 +105,7 @@ func TestNewConfig(t *testing.T) {
 		"EmitSignalNameMetricsTag":                          {dynamicproperties.FrontendEmitSignalNameMetricsTag, true},
 		"Lockdown":                                          {dynamicproperties.Lockdown, false},
 		"EnableTasklistIsolation":                           {dynamicproperties.EnableTasklistIsolation, true},
+		"EnableScheduler":                                   {dynamicproperties.EnableScheduler, true},
 		"GlobalRatelimiterKeyMode":                          {dynamicproperties.FrontendGlobalRatelimiterMode, "disabled"},
 		"GlobalRatelimiterUpdateInterval":                   {dynamicproperties.GlobalRatelimiterUpdateInterval, 3 * time.Second},
 		"PinotOptimizedQueryColumns":                        {dynamicproperties.PinotOptimizedQueryColumns, map[string]interface{}{"foo": "bar"}},


### PR DESCRIPTION
**What changed?**

`CreateSchedule` now checks `worker.enableScheduler` for the domain before proceeding and returns a `BadRequestError` if it is not set.

**Why?**

When `worker.enableScheduler` is false for a domain, no scheduler worker polls the task list, so the scheduler workflow created by `CreateSchedule` sits unprocessed indefinitely. The schedule appears to exist, it shows up in the UI and list APIs but never fires, and cannot be described, paused, updated, or deleted until the flag is enabled. There was no error returned to the caller.

**How did you test it?**

```
go test -race -run TestCreateSchedule ./service/frontend/api/...
go test -race ./service/frontend/config/...
```

**Potential risks**

Any domain that calls `CreateSchedule` without `worker.enableScheduler=true` will now get an error instead of a zombie schedule. This is the intended behavior, those schedules were silently broken before. Domains that already have the flag enabled are unaffected.

**Release notes**

`CreateSchedule` now returns an error immediately when `worker.enableScheduler` is not enabled for the domain, with a message indicating which dynamic config key to set.

**Documentation Changes**

N/A: the error message itself tells operators what to configure.