### PR TITLE
feat(queuev2): add inject-attempt metrics to cached queue reader

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2990,6 +2990,8 @@ const (
 	CachedQueueMissesCounter
 	CachedQueueSizeHistogram
 	CachedQueueShadowMismatchCounter
+	CachedQueueInjectAttemptCounter
+	CachedQueueDroppedFutureTimerTasksDurationHistogram
 
 	TaskRequestsPerTaskList
 	TaskLatencyPerTaskListHistogram
@@ -3973,6 +3975,8 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		CachedQueueMissesCounter:                                      {metricName: "cached_queue_misses", metricType: Counter},
 		CachedQueueSizeHistogram:                                      {metricName: "cached_queue_size", metricType: Histogram, buckets: TaskCountBuckets},
 		CachedQueueShadowMismatchCounter:                              {metricName: "cached_queue_shadow_mismatch", metricType: Counter},
+		CachedQueueInjectAttemptCounter:                               {metricName: "cached_queue_inject_attempt", metricType: Counter},
+		CachedQueueDroppedFutureTimerTasksDurationHistogram:           {metricName: "cached_queue_dropped_future_timer_tasks_duration_ns", metricType: Histogram, exponentialBuckets: Mid1ms24h},
 	},
 	Matching: {
 		PollSuccessPerTaskListCounter:                                    {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -392,6 +392,11 @@ func Range(value string) Tag {
 	return metricWithUnknown("range", value)
 }
 
+// StatusTag returns a new status tag.
+func StatusTag(value string) Tag {
+	return metricWithUnknown("status", value)
+}
+
 // DecisionTag returns a new decision tag
 func DecisionTag(decision string) Tag {
 	return metricWithUnknown("decision", decision)

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -659,6 +659,15 @@ func (q *cachedQueueReader) UpdateReadLevel(readLevel persistence.HistoryTaskKey
 	q.advanceInclusiveLowerBound(readLevel)
 }
 
+// inject status values reported via metrics.CachedQueueInjectAttemptCounter,
+// one per outcome branch of Inject.
+const (
+	injectStatusInjected     = "injected"
+	injectStatusBuffered     = "buffered"
+	injectStatusDroppedBelow = "dropped_below"
+	injectStatusDroppedUpper = "dropped_upper"
+)
+
 // Inject adds tasks that have just been persisted into the in-memory cache.
 // Tasks within the current cache window are inserted immediately. Tasks that
 // fall in [exclusiveUpperBound, prefetchTargetUpper) while a prefetch is
@@ -675,6 +684,9 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	now := q.clock.Now()
+	var injected, buffered, droppedBelow, droppedUpper int64
+
 	var covered []persistence.Task
 	for _, t := range tasks {
 		if t.GetTaskID() == 0 {
@@ -682,17 +694,18 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 			continue
 		}
 		if q.isTaskCovered(t.GetTaskKey()) {
+			injected++
 			if q.logger.DebugOn() {
 				q.logger.Debug("injecting task",
 					tag.Dynamic("taskKey", t.GetTaskKey()),
 					tag.Dynamic("cacheState", q.getState()),
 				)
 			}
-
 			covered = append(covered, t)
 			continue
 		}
 		if q.isToBufferTask(t.GetTaskKey()) {
+			buffered++
 			if q.logger.DebugOn() {
 				q.logger.Debug("buffering task",
 					tag.Dynamic("taskKey", t.GetTaskKey()),
@@ -707,6 +720,7 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 		// as the processor should only be persisting tasks near the current upper bound
 		// but log just in case to help debug any unexpected ordering issues
 		if t.GetTaskKey().Less(q.inclusiveLowerBound) {
+			droppedBelow++
 			q.logger.Warn("task key is below the lower bound, dropping task",
 				tag.Dynamic("taskKey", t.GetTaskKey()),
 				tag.Dynamic("cacheState", q.getState()),
@@ -714,6 +728,17 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 			continue
 		}
 
+		// Task key is at or beyond the cache's exclusive upper bound (the prefetch
+		// frontier) and outside the in-flight prefetch buffer window, so the cache
+		// does not cover it and it is dropped. Record how far ahead of now it is
+		// scheduled: the frontier normally sits near now+lookahead, so this typically
+		// measures how far into the future the dropped task was scheduled, which helps
+		// tune the look-ahead window.
+		droppedUpper++
+		q.metrics.ExponentialHistogram(
+			metrics.CachedQueueDroppedFutureTimerTasksDurationHistogram,
+			t.GetTaskKey().GetScheduledTime().Sub(now),
+		)
 		if q.logger.DebugOn() {
 			q.logger.Debug("task key is beyond the upper/target prefetch bound, dropping task",
 				tag.Dynamic("taskKey", t.GetTaskKey()),
@@ -722,7 +747,21 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 		}
 	}
 
+	q.emitInjectStatusCount(injectStatusInjected, injected)
+	q.emitInjectStatusCount(injectStatusBuffered, buffered)
+	q.emitInjectStatusCount(injectStatusDroppedBelow, droppedBelow)
+	q.emitInjectStatusCount(injectStatusDroppedUpper, droppedUpper)
+
 	q.putTasks(covered)
+}
+
+// emitInjectStatusCount records the number of injected tasks that took the given
+// outcome path, tagged by status. Zero counts are skipped to avoid emitting empty series.
+func (q *cachedQueueReader) emitInjectStatusCount(status string, count int64) {
+	if count == 0 {
+		return
+	}
+	q.metrics.Tagged(metrics.StatusTag(status)).AddCounter(metrics.CachedQueueInjectAttemptCounter, count)
 }
 
 // GetTask serves tasks from the cache when the starting key is covered.

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common/clock"
@@ -63,10 +64,11 @@ func testOptions(overrides ...func(*cachedQueueReaderOptions)) *cachedQueueReade
 }
 
 type cachedQueueReaderMockDeps struct {
-	mockBase  *MockQueueReader
-	mockQueue *MockInMemQueue
-	mockShard *shard.MockContext
-	clock     clock.MockedTimeSource
+	mockBase     *MockQueueReader
+	mockQueue    *MockInMemQueue
+	mockShard    *shard.MockContext
+	clock        clock.MockedTimeSource
+	metricsScope tally.TestScope
 }
 
 func setupMocksForCachedQueueReader(
@@ -79,11 +81,13 @@ func setupMocksForCachedQueueReader(
 	mockShard.EXPECT().GetRangeID().Return(int64(0)).AnyTimes()
 	mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(0).AnyTimes()
+	metricsScope := tally.NewTestScope("", nil)
 	deps := &cachedQueueReaderMockDeps{
-		mockBase:  NewMockQueueReader(ctrl),
-		mockQueue: NewMockInMemQueue(ctrl),
-		mockShard: mockShard,
-		clock:     clock.NewMockedTimeSource(),
+		mockBase:     NewMockQueueReader(ctrl),
+		mockQueue:    NewMockInMemQueue(ctrl),
+		mockShard:    mockShard,
+		clock:        clock.NewMockedTimeSource(),
+		metricsScope: metricsScope,
 	}
 
 	r := newCachedQueueReaderWithOptions(
@@ -92,7 +96,7 @@ func setupMocksForCachedQueueReader(
 		deps.mockShard,
 		deps.clock,
 		testlogger.New(t),
-		metrics.NoopScope,
+		metrics.NewClient(metricsScope, metrics.History, metrics.MigrationConfig{}).Scope(metrics.TimerQueueProcessorV2Scope),
 		testOptions(overrides...),
 	)
 
@@ -279,13 +283,18 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 	trimKey := inside.GetTaskKey().Next()
 
 	tests := []struct {
-		name               string
-		tasks              []persistence.Task
-		initPrefetchTarget persistence.HistoryTaskKey
-		optsOverride       func(*cachedQueueReaderOptions)
-		setupMocks         func(queue *MockInMemQueue)
-		wantUpper          persistence.HistoryTaskKey
-		wantBufferLen      int
+		name                string
+		tasks               []persistence.Task
+		initPrefetchTarget  persistence.HistoryTaskKey
+		optsOverride        func(*cachedQueueReaderOptions)
+		setupMocks          func(queue *MockInMemQueue)
+		wantUpper           persistence.HistoryTaskKey
+		wantBufferLen       int
+		wantInjected        int64
+		wantBuffered        int64
+		wantDroppedBelow    int64
+		wantDroppedUpper    int64
+		wantFutureHistogram bool
 	}{
 		{
 			name:  "disabled clears stale cache",
@@ -307,7 +316,8 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 				queue.EXPECT().PutTasks([]persistence.Task{inside})
 				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
 			},
-			wantUpper: upper,
+			wantUpper:    upper,
+			wantInjected: 1,
 		},
 		{
 			name:  "task before lower skipped",
@@ -315,7 +325,8 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 			},
-			wantUpper: upper,
+			wantUpper:        upper,
+			wantDroppedBelow: 1,
 		},
 		{
 			name:  "task at upper bound (exclusive) skipped",
@@ -323,7 +334,9 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 			},
-			wantUpper: upper,
+			wantUpper:           upper,
+			wantDroppedUpper:    1,
+			wantFutureHistogram: true,
 		},
 		{
 			name:  "mixed: only inside accepted",
@@ -333,7 +346,11 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 				queue.EXPECT().PutTasks([]persistence.Task{inside})
 				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
 			},
-			wantUpper: upper,
+			wantUpper:           upper,
+			wantInjected:        1,
+			wantDroppedBelow:    1,
+			wantDroppedUpper:    1,
+			wantFutureHistogram: true,
 		},
 		{
 			// putTasks short-circuits on empty slice, so no queue calls expected.
@@ -354,7 +371,8 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 				queue.EXPECT().PutTasks([]persistence.Task{inside})
 				queue.EXPECT().RTrimBySize(1).Return(trimKey, true)
 			},
-			wantUpper: trimKey,
+			wantUpper:    trimKey,
+			wantInjected: 1,
 		},
 		{
 			name:               "task in [upper, prefetchTarget) buffered when prefetch in-flight",
@@ -365,6 +383,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			},
 			wantUpper:     upper,
 			wantBufferLen: 1,
+			wantBuffered:  1,
 		},
 		{
 			name:               "task beyond prefetchTarget dropped even when prefetch in-flight",
@@ -373,8 +392,10 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 			},
-			wantUpper:     upper,
-			wantBufferLen: 0,
+			wantUpper:           upper,
+			wantBufferLen:       0,
+			wantDroppedUpper:    1,
+			wantFutureHistogram: true,
 		},
 		{
 			name:               "task with ID=0 not buffered even when prefetch in-flight",
@@ -406,8 +427,42 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			r.mu.RUnlock()
 			assert.True(t, gotUpper.Equal(tc.wantUpper), "upper: got %v want %v", gotUpper, tc.wantUpper)
 			assert.Equal(t, tc.wantBufferLen, gotBufferLen, "buffer length")
+
+			snapshot := deps.metricsScope.Snapshot()
+			assert.Equal(t, tc.wantInjected, injectCounterValue(snapshot, injectStatusInjected), "injected count")
+			assert.Equal(t, tc.wantBuffered, injectCounterValue(snapshot, injectStatusBuffered), "buffered count")
+			assert.Equal(t, tc.wantDroppedBelow, injectCounterValue(snapshot, injectStatusDroppedBelow), "dropped_below count")
+			assert.Equal(t, tc.wantDroppedUpper, injectCounterValue(snapshot, injectStatusDroppedUpper), "dropped_upper count")
+			assert.Equal(t, tc.wantFutureHistogram, hasFutureDurationHistogram(snapshot), "future duration histogram recorded")
 		})
 	}
+}
+
+// injectCounterValue sums the cached_queue_inject_attempt counter samples tagged with the given status.
+func injectCounterValue(snapshot tally.Snapshot, status string) int64 {
+	var total int64
+	for _, c := range snapshot.Counters() {
+		if c.Name() == "cached_queue_inject_attempt" && c.Tags()["status"] == status {
+			total += c.Value()
+		}
+	}
+	return total
+}
+
+// hasFutureDurationHistogram reports whether the cached_queue_dropped_future_timer_tasks_duration_ns
+// histogram recorded at least one sample.
+func hasFutureDurationHistogram(snapshot tally.Snapshot) bool {
+	for _, h := range snapshot.Histograms() {
+		if h.Name() != "cached_queue_dropped_future_timer_tasks_duration_ns" {
+			continue
+		}
+		for _, count := range h.Durations() {
+			if count > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestCachedQueueReader_Clear(t *testing.T) {


### PR DESCRIPTION
**What changed?**
Instrument `cachedQueueReader.Inject`, the entry point for freshly-persisted timer tasks, with two metrics:
- `cached_queue_inject_attempt` (Counter) tagged `status:{injected, buffered, dropped_below, dropped_upper}`, one increment per task, per outcome branch.
- `cached_queue_dropped_future_timer_tasks_duration_ns` (duration histogram, exponential buckets), `scheduledTime - now()`, emitted only on the `dropped_upper` path to show how far in the future a dropped task was scheduled.

**Why?**
Inject classifies each task into one of four paths (injected into the cache, buffered behind an in-flight prefetch, dropped below the lower bound, or dropped at/above the prefetch frontier), but none of them was instrumented, so we had no visibility into the pattern of injects. The counter lets us see the mix of outcomes by status (rates, ratios, per-shard), and the histogram measures how far ahead of `now` the dropped-upper tasks sit, the signal needed to tune the cache look-ahead / prefetch window. A Counter (not Histogram) fits discrete events bucketed by status; the one continuous quantity worth a distribution (future scheduling distance) is the separate duration histogram. It is a duration histogram rather than a timer because M3 deprecates timers in favor of duration histograms.

#7953 

**How did you test it?**
- Unit: `go test -run TestCachedQueueReader_Inject ./service/history/queuev2/...`
- Race: `go test -race -run TestCachedQueueReader_Inject ./service/history/queuev2/...` `go test -race ./common/metrics/...` The test asserts the per-status counter values and that the future-duration histogram recorded a sample on the dropped-upper path.
- Ran locally with Cassandra, Prometheus, and Grafana containers:
<img width="1909" height="823" alt="Screenshot 2026-08-10 at 14 22 52" src="https://github.com/user-attachments/assets/ef054d5e-b9b4-496a-b902-44035de93aa4" />
<img width="1915" height="955" alt="Screenshot 2026-08-10 at 14 23 09" src="https://github.com/user-attachments/assets/ad9e8b4a-14d9-4b6a-aca2-d99ce19528a9" />


**Potential risks**
Metrics-only change on the core task-injection path. The counter and duration histogram are emitted under the existing `q.mu` lock alongside the current histogram calls, so no new locking. No API, IDL, or schema change; fully backward compatible and safe to roll back.

**Release notes**
N/A (internal observability only).

**Documentation Changes**
N/A

