### PR TITLE
feat(queuev2): drop periodic shadow sample log

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -828,9 +828,7 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 		},
 	}
 
-	isPeriodicShadowSample := q.isPeriodicShadowSample()
-	if q.isShadow() || isPeriodicShadowSample {
-		logTags = append(logTags, tag.Dynamic("isPeriodicShadowSample", isPeriodicShadowSample))
+	if q.isShadow() || q.isPeriodicShadowSample() {
 		return q.getTaskInShadow(ctx, req, cacheResp, logTags)
 	}
 

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -828,9 +828,12 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 		},
 	}
 
-	if q.isShadow() || q.isPeriodicShadowSample() {
+	isPeriodicShadowSample := q.isPeriodicShadowSample()
+	if q.isShadow() || isPeriodicShadowSample {
+		logTags = append(logTags, tag.Dynamic("isPeriodicShadowSample", isPeriodicShadowSample))
 		return q.getTaskInShadow(ctx, req, cacheResp, logTags)
 	}
+
 	return cacheResp, nil
 }
 
@@ -860,7 +863,6 @@ func (q *cachedQueueReader) isPeriodicShadowSample() bool {
 	if !q.lastShadowSampleUnixNano.CompareAndSwap(last, now) {
 		return false
 	}
-	q.logger.Info("shadow sample check")
 	return true
 }
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
-	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
@@ -1118,7 +1117,6 @@ type periodicShadowSampleStep struct {
 	advance              time.Duration // clock advance applied before this call
 	setupMocks           func(base *MockQueueReader, queue *MockInMemQueue)
 	wantResp             *GetTaskResponse
-	wantSampleLogCount   int // cumulative count of logs tagged isPeriodicShadowSample=true after this call
 	wantMismatchLogCount int // cumulative "potential severe mismatch..." log count after this call
 }
 
@@ -1164,31 +1162,31 @@ func TestCachedQueueReader_GetTask_PeriodicShadowSample(t *testing.T) {
 			name:     "first call after start samples immediately",
 			interval: 5 * time.Minute,
 			steps: []periodicShadowSampleStep{
-				{setupMocks: sampledHit, wantResp: dbResp, wantSampleLogCount: 1},
+				{setupMocks: sampledHit, wantResp: dbResp},
 			},
 		},
 		{
 			name:     "second call within interval does not re-sample",
 			interval: 5 * time.Minute,
 			steps: []periodicShadowSampleStep{
-				{setupMocks: sampledHit, wantResp: dbResp, wantSampleLogCount: 1},
-				{setupMocks: cacheHit, wantResp: cacheOnlyResp, wantSampleLogCount: 1},
+				{setupMocks: sampledHit, wantResp: dbResp},
+				{setupMocks: cacheHit, wantResp: cacheOnlyResp},
 			},
 		},
 		{
 			name:     "call after interval elapses samples again",
 			interval: 5 * time.Minute,
 			steps: []periodicShadowSampleStep{
-				{setupMocks: sampledHit, wantResp: dbResp, wantSampleLogCount: 1},
-				{advance: 5 * time.Minute, setupMocks: sampledHit, wantResp: dbResp, wantSampleLogCount: 2},
+				{setupMocks: sampledHit, wantResp: dbResp},
+				{advance: 5 * time.Minute, setupMocks: sampledHit, wantResp: dbResp},
 			},
 		},
 		{
 			name:     "interval <= 0 disables sampling",
 			interval: 0,
 			steps: []periodicShadowSampleStep{
-				{advance: time.Hour, setupMocks: cacheHit, wantResp: cacheOnlyResp, wantSampleLogCount: 0},
-				{advance: time.Hour, setupMocks: cacheHit, wantResp: cacheOnlyResp, wantSampleLogCount: 0},
+				{advance: time.Hour, setupMocks: cacheHit, wantResp: cacheOnlyResp},
+				{advance: time.Hour, setupMocks: cacheHit, wantResp: cacheOnlyResp},
 			},
 		},
 		{
@@ -1202,7 +1200,6 @@ func TestCachedQueueReader_GetTask_PeriodicShadowSample(t *testing.T) {
 						base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(dbResp, nil)
 					},
 					wantResp:             dbResp,
-					wantSampleLogCount:   1,
 					wantMismatchLogCount: 1,
 				},
 			},
@@ -1246,10 +1243,6 @@ func TestCachedQueueReader_GetTask_PeriodicShadowSample(t *testing.T) {
 
 				require.NoErrorf(t, err, "step %d", i)
 				require.Equalf(t, step.wantResp, resp, "step %d", i)
-				assert.Equalf(t, step.wantSampleLogCount, obs.Filter(func(e observer.LoggedEntry) bool {
-					v, ok := e.ContextMap()["isPeriodicShadowSample"]
-					return ok && v == true
-				}).Len(), "step %d: sample log count", i)
 				assert.Equalf(t, step.wantMismatchLogCount, obs.FilterMessage("potential severe mismatch between db and cache states").Len(), "step %d: mismatch log count", i)
 			}
 		})

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
@@ -1117,7 +1118,7 @@ type periodicShadowSampleStep struct {
 	advance              time.Duration // clock advance applied before this call
 	setupMocks           func(base *MockQueueReader, queue *MockInMemQueue)
 	wantResp             *GetTaskResponse
-	wantSampleLogCount   int // cumulative "shadow sample check" log count after this call
+	wantSampleLogCount   int // cumulative count of logs tagged isPeriodicShadowSample=true after this call
 	wantMismatchLogCount int // cumulative "potential severe mismatch..." log count after this call
 }
 
@@ -1245,7 +1246,10 @@ func TestCachedQueueReader_GetTask_PeriodicShadowSample(t *testing.T) {
 
 				require.NoErrorf(t, err, "step %d", i)
 				require.Equalf(t, step.wantResp, resp, "step %d", i)
-				assert.Equalf(t, step.wantSampleLogCount, obs.FilterMessage("shadow sample check").Len(), "step %d: sample log count", i)
+				assert.Equalf(t, step.wantSampleLogCount, obs.Filter(func(e observer.LoggedEntry) bool {
+					v, ok := e.ContextMap()["isPeriodicShadowSample"]
+					return ok && v == true
+				}).Len(), "step %d: sample log count", i)
 				assert.Equalf(t, step.wantMismatchLogCount, obs.FilterMessage("potential severe mismatch between db and cache states").Len(), "step %d: mismatch log count", i)
 			}
 		})


### PR DESCRIPTION
**What changed?**
Removed the `"shadow sample check"` log line in `cachedQueueReader.isPeriodicShadowSample`.

**Why?**
The log fired every sample cycle with no useful fields, making it noise rather than a debugging aid.

**How did you test it?**
`go test ./service/history/queuev2/... -run TestCachedQueueReader_GetTask_PeriodicShadowSample -count=1 -v`
`go test ./service/history/queuev2/... -count=1`
`make pr GEN_DIR=service/history/queuev2`

**Potential risks**
N/A — log removal only, no behavior change to cache/DB comparison logic.

**Release notes**
N/A — internal observability change only.

**Documentation Changes**
N/A