### PR TITLE
fix(queuev2): exclude taskID boundary noise from timer cache shadow comparison

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -789,6 +789,12 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 		inclusiveMinTaskKey = req.Progress.NextTaskKey
 	}
 
+	// Cassandra's timer task query range-filters only on scheduledTime; taskID is never
+	// enforced as a DB-side bound (unlike transfer/replication tasks, where taskID is the
+	// sole range key). Drop it here so the cache's filtering matches what the DB actually
+	// guarantees, instead of being stricter than the DB and causing false shadow mismatches.
+	inclusiveMinTaskKey = persistence.NewHistoryTaskKey(inclusiveMinTaskKey.GetScheduledTime(), 0)
+
 	q.mu.RLock()
 	covered := q.isRangeCovered(inclusiveMinTaskKey, exclusiveMaxTaskKey)
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -671,6 +671,35 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 			},
 		},
 		{
+			// Cassandra's timer task query never filters by taskID, only scheduledTime, so a
+			// request floor with a non-zero taskID must be zeroed before querying the cache -
+			// otherwise the cache would be stricter than the DB ever was at a shared timestamp.
+			name:  "hit: non-zero taskID floor at same scheduledTime as lower bound is zeroed before querying cache",
+			mode:  "enabled",
+			lower: lower, upper: upper,
+			req: &GetTaskRequest{
+				Progress:  newProgress(newTaskKey(now, 5), upper),
+				Predicate: NewUniversalPredicate(),
+				PageSize:  10,
+			},
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				// Expect the zeroed-taskID key (== lower), not the request's raw (now, taskID=5) key.
+				queue.EXPECT().GetTasks(lower, upper, gomock.Any(), 10).
+					Return([]persistence.Task{t1, t2}, upper)
+			},
+			wantResp: &GetTaskResponse{
+				Tasks: []persistence.Task{t1, t2},
+				Progress: &GetTaskProgress{
+					Range: Range{
+						InclusiveMinTaskKey: upper,
+						ExclusiveMaxTaskKey: upper,
+					},
+					NextTaskKey: upper,
+				},
+			},
+		},
+		{
 			// NextPageToken set and NextTaskKey falls inside cache window → cache hit.
 			name:  "nextPageToken with nextTaskKey inside cache hits cache",
 			mode:  "enabled",


### PR DESCRIPTION
**What changed?**

`findMismatchesInShadow` no longer counts a DB-only timer task as a real cache mismatch when it can be fully explained by Cassandra not filtering timer task reads by `taskID`. Such tasks are now reported in a separate `TaskIDBoundaryNoise` field instead of `Missed`. Real cache-hit serving (`CachedQueueReader.GetTask`) is unchanged — it keeps the exact `(scheduledTime, taskID)` filtering it always had.

**Why?**

Cassandra's timer task query (`templateGetTimerTasksQuery`) range-filters only on `visibility_ts`; `task_id` is never bound as a query parameter and is not enforced as a range bound for the Timer task category. This is unlike Transfer/Replication tasks, where `task_id` is the sole range-filter key in the CQL query.

The in-memory cache used by `CachedQueueReader` filters reads by the full `(scheduledTime, taskID)` `HistoryTaskKey`, which is stricter than the database ever was. At a boundary timestamp shared by multiple timer tasks, the DB returns every task with `visibility_ts` in range regardless of `task_id`, while the cache excludes tasks below the requested `taskID` floor. This caused shadow-mode comparison (`getTaskInShadow` / `findMismatchesInShadow`) to report false-positive "missed" mismatches that don't reflect any real cache/DB inconsistency, adding noise to the signal used to evaluate the `CachedQueueReader` rollout.

Since the DB enforces `scheduledTime >= InclusiveMinTaskKey.GetScheduledTime()` as a hard bound, the only way a DB-only task's full key can compare less than the request's `InclusiveMinTaskKey` is exactly this scenario: same `scheduledTime`, lower `taskID`. That single check (`t.GetTaskKey().Less(inclusiveMinTaskKey)`) is enough to separate known DB-semantics noise from genuine mismatches, without touching `InMemQueue` or real serving behavior at all.

**How did you test it?**

```
go test -race -run TestFindMismatchesInShadow ./service/history/queuev2/...
go test -race -run TestCachedQueueReader_GetTask ./service/history/queuev2/...
go test -race ./service/history/queuev2/...
```

Added two `TestFindMismatchesInShadow` cases: one where a DB-only task at the same `scheduledTime` as the floor but a lower `taskID` is classified as `TaskIDBoundaryNoise` (not `Missed`), and one confirming a genuinely missed task after the floor is still reported as a real mismatch. Verified the new cases fail to even compile without the fix (the test literal references the new `TaskIDBoundaryNoise` field), and pass with it restored.

**Potential risks**

Very low. This only changes shadow-mode diagnostic classification/logging (`findMismatchesInShadow`, `reportShadowComparison`); it does not change any DB query, the `InMemQueue` data structure, or what tasks are actually served to a caller in either shadow or non-shadow mode. `TaskIDBoundaryNoise` entries are excluded from `CachedQueueShadowMismatchCounter` and from the severity switch in `reportShadowComparison`, but remain visible in the logged `shadowComparison` struct for debugging.

**Release notes**

N/A - internal fix to shadow-mode diagnostics for the (currently shadow/experimental) `CachedQueueReader` used by the timer queue processor. No user-facing behavior change.

**Documentation Changes**

N/A