### PR TITLE
feat(history): notify queue processors on ReinjectHistoryTasks

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1546,6 +1546,13 @@ func (s *contextImpl) ReplicateFailoverMarkers(
 	return err
 }
 
+// reinjectExecutionKey groups reinjected tasks by the execution they belong to, so
+// allocateTaskIDsLocked can allocate IDs on a per-execution basis.
+type reinjectExecutionKey struct {
+	domainID   string
+	workflowID string
+}
+
 func (s *contextImpl) ReinjectHistoryTasks(
 	ctx context.Context,
 	tasks []persistence.Task,
@@ -1554,14 +1561,9 @@ func (s *contextImpl) ReinjectHistoryTasks(
 		return err
 	}
 
-	// Group tasks by execution to allow allocateTaskIDsLocked to allocate IDs on a per-execution basis.
-	type executionKey struct {
-		domainID   string
-		workflowID string
-	}
-	tasksByExecution := make(map[executionKey]persistence.HistoryTasksByCategory)
+	tasksByExecution := make(map[reinjectExecutionKey]persistence.HistoryTasksByCategory)
 	for _, task := range tasks {
-		key := executionKey{domainID: task.GetDomainID(), workflowID: task.GetWorkflowID()}
+		key := reinjectExecutionKey{domainID: task.GetDomainID(), workflowID: task.GetWorkflowID()}
 		if tasksByExecution[key] == nil {
 			tasksByExecution[key] = make(persistence.HistoryTasksByCategory)
 		}
@@ -1587,6 +1589,16 @@ func (s *contextImpl) ReinjectHistoryTasks(
 	s.Lock()
 	defer s.Unlock()
 
+	tasksByCategory, err := s.reinjectHistoryTasksLocked(ctx, tasksByExecution, domainEntries)
+	s.notifyTasksFromReinjectHistoryTasks(tasksByCategory, err)
+	return err
+}
+
+func (s *contextImpl) reinjectHistoryTasksLocked(
+	ctx context.Context,
+	tasksByExecution map[reinjectExecutionKey]persistence.HistoryTasksByCategory,
+	domainEntries map[string]*cache.DomainCacheEntry,
+) (persistence.HistoryTasksByCategory, error) {
 	immediateTaskMaxReadLevel := int64(0)
 	// tasksByCategory is built after allocation of taskIDs. It is used to build the persistence request.
 	tasksByCategory := make(persistence.HistoryTasksByCategory)
@@ -1597,7 +1609,7 @@ func (s *contextImpl) ReinjectHistoryTasks(
 			executionTasks,
 			&immediateTaskMaxReadLevel,
 		); err != nil {
-			return err
+			return tasksByCategory, err
 		}
 		for category, categoryTasks := range executionTasks {
 			tasksByCategory[category] = append(tasksByCategory[category], categoryTasks...)
@@ -1605,7 +1617,7 @@ func (s *contextImpl) ReinjectHistoryTasks(
 	}
 
 	if err := s.closedError(); err != nil {
-		return err
+		return tasksByCategory, err
 	}
 	err := s.executionManager.CreateHistoryTasks(
 		ctx,
@@ -1631,7 +1643,7 @@ func (s *contextImpl) ReinjectHistoryTasks(
 			tag.Error(err),
 		)
 	}
-	return err
+	return tasksByCategory, err
 }
 
 func (s *contextImpl) AddingPendingFailoverMarker(

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/engine"
 	"github.com/uber/cadence/service/history/events"
@@ -535,6 +536,9 @@ func (s *contextTestSuite) TestReinjectHistoryTasks() {
 
 	s.Run("transfer tasks get fresh, strictly-increasing IDs", func() {
 		s.SetupTest()
+		mockEngine := engine.NewMockEngine(s.controller)
+		s.context.SetEngine(mockEngine)
+		mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).Times(1)
 		s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(s.setupAllocateTimerIDsTest(), nil)
 		task1, task2 := newTransferTask(), newTransferTask()
 		s.mockResource.ExecutionMgr.On("CreateHistoryTasks", mock.Anything, mock.MatchedBy(func(req *persistence.CreateHistoryTasksRequest) bool {
@@ -551,6 +555,9 @@ func (s *contextTestSuite) TestReinjectHistoryTasks() {
 
 	s.Run("timer tasks are allocated using the per-domain entry", func() {
 		s.SetupTest()
+		mockEngine := engine.NewMockEngine(s.controller)
+		s.context.SetEngine(mockEngine)
+		mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).Times(1)
 		s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(s.setupAllocateTimerIDsTest(), nil)
 		timerTask := s.createMockTimerTask(createMockTimerTaskParams{
 			Version:    constants.EmptyVersion,
@@ -570,6 +577,10 @@ func (s *contextTestSuite) TestReinjectHistoryTasks() {
 
 	s.Run("multiple workflows in one domain share a single domain lookup", func() {
 		s.SetupTest()
+		mockEngine := engine.NewMockEngine(s.controller)
+		s.context.SetEngine(mockEngine)
+		// A single aggregated notification is expected for the whole batch, not one per execution.
+		mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).Times(1)
 		// Two executions in the same domain must resolve the domain entry exactly once.
 		s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(s.setupAllocateTimerIDsTest(), nil).Times(1)
 		task1, task2 := newTransferTaskForWorkflow("workflow-1"), newTransferTaskForWorkflow("workflow-2")
@@ -585,6 +596,9 @@ func (s *contextTestSuite) TestReinjectHistoryTasks() {
 
 	s.Run("shard ownership lost closes the shard", func() {
 		s.SetupTest()
+		mockEngine := engine.NewMockEngine(s.controller)
+		s.context.SetEngine(mockEngine)
+		// ShardOwnershipLostError is a definitive failure — no notification should fire.
 		s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(s.setupAllocateTimerIDsTest(), nil)
 		s.mockResource.ExecutionMgr.On("CreateHistoryTasks", mock.Anything, mock.Anything).Once().Return(&persistence.ShardOwnershipLostError{})
 
@@ -595,6 +609,13 @@ func (s *contextTestSuite) TestReinjectHistoryTasks() {
 
 	s.Run("other errors are propagated without closing the shard", func() {
 		s.SetupTest()
+		mockEngine := engine.NewMockEngine(s.controller)
+		s.context.SetEngine(mockEngine)
+		// assert.AnError is not in the definitive-failure whitelist, so it is treated as
+		// possibly-successful and still triggers a notification with PersistenceError set.
+		mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).Times(1).Do(func(info *hcommon.NotifyTaskInfo) {
+			s.True(info.PersistenceError)
+		})
 		s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(s.setupAllocateTimerIDsTest(), nil)
 		s.mockResource.ExecutionMgr.On("CreateHistoryTasks", mock.Anything, mock.Anything).Once().Return(assert.AnError)
 

--- a/service/history/shard/notify_task.go
+++ b/service/history/shard/notify_task.go
@@ -106,6 +106,22 @@ func (s *contextImpl) notifyTasksFromConflictResolveWorkflowExecution(
 	))
 }
 
+// notifyTasksFromReinjectHistoryTasks sends task notifications for a ReinjectHistoryTasks operation.
+// Unlike the other notifyTasksFrom* functions, reinjection can span multiple executions in a single
+// call, so there is no single WorkflowExecutionInfo to notify with; ExecutionInfo is left nil since
+// none of the transfer/timer notification consumers dereference it.
+// Must be called while holding s.Lock().
+func (s *contextImpl) notifyTasksFromReinjectHistoryTasks(
+	tasksByCategory persistence.HistoryTasksByCategory,
+	err error,
+) {
+	if notify, persistenceError := isNotifyTaskNeeded(err); notify {
+		s.notifyTasks(nil, tasksByCategory, persistenceError)
+		return
+	}
+	s.logNotifyTaskDroppedOnPersistenceError(err, taskIDsFromCategories(tasksByCategory))
+}
+
 // logNotifyTaskDroppedOnPersistenceError logs dropped task IDs when the cached queue reader
 // is in shadow mode. In shadow mode the cache is validated against the DB, so dropped tasks
 // produce observable mismatches that are worth tracking. In other modes the log is noise.


### PR DESCRIPTION
**What changed?**
`ReinjectHistoryTasks` now notifies the in-memory queue processors (`NotifyNewTransferTasks`/`NotifyNewTimerTasks`) after persisting DLQ-recovered timer/transfer tasks, and is split into `ReinjectHistoryTasks` + `reinjectHistoryTasksLocked` to mirror the `CreateWorkflowExecution`/`createWorkflowExecutionLocked` pattern.

**Why?**
`CreateWorkflowExecution`, `UpdateWorkflowExecution`, and `ConflictResolveWorkflowExecution` all notify queue processors immediately after their persistence write, so the `CachedQueueReader` (queuev2) learns about new tasks right away. `ReinjectHistoryTasks` (used by the history task DLQ reprocessor) was the one task-creating path that skipped this step: DLQ-reinjected tasks were correctly persisted to the DB, but the in-memory cache would only pick them up on its next full refresh/shadow-reconciliation cycle, delaying processing and risking the same cache/DB divergence previously seen with timer cache shadow mismatches.

This adds a `notifyTasksFromReinjectHistoryTasks` helper alongside the existing `notifyTasksFrom{Create,Update,ConflictResolve}WorkflowExecution` functions, reusing the same `isNotifyTaskNeeded`/`logNotifyTaskDroppedOnPersistenceError` machinery. Since a single reinject call can batch tasks across multiple workflow executions, the notification is sent once per batch per task category with `ExecutionInfo` left nil (unused by `NotifyNewTransferTasks`/`NotifyNewTimerTasks`/queuev2 for these categories).

#7953 

**How did you test it?**
`go test ./service/history/shard/...`
`go test -v ./service/history/shard/... -run 'TestContextSuite/TestReinjectHistoryTasks'`

**Potential risks**
Low risk: additive notification call on an existing, already-locked code path. No schema/API changes. On definitive persistence failure (e.g. `ShardOwnershipLostError`), behavior matches existing create/update/conflict-resolve paths — no notification is sent.

**Release notes**
N/A - internal bug fix, no user-facing behavior change beyond faster pickup of DLQ-reinjected tasks by queue processors.

**Documentation Changes**
N/A