### PR TITLE
feat(queuev2): add prefetch cycle metrics to cached queue reader

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2992,6 +2992,12 @@ const (
 	CachedQueueShadowMismatchCounter
 	CachedQueueInjectAttemptCounter
 	CachedQueueDroppedFutureTimerTasksDurationHistogram
+	CachedQueuePrefetchSuccessCounter
+	CachedQueuePrefetchFailureCounter
+	CachedQueuePrefetchGapDetectedCounter
+	CachedQueuePrefetchLatency
+	CachedQueuePrefetchLatencyHistogram
+	CachedQueuePrefetchWindowSpanHistogram
 
 	TaskRequestsPerTaskList
 	TaskLatencyPerTaskListHistogram
@@ -3977,6 +3983,12 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		CachedQueueShadowMismatchCounter:                              {metricName: "cached_queue_shadow_mismatch", metricType: Counter},
 		CachedQueueInjectAttemptCounter:                               {metricName: "cached_queue_inject_attempt", metricType: Counter},
 		CachedQueueDroppedFutureTimerTasksDurationHistogram:           {metricName: "cached_queue_dropped_future_timer_tasks_duration_ns", metricType: Histogram, exponentialBuckets: Mid1ms24h},
+		CachedQueuePrefetchSuccessCounter:                             {metricName: "cached_queue_prefetch_success", metricType: Counter},
+		CachedQueuePrefetchFailureCounter:                             {metricName: "cached_queue_prefetch_failure", metricType: Counter},
+		CachedQueuePrefetchGapDetectedCounter:                         {metricName: "cached_queue_prefetch_gap_detected", metricType: Counter},
+		CachedQueuePrefetchLatency:                                    {metricName: "cached_queue_prefetch_latency", metricType: Timer},
+		CachedQueuePrefetchLatencyHistogram:                           {metricName: "cached_queue_prefetch_latency_ns", metricType: Histogram, exponentialBuckets: Mid1ms24h},
+		CachedQueuePrefetchWindowSpanHistogram:                        {metricName: "cached_queue_prefetch_window_span_ns", metricType: Histogram, exponentialBuckets: Mid1ms24h},
 	},
 	Matching: {
 		PollSuccessPerTaskListCounter:                                    {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -423,6 +423,10 @@ func (q *cachedQueueReader) prefetch() error {
 
 	now := q.clock.Now()
 
+	// Started after the no-op guards so skips aren't timed.
+	sw := q.metrics.StartTimerWithExponentialHistogram(metrics.CachedQueuePrefetchLatency, metrics.CachedQueuePrefetchLatencyHistogram)
+	defer sw.Stop()
+
 	// Ceiling of the look-ahead window; tasks at or after this time aren't due yet.
 	exclusiveMaxTaskKey := persistence.NewHistoryTaskKey(now.Add(q.options.MaxLookAheadWindow()), 0)
 
@@ -466,11 +470,14 @@ func (q *cachedQueueReader) prefetch() error {
 	q.prefetchTargetUpper = persistence.MinimumHistoryTaskKey
 
 	if err != nil {
+		q.metrics.IncCounter(metrics.CachedQueuePrefetchFailureCounter)
 		q.logger.Error("prefetch failed", tag.Error(err))
 		return fmt.Errorf("prefetch failed: %w", err)
 	}
 
 	if q.isDisabled() {
+		// Mode flipped to disabled mid-fetch: the result is discarded rather than
+		// completed, so it is neither a success nor a failure and is not counted.
 		q.logger.Info("prefetch result discarded, mode switched to disabled during prefetch")
 		q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
 		return nil
@@ -483,6 +490,7 @@ func (q *cachedQueueReader) prefetch() error {
 	// existing cache remains valid for [inclusiveLowerBound, exclusiveUpperBound).
 	// The next prefetch will fill the gap from the new exclusiveUpperBound.
 	if !q.exclusiveUpperBound.Equal(upperBound) {
+		q.metrics.IncCounter(metrics.CachedQueuePrefetchGapDetectedCounter)
 		q.logger.Info("gap detected, discarding fetched data",
 			tag.Dynamic("prevUpper", upperBound),
 			tag.Dynamic("cacheState", q.getState()),
@@ -497,16 +505,22 @@ func (q *cachedQueueReader) prefetch() error {
 	}
 
 	// If a trim occurred, putTasks already updated the upper bound correctly.
-	if trimmed := q.putTasks(resp.Tasks); trimmed {
-		return nil
+	// Otherwise advance to NextTaskKey: the key to start the next page, pointing
+	// to the first task beyond the current page (or ExclusiveMaxTaskKey when
+	// there are no more tasks to fetch).
+	if trimmed := q.putTasks(resp.Tasks); !trimmed {
+		q.updateExclusiveUpperBound(resp.Progress.NextTaskKey)
 	}
 
-	// NextTaskKey is the key to start the next page; it points to the first task beyond the current page
-	// or may be equal to ExclusiveMaxTaskKey if there are no more tasks to fetch
-	q.updateExclusiveUpperBound(resp.Progress.NextTaskKey)
+	q.metrics.IncCounter(metrics.CachedQueuePrefetchSuccessCounter)
+
+	// Whether prefetch is keeping up with newly created tasks.
+	windowSpan := q.exclusiveUpperBound.GetScheduledTime().Sub(q.inclusiveLowerBound.GetScheduledTime())
+	q.metrics.ExponentialHistogram(metrics.CachedQueuePrefetchWindowSpanHistogram, windowSpan)
 
 	q.logger.Debug("prefetch complete",
 		tag.Dynamic("tasksFetched", len(resp.Tasks)),
+		tag.Dynamic("windowSpan", windowSpan),
 		tag.Dynamic("cacheState", q.getState()),
 	)
 	return nil

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -433,27 +433,41 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			assert.Equal(t, tc.wantBuffered, injectCounterValue(snapshot, injectStatusBuffered), "buffered count")
 			assert.Equal(t, tc.wantDroppedBelow, injectCounterValue(snapshot, injectStatusDroppedBelow), "dropped_below count")
 			assert.Equal(t, tc.wantDroppedUpper, injectCounterValue(snapshot, injectStatusDroppedUpper), "dropped_upper count")
-			assert.Equal(t, tc.wantFutureHistogram, hasFutureDurationHistogram(snapshot), "future duration histogram recorded")
+			assert.Equal(t, tc.wantFutureHistogram, histogramHasSample(snapshot, "cached_queue_dropped_future_timer_tasks_duration_ns"), "future duration histogram recorded")
 		})
 	}
 }
 
-// injectCounterValue sums the cached_queue_inject_attempt counter samples tagged with the given status.
-func injectCounterValue(snapshot tally.Snapshot, status string) int64 {
+// counterValue sums counter samples matching name and all of wantTags (nil matches any tags).
+func counterValue(snapshot tally.Snapshot, name string, wantTags map[string]string) int64 {
 	var total int64
 	for _, c := range snapshot.Counters() {
-		if c.Name() == "cached_queue_inject_attempt" && c.Tags()["status"] == status {
+		if c.Name() != name {
+			continue
+		}
+		match := true
+		for k, v := range wantTags {
+			if c.Tags()[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
 			total += c.Value()
 		}
 	}
 	return total
 }
 
-// hasFutureDurationHistogram reports whether the cached_queue_dropped_future_timer_tasks_duration_ns
-// histogram recorded at least one sample.
-func hasFutureDurationHistogram(snapshot tally.Snapshot) bool {
+// injectCounterValue sums the cached_queue_inject_attempt counter samples tagged with the given status.
+func injectCounterValue(snapshot tally.Snapshot, status string) int64 {
+	return counterValue(snapshot, "cached_queue_inject_attempt", map[string]string{"status": status})
+}
+
+// histogramHasSample reports whether the named duration histogram recorded at least one sample.
+func histogramHasSample(snapshot tally.Snapshot, name string) bool {
 	for _, h := range snapshot.Histograms() {
-		if h.Name() != "cached_queue_dropped_future_timer_tasks_duration_ns" {
+		if h.Name() != name {
 			continue
 		}
 		for _, count := range h.Durations() {
@@ -463,6 +477,24 @@ func hasFutureDurationHistogram(snapshot tally.Snapshot) bool {
 		}
 	}
 	return false
+}
+
+// assertPrefetchMetrics asserts a cycle emitted only the wantOutcome counter, the latency histogram (wantLatency), and the window-span histogram (wantWindowSpan).
+func assertPrefetchMetrics(t *testing.T, snapshot tally.Snapshot, wantOutcome string, wantLatency, wantWindowSpan bool) {
+	t.Helper()
+	for _, name := range []string{
+		"cached_queue_prefetch_success",
+		"cached_queue_prefetch_failure",
+		"cached_queue_prefetch_gap_detected",
+	} {
+		want := int64(0)
+		if name == wantOutcome {
+			want = 1
+		}
+		assert.Equal(t, want, counterValue(snapshot, name, nil), "prefetch counter %q", name)
+	}
+	assert.Equal(t, wantLatency, histogramHasSample(snapshot, "cached_queue_prefetch_latency_ns"), "prefetch latency histogram")
+	assert.Equal(t, wantWindowSpan, histogramHasSample(snapshot, "cached_queue_prefetch_window_span_ns"), "prefetch window span histogram")
 }
 
 func TestCachedQueueReader_Clear(t *testing.T) {
@@ -1641,17 +1673,19 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 	t2 := newTask(2, now.Add(10*time.Minute))
 	t3 := newTask(3, now.Add(35*time.Minute))
 	t4 := newTask(4, now.Add(40*time.Minute))
-
 	tests := []struct {
-		name         string
-		optsOverride func(*cachedQueueReaderOptions)
-		initLower    persistence.HistoryTaskKey
-		initUpper    persistence.HistoryTaskKey
-		initBuffer   []persistence.Task
-		setupMocks   func(base *MockQueueReader, queue *MockInMemQueue, r *cachedQueueReader)
-		wantErr      bool
-		wantLower    persistence.HistoryTaskKey
-		wantUpper    persistence.HistoryTaskKey
+		name                  string
+		optsOverride          func(*cachedQueueReaderOptions)
+		initLower             persistence.HistoryTaskKey
+		initUpper             persistence.HistoryTaskKey
+		initBuffer            []persistence.Task
+		setupMocks            func(base *MockQueueReader, queue *MockInMemQueue, r *cachedQueueReader)
+		wantErr               bool
+		wantLower             persistence.HistoryTaskKey
+		wantUpper             persistence.HistoryTaskKey
+		wantOutcomeMetricName string
+		wantLatencyMetric     bool
+		wantWindowSpanMetric  bool
 	}{
 		{
 			name: "disabled: no-op when cache empty",
@@ -1696,9 +1730,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
-			wantErr:   true,
-			wantLower: someLower,
-			wantUpper: someUpper,
+			wantErr:               true,
+			wantLower:             someLower,
+			wantUpper:             someUpper,
+			wantOutcomeMetricName: "cached_queue_prefetch_failure",
+			wantLatencyMetric:     true,
 		},
 		{
 			name:      "clear cache, first prefetch, no tasks",
@@ -1711,8 +1747,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 					Progress: &GetTaskProgress{NextTaskKey: maxKey},
 				}, nil)
 			},
-			wantLower: evictBefore,
-			wantUpper: maxKey,
+			wantLower:             evictBefore,
+			wantUpper:             maxKey,
+			wantOutcomeMetricName: "cached_queue_prefetch_success",
+			wantLatencyMetric:     true,
+			wantWindowSpanMetric:  true,
 		},
 		{
 			name:      "clear cache, first prefetch, tasks returned",
@@ -1727,8 +1766,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				queue.EXPECT().PutTasks([]persistence.Task{t1, t2})
 				queue.EXPECT().RTrimBySize(maxSize).Return(persistence.MinimumHistoryTaskKey, false)
 			},
-			wantLower: evictBefore,
-			wantUpper: maxKey,
+			wantLower:             evictBefore,
+			wantUpper:             maxKey,
+			wantOutcomeMetricName: "cached_queue_prefetch_success",
+			wantLatencyMetric:     true,
+			wantWindowSpanMetric:  true,
 		},
 		{
 			name:      "subsequent prefetch, no tasks",
@@ -1741,8 +1783,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 					Progress: &GetTaskProgress{NextTaskKey: maxKey},
 				}, nil)
 			},
-			wantLower: someLower,
-			wantUpper: maxKey,
+			wantLower:             someLower,
+			wantUpper:             maxKey,
+			wantOutcomeMetricName: "cached_queue_prefetch_success",
+			wantLatencyMetric:     true,
+			wantWindowSpanMetric:  true,
 		},
 		{
 			name:      "subsequent prefetch, tasks returned, tasks inserted",
@@ -1757,8 +1802,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				queue.EXPECT().PutTasks([]persistence.Task{t3, t4})
 				queue.EXPECT().RTrimBySize(maxSize).Return(persistence.MinimumHistoryTaskKey, false)
 			},
-			wantLower: someLower,
-			wantUpper: t4.GetTaskKey().Next(),
+			wantLower:             someLower,
+			wantUpper:             t4.GetTaskKey().Next(),
+			wantOutcomeMetricName: "cached_queue_prefetch_success",
+			wantLatencyMetric:     true,
+			wantWindowSpanMetric:  true,
 		},
 		{
 			name: "subsequent prefetch, tasks returned, tasks inserted, trimmed by size",
@@ -1779,8 +1827,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				queue.EXPECT().PutTasks([]persistence.Task{t3})
 				queue.EXPECT().RTrimBySize(1).Return(trimKey, true)
 			},
-			wantLower: evictBefore,
-			wantUpper: trimKey,
+			wantLower:             evictBefore,
+			wantUpper:             trimKey,
+			wantOutcomeMetricName: "cached_queue_prefetch_success",
+			wantLatencyMetric:     true,
+			wantWindowSpanMetric:  true,
 		},
 		{
 			name:      "gap detected: upper changed during fetch, returns error, bounds unchanged",
@@ -1801,9 +1852,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 					},
 				)
 			},
-			wantErr:   true,
-			wantLower: someLower,
-			wantUpper: differentUpper,
+			wantErr:               true,
+			wantLower:             someLower,
+			wantUpper:             differentUpper,
+			wantOutcomeMetricName: "cached_queue_prefetch_gap_detected",
+			wantLatencyMetric:     true,
 		},
 		{
 			// A task buffered in pendingInjectBuffer (arrived while prefetch was in-flight)
@@ -1827,8 +1880,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				queue.EXPECT().PutTasks([]persistence.Task{tBuf})
 				queue.EXPECT().RTrimBySize(maxSize).Return(persistence.MinimumHistoryTaskKey, false)
 			},
-			wantLower: someLower,
-			wantUpper: maxKey,
+			wantLower:             someLower,
+			wantUpper:             maxKey,
+			wantOutcomeMetricName: "cached_queue_prefetch_success",
+			wantLatencyMetric:     true,
+			wantWindowSpanMetric:  true,
 		},
 		{
 			name:      "mode switched to disabled during in-flight fetch discards results and buffer",
@@ -1849,8 +1905,9 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 					},
 				)
 			},
