### PR TITLE
test(simulation): reproduce lost activity retry across domain failover

### DIFF
--- a/config/dynamicconfig/replication_simulation_activityretryfailover.yml
+++ b/config/dynamicconfig/replication_simulation_activityretryfailover.yml
@@ -1,0 +1,27 @@
+# This file is used as dynamicconfig override for "activityretryfailover" replication simulation scenario configured via simulation/replication/testdata/replication_simulation_activityretryfailover.yaml
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"
+history.replicatorTaskBatchSize:
+  - value: 25
+    constraints: {}
+frontend.failoverCoolDown:
+  - value: 5s
+history.ReplicationTaskProcessorStartWait: # repl task processor sleeps this much before processing received messages (registered default is 0)
+  - value: 10ms
+# The four overrides below make the queue processors read tasks and advance their queue
+# states within seconds instead of minutes. This is required so that the new active
+# cluster's ActivityTaskScheduled transfer task is fully retired (acked by the standby
+# executor once it observes the activity STARTED, and passed by both processors' ack
+# levels) BEFORE the scenario's failover. Otherwise the queue-processor restart during
+# failover replays that task as active and re-dispatches the activity, masking the
+# lost-retry-timer bug this scenario exists to demonstrate.
+history.transferProcessorMaxPollInterval: # default is 1m
+  - value: 5s
+history.transferProcessorUpdateAckInterval: # default is 30s
+  - value: 5s
+history.timerProcessorMaxPollInterval: # default is 5m
+  - value: 5s
+history.timerProcessorUpdateAckInterval: # default is 30s
+  - value: 5s

--- a/simulation/replication/replication_simulation_test.go
+++ b/simulation/replication/replication_simulation_test.go
@@ -104,6 +104,8 @@ func TestReplicationSimulation(t *testing.T) {
 			err = signalWithStartWorkflow(t, op, simCfg, sim)
 		case simTypes.ReplicationSimulationOperationValidateWorkflowReplication:
 			err = validateWorkflowReplication(t, op, simCfg)
+		case simTypes.ReplicationSimulationOperationValidatePendingActivity:
+			err = validatePendingActivity(t, op, simCfg)
 		default:
 			require.Failf(t, "unknown operation type", "operation type: %s", op.Type)
 		}
