### PR TITLE
chore: Increase suite duration to reduce flakes

### DIFF
--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -51,9 +51,9 @@ import (
 )
 
 const (
-	defaultTestLimit   = 3 * time.Second
+	defaultTestLimit   = 5 * time.Second
 	slowTestLimit      = 40 * time.Second
-	suiteOverheadLimit = 30 * time.Second
+	suiteOverheadLimit = 60 * time.Second
 	slowTestSuffix     = "_SLOW"
 )
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Increases the suite overhead duration from 30 to 60 seconds. 

**Why?**

Many of our suites were failing after this duration, regardless of whether the tests internally were succeeding. This increases the buffer we have when GitHub actions/runners are in any way degraded, reducing the likelihood of flakes. 

**How did you test it?**

Will test via CI. 

**Potential risks**

This is going to increase the duration it takes to run our tests. We are already suffering from the extremely long testing time in CI, which seems to have exacerbated in the last few weeks (before multiple changes to increase timeouts on some tests). 

We need to follow up with other efficiency gains or analysis of specific slow tests. 

**Release notes**

N/A

**Documentation Changes**

N/A