### PR TITLE
fix(queuev2): exclude taskID boundary noise from timer cache shadow comparison

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -764,6 +764,21 @@ func (q *cachedQueueReader) emitInjectStatusCount(status string, count int64) {
 	q.metrics.Tagged(metrics.StatusTag(status)).AddCounter(metrics.CachedQueueInjectAttemptCounter, count)
 }
 
+// resolveInclusiveMinTaskKey returns the effective InclusiveMinTaskKey for req, accounting for
+// the NextPageToken/NextTaskKey pagination-continuation override in GetTaskProgress. The second
+// return value is false only when NextPageToken is set but NextTaskKey was never populated — an
+// edge case callers should handle by delegating to the base reader.
+func resolveInclusiveMinTaskKey(req *GetTaskRequest) (persistence.HistoryTaskKey, bool) {
+	inclusiveMinTaskKey := req.Progress.Range.InclusiveMinTaskKey
+	if req.Progress.NextPageToken != nil {
+		if req.Progress.NextTaskKey.Equal(persistence.MinimumHistoryTaskKey) {
+			return persistence.HistoryTaskKey{}, false
+		}
+		inclusiveMinTaskKey = req.Progress.NextTaskKey
+	}
+	return inclusiveMinTaskKey, true
+}
+
 // GetTask serves tasks from the cache when the starting key is covered.
 // Disabled mode bypasses the cache entirely.
 func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*GetTaskResponse, error) {
@@ -776,18 +791,12 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 		return q.base.GetTask(ctx, req)
 	}
 
-	inclusiveMinTaskKey := req.Progress.Range.InclusiveMinTaskKey
-	exclusiveMaxTaskKey := req.Progress.Range.ExclusiveMaxTaskKey
-
-	// When NextPageToken is set, we need to use NextTaskKey as the starting point
-	if req.Progress.NextPageToken != nil {
-		// If NextTaskKey is not set, it delegates to the base reader to handle this edge case
-		if req.Progress.NextTaskKey.Equal(persistence.MinimumHistoryTaskKey) {
-			q.logger.Info("NextPageToken is set but NextTaskKey is not set, delegating to base reader", tag.Dynamic("getTaskRequest", req))
-			return q.base.GetTask(ctx, req)
-		}
-		inclusiveMinTaskKey = req.Progress.NextTaskKey
+	inclusiveMinTaskKey, ok := resolveInclusiveMinTaskKey(req)
+	if !ok {
+		q.logger.Info("NextPageToken is set but NextTaskKey is not set, delegating to base reader", tag.Dynamic("getTaskRequest", req))
+		return q.base.GetTask(ctx, req)
 	}
+	exclusiveMaxTaskKey := req.Progress.Range.ExclusiveMaxTaskKey
 
 	q.mu.RLock()
 	covered := q.isRangeCovered(inclusiveMinTaskKey, exclusiveMaxTaskKey)
@@ -937,7 +946,7 @@ func (q *cachedQueueReader) getTaskInShadow(
 		)
 		return dbResp, err
 	}
-	result := q.findMismatchesInShadow(cacheResp, dbResp)
+	result := q.findMismatchesInShadow(cacheResp, dbResp, req)
 	q.reportShadowComparison(result, logTags)
 	return dbResp, nil
 }