@@ -555,6 +557,92 @@ func validateWorkflowReplication(
 
 	if !reflect.DeepEqual(sourceClusterWorkflowExecution, targetClusterWorkflowExecution) {
 		return fmt.Errorf("workflow execution info mismatch between source cluster %s and target cluster %s for workflow %s. \nSource: %+v\nTarget: %+v", op.SourceCluster, op.TargetCluster, op.WorkflowID, *sourceClusterWorkflowExecution, *targetClusterWorkflowExecution)
+	}
+
+	return nil
+}
+
+// validatePendingActivity validates the pending-activity state of a workflow via
+// DescribeWorkflowExecution on the given cluster. Like validate, it must return an
+// error rather than failing the test directly. Two validation modes are supported:
+//   - want.pendingActivityState (+ optional want.pendingActivityAttempt): the workflow
+//     must have exactly one pending activity in the given state (and attempt).
+//   - want.activityDispatched=true: no pending activity may be stuck in SCHEDULED
+//     state at attempt > 0 past its scheduled time. A violation means a recorded
+//     activity retry was never dispatched to a worker in this cluster.
+func validatePendingActivity(
+	t *testing.T,
+	op *simTypes.Operation,
+	simCfg *simTypes.ReplicationSimulationConfig,
+) error {
+	t.Helper()
+
+	if op.Want.PendingActivityState == "" && op.Want.ActivityDispatched == nil {
+		return fmt.Errorf("validate_pending_activity op for workflow %s requires want.pendingActivityState and/or want.activityDispatched", op.WorkflowID)
+	}
+	if op.Want.ActivityDispatched != nil && !*op.Want.ActivityDispatched {
+		return fmt.Errorf("validate_pending_activity op for workflow %s: activityDispatched only supports true", op.WorkflowID)
+	}
+
+	simTypes.Logf(t, "Validating pending activities of workflow: %s on domain: %s on cluster: %s", op.WorkflowID, op.Domain, op.Cluster)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := simCfg.MustGetFrontendClient(t, op.Cluster).DescribeWorkflowExecution(ctx,
+		&types.DescribeWorkflowExecutionRequest{
+			Domain: op.Domain,
+			Execution: &types.WorkflowExecution{
+				WorkflowID: op.WorkflowID,
+			},
+		})
+	if err != nil {
+		return fmt.Errorf("failed to describe workflow %s: %w", op.WorkflowID, err)
+	}
+
+	pending := resp.GetPendingActivities()
+
+	if op.Want.PendingActivityState != "" {
+		var wantState types.PendingActivityState
+		switch op.Want.PendingActivityState {
+		case "scheduled":
+			wantState = types.PendingActivityStateScheduled
+		case "started":
+			wantState = types.PendingActivityStateStarted
+		default:
+			return fmt.Errorf("unsupported pendingActivityState %q in scenario config", op.Want.PendingActivityState)
+		}
+
+		if len(pending) != 1 {
+			return fmt.Errorf("expected exactly 1 pending activity for workflow %s on cluster %s, got %d", op.WorkflowID, op.Cluster, len(pending))
+		}
+		ai := pending[0]
+		if ai.GetState() != wantState {
+			return fmt.Errorf("pending activity %s of workflow %s on cluster %s is in state %s, expected %s", ai.ActivityID, op.WorkflowID, op.Cluster, ai.GetState(), wantState)
+		}
+		if op.Want.PendingActivityAttempt != nil && ai.Attempt != *op.Want.PendingActivityAttempt {
+			return fmt.Errorf("pending activity %s of workflow %s on cluster %s is at attempt %d, expected %d", ai.ActivityID, op.WorkflowID, op.Cluster, ai.Attempt, *op.Want.PendingActivityAttempt)
+		}
+		simTypes.Logf(t, "Validated pending activity of workflow %s on cluster %s: state %s, attempt %d", op.WorkflowID, op.Cluster, ai.GetState(), ai.Attempt)
+	}
+
+	if op.Want.ActivityDispatched != nil && *op.Want.ActivityDispatched {
+		now := time.Now()
+		for _, ai := range pending {
+			var scheduledTimestamp int64
+			if ai.ScheduledTimestamp != nil {
+				scheduledTimestamp = *ai.ScheduledTimestamp
+			}
+			if ai.GetState() == types.PendingActivityStateScheduled &&
+				ai.Attempt > 0 &&
+				scheduledTimestamp > 0 &&
+				time.Unix(0, scheduledTimestamp).Before(now) {
+				return fmt.Errorf(
+					"activity retry was never dispatched: workflow %s on cluster %s still has pending activity %s stuck in SCHEDULED state at attempt %d (retry was scheduled for %v, now %v). "+
+						"This is the lost-activity-retry-across-failover bug: the previously-active cluster's ActivityRetryTimerTask was silently dropped by its standby timer executor and the new active cluster never generated one",
+					op.WorkflowID, op.Cluster, ai.ActivityID, ai.Attempt, time.Unix(0, scheduledTimestamp), now)
+			}
+		}
+		simTypes.Logf(t, "Validated activity dispatch for workflow %s on cluster %s: no pending activity stuck in SCHEDULED past its retry time", op.WorkflowID, op.Cluster)
 	}
 
 	return nil

--- a/simulation/replication/testdata/replication_simulation_activityretryfailover.yaml
+++ b/simulation/replication/testdata/replication_simulation_activityretryfailover.yaml
@@ -1,0 +1,109 @@
+# This file is a replication simulation scenario spec.
+# It is parsed into ReplicationSimulationConfig struct.
+# Replication simulations can be run via ./simulation/replication/run.sh --scenario activityretryfailover
+#
+# Reproduces the lost-activity-retry-across-failover bug:
+#   Given an activity with a retry policy starts, runs, and then fails with a retriable error
+#     in the active cluster (RetryActivity writes an ActivityRetryTimerTask into that cluster's
+#     timer queue, scheduled for now + backoff),
+#   When the domain fails over to the other cluster before the retry backoff elapses,
+#   Then the retry is never dispatched in either cluster:
+#     - the old active cluster's standby timer executor silently acks the retry timer task
+#       (service/history/task/timer_standby_task_executor.go ActivityRetryTimerTask no-op branch)
+#     - the new active cluster applied the SyncActivity for the bumped attempt but never
+#       generates a retry timer (service/history/ndc/activity_replicator.go creates only
+#       activity timeout timers)
+#
+# Timing is load-bearing. The new active cluster must have fully retired its own
+# ActivityTaskScheduled transfer task BEFORE the failover, or the queue-processor restart
+# during failover replays that task as active and re-dispatches the activity, masking the
+# bug (production incidents don't have this rescue because the schedule transfer task was
+# processed hours earlier). Retiring the task requires all of:
+#   1. The standby transfer executor acks it, which only happens when it observes the
+#      activity STARTED (transfer_standby_task_executor.go). It re-evaluates a pending task
+#      on a hardcoded ~30s backoff (service/history/task/task.go), so attempt 0 runs for
+#      60s to guarantee a re-evaluation lands inside the started window.
+#   2. Both the active and standby queue processors advance their queue states past the
+#      task before the failover — the poll and update-ack intervals are lowered in this
+#      scenario's dynamic config so this happens within seconds rather than minutes.
+#
+# The assertions below encode the EXPECTED (post-fix) behavior: the new active cluster
+# dispatches the retry after failover and the workflow completes there. This scenario
+# therefore FAILS on master today, demonstrating the bug. Once the fix lands it passes
+# unchanged — at that point add "activityretryfailover" to the scenario matrix in
+# .github/workflows/replication-simulation.yml to make it a regression test. It is
+# intentionally NOT in the CI matrix until then.
+
+clusters:
+  cluster0:
+    grpcEndpoint: "cadence-cluster0:7833"
+  cluster1:
+    grpcEndpoint: "cadence-cluster1:7833"
+
+# primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
+primaryCluster: "cluster0"
+
+domains:
+  test-domain:
+    activeClusterName: cluster0
+
+operations:
+  # The workflow schedules one activity with retry policy InitialInterval=45s,
+  # BackoffCoefficient=1. Attempt 0 starts ~t+1s, runs for 60s, and fails with a
+  # retriable error ~t+61s (recorded in cluster0 while it is still active), which
+  # schedules the retry for ~t+106s. Any attempt >= 1 succeeds immediately.
+  - op: start_workflow
+    at: 0s
+    workflowType: activity-retry-failover-workflow
+    workflowID: activity-retry-failover-workflow1
+    cluster: cluster0
+    domain: test-domain
+    workflowExecutionStartToCloseTimeout: 300s
+    workflowDuration: 60s
+
+  # Fail over cluster0 -> cluster1 after the failure is recorded (~t+61s) but well
+  # before the retry backoff expires (~t+106s). cluster0's ActivityRetryTimerTask will
+  # fire while cluster0 is standby.
+  - op: change_active_clusters
+    at: 70s
+    domain: test-domain
+    newActiveCluster: cluster1
+    # failoverTimeoutSec unset means force failover
+
+  # Sanity check (passes both pre- and post-fix): the SyncActivity for the bumped
+  # attempt has been applied in cluster1 before the retry timer would fire (~t+106s):
+  # cluster1's view of the activity is SCHEDULED at attempt 1. If this fails with
+  # attempt 0, or finds 0 pending activities (workflow already completed), the setup
+  # raced — see the timing notes at the top of this file.
+  - op: validate_pending_activity
+    at: 85s
+    workflowID: activity-retry-failover-workflow1
+    cluster: cluster1
+    domain: test-domain
+    want:
+      pendingActivityState: scheduled
+      pendingActivityAttempt: 1
+
+  # The bug assertion: by t+150s the retry (scheduled ~t+106s) must have been dispatched
+  # by the new active cluster. On master this FAILS: the pending activity is still
+  # stuck in SCHEDULED state at attempt 1 with its scheduled time long past, because
+  # no cluster holds a retry timer task for it anymore.
+  - op: validate_pending_activity
+    at: 150s
+    workflowID: activity-retry-failover-workflow1
+    cluster: cluster1
+    domain: test-domain
+    want:
+      activityDispatched: true
+
+  # Post-fix end state: attempt 1 succeeds shortly after ~t+106s and the workflow
+  # completes in cluster1.
+  - op: validate
+    at: 155s
+    workflowID: activity-retry-failover-workflow1
+    cluster: cluster1
+    domain: test-domain
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster0
+      completedByWorkersInCluster: cluster1

--- a/simulation/replication/types/repl_sim_config.go
+++ b/simulation/replication/types/repl_sim_config.go
@@ -51,6 +51,7 @@ const (
 	ReplicationSimulationOperationQueryWorkflow               ReplicationSimulationOperation = "query_workflow"
 	ReplicationSimulationOperationSignalWithStartWorkflow     ReplicationSimulationOperation = "signal_with_start_workflow"
 	ReplicationSimulationOperationValidateWorkflowReplication ReplicationSimulationOperation = "validate_workflow_replication"
+	ReplicationSimulationOperationValidatePendingActivity     ReplicationSimulationOperation = "validate_pending_activity"
 )
 
 type ReplicationSimulationConfig struct {
@@ -126,6 +127,17 @@ type Validation struct {
 	CompletedByWorkersInCluster string `yaml:"completedByWorkersInCluster"`
 	Error                       string `yaml:"error"`
 	QueryResult                 any    `yaml:"queryResult"`
+
+	// PendingActivityState asserts the workflow has exactly one pending activity
+	// in the given state. Supported values: "scheduled", "started".
+	PendingActivityState string `yaml:"pendingActivityState"`
+	// PendingActivityAttempt asserts the pending activity's attempt count.
+	// Only checked when PendingActivityState is set.
+	PendingActivityAttempt *int32 `yaml:"pendingActivityAttempt"`
+	// ActivityDispatched=true asserts that no pending activity is stuck in
+	// SCHEDULED state at attempt > 0 past its scheduled time, i.e. any recorded
+	// activity retry has actually been dispatched to a worker.
+	ActivityDispatched *bool `yaml:"activityDispatched"`
 }
 
 type Cluster struct {

--- a/simulation/replication/workflows/retryactivityfailover/workflow.go
+++ b/simulation/replication/workflows/retryactivityfailover/workflow.go
@@ -1,0 +1,72 @@
+package retryactivityfailover
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/workflow"
+
+	"github.com/uber/cadence/simulation/replication/types"
+)
+
+// Workflow executes a single activity with a retry policy. The activity fails
+// with a retriable error on its first attempt (attempt 0) and succeeds on any
+// subsequent attempt, so exactly one retry backoff (InitialInterval) separates
+// the failure from the expected redispatch. The retry policy expiration and the
+// activity timeouts are deliberately much longer than the simulation window so
+// that no timeout can rescue a lost retry within the test's runtime.
+func Workflow(ctx workflow.Context, input types.WorkflowInput) (types.WorkflowOutput, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Sugar().Infof("activity-retry-failover-workflow started with input: %+v", input)
+
+	aCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		TaskList:               types.TasklistName,
+		ScheduleToStartTimeout: 10 * time.Minute,
+		StartToCloseTimeout:    90 * time.Second,
+		ScheduleToCloseTimeout: 10 * time.Minute,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:    45 * time.Second,
+			BackoffCoefficient: 1.0,
+			MaximumInterval:    45 * time.Second,
+			ExpirationInterval: 15 * time.Minute,
+		},
+	})
+
+	var result string
+	if err := workflow.ExecuteActivity(aCtx, FailOnFirstAttemptActivity, "World").Get(ctx, &result); err != nil {
+		logger.Sugar().Errorf("activity-retry-failover-workflow activity failed: %v", err)
+		return types.WorkflowOutput{}, err
+	}
+
+	logger.Sugar().Infof("activity-retry-failover-workflow completed with result: %s", result)
+	return types.WorkflowOutput{Count: 1}, nil
+}
+
+// FailOnFirstAttemptActivity runs for activeDuration and then fails with a retriable
+// error on attempt 0; it succeeds immediately on any later attempt.
+//
+// The attempt-0 run time is load-bearing for the activityretryfailover scenario: it keeps
+// the activity in STARTED state long enough for the standby cluster to observe the started
+// state via SyncActivity and ack its pending ActivityTaskScheduled transfer task. The
+// standby executor re-evaluates a pending task on a hardcoded ~30s backoff
+// (standbyTaskRedispatchInitialInterval in service/history/task/task.go), so the window
+// must comfortably cover one such re-evaluation. If the transfer task were still pending
+// (activity never observed as started) at failover time, the queue-processor restart on
+// failover would replay it as active and re-dispatch the activity, masking the
+// lost-retry-timer bug under test.
+func FailOnFirstAttemptActivity(ctx context.Context, input string) (string, error) {
+	const activeDuration = 60 * time.Second
+
+	logger := activity.GetLogger(ctx)
+	attempt := activity.GetInfo(ctx).Attempt
+	if attempt == 0 {
+		logger.Sugar().Infof("fail-on-first-attempt-activity attempt %d running for %v before failing with retriable error", attempt, activeDuration)
+		time.Sleep(activeDuration)
+		return "", fmt.Errorf("retriable failure on attempt %d", attempt)
+	}
+	logger.Sugar().Infof("fail-on-first-attempt-activity succeeding on attempt %d", attempt)
+	return fmt.Sprintf("Hello, %s!", input), nil
+}

