### PR TITLE
fix(frontend): feature flags deserialization should ignore unknown fields

### DIFF
--- a/common/client/versionChecker.go
+++ b/common/client/versionChecker.go
@@ -25,6 +25,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/hashicorp/go-version"
@@ -125,8 +126,8 @@ func GetFeatureFlagsFromHeader(call *yarpc.Call) apiv1.FeatureFlags {
 	featureFlagsSerialized := call.Header(common.ClientFeatureFlagsHeaderName)
 
 	var featureFlags apiv1.FeatureFlags
-	err := jsonpb.UnmarshalString(featureFlagsSerialized, &featureFlags)
-	if err != nil {
+	unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
+	if err := unmarshaler.Unmarshal(strings.NewReader(featureFlagsSerialized), &featureFlags); err != nil {
 		// fail open and return empty feature flags
 		return apiv1.FeatureFlags{}
 	}

--- a/common/client/versionChecker_test.go
+++ b/common/client/versionChecker_test.go
@@ -469,6 +469,13 @@ func TestGetFeatureFlagsFromHeader(t *testing.T) {
 			},
 		},
 		{
+			name:              "proto field name is also accepted",
+			featureFlagsValue: `{"workflow_execution_already_completed_error_enabled":true}`,
+			want: apiv1.FeatureFlags{
+				WorkflowExecutionAlreadyCompletedErrorEnabled: true,
+			},
+		},
+		{
 			name:              "invalid JSON returns empty",
 			featureFlagsValue: `{invalid}`,
 			want:              apiv1.FeatureFlags{},
@@ -476,6 +483,30 @@ func TestGetFeatureFlagsFromHeader(t *testing.T) {
 		{
 			name:              "empty JSON object",
 			featureFlagsValue: `{}`,
+			want:              apiv1.FeatureFlags{},
+		},
+		{
+			name:              "unknown flag from a newer client is ignored",
+			featureFlagsValue: `{"SomeFlagAddedLater":true}`,
+			want:              apiv1.FeatureFlags{},
+		},
+		{
+			name:              "unknown flag does not discard known flags",
+			featureFlagsValue: `{"WorkflowExecutionAlreadyCompletedErrorEnabled":true,"SomeFlagAddedLater":true}`,
+			want: apiv1.FeatureFlags{
+				WorkflowExecutionAlreadyCompletedErrorEnabled: true,
+			},
+		},
+		{
+			name:              "unknown flag with composite value does not discard known flags",
+			featureFlagsValue: `{"WorkflowExecutionAlreadyCompletedErrorEnabled":true,"SomeFlagAddedLater":{"nested":[1,"two",null]}}`,
+			want: apiv1.FeatureFlags{
+				WorkflowExecutionAlreadyCompletedErrorEnabled: true,
+			},
+		},
+		{
+			name:              "wrong type for known flag returns empty",
+			featureFlagsValue: `{"WorkflowExecutionAlreadyCompletedErrorEnabled":"true"}`,
 			want:              apiv1.FeatureFlags{},
 		},
 	}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

ignore additional fields instead of silently failing the feature flags fetching

**Why?**

The switch from thrift to proto decoding #7708 breaks java client's feature flag population

**How did you test it?**

Unit Test

**Potential risks**

No

**Release notes**


**Documentation Changes**