-			wantLower: someLower,
-			wantUpper: someUpper,
+			wantLower:         someLower,
+			wantUpper:         someUpper,
+			wantLatencyMetric: true, // fetch ran (DB round-trip) before the mode-switch discard, so latency is recorded
 		},
 	}
 
@@ -1889,6 +1946,8 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			assert.True(t, gotLower.Equal(tc.wantLower), "lower: got %v want %v", gotLower, tc.wantLower)
 			assert.True(t, gotUpper.Equal(tc.wantUpper), "upper: got %v want %v", gotUpper, tc.wantUpper)
 			assert.Equal(t, 0, gotBufferLen, "pending inject buffer should be empty after prefetch")
+
+			assertPrefetchMetrics(t, deps.metricsScope.Snapshot(), tc.wantOutcomeMetricName, tc.wantLatencyMetric, tc.wantWindowSpanMetric)
 		})
 	}
 }


### PR DESCRIPTION
**What changed?**
Added five metrics emitted by the Timer Queue V2 cached queue reader's prefetch loop:
- `cached_queue_prefetch_success` / `_failure` / `_gap_detected`: one counter per terminal prefetch-cycle outcome.
- `cached_queue_prefetch_latency_ns`: prefetch-cycle duration (exponential-bucket histogram).
- `cached_queue_prefetch_window_span_ns`: scheduled-time span of the cache window after a successful prefetch (exponential-bucket histogram).