--- a/simulation/replication/workflows/workflows.go
+++ b/simulation/replication/workflows/workflows.go
@@ -4,6 +4,7 @@ import (
 	"github.com/uber/cadence/simulation/replication/workflows/activityloop"
 	"github.com/uber/cadence/simulation/replication/workflows/childactivityloop"
 	"github.com/uber/cadence/simulation/replication/workflows/query"
+	"github.com/uber/cadence/simulation/replication/workflows/retryactivityfailover"
 	"github.com/uber/cadence/simulation/replication/workflows/timeractivityloop"
 )
 
@@ -12,14 +13,16 @@ var (
 	Workflows = func(clusterName string) map[string]any {
 		queryWFRunner := &query.Runner{ClusterName: clusterName}
 		return map[string]any{
-			"timer-activity-loop-workflow": timeractivityloop.Workflow,
-			"activity-loop-workflow":       activityloop.Workflow,
-			"query-workflow":               queryWFRunner.Workflow,
-			"child-activity-loop-workflow": childactivityloop.Workflow,
+			"timer-activity-loop-workflow":     timeractivityloop.Workflow,
+			"activity-loop-workflow":           activityloop.Workflow,
+			"query-workflow":                   queryWFRunner.Workflow,
+			"child-activity-loop-workflow":     childactivityloop.Workflow,
+			"activity-retry-failover-workflow": retryactivityfailover.Workflow,
 		}
 	}
 	Activities = map[string]any{
 		"timer-activity-loop-format-string-activity": timeractivityloop.FormatStringActivity,
 		"activity-loop-format-string-activity":       activityloop.FormatStringActivity,
+		"fail-on-first-attempt-activity":             retryactivityfailover.FailOnFirstAttemptActivity,
 	}
 )


