### PR TITLE
chore(cassandra): upgrade gocql to v1.7.0

### DIFF
--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
-	github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1 // indirect
+	github.com/gocql/gocql v1.7.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.7.0-rc.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/cmd/server/go.sum
+++ b/cmd/server/go.sum
@@ -183,8 +183,8 @@ github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI6
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-zookeeper/zk v1.0.3 h1:7M2kwOsc//9VeeFiPtf+uSJlVpU66x9Ba5+8XK7/TDg=
 github.com/go-zookeeper/zk v1.0.3/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
-github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1 h1:px9qUCy/RNJNsfCam4m2IxWGxNuimkrioEF0vrrbPsg=
-github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
+github.com/gocql/gocql v1.7.0 h1:O+7U7/1gSN7QTEAaMEsJc1Oq2QHXvCWoF3DFK9HDHus=
+github.com/gocql/gocql v1.7.0/go.mod h1:vnlvXyFZeLBF0Wy+RS8hrOdbn0UWsWtdg07XJnFxZ+4=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -93,8 +93,8 @@ func newCassandraCluster(cfg ClusterConfig) *gocql.ClusterConfig {
 		cluster.NumConns = cfg.MaxConns
 	}
 
-	if cfg.HostSelectionPolicy != nil {
-		cluster.PoolConfig.HostSelectionPolicy = cfg.HostSelectionPolicy
+	if cfg.HostSelectionPolicyFactory != nil {
+		cluster.PoolConfig.HostSelectionPolicy = cfg.HostSelectionPolicyFactory()
 	} else {
 		// set default option if configuration was not provided
 		cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
@@ -60,6 +60,7 @@ func Test_RegisterClientNotNil(t *testing.T) {
 }
 
 func Test_newCassandraCluster(t *testing.T) {
+	policyFactoryCalls := 0
 	testFullConfig := ClusterConfig{
 		Hosts:      "testHost1,testHost2,testHost3,testHost4",
 		Port:       123,
@@ -74,8 +75,13 @@ func Test_newCassandraCluster(t *testing.T) {
 			KeyFile:  "testKeyFile",
 		},
 		MaxConns: 10,
+		HostSelectionPolicyFactory: func() gocql.HostSelectionPolicy {
+			policyFactoryCalls++
+			return gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+		},
 	}
 	clusterConfig := newCassandraCluster(testFullConfig)
+	secondClusterConfig := newCassandraCluster(testFullConfig)
 	assert.Equal(t, []string{"testHost1", "testHost2", "testHost3", "testHost4"}, clusterConfig.Hosts)
 	assert.Equal(t, testFullConfig.Port, clusterConfig.Port)
 	assert.Equal(t, testFullConfig.User, clusterConfig.Authenticator.(gocql.PasswordAuthenticator).Username)
@@ -84,6 +90,8 @@ func Test_newCassandraCluster(t *testing.T) {
 	assert.Equal(t, testFullConfig.TLS.CertFile, clusterConfig.SslOpts.CertPath)
 	assert.Equal(t, testFullConfig.TLS.KeyFile, clusterConfig.SslOpts.KeyPath)
 	assert.Equal(t, testFullConfig.MaxConns, clusterConfig.NumConns)
+	assert.Equal(t, 2, policyFactoryCalls)
+	assert.NotSame(t, clusterConfig.PoolConfig.HostSelectionPolicy, secondClusterConfig.PoolConfig.HostSelectionPolicy)
 
 	assert.False(t, clusterConfig.HostFilter.Accept(&gocql.HostInfo{}))
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
@@ -103,21 +103,21 @@ type (
 
 	// ClusterConfig is the config for cassandra connection
 	ClusterConfig struct {
-		Hosts                 string
-		Port                  int
-		User                  string
-		Password              string
-		AllowedAuthenticators []string
-		Keyspace              string
-		Region                string
-		Datacenter            string
-		MaxConns              int
-		TLS                   *config.TLS
-		ProtoVersion          int
-		Consistency           Consistency
-		SerialConsistency     SerialConsistency
-		Timeout               time.Duration
-		ConnectTimeout        time.Duration
-		HostSelectionPolicy   gocql.HostSelectionPolicy
+		Hosts                      string
+		Port                       int
+		User                       string
+		Password                   string
+		AllowedAuthenticators      []string
+		Keyspace                   string
+		Region                     string
+		Datacenter                 string
+		MaxConns                   int
+		TLS                        *config.TLS
+		ProtoVersion               int
+		Consistency                Consistency
+		SerialConsistency          SerialConsistency
+		Timeout                    time.Duration
+		ConnectTimeout             time.Duration
+		HostSelectionPolicyFactory func() gocql.HostSelectionPolicy
 	}
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
@@ -126,41 +126,45 @@ func toGoCqlConfig(cfg *config.NoSQL) (gocql.ClusterConfig, error) {
 		return gocql.ClusterConfig{}, err
 	}
 
-	hostSelection, err := toHostSelectionPolicy(cfg.HostSelectionPolicy)
+	hostSelectionPolicyFactory, err := toHostSelectionPolicyFactory(cfg.HostSelectionPolicy)
 	if err != nil {
 		return gocql.ClusterConfig{}, err
 	}
 
 	return gocql.ClusterConfig{
-		Hosts:                 cfg.Hosts,
-		Port:                  cfg.Port,
-		User:                  cfg.User,
-		Password:              cfg.Password,
-		AllowedAuthenticators: cfg.AllowedAuthenticators,
-		Keyspace:              cfg.Keyspace,
-		Region:                cfg.Region,
-		Datacenter:            cfg.Datacenter,
-		MaxConns:              cfg.MaxConns,
-		TLS:                   cfg.TLS,
-		ProtoVersion:          cfg.ProtoVersion,
-		Consistency:           consistency,
-		SerialConsistency:     serialConsistency,
-		Timeout:               cfg.Timeout,
-		ConnectTimeout:        cfg.ConnectTimeout,
-		HostSelectionPolicy:   hostSelection,
+		Hosts:                      cfg.Hosts,
+		Port:                       cfg.Port,
+		User:                       cfg.User,
+		Password:                   cfg.Password,
+		AllowedAuthenticators:      cfg.AllowedAuthenticators,
+		Keyspace:                   cfg.Keyspace,
+		Region:                     cfg.Region,
+		Datacenter:                 cfg.Datacenter,
+		MaxConns:                   cfg.MaxConns,
+		TLS:                        cfg.TLS,
+		ProtoVersion:               cfg.ProtoVersion,
+		Consistency:                consistency,
+		SerialConsistency:          serialConsistency,
+		Timeout:                    cfg.Timeout,
+		ConnectTimeout:             cfg.ConnectTimeout,
+		HostSelectionPolicyFactory: hostSelectionPolicyFactory,
 	}, nil
 }
 
-func toHostSelectionPolicy(policy string) (gogocql.HostSelectionPolicy, error) {
+func toHostSelectionPolicyFactory(policy string) (func() gogocql.HostSelectionPolicy, error) {
 	switch policy {
 	case "", "tokenaware,roundrobin":
-		return gogocql.TokenAwareHostPolicy(gogocql.RoundRobinHostPolicy()), nil
+		return func() gogocql.HostSelectionPolicy {
+			return gogocql.TokenAwareHostPolicy(gogocql.RoundRobinHostPolicy())
+		}, nil
 	case "hostpool-epsilon-greedy":
-		return gogocql.HostPoolHostPolicy(
-			hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
-		), nil
+		return func() gogocql.HostSelectionPolicy {
+			return gogocql.HostPoolHostPolicy(
+				hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
+			)
+		}, nil
 	case "roundrobin":
-		return gogocql.RoundRobinHostPolicy(), nil
+		return gogocql.RoundRobinHostPolicy, nil
 	default:
 		return nil, fmt.Errorf("unknown gocql host selection policy: %q", policy)
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
@@ -47,14 +47,13 @@ func Test_toGoCqlConfig(t *testing.T) {
 			"empty config will be filled with defaults",
 			&config.NoSQL{},
 			gocql.ClusterConfig{
-				Hosts:               environment.Localhost,
-				Port:                9042,
-				ProtoVersion:        4,
-				Timeout:             time.Second * 10,
-				Consistency:         gocql.LocalQuorum,
-				SerialConsistency:   gocql.LocalSerial,
-				ConnectTimeout:      time.Second * 2,
-				HostSelectionPolicy: gogocql.TokenAwareHostPolicy(gogocql.RoundRobinHostPolicy()),
+				Hosts:             environment.Localhost,
+				Port:              9042,
+				ProtoVersion:      4,
+				Timeout:           time.Second * 10,
+				Consistency:       gocql.LocalQuorum,
+				SerialConsistency: gocql.LocalSerial,
+				ConnectTimeout:    time.Second * 2,
 			},
 			assert.NoError,
 		},
@@ -65,12 +64,14 @@ func Test_toGoCqlConfig(t *testing.T) {
 			if !tt.wantErr(t, err, fmt.Sprintf("toGoCqlConfig(%v)", tt.cfg)) {
 				return
 			}
+			assert.NotNil(t, got.HostSelectionPolicyFactory)
+			got.HostSelectionPolicyFactory = nil
 			assert.Equalf(t, tt.want, got, "toGoCqlConfig(%v)", tt.cfg)
 		})
 	}
 }
 
-func Test_toHostSelectionPolicy(t *testing.T) {
+func Test_toHostSelectionPolicyFactory(t *testing.T) {
 	tests := []struct {
 		name    string
 		policy  string
@@ -83,12 +84,19 @@ func Test_toHostSelectionPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := toHostSelectionPolicy(tt.policy)
-			if !tt.wantErr(t, err, fmt.Sprintf("toHostSelectionPolicy(%v)", tt.policy)) {
+			got, err := toHostSelectionPolicyFactory(tt.policy)
+			if !tt.wantErr(t, err, fmt.Sprintf("toHostSelectionPolicyFactory(%v)", tt.policy)) {
+				return
+			}
+			if err != nil {
+				assert.Nil(t, got)
 				return
 			}
 
-			assert.Equal(t, tt.want, got, "toHostSelectionPolicy(%v)", tt.policy)
+			first := got()
+			second := got()
+			assert.Equal(t, tt.want, first, "toHostSelectionPolicyFactory(%v)", tt.policy)
+			assert.NotSame(t, first, second)
 		})
 	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	gogocql "github.com/gocql/gocql"
+
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
@@ -142,11 +144,23 @@ func toTaskListPartition(partition map[string]any) *persistence.TaskListPartitio
 	}
 }
 
-func fromTaskListPartitionConfig(config *persistence.TaskListPartitionConfig) map[string]interface{} {
+// nullableMap preserves nil as a CQL null UDT. gocql v1.7 otherwise treats a
+// typed nil map as a present UDT and encodes each field as null. When decoded,
+// that value becomes a map containing zero-valued fields. Non-nil maps use normal UDT marshaling.
+type nullableMap map[string]interface{}
+
+func (m nullableMap) MarshalCQL(info gogocql.TypeInfo) ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return gogocql.Marshal(info, map[string]interface{}(m))
+}
+
+func fromTaskListPartitionConfig(config *persistence.TaskListPartitionConfig) nullableMap {
 	if config == nil {
 		return nil
 	}
-	return map[string]interface{}{
+	return nullableMap{
 		"version":              config.Version,
 		"num_read_partitions":  len(config.ReadPartitions),
 		"num_write_partitions": len(config.WritePartitions),

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	gogocql "github.com/gocql/gocql"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/mock/gomock"
 
@@ -157,6 +158,42 @@ func TestSelectTaskList(t *testing.T) {
 			},
 		},
 		{
+			name: "success - null adaptive partition config",
+			filter: &nosqlplugin.TaskListFilter{
+				DomainID:     "domain1",
+				TaskListName: "tasklist1",
+				TaskListType: 1,
+			},
+			queryMockFn: func(query *gocql.MockQuery) {
+				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
+				query.EXPECT().Scan(gomock.Any()).DoAndReturn(func(args ...interface{}) error {
+					rangeID := args[0].(*int64)
+					*rangeID = 25
+					tlDB := args[1].(*map[string]interface{})
+					*tlDB = map[string]interface{}{
+						"ack_level":                 int64(1000),
+						"kind":                      2,
+						"last_updated":              now,
+						"adaptive_partition_config": nil,
+					}
+					return nil
+				}).Times(1)
+			},
+			wantRow: &nosqlplugin.TaskListRow{
+				DomainID:                "domain1",
+				TaskListName:            "tasklist1",
+				TaskListType:            1,
+				TaskListKind:            2,
+				AckLevel:                1000,
+				RangeID:                 25,
+				LastUpdatedTime:         now,
+				AdaptivePartitionConfig: nil,
+			},
+			wantQueries: []string{
+				`SELECT range_id, task_list FROM tasks WHERE domain_id = domain1 and task_list_name = tasklist1 and task_list_type = 1 and type = 1 and task_id = -12345`,
+			},
+		},
+		{
 			name: "scan failure",
 			filter: &nosqlplugin.TaskListFilter{
 				DomainID:     "domain1",
@@ -204,6 +241,70 @@ func TestSelectTaskList(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantQueries, session.queries); diff != "" {
 				t.Fatalf("Query mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFromTaskListPartitionConfigMarshaling(t *testing.T) {
+	protoVersion := byte(4)
+	udtType := gogocql.UDTTypeInfo{
+		NativeType: gogocql.NewNativeType(protoVersion, gogocql.TypeUDT, ""),
+		Elements: []gogocql.UDTField{
+			{Name: "version", Type: gogocql.NewNativeType(protoVersion, gogocql.TypeBigInt, "")},
+			{Name: "num_read_partitions", Type: gogocql.NewNativeType(protoVersion, gogocql.TypeInt, "")},
+			{Name: "num_write_partitions", Type: gogocql.NewNativeType(protoVersion, gogocql.TypeInt, "")},
+		},
+	}
+	tests := []struct {
+		name       string
+		config     *persistence.TaskListPartitionConfig
+		want       map[string]interface{}
+		wantCQLNil bool
+	}{
+		{
+			name:       "nil config",
+			wantCQLNil: true,
+		},
+		{
+			name: "populated config",
+			config: &persistence.TaskListPartitionConfig{
+				Version: 3,
+				ReadPartitions: map[int]*persistence.TaskListPartition{
+					0: {},
+					1: {},
+				},
+				WritePartitions: map[int]*persistence.TaskListPartition{
+					0: {},
+				},
+			},
+			want: map[string]interface{}{
+				"version":              int64(3),
+				"num_read_partitions":  2,
+				"num_write_partitions": 1,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := gogocql.Marshal(udtType, fromTaskListPartitionConfig(tc.config))
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if tc.wantCQLNil {
+				if data != nil {
+					t.Fatalf("Marshal() = %v, want nil", data)
+				}
+				return
+			}
+
+			var got map[string]interface{}
+			if err := gogocql.Unmarshal(udtType, data, &got); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("Map mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/emirpasic/gods v1.18.1
 	github.com/fatih/color v1.15.0
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1
+	github.com/gocql/gocql v1.7.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/mock v1.7.0-rc.1

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
-github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1 h1:px9qUCy/RNJNsfCam4m2IxWGxNuimkrioEF0vrrbPsg=
-github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
+github.com/gocql/gocql v1.7.0 h1:O+7U7/1gSN7QTEAaMEsJc1Oq2QHXvCWoF3DFK9HDHus=
+github.com/gocql/gocql v1.7.0/go.mod h1:vnlvXyFZeLBF0Wy+RS8hrOdbn0UWsWtdg07XJnFxZ+4=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
  - Upgraded `github.com/gocql/gocql` from the existing 2021 pseudo-version to v1.7.0.
  - Changed Cassandra host-selection policy configuration to create a fresh policy for every session.
  - Added local `nullableMap` marshaling for the optional adaptive task-list partition configuration.
  - Added regression tests for policy creation and nullable UDT marshaling.

**Why?**
Ref #7960 
The existing gocql dependency is several years old. Upgrading exposed two compatibility issues in Cadence: 
1. gocql v1.1+ rejects sharing a `TokenAwareHostPolicy` between sessions. Cadence reused the policy when recreating a session after `ErrNoConnections`, which causes a panic. Creating a fresh policy per session also prevents topology and metadata state from being shared between old and replacement sessions. 
2. gocql v1.7 marshals a typed nil UDT map as a present UDT containing null fields. When decoded, it appears as a map containing zero values. `nullableMap` preserves the intended behavior by encoding nil as CQL null while delegating non-nil values to standard gocql UDT marshaling.

**How did you test it?**
  - Cassandra adapter unit tests:

    `go test ./common/persistence/nosql/nosqlplugin/cassandra/...`

  - Complete live Cassandra persistence suite:

    `CASSANDRA=1 CASSANDRA_PROTO_VERSION=4 go test -v ./host/persistence/cassandra -count=1`

- Smoke test

**Potential risks**
This upgrades a core Cassandra driver and therefore affects connection management, topology discovery, query execution, and value marshaling.

  The compatibility changes:

  - Existing host-selection policy choices and token-aware routing behavior are preserved.
  - Only the optional adaptive partition configuration uses custom nullable marshaling.
  - No Cassandra schema or persisted data migration is required.


**Release notes**
Upgraded the Cassandra Go driver to gocql v1.7.0 and added compatibility handling for session recreation and nullable task-list partition configuration. 
Most deployments require no configuration changes. However, starting with gocql v1.1, `HostFilter` also applies to control connections. Cadence enables this filter when `datacenter` or `region` is configured. If all configured Cassandra seed hosts are outside the selected datacenter or region, Cadence may fail to initialize the session before topology discovery. Before upgrading, verify that at least one configured Cassandra seed host matches the selected datacenter or region.

**Documentation Changes**

