### PR TITLE
feat(queuev2): add lifecycle logs to cached queue reader

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -218,6 +218,7 @@ func (q *cachedQueueReader) Start() {
 	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
+	q.logger.Info("Cached Queue Reader state changed", tag.LifeCycleStarting)
 	q.wg.Add(1)
 	go q.prefetchLoop()
 }
@@ -227,8 +228,10 @@ func (q *cachedQueueReader) Stop() {
 	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
+	q.logger.Info("Cached Queue Reader state changed", tag.LifeCycleStopping)
 	q.cancel()
 	q.wg.Wait()
+	q.logger.Info("Cached Queue Reader state changed", tag.LifeCycleStopped)
 }
 
 // prefetchLoop fetches tasks into the look-ahead window on a timer. It fires
@@ -240,10 +243,11 @@ func (q *cachedQueueReader) prefetchLoop() {
 	timer := q.clock.NewTimer(time.Millisecond)
 	defer timer.Stop()
 
+	q.logger.Info("Cached Queue Reader state changed", tag.LifeCycleStarted)
+
 	for {
 		select {
 		case <-q.ctx.Done():
-			q.logger.Info("prefetch loop stopping")
 			return
 		case <-q.prefetchCh:
 			// Upper bound changed externally, recompute delay and reset timer.


### PR DESCRIPTION
**What changed?**
Adds `Starting`/`Started`/`Stopping`/`Stopped` lifecycle logging to `CachedQueueReader` tagged with the existing `tag.LifeCycle` values, under the log line `"Cached Queue Reader state changed"`. Removes the old `"prefetch loop stopping"` log, which only fired at the tail end of shutdown.

**Why?**
CachedQueueReader previously had no way to trace its lifecycle other than a single "prefetch loop stopping" log on shutdown. This made it hard to tell when the reader actually began accepting injected tasks, when its background prefetch loop started running, or when a stop was requested vs completed. This mirrors the "<Component> state changed" lifecycle-logging pattern already used by other shard components (history engine, transfer/timer queue processor base, queue_scheduled, queue_immediate, virtual_queue), so `CachedQueueReader` is now consistent with the rest of the codebase for lifecycle tracing.

**How did you test it?**
`go test ./service/history/queuev2/...` 

**Potential risks**
None. Logging-only change; no behavior, API, IDL, or schema changes.

**Release notes**
N/A - internal observability improvement, not user facing.

**Documentation Changes**
N/A