### PR DESCRIPTION
**What changed?**

Added a replication-simulation scenario `activityretryfailover` that reproduces the lost-activity-retry-across-failover bug, plus a new `validate_pending_activity` simulation operation asserting pending-activity state/attempt, or (`activityDispatched: true`) that no retry is stuck in SCHEDULED past its scheduled time.

**Why?**

When an activity fails retriably, the `ActivityRetryTimerTask` exists only in the cluster that recorded the failure (timer tasks are never replicated). If the domain fails over before the backoff elapses, the old cluster's standby timer executor silently acks the task, and the new active cluster's SyncActivity apply path creates only timeout timers — the retry is lost until the ScheduleToStart timeout fires, potentially weeks later.

The scenario: an activity fails on attempt 0 (45s backoff), the domain fails over mid-backoff, then assertions check the retry is applied and dispatched in the new active cluster. Assertions encode expected (post-fix) behavior, so the scenario **fails on master by design** and is intentionally not in the CI matrix; once the fix lands, flipping it to a regression test is just adding it to `.github/workflows/replication-simulation.yml`. The YAML header documents the harness subtleties (failover transfer-task replay can rescue the retry in short-lived clusters; the scenario's timings and 5s queue-interval overrides defeat that).

**How did you test it?**

```
./simulation/replication/run.sh --scenario activityretryfailover
```

Fails on master with: `activity retry was never dispatched: ... stuck in SCHEDULED state at attempt 1`.
Also `go build ./simulation/... && go vet ./simulation/...`.

**Potential risks**

None — simulation/test code only; scenario not in the CI matrix.

**Release notes**

N/A

**Documentation Changes**

N/A
