### PR TITLE
feat(schema): add new metadata table schema

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -610,3 +610,17 @@ CREATE TABLE history_task_dlq_ack_level (
 ) WITH compaction = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
 };
+
+-- Distributed semaphore metadata: capacity and configuration for a regional counting semaphore.
+-- Partitioned by domain_id so all semaphores in a domain list together; clustered by semaphore_name.
+-- Source of truth for size and bucket_size (which derive N = ceil(size / bucket_size)).
+CREATE TABLE semaphore_metadata (
+    domain_id         uuid,      -- domain that owns the semaphore
+    semaphore_name    text,      -- user-chosen semaphore name
+    size              int,       -- total capacity (max concurrent tokens)
+    bucket_size       int,       -- tokens per bucket (per-host budget); sets N = ceil(size / bucket_size)
+    created_time      timestamp,
+    PRIMARY KEY ((domain_id), semaphore_name)
+) WITH compaction = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+};

--- a/schema/cassandra/cadence/versioned/v0.50/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.50/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.50",
+  "MinCompatibleVersion": "0.50",
+  "Description": "Add semaphore_metadata table",
+  "SchemaUpdateCqlFiles": [
+    "semaphore_metadata.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.50/semaphore_metadata.cql
+++ b/schema/cassandra/cadence/versioned/v0.50/semaphore_metadata.cql
@@ -1,0 +1,13 @@
+-- Distributed semaphore metadata: capacity and configuration for a regional counting semaphore.
+-- Partitioned by domain_id so all semaphores in a domain list together; clustered by semaphore_name.
+-- Source of truth for size and bucket_size (which derive N = ceil(size / bucket_size)).
+CREATE TABLE semaphore_metadata (
+    domain_id         uuid,      -- domain that owns the semaphore
+    semaphore_name    text,      -- user-chosen semaphore name
+    size              int,       -- total capacity (max concurrent tokens)
+    bucket_size       int,       -- tokens per bucket (per-host budget); sets N = ceil(size / bucket_size)
+    created_time      timestamp,
+    PRIMARY KEY ((domain_id), semaphore_name)
+) WITH compaction = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+};

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -25,7 +25,7 @@ import "github.com/uber/cadence/schema/common"
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.49"
+const Version = "0.50"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.10"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49", "v0.50"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**Detailed Description**
Adds one new Cassandra metadata table, to the cadence keyspace, and bumps the main keyspace schema version 0.49 → 0.50. This is a purely additive change — no existing table, column, or data structure is modified or removed.

No IDL/proto or Go interface changes are included in this PR — it is schema-only.

**Impact Analysis**
- Backward Compatibility: Fully backward compatible. The change only introduces a brand-new table; no existing schema is touched. Older server binaries are unaware of the table and simply ignore it. No data migration or backfill is required.
- Forward Compatibility: Additive and reversible. Future persistence layer code will read/write this table, so the v0.50 migration must be applied before that code is enabled. The migration can be reverted by dropping the table while it is empty.

**Testing Plan**
- Unit Tests: Yes for the schema bookkeeping — go test ./schema/... ./tools/common/schema/... covers TestSchema (version sequencing and latest-version-matches-Version-constant) and TestReadSchemaDirFromEmbeddings. The CREATE TABLE DDL itself has no unit-testable logic.
- Persistence Tests: Not in this PR — it contains no persistence-layer code. 
- Integration Tests: N/A for this PR. The table has no consumers yet; integration coverage arrives with the acquire path / management APIs in later phases.
- Compatibility Tests: Verified the fresh-install path (schema.cql) and the upgrade path (versioned/v0.50) produce an identical table definition. Since the change is additive with no modified structures, there is no backward/forward compatibility surface to break.

**Rollout Plan**
- Rollout plan: Apply the v0.50 schema migration to the Cassandra cluster. No server code reads or writes the table yet, so the table is inert after the migration.
- Does deployment order matter?: Not for this PR (nothing consumes the table). Going forward, apply the schema migration before deploying any code that uses the table — schema first, then binaries.
- Is it safe to rollback? Does order matter?: Yes, safe. Rolling back binaries leaves an empty, unused additive table behind (harmless). The table can be dropped while empty. Rollback order does not matter because no code depends on it.
- Kill switch: The new feature will be gated by a dynamic-config flag (shipped off) with its consumers; until that lands the table is inert regardless of deployment state, so nothing needs mitigating.