@@ -976,6 +985,13 @@ type TaskMismatches struct {
 	Extra []shadowMismatchTaskInfo `json:"extra,omitempty"`
 	// Missed holds tasks present in the DB response but absent from the cache snapshot.
 	Missed []shadowMismatchTaskInfo `json:"missed,omitempty"`
+	// TaskIDBoundaryNoise holds DB-only tasks that are not real mismatches: Cassandra's timer
+	// task query range-filters only on scheduledTime, never taskID, so at a shared boundary
+	// timestamp the DB can return tasks below the requested floor's taskID that the (correctly,
+	// more strictly filtered) cache excludes. A task's rangeID is independent of this check, so
+	// it is bucketed the same way Missed/Extra are. Kept separate from Missed so it doesn't
+	// affect mismatch severity or CachedQueueShadowMismatchCounter, while remaining visible.
+	TaskIDBoundaryNoise []shadowMismatchTaskInfo `json:"taskIDBoundaryNoise,omitempty"`
 }
 
 func (m TaskMismatches) isEmpty() bool {
@@ -986,6 +1002,7 @@ func (m TaskMismatches) cap() TaskMismatches {
 	m.RangeIDs = capShadowMismatchSlice(m.RangeIDs)
 	m.Extra = capShadowMismatchSlice(m.Extra)
 	m.Missed = capShadowMismatchSlice(m.Missed)
+	m.TaskIDBoundaryNoise = capShadowMismatchSlice(m.TaskIDBoundaryNoise)
 	return m
 }
 
@@ -1076,10 +1093,28 @@ func (q *cachedQueueReader) emitShadowMismatchMetrics(result findMismatchesInSha
 // at creation and immutable) against the shard's CurrentRangeID: greater into NewRange,
 // equal into CurrentRange, less into PreviousRange. DB tasks missing from the cache land
 // in the bucket's Missed field; cache tasks missing from the DB response land in Extra.
+//
+// A DB task missing from the cache is first checked against req's effective InclusiveMinTaskKey
+// (resolved the same way GetTask resolves it, via resolveInclusiveMinTaskKey): Cassandra's timer
+// task query enforces scheduledTime >= that floor's scheduledTime as a hard bound but never
+// filters on taskID, so the only way a DB task's key can compare less than the floor is a shared
+// boundary timestamp with a lower taskID — the cache correctly excludes it under its own
+// (taskID-inclusive) filtering, and it is not a real mismatch. Such tasks land in the same
+// rangeID bucket's TaskIDBoundaryNoise field instead of its Missed field: the boundary-noise
+// check is orthogonal to which range the task's taskID encodes, so it can occur in any bucket.
 func (q *cachedQueueReader) findMismatchesInShadow(
 	cacheResp *GetTaskResponse,
 	dbResp *GetTaskResponse,
+	req *GetTaskRequest,
 ) findMismatchesInShadowResult {
+	inclusiveMinTaskKey, ok := resolveInclusiveMinTaskKey(req)
+	if !ok {
+		// Unreachable in practice: GetTask already returned early via the base reader for this
+		// same req before getTaskInShadow could be reached. Fall back to the safe default of
+		// never suppressing a mismatch as boundary noise.
+		inclusiveMinTaskKey = persistence.MinimumHistoryTaskKey
+	}
+
 	cacheTaskKeys := make(map[int64]struct{}, len(cacheResp.Tasks))
 	for _, t := range cacheResp.Tasks {
 		cacheTaskKeys[t.GetTaskID()] = struct{}{}
@@ -1118,6 +1153,10 @@ func (q *cachedQueueReader) findMismatchesInShadow(
 		}
 
 		b := bucket(q.getTaskRangeID(t.GetTaskID()))
+		if t.GetTaskKey().Less(inclusiveMinTaskKey) {
+			b.TaskIDBoundaryNoise = append(b.TaskIDBoundaryNoise, toShadowMismatchTaskInfo(t))
+			continue
+		}
 		b.Missed = append(b.Missed, toShadowMismatchTaskInfo(t))
 	}
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1265,6 +1265,14 @@ func TestFindMismatchesInShadow(t *testing.T) {
 	// the default mock's currentRangeID=0: PreviousRange. Synthetic, but exercises the bucket
 	// without needing to reconfigure the mocked shard's rangeID.
 	tPrevRange := newTask(-1, now.Add(10*time.Minute))
+	// tBoundary shares its scheduledTime with a floor used below (newTaskKey(now, 5)) but has a
+	// lower taskID, simulating what Cassandra's timer task query returns at a shared boundary
+	// timestamp since it never filters by taskID.
+	tBoundary := newTask(3, now)
+	// tBoundaryPrevRange is the same boundary-noise scenario as tBoundary, but its taskID also
+	// encodes a previous rangeID, proving the check applies regardless of which bucket the task
+	// would otherwise land in.
+	tBoundaryPrevRange := newTask(-1, now)
 
 	info := func(t persistence.Task) shadowMismatchTaskInfo { return toShadowMismatchTaskInfo(t) }
 
@@ -1272,6 +1280,7 @@ func TestFindMismatchesInShadow(t *testing.T) {
 		name         string
 		snapshotResp *GetTaskResponse
 		dbResp       *GetTaskResponse
+		req          *GetTaskRequest
 		wantResult   findMismatchesInShadowResult
 	}{
 		{
@@ -1434,13 +1443,63 @@ func TestFindMismatchesInShadow(t *testing.T) {
 				DBTaskCount:    1,
 			},
 		},
+		{
+			// Cassandra's timer task query enforces scheduledTime >= inclusiveMinTaskKey's floor
+			// but never filters by taskID. tBoundary shares its scheduledTime with the floor and
+			// has a lower taskID, so the DB returns it even though the cache (which filters by the
+			// full key) correctly excludes it. This is not a real mismatch, and it's still bucketed
+			// by rangeID like any other Missed/Extra task (here, CurrentRange).
+			name:         "DB task below taskID floor at shared boundary timestamp: not a mismatch",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{tBoundary, t1}},
+			req:          &GetTaskRequest{Progress: newProgress(newTaskKey(now, 5), persistence.MaximumHistoryTaskKey)},
+			wantResult: findMismatchesInShadowResult{
+				CurrentRange: TaskMismatches{
+					TaskIDBoundaryNoise: []shadowMismatchTaskInfo{info(tBoundary)},
+				},
+				CacheTaskCount: 1,
+				DBTaskCount:    2,
+			},
+		},
+		{
+			// The boundary-noise check is orthogonal to which range a task's taskID encodes: a
+			// task from an older range can just as easily land at a shared boundary timestamp.
+			name:         "DB task below taskID floor from a previous range: not a mismatch, still bucketed by rangeID",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{tBoundaryPrevRange, t1}},
+			req:          &GetTaskRequest{Progress: newProgress(newTaskKey(now, 5), persistence.MaximumHistoryTaskKey)},
+			wantResult: findMismatchesInShadowResult{
+				PreviousRange: TaskMismatches{
+					RangeIDs:            []int64{-1},
+					TaskIDBoundaryNoise: []shadowMismatchTaskInfo{info(tBoundaryPrevRange)},
+				},
+				CacheTaskCount: 1,
+				DBTaskCount:    2,
+			},
+		},
+		{
+			// A genuinely missed task at a later scheduledTime than the floor is unaffected by the
+			// boundary-noise check and still counts as a real mismatch.
+			name:         "DB task missing from cache after floor: still a real mismatch",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t2}},
+			req:          &GetTaskRequest{Progress: newProgress(newTaskKey(now, 5), persistence.MaximumHistoryTaskKey)},
+			wantResult: findMismatchesInShadowResult{
+				CurrentRange: TaskMismatches{Missed: []shadowMismatchTaskInfo{info(t2)}},
+				DBTaskCount:  1,
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			r, _ := setupMocksForCachedQueueReader(t, ctrl)
-			got := r.findMismatchesInShadow(tc.snapshotResp, tc.dbResp)
+			req := tc.req
+			if req == nil {
+				req = &GetTaskRequest{Progress: &GetTaskProgress{}}
+			}
+			got := r.findMismatchesInShadow(tc.snapshotResp, tc.dbResp, req)
 			slices.Sort(got.NewRange.RangeIDs)
 			slices.Sort(got.PreviousRange.RangeIDs)
 			require.Equal(t, tc.wantResult, got)


### PR DESCRIPTION
**What changed?**

`findMismatchesInShadow` no longer counts a DB-only timer task as a real cache mismatch when it can be fully explained by Cassandra not filtering timer task reads by `taskID`. Such tasks are now reported in a separate `TaskIDBoundaryNoise` field on each rangeID's `TaskMismatches` bucket (`NewRange`/`CurrentRange`/`PreviousRange`), instead of that bucket's `Missed` field. Real cache-hit serving (`CachedQueueReader.GetTask`) is unchanged — it keeps the exact `(scheduledTime, taskID)` filtering it always had.

The `InclusiveMinTaskKey`/`NextTaskKey` resolution logic `GetTask` already used (accounting for the `NextPageToken` pagination-continuation override) is extracted into a shared `resolveInclusiveMinTaskKey(req *GetTaskRequest)` helper, so `findMismatchesInShadow` derives the same effective floor directly from the `*GetTaskRequest` it's already given, rather than having it hand-threaded through as a separate parameter.

**Why?**

Cassandra's timer task query (`templateGetTimerTasksQuery`) range-filters only on `visibility_ts`; `task_id` is never bound as a query parameter and is not enforced as a range bound for the Timer task category. This is unlike Transfer/Replication tasks, where `task_id` is the sole range-filter key in the CQL query.

The in-memory cache used by `CachedQueueReader` filters reads by the full `(scheduledTime, taskID)` `HistoryTaskKey`, which is stricter than the database ever was. At a boundary timestamp shared by multiple timer tasks, the DB returns every task with `visibility_ts` in range regardless of `task_id`, while the cache excludes tasks below the requested `taskID` floor. This caused shadow-mode comparison (`getTaskInShadow` / `findMismatchesInShadow`) to report false-positive "missed" mismatches that don't reflect any real cache/DB inconsistency, adding noise to the signal used to evaluate the `CachedQueueReader` rollout.

Since the DB enforces `scheduledTime >= floor.GetScheduledTime()` as a hard bound, the only way a DB-only task's full key can compare less than the effective floor is exactly this scenario: same `scheduledTime`, lower `taskID`. That single check (`t.GetTaskKey().Less(inclusiveMinTaskKey)`) is enough to separate known DB-semantics noise from genuine mismatches, without touching `InMemQueue` or real serving behavior at all.

This boundary-noise condition is independent of which rangeID a task's `taskID` encodes, so it can occur for the current range as well as previous ranges. `TaskIDBoundaryNoise` is therefore bucketed the same way `Missed`/`Extra` are (per-rangeID, inside `TaskMismatches`), rather than being a single flat field on the overall result.

**How did you test it?**

```
go test -race -run TestFindMismatchesInShadow ./service/history/queuev2/...
go test -race -run TestCachedQueueReader_GetTask ./service/history/queuev2/...
go test -race ./service/history/queuev2/...
```

Added `TestFindMismatchesInShadow` cases: one where a DB-only task at the same `scheduledTime` as the request's floor but a lower `taskID` is classified as `TaskIDBoundaryNoise` in `CurrentRange` (not `Missed`); one for the same scenario where the task's `taskID` also encodes a previous rangeID, proving the classification and rangeID bucketing are independent; and one confirming a genuinely missed task after the floor is still reported as a real mismatch. Verified the new cases fail without the `TaskIDBoundaryNoise` classification logic, and pass with it in place.

**Potential risks**

Very low. This only changes shadow-mode diagnostic classification/logging (`findMismatchesInShadow`, `reportShadowComparison`); it does not change any DB query, the `InMemQueue` data structure, or what tasks are actually served to a caller in either shadow or non-shadow mode. `TaskIDBoundaryNoise` entries are excluded from `CachedQueueShadowMismatchCounter` and from the severity switch in `reportShadowComparison`, but remain visible in the logged `shadowComparison` struct for debugging.

**Release notes**

N/A - internal fix to shadow-mode diagnostics for the (currently shadow/experimental) `CachedQueueReader` used by the timer queue processor. No user-facing behavior change.

**Documentation Changes**

N/A