**Why?**
The cached reader prefetches pages of timer tasks into an in-memory look-ahead window, but the prefetch loop emitted no metrics. There's no signal on whether prefetch is succeeding, how long each cycle takes, or how wide the cached window is, which makes the feature hard to observe and tune during rollout. The `gap_detected` counter distinguishes the case where the upper bound moved mid-fetch and the page was discarded; window span surfaces whether prefetch is keeping up with newly created tasks.

#7953

**How did you test it?**
- Unit tests: `go test -race ./service/history/queuev2/...`
- Manual: ran a local single-node server with the cached reader enabled (`history.enableTimerQueueV2: true`, `history.timerProcessorCachedQueueReaderMode: enabled`) under workflow traffic, and confirmed the new time series in Prometheus/Grafana
<img width="1930" height="980" alt="Screenshot 2026-08-11 at 13 04 50" src="https://github.com/user-attachments/assets/4f1f1750-cae6-4a41-b43e-a2fb2facc717" />
<img width="1907" height="990" alt="Screenshot 2026-08-11 at 13 05 20" src="https://github.com/user-attachments/assets/91c13ca3-e651-4157-a79b-1f83298183f0" />
<img width="1890" height="1065" alt="Screenshot 2026-08-11 at 13 05 42" src="https://github.com/user-attachments/assets/582d017c-60fa-4d72-9523-35abf52d021a" />


**Potential risks**
Additive observability only, no change to task-processing behavior.

**Release notes**
N/A (internal observability only).

**Documentation Changes**
N/A.