### PR TITLE
fix(frontend): enforce authorization for ListDomains

### DIFF
--- a/common/authorization/README.md
+++ b/common/authorization/README.md
@@ -44,6 +44,24 @@ In order to configure, add an authorization section to Cadence server config [ex
         noopAuthorizer:
             enable: true
 
+## Authentication-only authorizer
+
+The authenticator uses the same `authorization.oauthAuthorizer.enable` flag: when enabled,
+it validates JWTs without checking permissions; otherwise, it is a no-op. It lets APIs
+such as `ListDomains` check credentials before checking access to individual domains.
+
+If you use a custom authorizer, then it's recommended you can provide an optional `resource.Params.Authenticator`
+implementing the same `Authorizer` interface. The authenticator checks credentials only; the
+authorizer also checks permissions. The authorizer must still validate credentials because
+other APIs call it directly. For an example of sharing credential validation,
+see `oauthAuthority` and `NewOAuthAuthorizerAndAuthenticator` in
+[oauthAuthority.go](oauthAuthority.go). If no custom authenticator is supplied, the configured OAuth
+or no-op behavior applies.
+
+This is an interim step toward separating authentication from authorization. The authorizer
+still validates credentials on each call; a future change could authenticate once per
+request and pass the caller's identity to the authorizer.
+
 ## Background
 
 The server constructs an authorization.Attributes object for each API call (actor, API name, domain, optional workflow/tasklist), evaluates the token, and returns an allow/deny Decision. JWTs are expected to contain Cadence-specific claims including groups and (optionally) an admin flag.

--- a/common/authorization/authorizer.go
+++ b/common/authorization/authorizer.go
@@ -41,6 +41,8 @@ const (
 	DecisionDeny Decision = iota + 1
 	// DecisionAllow means auth decision is allow
 	DecisionAllow
+	// DecisionUnauthenticated means the caller did not provide valid credentials
+	DecisionUnauthenticated
 )
 
 const (
@@ -59,13 +61,14 @@ type (
 	// Attributes is input for authority to make decision.
 	// It can be extended in future if required auth on resources like WorkflowType and TaskList
 	Attributes struct {
-		Actor        string
-		APIName      string
-		DomainName   string
-		WorkflowType *types.WorkflowType
-		TaskList     *types.TaskList
-		Permission   Permission
-		RequestBody  FilteredRequestBody // request object except for data inputs (PII)
+		Actor              string
+		APIName            string
+		DomainName         string
+		WorkflowType       *types.WorkflowType
+		TaskList           *types.TaskList
+		Permission         Permission
+		RequestBody        FilteredRequestBody // request object except for data inputs (PII)
+		AuthenticationOnly bool                // validate caller credentials without checking resource permissions
 	}
 
 	// Result is result from authority.

--- a/common/authorization/authorizer.go
+++ b/common/authorization/authorizer.go
@@ -41,8 +41,6 @@ const (
 	DecisionDeny Decision = iota + 1
 	// DecisionAllow means auth decision is allow
 	DecisionAllow
-	// DecisionUnauthenticated means the caller did not provide valid credentials
-	DecisionUnauthenticated
 )
 
 const (
@@ -61,14 +59,13 @@ type (
 	// Attributes is input for authority to make decision.
 	// It can be extended in future if required auth on resources like WorkflowType and TaskList
 	Attributes struct {
-		Actor              string
-		APIName            string
-		DomainName         string
-		WorkflowType       *types.WorkflowType
-		TaskList           *types.TaskList
-		Permission         Permission
-		RequestBody        FilteredRequestBody // request object except for data inputs (PII)
-		AuthenticationOnly bool                // validate caller credentials without checking resource permissions
+		Actor        string
+		APIName      string
+		DomainName   string
+		WorkflowType *types.WorkflowType
+		TaskList     *types.TaskList
+		Permission   Permission
+		RequestBody  FilteredRequestBody // request object except for data inputs (PII)
 	}
 
 	// Result is result from authority.

--- a/common/authorization/factory.go
+++ b/common/authorization/factory.go
@@ -34,3 +34,41 @@ func NewAuthorizer(authorization config.Authorization, logger log.Logger, domain
 		return NewNopAuthorizer()
 	}
 }
+
+// NewAuthenticator creates an Authorizer that only validates caller credentials,
+// matching however the configured authorizer identifies callers.
+//
+// Prefer NewAuthorizerAndAuthenticator when the deployment needs both.
+func NewAuthenticator(authorization config.Authorization, logger log.Logger) (Authorizer, error) {
+	switch true {
+	case authorization.OAuthAuthorizer.Enable:
+		return NewOAuthAuthenticator(authorization.OAuthAuthorizer, logger)
+	default:
+		return NewNopAuthorizer()
+	}
+}
+
+// NewAuthorizerAndAuthenticator creates an authorizer and a matching authenticator.
+// For OAuth, both share one token validator and verification key set. This avoids
+// duplicate JWKS fetches and potentially different keys from separate initialization.
+// Use this constructor when both implementations are needed.
+func NewAuthorizerAndAuthenticator(
+	authorization config.Authorization,
+	logger log.Logger,
+	domainCache cache.DomainCache,
+) (Authorizer, Authorizer, error) {
+	switch true {
+	case authorization.OAuthAuthorizer.Enable:
+		return NewOAuthAuthorizerAndAuthenticator(authorization.OAuthAuthorizer, logger, domainCache)
+	default:
+		authorizer, err := NewNopAuthorizer()
+		if err != nil {
+			return nil, nil, err
+		}
+		authenticator, err := NewNopAuthorizer()
+		if err != nil {
+			return nil, nil, err
+		}
+		return authorizer, authenticator, nil
+	}
+}

--- a/common/authorization/factory_test.go
+++ b/common/authorization/factory_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common"
@@ -82,11 +84,14 @@ func (s *factorySuite) TestFactoryNoopAuthorizer() {
 		err      error
 	}{
 		{cfgNoop(), &nopAuthority{}, nil},
-		{cfgOAuthVar, &oauthAuthority{
-			config:    cfgOAuthVar.OAuthAuthorizer,
-			log:       s.logger,
-			publicKey: publicKey,
-			parser:    jwt.NewParser(jwt.WithValidMethods([]string{cfgOAuthVar.OAuthAuthorizer.JwtCredentials.Algorithm}), jwt.WithIssuedAt()),
+		{cfgOAuthVar, &oauthAuthorizer{
+			authority: &oauthAuthority{
+				config:    cfgOAuthVar.OAuthAuthorizer,
+				log:       s.logger,
+				publicKey: publicKey,
+				parser:    jwt.NewParser(jwt.WithValidMethods([]string{cfgOAuthVar.OAuthAuthorizer.JwtCredentials.Algorithm}), jwt.WithIssuedAt()),
+			},
+			log: s.logger,
 		}, nil},
 	}
 
@@ -95,4 +100,65 @@ func (s *factorySuite) TestFactoryNoopAuthorizer() {
 		s.Equal(authorizer, test.expected)
 		s.Equal(err, test.err)
 	}
+}
+
+func TestNewAuthenticator(t *testing.T) {
+	logger := testlogger.New(t)
+
+	testCases := []struct {
+		name string
+		cfg  config.Authorization
+		want Authorizer
+	}{
+		{
+			name: "noop when oauth is disabled",
+			cfg:  cfgNoop(),
+			want: &nopAuthority{},
+		},
+		{
+			name: "oauth authenticator when oauth is enabled",
+			cfg:  cfgOAuth(),
+			want: &oauthAuthenticator{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			authenticator, err := NewAuthenticator(tc.cfg, logger)
+			require.NoError(t, err)
+			assert.IsType(t, tc.want, authenticator)
+		})
+	}
+}
+
+func TestNewAuthorizerAndAuthenticator(t *testing.T) {
+	logger := testlogger.New(t)
+
+	t.Run("noop when oauth is disabled", func(t *testing.T) {
+		authorizer, authenticator, err := NewAuthorizerAndAuthenticator(cfgNoop(), logger, nil)
+		require.NoError(t, err)
+		assert.Equal(t, &nopAuthority{}, authorizer)
+		assert.Equal(t, &nopAuthority{}, authenticator)
+	})
+
+	t.Run("oauth pair shares one authority", func(t *testing.T) {
+		authorizer, authenticator, err := NewAuthorizerAndAuthenticator(cfgOAuth(), logger, nil)
+		require.NoError(t, err)
+
+		require.IsType(t, &oauthAuthorizer{}, authorizer)
+		require.IsType(t, &oauthAuthenticator{}, authenticator)
+		assert.Same(t,
+			authorizer.(*oauthAuthorizer).authority,
+			authenticator.(*oauthAuthenticator).authority)
+	})
+
+	t.Run("propagates construction failures", func(t *testing.T) {
+		cfg := cfgOAuth()
+		cfg.OAuthAuthorizer.JwtCredentials.Algorithm = "SHA256"
+
+		authorizer, authenticator, err := NewAuthorizerAndAuthenticator(cfg, logger, nil)
+		assert.ErrorContains(t, err, `algorithm "SHA256" is not supported`)
+		assert.Nil(t, authorizer)
+		assert.Nil(t, authenticator)
+	})
 }

--- a/common/authorization/oauthAuthenticator.go
+++ b/common/authorization/oauthAuthenticator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2026 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,62 +23,36 @@ package authorization
 import (
 	"context"
 
-	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/log/tag"
 )
 
-type oauthAuthorizer struct {
-	authority   *oauthAuthority
-	domainCache cache.DomainCache
-	log         log.Logger
+type oauthAuthenticator struct {
+	authority *oauthAuthority
 }
 
-// NewOAuthAuthorizer creates an oauth Authorizer
-func NewOAuthAuthorizer(
-	oauthConfig config.OAuthAuthorizer,
-	log log.Logger,
-	domainCache cache.DomainCache,
-) (Authorizer, error) {
+// NewOAuthAuthenticator creates an Authorizer that validates caller credentials and
+// nothing else. It ignores the attributes: it reports whether callers are who they
+// claim to be, not what they are allowed to do. Use it for endpoints that name no
+// resource to authorize against, and that check permissions on each item they return.
+//
+// Prefer NewOAuthAuthorizerAndAuthenticator when the deployment needs both, so that the
+// two share one oauthAuthority.
+func NewOAuthAuthenticator(oauthConfig config.OAuthAuthorizer, log log.Logger) (Authorizer, error) {
 	authority, err := newOAuthAuthority(oauthConfig, log)
 	if err != nil {
 		return nil, err
 	}
 
-	return newOAuthAuthorizer(authority, log, domainCache), nil
+	return newOAuthAuthenticator(authority), nil
 }
 
-func newOAuthAuthorizer(
-	authority *oauthAuthority,
-	log log.Logger,
-	domainCache cache.DomainCache,
-) *oauthAuthorizer {
-	return &oauthAuthorizer{
-		authority:   authority,
-		domainCache: domainCache,
-		log:         log,
-	}
+func newOAuthAuthenticator(authority *oauthAuthority) *oauthAuthenticator {
+	return &oauthAuthenticator{authority: authority}
 }
 
-// Authorize validates caller credentials and checks domain permissions.
-func (a *oauthAuthorizer) Authorize(ctx context.Context, attributes *Attributes) (Result, error) {
-	claims, err := a.authority.getAuthClaims(ctx)
-	if err != nil {
-		return Result{Decision: DecisionDeny}, nil
-	}
-
-	if claims.Admin {
-		return Result{Decision: DecisionAllow}, nil
-	}
-
-	domain, err := a.domainCache.GetDomain(attributes.DomainName)
-	if err != nil {
-		return Result{Decision: DecisionDeny}, err
-	}
-
-	if err := validatePermission(claims, attributes, domain.GetInfo().Data); err != nil {
-		a.log.Debug("request is not authorized", tag.Error(err))
+func (a *oauthAuthenticator) Authorize(ctx context.Context, _ *Attributes) (Result, error) {
+	if _, err := a.authority.getAuthClaims(ctx); err != nil {
 		return Result{Decision: DecisionDeny}, nil
 	}
 

--- a/common/authorization/oauthAuthenticator_test.go
+++ b/common/authorization/oauthAuthenticator_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package authorization
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/encoding"
+	"go.uber.org/yarpc/api/transport"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/log/testlogger"
+)
+
+func TestOAuthAuthenticator(t *testing.T) {
+	authenticator, err := NewOAuthAuthenticator(cfgOAuth().OAuthAuthorizer, testlogger.New(t))
+	require.NoError(t, err)
+	privateKey, err := common.LoadRSAPrivateKey("../../config/credentials/keytest")
+	require.NoError(t, err)
+
+	now := time.Now()
+	signToken := func(expiresAt time.Time) string {
+		token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, JWTClaims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Issuer:    jwtInternalIssuer,
+				IssuedAt:  jwt.NewNumericDate(now.Add(-2 * time.Minute)),
+				ExpiresAt: jwt.NewNumericDate(expiresAt),
+			},
+		}).SignedString(privateKey)
+		require.NoError(t, err)
+		return token
+	}
+
+	testCases := []struct {
+		name  string
+		token string
+		want  Decision
+	}{
+		{"valid token without groups", signToken(now.Add(time.Minute)), DecisionAllow},
+		{"missing token", "", DecisionDeny},
+		{"malformed token", "not-a-jwt", DecisionDeny},
+		{"expired token", signToken(now.Add(-time.Minute)), DecisionDeny},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, call := encoding.NewInboundCall(context.Background())
+			request := &transport.Request{}
+			if tc.token != "" {
+				request.Headers = transport.NewHeaders().With(common.AuthorizationTokenHeaderName, tc.token)
+			}
+			require.NoError(t, call.ReadFromRequest(request))
+
+			// Authentication must succeed without domain permissions.
+			result, err := authenticator.Authorize(ctx, &Attributes{
+				APIName:    "ListDomains",
+				Permission: PermissionRead,
+				DomainName: "some-domain",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, result.Decision)
+		})
+	}
+}

--- a/common/authorization/oauthAuthority.go
+++ b/common/authorization/oauthAuthority.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package authorization
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jmespath/go-jmespath"
+	"go.uber.org/yarpc"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+)
+
+var _ jwt.Claims = (*JWTClaims)(nil)
+
+const (
+	groupSeparator    = " "
+	jwtInternalIssuer = "internal-jwt"
+)
+
+// oauthAuthority verifies caller credentials and is shared by oauthAuthorizer and oauthAuthenticator.
+type oauthAuthority struct {
+	config    config.OAuthAuthorizer
+	log       log.Logger
+	parser    *jwt.Parser
+	publicKey interface{}
+	jwks      *keyfunc.JWKS
+}
+
+// JWTClaims is a Cadence specific claim with embeded Claims defined https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
+type JWTClaims struct {
+	jwt.RegisteredClaims
+
+	Name   string
+	Groups string // separated by space
+	Admin  bool
+	TTL    int64 // TODO should be removed. ExpiresAt should be used
+}
+
+func (j JWTClaims) GetGroups() []string {
+	return strings.Split(j.Groups, groupSeparator)
+}
+
+func newOAuthAuthority(oauthConfig config.OAuthAuthorizer, log log.Logger) (*oauthAuthority, error) {
+	var jwks *keyfunc.JWKS
+	var key interface{}
+	var err error
+
+	if oauthConfig.JwtCredentials != nil {
+		if oauthConfig.JwtCredentials.Algorithm != jwt.SigningMethodRS256.Name {
+			return nil, fmt.Errorf("algorithm %q is not supported", oauthConfig.JwtCredentials.Algorithm)
+		}
+
+		if key, err = common.LoadRSAPublicKey(oauthConfig.JwtCredentials.PublicKey); err != nil {
+			return nil, fmt.Errorf("loading RSA public key: %w", err)
+		}
+	}
+
+	if oauthConfig.Provider != nil {
+		if oauthConfig.Provider.JWKSURL == "" {
+			return nil, fmt.Errorf("JWKSURL is not set")
+		}
+		// Create the JWKS from the resource at the given URL.
+		if jwks, err = keyfunc.Get(oauthConfig.Provider.JWKSURL, keyfunc.Options{}); err != nil {
+			return nil, fmt.Errorf("creating JWKS from resource: %s error: %w", oauthConfig.Provider.JWKSURL, err)
+		}
+	}
+
+	return &oauthAuthority{
+		config: oauthConfig,
+		log:    log,
+		parser: jwt.NewParser(
+			jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Name}),
+			jwt.WithIssuedAt(),
+		),
+		publicKey: key,
+		jwks:      jwks,
+	}, nil
+}
+
+// NewOAuthAuthorizerAndAuthenticator creates an oauth Authorizer together with a matching
+// authentication-only Authorizer, both backed by a single oauthAuthority.
+//
+// An authority configured against a JWKS endpoint fetches the key set when constructed.
+// Building the pair together makes one initial fetch and shares the same key set between
+// authentication and authorization. The current JWKS options do not enable automatic refresh.
+func NewOAuthAuthorizerAndAuthenticator(
+	oauthConfig config.OAuthAuthorizer,
+	log log.Logger,
+	domainCache cache.DomainCache,
+) (Authorizer, Authorizer, error) {
+	authority, err := newOAuthAuthority(oauthConfig, log)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return newOAuthAuthorizer(authority, log, domainCache), newOAuthAuthenticator(authority), nil
+}
+
+// getAuthClaims verifies the caller's credentials and returns the claims they carry.
+func (a *oauthAuthority) getAuthClaims(ctx context.Context) (*JWTClaims, error) {
+	claims, err := a.parseClaims(ctx)
+	if err != nil {
+		a.log.Debug("request is not authenticated", tag.Error(err))
+		return nil, err
+	}
+	return claims, nil
+}
+
+func (a *oauthAuthority) parseClaims(ctx context.Context) (*JWTClaims, error) {
+	call := yarpc.CallFromContext(ctx)
+
+	token := call.Header(common.AuthorizationTokenHeaderName)
+	if token == "" {
+		return nil, errors.New("token is not set in header")
+	}
+
+	var claims JWTClaims
+	parsedToken, err := a.parser.ParseWithClaims(token, &claims, a.keyFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isTokenInternal(parsedToken) {
+		parsed, _, err := a.parser.ParseUnverified(token, jwt.MapClaims{})
+		if err != nil {
+			return nil, err
+		}
+
+		if err := a.parseExternal(parsed.Claims.(jwt.MapClaims), &claims); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := a.validateTTL(&claims); err != nil {
+		return nil, err
+	}
+
+	return &claims, nil
+}
+
+// keyFunc returns correct key to check signature
+func (a *oauthAuthority) keyFunc(token *jwt.Token) (interface{}, error) {
+	if isTokenInternal(token) && a.publicKey != nil {
+		return a.publicKey, nil
+	}
+	// External provider with JWKS provided
+	// https://datatracker.ietf.org/doc/html/rfc7517
+	if a.jwks != nil {
+		return a.jwks.Keyfunc(token)
+	}
+
+	return nil, errors.New("no public key for verification")
+}
+
+func (a *oauthAuthority) validateTTL(claims *JWTClaims) error {
+	// Fill ExpiresAt when TTL is passed
+	if claims.TTL > 0 {
+		claims.ExpiresAt = jwt.NewNumericDate(claims.IssuedAt.Time.Add(time.Second * time.Duration(claims.TTL)))
+	}
+
+	exp, err := claims.GetExpirationTime()
+
+	if err != nil || exp == nil {
+		return errors.New("ExpiresAt is not set")
+	}
+
+	timeLeft := exp.Unix() - time.Now().Unix()
+	if timeLeft < 0 {
+		return errors.New("token is expired")
+	}
+
+	if timeLeft > a.config.MaxJwtTTL {
+		return fmt.Errorf("token TTL: %d is larger than MaxTTL allowed: %d", timeLeft, a.config.MaxJwtTTL)
+	}
+
+	return nil
+}
+
+func isTokenInternal(token *jwt.Token) bool {
+	// external providers should set kid part always
+	if _, ok := token.Header["kid"]; !ok {
+		return true
+	}
+
+	issuer, err := token.Claims.GetIssuer()
+	if err != nil {
+		return false
+	}
+
+	return issuer == jwtInternalIssuer
+}
+
+func (a *oauthAuthority) parseExternal(rawClaims map[string]interface{}, claims *JWTClaims) error {
+	if a.config.Provider.GroupsAttributePath != "" {
+		userGroups, err := jmespath.Search(a.config.Provider.GroupsAttributePath, rawClaims)
+		if err != nil {
+			return fmt.Errorf("extracting JWT Groups claim: %w", err)
+		}
+
+		if _, ok := userGroups.(string); !ok {
+			return errors.New("cannot convert groups to string")
+		}
+
+		claims.Groups = userGroups.(string)
+	}
+
+	if a.config.Provider.AdminAttributePath != "" {
+		isAdmin, err := jmespath.Search(a.config.Provider.AdminAttributePath, rawClaims)
+		if err != nil {
+			return fmt.Errorf("extracting JWT Admin claim: %w", err)
+		}
+		if _, ok := isAdmin.(bool); !ok {
+			return errors.New("cannot convert isAdmin to bool")
+		}
+		claims.Admin = isAdmin.(bool)
+	}
+
+	return nil
+}

--- a/common/authorization/oauthAuthorizer.go
+++ b/common/authorization/oauthAuthorizer.go
@@ -118,36 +118,39 @@ func (a *oauthAuthority) Authorize(ctx context.Context, attributes *Attributes) 
 
 	token := call.Header(common.AuthorizationTokenHeaderName)
 	if token == "" {
-		a.log.Debug("request is not authorized", tag.Error(errors.New("token is not set in header")))
-		return Result{Decision: DecisionDeny}, nil
+		a.log.Debug("request is not authenticated", tag.Error(errors.New("token is not set in header")))
+		return Result{Decision: DecisionUnauthenticated}, nil
 	}
 
 	var claims JWTClaims
 	parsedToken, err := a.parser.ParseWithClaims(token, &claims, a.keyFunc)
 	if err != nil {
-		a.log.Debug("request is not authorized", tag.Error(err))
-		return Result{Decision: DecisionDeny}, nil
+		a.log.Debug("request is not authenticated", tag.Error(err))
+		return Result{Decision: DecisionUnauthenticated}, nil
 	}
 
 	if !isTokenInternal(parsedToken) {
 		parsed, _, err := a.parser.ParseUnverified(token, jwt.MapClaims{})
 		if err != nil {
-			a.log.Debug("request is not authorized", tag.Error(err))
-			return Result{Decision: DecisionDeny}, nil
+			a.log.Debug("request is not authenticated", tag.Error(err))
+			return Result{Decision: DecisionUnauthenticated}, nil
 		}
 
 		if err := a.parseExternal(parsed.Claims.(jwt.MapClaims), &claims); err != nil {
-			a.log.Debug("request is not authorized", tag.Error(err))
-			return Result{Decision: DecisionDeny}, nil
+			a.log.Debug("request is not authenticated", tag.Error(err))
+			return Result{Decision: DecisionUnauthenticated}, nil
 		}
 	}
 
 	if err := a.validateTTL(&claims); err != nil {
-		a.log.Debug("request is not authorized", tag.Error(err))
-		return Result{Decision: DecisionDeny}, nil
+		a.log.Debug("request is not authenticated", tag.Error(err))
+		return Result{Decision: DecisionUnauthenticated}, nil
 	}
 
 	if claims.Admin {
+		return Result{Decision: DecisionAllow}, nil
+	}
+	if attributes.AuthenticationOnly {
 		return Result{Decision: DecisionAllow}, nil
 	}
 

--- a/common/authorization/oauthAuthorizer_test.go
+++ b/common/authorization/oauthAuthorizer_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc/api/encoding"
@@ -61,6 +62,47 @@ type (
 
 func TestOAuthSuite(t *testing.T) {
 	suite.Run(t, new(oauthSuite))
+}
+
+func TestOAuthAuthorizerAuthenticationOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	privateKey, err := common.LoadRSAPrivateKey("../../config/credentials/keytest")
+	require.NoError(t, err)
+
+	now := time.Now()
+	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, JWTClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    jwtInternalIssuer,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute)),
+		},
+		Name: "non-admin-user",
+	}).SignedString(privateKey)
+	require.NoError(t, err)
+
+	ctx, call := encoding.NewInboundCall(context.Background())
+	require.NoError(t, call.ReadFromRequest(&transport.Request{
+		Headers: transport.NewHeaders().With(common.AuthorizationTokenHeaderName, token),
+	}))
+
+	authorizer, err := NewOAuthAuthorizer(config.OAuthAuthorizer{
+		Enable: true,
+		JwtCredentials: &config.JwtCredentials{
+			Algorithm: jwt.SigningMethodRS256.Name,
+			PublicKey: "../../config/credentials/keytest.pub",
+		},
+		MaxJwtTTL: 60,
+	}, log.NewMockLogger(ctrl), cache.NewMockDomainCache(ctrl))
+	require.NoError(t, err)
+
+	result, err := authorizer.Authorize(ctx, &Attributes{
+		APIName:            "ListDomains",
+		Permission:         PermissionRead,
+		AuthenticationOnly: true,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, DecisionAllow, result.Decision)
 }
 
 func (s *oauthSuite) SetupTest() {
@@ -227,20 +269,6 @@ func (s *oauthSuite) TestIatExpiredToken() {
 	}))
 	result, _ := authorizer.Authorize(ctx, &s.att)
 	s.Equal(result.Decision, DecisionUnauthenticated)
-}
-
-func (s *oauthSuite) TestListDomainsAuthorizationProbe() {
-	authorizer, err := NewOAuthAuthorizer(s.cfg, s.logger, s.domainCache)
-	s.NoError(err)
-
-	result, err := authorizer.Authorize(s.ctx, &Attributes{
-		APIName:            "ListDomains",
-		Permission:         PermissionRead,
-		AuthenticationOnly: true,
-	})
-
-	s.NoError(err)
-	s.Equal(DecisionAllow, result.Decision)
 }
 
 func (s *oauthSuite) TestDifferentGroup() {

--- a/common/authorization/oauthAuthorizer_test.go
+++ b/common/authorization/oauthAuthorizer_test.go
@@ -154,11 +154,11 @@ func (s *oauthSuite) TestEmptyToken() {
 	s.NoError(err)
 	authorizer, err := NewOAuthAuthorizer(s.cfg, s.logger, s.domainCache)
 	s.NoError(err)
-	s.logger.EXPECT().Debug("request is not authorized", gomock.Cond(func(t []tag.Tag) bool {
+	s.logger.EXPECT().Debug("request is not authenticated", gomock.Cond(func(t []tag.Tag) bool {
 		return fmt.Sprintf("%v", t[0].Field().Interface) == "token is not set in header"
 	}))
 	result, _ := authorizer.Authorize(ctx, &s.att)
-	s.Equal(result.Decision, DecisionDeny)
+	s.Equal(result.Decision, DecisionUnauthenticated)
 }
 
 func (s *oauthSuite) TestGetDomainError() {
@@ -188,11 +188,11 @@ func (s *oauthSuite) TestMaxTTLLargerInToken() {
 	s.cfg.MaxJwtTTL = 1
 	authorizer, err := NewOAuthAuthorizer(s.cfg, s.logger, s.domainCache)
 	s.NoError(err)
-	s.logger.EXPECT().Debug("request is not authorized", gomock.Cond(func(t []tag.Tag) bool {
+	s.logger.EXPECT().Debug("request is not authenticated", gomock.Cond(func(t []tag.Tag) bool {
 		return strings.HasPrefix(fmt.Sprintf("%v", t[0].Field().Interface), "token TTL:")
 	}))
 	result, _ := authorizer.Authorize(s.ctx, &s.att)
-	s.Equal(result.Decision, DecisionDeny)
+	s.Equal(result.Decision, DecisionUnauthenticated)
 }
 
 func (s *oauthSuite) TestIncorrectToken() {
@@ -204,11 +204,11 @@ func (s *oauthSuite) TestIncorrectToken() {
 	s.NoError(err)
 	authorizer, err := NewOAuthAuthorizer(s.cfg, s.logger, s.domainCache)
 	s.NoError(err)
-	s.logger.EXPECT().Debug("request is not authorized", gomock.Cond(func(t []tag.Tag) bool {
+	s.logger.EXPECT().Debug("request is not authenticated", gomock.Cond(func(t []tag.Tag) bool {
 		return fmt.Sprintf("%v", t[0].Field().Interface) == "token is malformed: token contains an invalid number of segments"
 	}))
 	result, _ := authorizer.Authorize(ctx, &s.att)
-	s.Equal(result.Decision, DecisionDeny)
+	s.Equal(result.Decision, DecisionUnauthenticated)
 }
 
 func (s *oauthSuite) TestIatExpiredToken() {
@@ -222,11 +222,25 @@ func (s *oauthSuite) TestIatExpiredToken() {
 	s.NoError(err)
 	authorizer, err := NewOAuthAuthorizer(s.cfg, s.logger, s.domainCache)
 	s.NoError(err)
-	s.logger.EXPECT().Debug("request is not authorized", gomock.Cond(func(t []tag.Tag) bool {
+	s.logger.EXPECT().Debug("request is not authenticated", gomock.Cond(func(t []tag.Tag) bool {
 		return fmt.Sprintf("%v", t[0].Field().Interface) == "token is expired"
 	}))
 	result, _ := authorizer.Authorize(ctx, &s.att)
-	s.Equal(result.Decision, DecisionDeny)
+	s.Equal(result.Decision, DecisionUnauthenticated)
+}
+
+func (s *oauthSuite) TestListDomainsAuthorizationProbe() {
+	authorizer, err := NewOAuthAuthorizer(s.cfg, s.logger, s.domainCache)
+	s.NoError(err)
+
+	result, err := authorizer.Authorize(s.ctx, &Attributes{
+		APIName:            "ListDomains",
+		Permission:         PermissionRead,
+		AuthenticationOnly: true,
+	})
+
+	s.NoError(err)
+	s.Equal(DecisionAllow, result.Decision)
 }
 
 func (s *oauthSuite) TestDifferentGroup() {

--- a/common/authorization/oauthAuthorizer_test.go
+++ b/common/authorization/oauthAuthorizer_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc/api/encoding"
@@ -62,47 +61,6 @@ type (
 
 func TestOAuthSuite(t *testing.T) {
 	suite.Run(t, new(oauthSuite))
-}
-
-func TestOAuthAuthorizerAuthenticationOnly(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	privateKey, err := common.LoadRSAPrivateKey("../../config/credentials/keytest")
-	require.NoError(t, err)
-
-	now := time.Now()
-	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, JWTClaims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			Issuer:    jwtInternalIssuer,
-			IssuedAt:  jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute)),
-		},
-		Name: "non-admin-user",
-	}).SignedString(privateKey)
-	require.NoError(t, err)
-
-	ctx, call := encoding.NewInboundCall(context.Background())
-	require.NoError(t, call.ReadFromRequest(&transport.Request{
-		Headers: transport.NewHeaders().With(common.AuthorizationTokenHeaderName, token),
-	}))
-
-	authorizer, err := NewOAuthAuthorizer(config.OAuthAuthorizer{
-		Enable: true,
-		JwtCredentials: &config.JwtCredentials{
-			Algorithm: jwt.SigningMethodRS256.Name,
-			PublicKey: "../../config/credentials/keytest.pub",
-		},
-		MaxJwtTTL: 60,
-	}, log.NewMockLogger(ctrl), cache.NewMockDomainCache(ctrl))
-	require.NoError(t, err)
-
-	result, err := authorizer.Authorize(ctx, &Attributes{
-		APIName:            "ListDomains",
-		Permission:         PermissionRead,
-		AuthenticationOnly: true,
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, DecisionAllow, result.Decision)
 }
 
 func (s *oauthSuite) SetupTest() {
@@ -200,7 +158,7 @@ func (s *oauthSuite) TestEmptyToken() {
 		return fmt.Sprintf("%v", t[0].Field().Interface) == "token is not set in header"
 	}))
 	result, _ := authorizer.Authorize(ctx, &s.att)
-	s.Equal(result.Decision, DecisionUnauthenticated)
+	s.Equal(result.Decision, DecisionDeny)
 }
 
 func (s *oauthSuite) TestGetDomainError() {
@@ -234,7 +192,7 @@ func (s *oauthSuite) TestMaxTTLLargerInToken() {
 		return strings.HasPrefix(fmt.Sprintf("%v", t[0].Field().Interface), "token TTL:")
 	}))
 	result, _ := authorizer.Authorize(s.ctx, &s.att)
-	s.Equal(result.Decision, DecisionUnauthenticated)
+	s.Equal(result.Decision, DecisionDeny)
 }
 
 func (s *oauthSuite) TestIncorrectToken() {
@@ -250,7 +208,7 @@ func (s *oauthSuite) TestIncorrectToken() {
 		return fmt.Sprintf("%v", t[0].Field().Interface) == "token is malformed: token contains an invalid number of segments"
 	}))
 	result, _ := authorizer.Authorize(ctx, &s.att)
-	s.Equal(result.Decision, DecisionUnauthenticated)
+	s.Equal(result.Decision, DecisionDeny)
 }
 
 func (s *oauthSuite) TestIatExpiredToken() {
@@ -268,7 +226,7 @@ func (s *oauthSuite) TestIatExpiredToken() {
 		return fmt.Sprintf("%v", t[0].Field().Interface) == "token is expired"
 	}))
 	result, _ := authorizer.Authorize(ctx, &s.att)
-	s.Equal(result.Decision, DecisionUnauthenticated)
+	s.Equal(result.Decision, DecisionDeny)
 }
 
 func (s *oauthSuite) TestDifferentGroup() {
@@ -343,10 +301,10 @@ func Test_oauthAuthority_validateTTL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validator := &oauthAuthority{
+			authority := &oauthAuthority{
 				config: config.OAuthAuthorizer{MaxJwtTTL: tt.ttlConfig},
 			}
-			tt.wantErr(t, validator.validateTTL(tt.claims), fmt.Sprintf("validateTTL(%v)", tt.claims))
+			tt.wantErr(t, authority.validateTTL(tt.claims), fmt.Sprintf("validateTTL(%v)", tt.claims))
 		})
 	}
 }
@@ -499,11 +457,11 @@ func Test_oauthAuthority_parseExternal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &oauthAuthority{
+			v := &oauthAuthority{
 				config: tt.config,
 			}
 			actualClaim := &JWTClaims{}
-			err := a.parseExternal(tt.mapToken, actualClaim)
+			err := v.parseExternal(tt.mapToken, actualClaim)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.wantGroups, actualClaim.Groups)
 			assert.Equal(t, tt.wantAdmin, actualClaim.Admin)

--- a/common/resource/params.go
+++ b/common/resource/params.go
@@ -86,6 +86,7 @@ type (
 		ArchivalMetadata           archiver.ArchivalMetadata
 		ArchiverProvider           provider.ArchiverProvider
 		Authorizer                 authorization.Authorizer // NOTE: this can be nil. If nil, AccessControlledHandlerImpl will initiate one with config.Authorization
+		Authenticator              authorization.Authorizer // NOTE: this can be nil. If nil, AccessControlledHandlerImpl will initiate one with config.Authorization
 		AuthorizationConfig        config.Authorization     // NOTE: empty(default) struct will get a authorization.NoopAuthorizer
 		IsolationGroupStore        configstore.Client       // This can be nil, the default config store will be created if so
 		IsolationGroupState        isolationgroup.State     // This can be nil, the default state store will be chosen if so

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -714,11 +714,12 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]membership.HostInfo, star
 	params.PinotClient = c.pinotClient
 	params.GetIsolationGroups = getFromDynamicConfig(params)
 	var err error
-	authorizer, err := authorization.NewAuthorizer(c.authorizationConfig, params.Logger, nil)
+	authorizer, authenticator, err := authorization.NewAuthorizerAndAuthenticator(c.authorizationConfig, params.Logger, nil)
 	if err != nil {
-		c.logger.Fatal("Unable to create authorizer", tag.Error(err))
+		c.logger.Fatal("Unable to create authorizer and authenticator", tag.Error(err))
 	}
 	params.Authorizer = authorizer
+	params.Authenticator = authenticator
 	params.PersistenceConfig, err = copyPersistenceConfig(c.persistenceConfig)
 	if err != nil {
 		c.logger.Fatal("Failed to copy persistence config for frontend", tag.Error(err))

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -158,7 +158,7 @@ func (s *Service) Start() {
 	if s.params.ClusterRedirectionPolicy != nil {
 		handler = clusterredirection.NewAPIHandler(handler, s, s.config, *s.params.ClusterRedirectionPolicy)
 	}
-	handler = accesscontrolled.NewAPIHandler(handler, s, s.params.Authorizer, s.params.AuthorizationConfig)
+	handler = accesscontrolled.NewAPIHandler(handler, s, s.params.Authorizer, s.params.Authenticator, s.params.AuthorizationConfig)
 
 	// Register the latest (most decorated) handler
 	thriftHandler := thrift.NewAPIHandler(handler)

--- a/service/frontend/templates/accesscontrolled.tmpl
+++ b/service/frontend/templates/accesscontrolled.tmpl
@@ -20,6 +20,7 @@ import (
 {{$permissionMap = set $permissionMap "GetWorkflowExecutionHistory" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "ListArchivedWorkflowExecutions" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "ListClosedWorkflowExecutions" "PermissionRead"}}
+{{$permissionMap = set $permissionMap "ListDomains" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "ListOpenWorkflowExecutions" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "ListWorkflowExecutions" "PermissionRead"}}
 {{$permissionMap = set $permissionMap "PollForActivityTask" "PermissionProcess"}}
@@ -54,7 +55,7 @@ import (
 {{$adminPermissionMap := dict }}
 {{$adminPermissionMap = set $adminPermissionMap "DescribeCluster" "PermissionRead"}}
 
-{{$nonDomainAuthAPIs := list "RegisterDomain" "DescribeDomain" "UpdateDomain" "DeprecateDomain" "DeleteDomain" "GetSearchAttributes" "GetClusterInfo" "ResetStickyTaskList" "RecordActivityTaskHeartbeat" "RespondActivityTaskCanceled" "RespondActivityTaskCompleted" "RespondActivityTaskFailed" "RespondDecisionTaskCompleted" "RespondDecisionTaskFailed" "RespondQueryTaskCompleted"}}
+{{$nonDomainAuthAPIs := list "RegisterDomain" "DescribeDomain" "UpdateDomain" "DeprecateDomain" "DeleteDomain" "ListDomains" "GetSearchAttributes" "GetClusterInfo" "ResetStickyTaskList" "RecordActivityTaskHeartbeat" "RespondActivityTaskCanceled" "RespondActivityTaskCompleted" "RespondActivityTaskFailed" "RespondDecisionTaskCompleted" "RespondDecisionTaskFailed" "RespondQueryTaskCompleted"}}
 {{$taskListAuthAPIs := list "PollForActivityTask" "PollForDecisionTask"}}
 {{$workflowTypeAuthAPIs := list "SignalWithStartWorkflowExecution" "StartWorkflowExecution" "SignalWithStartWorkflowExecutionAsync" "StartWorkflowExecutionAsync"}}
 
@@ -103,6 +104,9 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	{{- end}}
 	attr := &authorization.Attributes{
 		APIName: "{{$method.Name}}",
+		{{- if and (eq $handlerName "API") (eq $method.Name "ListDomains")}}
+		AuthenticationOnly: true,
+		{{- end}}
 		{{- if eq $handlerName "Admin"}}
 		{{- if hasKey $adminPermissionMap $method.Name}}
 		Permission: authorization.{{get $adminPermissionMap $method.Name}},
@@ -148,7 +152,11 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 		{{- end}}
 	}
 	{{- end}}
+	{{- if and (eq $handlerName "API") (eq $method.Name "ListDomains")}}
+	return a.listAuthorizedDomains(ctx, {{(index $method.Params 1).Name}}, scope)
+	{{- else}}
 	return a.handler.{{$method.Call}}
+	{{- end}}
 }
 {{- end}}
 {{end}}

--- a/service/frontend/templates/accesscontrolled.tmpl
+++ b/service/frontend/templates/accesscontrolled.tmpl
@@ -69,11 +69,30 @@ import (
 type {{$decorator}} struct {
 	handler {{.Interface.Type}}
 	authorizer authorization.Authorizer
+	{{- if eq $handlerName "API"}}
+	authenticator authorization.Authorizer
+	{{- end}}
 	resource.Resource
 }
 
 // New{{$Decorator}} creates frontend handler with authentication support
-func New{{$Decorator}}(handler {{$.Interface.Type}}, resource resource.Resource, authorizer authorization.Authorizer, cfg config.Authorization) {{.Interface.Type}} {
+func New{{$Decorator}}(handler {{$.Interface.Type}}, resource resource.Resource, authorizer authorization.Authorizer, {{if eq $handlerName "API"}}authenticator authorization.Authorizer, {{end}}cfg config.Authorization) {{.Interface.Type}} {
+	{{- if eq $handlerName "API"}}
+	// Built together so that they share one token validator, which matters when the
+	// configured scheme fetches verification keys from a remote endpoint.
+	var err error
+	switch {
+	case authorizer == nil && authenticator == nil:
+		authorizer, authenticator, err = authorization.NewAuthorizerAndAuthenticator(cfg, resource.GetLogger(), resource.GetDomainCache())
+	case authorizer == nil:
+		authorizer, err = authorization.NewAuthorizer(cfg, resource.GetLogger(), resource.GetDomainCache())
+	case authenticator == nil:
+		authenticator, err = authorization.NewAuthenticator(cfg, resource.GetLogger())
+	}
+	if err != nil {
+		resource.GetLogger().Fatal("Unable to initialize access control", tag.Error(err))
+	}
+	{{- else}}
 	if authorizer == nil {
 		var err error
 		authorizer, err = authorization.NewAuthorizer(cfg, resource.GetLogger(), resource.GetDomainCache())
@@ -81,9 +100,13 @@ func New{{$Decorator}}(handler {{$.Interface.Type}}, resource resource.Resource,
 			resource.GetLogger().Fatal("Error when initiating the Authorizer", tag.Error(err))
 		}
 	}
+	{{- end}}
 	return &{{$decorator}}{
 		handler: handler,
 		authorizer: authorizer,
+		{{- if eq $handlerName "API"}}
+		authenticator: authenticator,
+		{{- end}}
 		Resource: resource,
 	}
 }
@@ -104,9 +127,6 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	{{- end}}
 	attr := &authorization.Attributes{
 		APIName: "{{$method.Name}}",
-		{{- if and (eq $handlerName "API") (eq $method.Name "ListDomains")}}
-		AuthenticationOnly: true,
-		{{- end}}
 		{{- if eq $handlerName "Admin"}}
 		{{- if hasKey $adminPermissionMap $method.Name}}
 		Permission: authorization.{{get $adminPermissionMap $method.Name}},
@@ -134,6 +154,8 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	}
 	{{- if eq $handlerName "Admin"}}
 	isAuthorized, err := a.isAuthorized(ctx, attr)
+	{{- else if eq $method.Name "ListDomains"}}
+	isAuthorized, err := a.isAuthenticated(ctx, attr, scope)
 	{{- else}}
 	isAuthorized, err := a.isAuthorized(ctx, attr, scope)
 	{{- end}}
@@ -153,7 +175,7 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	}
 	{{- end}}
 	{{- if and (eq $handlerName "API") (eq $method.Name "ListDomains")}}
-	return a.listAuthorizedDomains(ctx, {{(index $method.Params 1).Name}}, scope)
+	return a.listAuthorizedDomains(ctx, {{(index $method.Params 1).Name}})
 	{{- else}}
 	return a.handler.{{$method.Call}}
 	{{- end}}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled.go
@@ -47,6 +47,18 @@ func (a *apiHandler) isAuthorized(
 	attr *authorization.Attributes,
 	scope metrics.Scope,
 ) (bool, error) {
+	result, err := a.authorize(ctx, attr, scope)
+	if err != nil {
+		return false, err
+	}
+	return result.Decision == authorization.DecisionAllow, nil
+}
+
+func (a *apiHandler) authorize(
+	ctx context.Context,
+	attr *authorization.Attributes,
+	scope metrics.Scope,
+) (authorization.Result, error) {
 	authStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceAuthorizationLatency)
 	defer func() {
@@ -57,13 +69,47 @@ func (a *apiHandler) isAuthorized(
 	result, err := a.authorizer.Authorize(ctx, attr)
 	if err != nil {
 		scope.IncCounter(metrics.CadenceErrAuthorizeFailedCounter)
-		return false, err
+		return authorization.Result{}, err
 	}
-	isAuth := result.Decision == authorization.DecisionAllow
-	if !isAuth {
+	if result.Decision != authorization.DecisionAllow {
 		scope.IncCounter(metrics.CadenceErrUnauthorizedCounter)
 	}
-	return isAuth, nil
+	return result, nil
+}
+
+func (a *apiHandler) listAuthorizedDomains(
+	ctx context.Context,
+	listRequest *types.ListDomainsRequest,
+	scope metrics.Scope,
+) (*types.ListDomainsResponse, error) {
+	response, err := a.handler.ListDomains(ctx, listRequest)
+	if err != nil || response == nil {
+		return response, err
+	}
+
+	requestBody := authorization.NewFilteredRequestBody(listRequest)
+	authorizedDomains := make([]*types.DescribeDomainResponse, 0, len(response.GetDomains()))
+	for _, domain := range response.GetDomains() {
+		result, err := a.authorize(ctx, &authorization.Attributes{
+			APIName:     "ListDomains",
+			Permission:  authorization.PermissionRead,
+			RequestBody: requestBody,
+			DomainName:  domain.GetDomainInfo().GetName(),
+		}, scope)
+		if err != nil {
+			return nil, err
+		}
+
+		switch result.Decision {
+		case authorization.DecisionAllow:
+			authorizedDomains = append(authorizedDomains, domain)
+		case authorization.DecisionUnauthenticated:
+			return nil, errUnauthorized
+		}
+	}
+
+	response.Domains = authorizedDomains
+	return response, nil
 }
 
 // getMetricsScopeWithDomain return metrics scope with domain tag

--- a/service/frontend/wrappers/accesscontrolled/access_controlled.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled.go
@@ -51,7 +51,11 @@ func (a *apiHandler) isAuthorized(
 	if err != nil {
 		return false, err
 	}
-	return result.Decision == authorization.DecisionAllow, nil
+	isAuthorized := result.Decision == authorization.DecisionAllow
+	if !isAuthorized {
+		scope.IncCounter(metrics.CadenceErrUnauthorizedCounter)
+	}
+	return isAuthorized, nil
 }
 
 func (a *apiHandler) authorize(
@@ -70,9 +74,6 @@ func (a *apiHandler) authorize(
 	if err != nil {
 		scope.IncCounter(metrics.CadenceErrAuthorizeFailedCounter)
 		return authorization.Result{}, err
-	}
-	if result.Decision != authorization.DecisionAllow {
-		scope.IncCounter(metrics.CadenceErrUnauthorizedCounter)
 	}
 	return result, nil
 }
@@ -104,6 +105,7 @@ func (a *apiHandler) listAuthorizedDomains(
 		case authorization.DecisionAllow:
 			authorizedDomains = append(authorizedDomains, domain)
 		case authorization.DecisionUnauthenticated:
+			scope.IncCounter(metrics.CadenceErrUnauthorizedCounter)
 			return nil, errUnauthorized
 		}
 	}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled.go
@@ -47,8 +47,33 @@ func (a *apiHandler) isAuthorized(
 	attr *authorization.Attributes,
 	scope metrics.Scope,
 ) (bool, error) {
-	result, err := a.authorize(ctx, attr, scope)
+	return a.checkAccess(ctx, a.authorizer, attr, scope)
+}
+
+func (a *apiHandler) isAuthenticated(
+	ctx context.Context,
+	attr *authorization.Attributes,
+	scope metrics.Scope,
+) (bool, error) {
+	return a.checkAccess(ctx, a.authenticator, attr, scope)
+}
+
+func (a *apiHandler) checkAccess(
+	ctx context.Context,
+	authorizer authorization.Authorizer,
+	attr *authorization.Attributes,
+	scope metrics.Scope,
+) (bool, error) {
+	authStart := time.Now()
+	sw := scope.StartTimer(metrics.CadenceAuthorizationLatency)
+	defer func() {
+		sw.Stop()
+		scope.ExponentialHistogram(metrics.CadenceAuthorizationLatencyHistogram, time.Since(authStart))
+	}()
+
+	result, err := authorizer.Authorize(ctx, attr)
 	if err != nil {
+		scope.IncCounter(metrics.CadenceErrAuthorizeFailedCounter)
 		return false, err
 	}
 	isAuthorized := result.Decision == authorization.DecisionAllow
@@ -58,30 +83,18 @@ func (a *apiHandler) isAuthorized(
 	return isAuthorized, nil
 }
 
-func (a *apiHandler) authorize(
-	ctx context.Context,
-	attr *authorization.Attributes,
-	scope metrics.Scope,
-) (authorization.Result, error) {
-	authStart := time.Now()
-	sw := scope.StartTimer(metrics.CadenceAuthorizationLatency)
-	defer func() {
-		sw.Stop()
-		scope.ExponentialHistogram(metrics.CadenceAuthorizationLatencyHistogram, time.Since(authStart))
-	}()
-
+// authorizeFilter checks individual resources without recording request authorization metrics.
+func (a *apiHandler) authorizeFilter(ctx context.Context, attr *authorization.Attributes) (bool, error) {
 	result, err := a.authorizer.Authorize(ctx, attr)
 	if err != nil {
-		scope.IncCounter(metrics.CadenceErrAuthorizeFailedCounter)
-		return authorization.Result{}, err
+		return false, err
 	}
-	return result, nil
+	return result.Decision == authorization.DecisionAllow, nil
 }
 
 func (a *apiHandler) listAuthorizedDomains(
 	ctx context.Context,
 	listRequest *types.ListDomainsRequest,
-	scope metrics.Scope,
 ) (*types.ListDomainsResponse, error) {
 	response, err := a.handler.ListDomains(ctx, listRequest)
 	if err != nil || response == nil {
@@ -91,22 +104,20 @@ func (a *apiHandler) listAuthorizedDomains(
 	requestBody := authorization.NewFilteredRequestBody(listRequest)
 	authorizedDomains := make([]*types.DescribeDomainResponse, 0, len(response.GetDomains()))
 	for _, domain := range response.GetDomains() {
-		result, err := a.authorize(ctx, &authorization.Attributes{
+		// A denied domain is filtered out rather than failing the whole request: the
+		// caller's credentials were already validated before the list was fetched.
+		isAuthorized, err := a.authorizeFilter(ctx, &authorization.Attributes{
 			APIName:     "ListDomains",
 			Permission:  authorization.PermissionRead,
 			RequestBody: requestBody,
 			DomainName:  domain.GetDomainInfo().GetName(),
-		}, scope)
+		})
 		if err != nil {
 			return nil, err
 		}
 
-		switch result.Decision {
-		case authorization.DecisionAllow:
+		if isAuthorized {
 			authorizedDomains = append(authorizedDomains, domain)
-		case authorization.DecisionUnauthenticated:
-			scope.IncCounter(metrics.CadenceErrUnauthorizedCounter)
-			return nil, errUnauthorized
 		}
 	}
 

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -204,3 +204,169 @@ func TestDescribeCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestListDomainsAuthorization(t *testing.T) {
+	someErr := errors.New("some random err")
+	nextPageToken := []byte("next-page")
+	testCases := []struct {
+		name              string
+		mockSetup         func(*authorization.MockAuthorizer, *api.MockHandler, *types.ListDomainsRequest)
+		wantDomains       []string
+		wantNextPageToken []byte
+		wantErr           error
+	}{
+		{
+			name: "unauthenticated request",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, _ *api.MockHandler, _ *types.ListDomainsRequest) {
+				authorizer.EXPECT().
+					Authorize(gomock.Any(), listDomainsAuthAttr("")).
+					Return(authorization.Result{Decision: authorization.DecisionUnauthenticated}, nil)
+			},
+			wantErr: errUnauthorized,
+		},
+		{
+			name: "operation denied",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, _ *api.MockHandler, _ *types.ListDomainsRequest) {
+				authorizer.EXPECT().
+					Authorize(gomock.Any(), listDomainsAuthAttr("")).
+					Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
+			},
+			wantErr: errUnauthorized,
+		},
+		{
+			name: "filters unauthorized domains",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+				gomock.InOrder(
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nextPageToken, "allowed-domain", "denied-domain"), nil),
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("allowed-domain")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("denied-domain")).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil),
+				)
+			},
+			wantDomains:       []string{"allowed-domain"},
+			wantNextPageToken: nextPageToken,
+		},
+		{
+			name: "preserves empty page",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+				gomock.InOrder(
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nextPageToken), nil),
+				)
+			},
+			wantNextPageToken: nextPageToken,
+		},
+		{
+			name: "preserves pagination when all domains are denied",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+				gomock.InOrder(
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nextPageToken, "denied-domain"), nil),
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("denied-domain")).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil),
+				)
+			},
+			wantNextPageToken: nextPageToken,
+		},
+		{
+			name: "returns all authorized domains",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+				gomock.InOrder(
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nil, "first-domain", "second-domain"), nil),
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("first-domain")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("second-domain")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+				)
+			},
+			wantDomains: []string{"first-domain", "second-domain"},
+		},
+		{
+			name: "handler error",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+				gomock.InOrder(
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					handler.EXPECT().ListDomains(gomock.Any(), request).Return(nil, someErr),
+				)
+			},
+			wantErr: someErr,
+		},
+		{
+			name: "authorizer error",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+				gomock.InOrder(
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nil, "error-domain"), nil),
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("error-domain")).Return(authorization.Result{}, someErr),
+				)
+			},
+			wantErr: someErr,
+		},
+		{
+			name: "authentication expires while filtering",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+				gomock.InOrder(
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nil, "domain"), nil),
+					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("domain")).Return(authorization.Result{Decision: authorization.DecisionUnauthenticated}, nil),
+				)
+			},
+			wantErr: errUnauthorized,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockAuthorizer := authorization.NewMockAuthorizer(ctrl)
+			mockHandler := api.NewMockHandler(ctrl)
+			mockResource := resource.NewMockResource(ctrl)
+			mockResource.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
+			request := &types.ListDomainsRequest{PageSize: 10}
+			tc.mockSetup(mockAuthorizer, mockHandler, request)
+
+			handler := NewAPIHandler(mockHandler, mockResource, mockAuthorizer, config.Authorization{})
+			response, err := handler.ListDomains(context.Background(), request)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				assert.Nil(t, response)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, response)
+			assert.Equal(t, tc.wantNextPageToken, response.NextPageToken)
+			assert.Equal(t, tc.wantDomains, domainNames(response.Domains))
+		})
+	}
+}
+
+func listDomainsAuthAttr(domain string) gomock.Matcher {
+	return gomock.Cond(func(attr *authorization.Attributes) bool {
+		return attr.APIName == "ListDomains" &&
+			attr.Permission == authorization.PermissionRead &&
+			attr.DomainName == domain &&
+			attr.AuthenticationOnly == (domain == "") &&
+			attr.RequestBody != nil
+	})
+}
+
+func listDomainsResponse(nextPageToken []byte, domains ...string) *types.ListDomainsResponse {
+	response := &types.ListDomainsResponse{NextPageToken: nextPageToken}
+	for _, domain := range domains {
+		response.Domains = append(response.Domains, &types.DescribeDomainResponse{
+			DomainInfo: &types.DomainInfo{Name: domain},
+		})
+	}
+	return response
+}
+
+func domainNames(domains []*types.DescribeDomainResponse) []string {
+	if len(domains) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(domains))
+	for _, domain := range domains {
+		names = append(names, domain.GetDomainInfo().GetName())
+	}
+	return names
+}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -82,7 +82,7 @@ func TestAuthorizationMetricsLabelConsistency(t *testing.T) {
 	mockHandler.EXPECT().RegisterDomain(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mockHandler.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.DescribeWorkflowExecutionResponse{}, nil).Times(1)
 
-	handler := NewAPIHandler(mockHandler, mockResource, mockAuthorizer, config.Authorization{})
+	handler := NewAPIHandler(mockHandler, mockResource, mockAuthorizer, mockAuthorizer, config.Authorization{})
 
 	ctx := context.Background()
 	_, err = handler.DescribeWorkflowExecution(ctx, &types.DescribeWorkflowExecutionRequest{Domain: "my-domain"})
@@ -208,36 +208,37 @@ func TestDescribeCluster(t *testing.T) {
 func TestListDomainsAuthorization(t *testing.T) {
 	someErr := errors.New("some random err")
 	nextPageToken := []byte("next-page")
+	allowGate := func(authenticator *authorization.MockAuthorizer) *gomock.Call {
+		return authenticator.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).
+			Return(authorization.Result{Decision: authorization.DecisionAllow}, nil)
+	}
+
 	testCases := []struct {
 		name              string
-		mockSetup         func(*authorization.MockAuthorizer, *api.MockHandler, *types.ListDomainsRequest)
+		mockSetup         func(authenticator, authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest)
 		wantDomains       []string
 		wantNextPageToken []byte
 		wantErr           error
 	}{
 		{
-			name: "unauthenticated request",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, _ *api.MockHandler, _ *types.ListDomainsRequest) {
-				authorizer.EXPECT().
-					Authorize(gomock.Any(), listDomainsAuthAttr("")).
-					Return(authorization.Result{Decision: authorization.DecisionUnauthenticated}, nil)
+			name: "unauthenticated caller is rejected",
+			mockSetup: func(authenticator, _ *authorization.MockAuthorizer, _ *api.MockHandler, _ *types.ListDomainsRequest) {
+				authenticator.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
 			},
 			wantErr: errUnauthorized,
 		},
 		{
-			name: "operation denied",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, _ *api.MockHandler, _ *types.ListDomainsRequest) {
-				authorizer.EXPECT().
-					Authorize(gomock.Any(), listDomainsAuthAttr("")).
-					Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
+			name: "returns authentication error without fetching domains",
+			mockSetup: func(authenticator, _ *authorization.MockAuthorizer, _ *api.MockHandler, _ *types.ListDomainsRequest) {
+				authenticator.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{}, someErr)
 			},
-			wantErr: errUnauthorized,
+			wantErr: someErr,
 		},
 		{
 			name: "filters unauthorized domains",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+			mockSetup: func(authenticator, authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
 				gomock.InOrder(
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					allowGate(authenticator),
 					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nextPageToken, "allowed-domain", "denied-domain"), nil),
 					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("allowed-domain")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
 					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("denied-domain")).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil),
@@ -247,20 +248,10 @@ func TestListDomainsAuthorization(t *testing.T) {
 			wantNextPageToken: nextPageToken,
 		},
 		{
-			name: "preserves empty page",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
-				gomock.InOrder(
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
-					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nextPageToken), nil),
-				)
-			},
-			wantNextPageToken: nextPageToken,
-		},
-		{
 			name: "preserves pagination when all domains are denied",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+			mockSetup: func(authenticator, authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
 				gomock.InOrder(
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					allowGate(authenticator),
 					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nextPageToken, "denied-domain"), nil),
 					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("denied-domain")).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil),
 				)
@@ -268,62 +259,40 @@ func TestListDomainsAuthorization(t *testing.T) {
 			wantNextPageToken: nextPageToken,
 		},
 		{
-			name: "returns all authorized domains",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+			name: "returns domain fetch error after authentication without checking domain permissions",
+			mockSetup: func(authenticator, _ *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
 				gomock.InOrder(
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
-					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nil, "first-domain", "second-domain"), nil),
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("first-domain")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("second-domain")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
-				)
-			},
-			wantDomains: []string{"first-domain", "second-domain"},
-		},
-		{
-			name: "handler error",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
-				gomock.InOrder(
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					allowGate(authenticator),
 					handler.EXPECT().ListDomains(gomock.Any(), request).Return(nil, someErr),
 				)
 			},
 			wantErr: someErr,
 		},
 		{
-			name: "authorizer error",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
+			name: "returns domain authorization error while filtering fetched domains",
+			mockSetup: func(authenticator, authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
 				gomock.InOrder(
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+					allowGate(authenticator),
 					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nil, "error-domain"), nil),
 					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("error-domain")).Return(authorization.Result{}, someErr),
 				)
 			},
 			wantErr: someErr,
 		},
-		{
-			name: "authentication expires while filtering",
-			mockSetup: func(authorizer *authorization.MockAuthorizer, handler *api.MockHandler, request *types.ListDomainsRequest) {
-				gomock.InOrder(
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("")).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
-					handler.EXPECT().ListDomains(gomock.Any(), request).Return(listDomainsResponse(nil, "domain"), nil),
-					authorizer.EXPECT().Authorize(gomock.Any(), listDomainsAuthAttr("domain")).Return(authorization.Result{Decision: authorization.DecisionUnauthenticated}, nil),
-				)
-			},
-			wantErr: errUnauthorized,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
+			mockAuthenticator := authorization.NewMockAuthorizer(ctrl)
 			mockAuthorizer := authorization.NewMockAuthorizer(ctrl)
 			mockHandler := api.NewMockHandler(ctrl)
 			mockResource := resource.NewMockResource(ctrl)
 			mockResource.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
 			request := &types.ListDomainsRequest{PageSize: 10}
-			tc.mockSetup(mockAuthorizer, mockHandler, request)
+			tc.mockSetup(mockAuthenticator, mockAuthorizer, mockHandler, request)
 
-			handler := NewAPIHandler(mockHandler, mockResource, mockAuthorizer, config.Authorization{})
+			handler := NewAPIHandler(mockHandler, mockResource, mockAuthorizer, mockAuthenticator, config.Authorization{})
 			response, err := handler.ListDomains(context.Background(), request)
 
 			if tc.wantErr != nil {
@@ -339,12 +308,13 @@ func TestListDomainsAuthorization(t *testing.T) {
 	}
 }
 
+// listDomainsAuthAttr matches the attributes for a single domain, or for the endpoint
+// gate itself when domain is empty.
 func listDomainsAuthAttr(domain string) gomock.Matcher {
 	return gomock.Cond(func(attr *authorization.Attributes) bool {
 		return attr.APIName == "ListDomains" &&
 			attr.Permission == authorization.PermissionRead &&
 			attr.DomainName == domain &&
-			attr.AuthenticationOnly == (domain == "") &&
 			attr.RequestBody != nil
 	})
 }

--- a/service/frontend/wrappers/accesscontrolled/api_generated.go
+++ b/service/frontend/wrappers/accesscontrolled/api_generated.go
@@ -324,7 +324,21 @@ func (a *apiHandler) ListClosedWorkflowExecutions(ctx context.Context, lp1 *type
 }
 
 func (a *apiHandler) ListDomains(ctx context.Context, lp1 *types.ListDomainsRequest) (lp2 *types.ListDomainsResponse, err error) {
-	return a.handler.ListDomains(ctx, lp1)
+	scope := a.GetMetricsClient().Scope(metrics.FrontendListDomainsScope).Tagged(metrics.NonDomainTag())
+	attr := &authorization.Attributes{
+		APIName:            "ListDomains",
+		AuthenticationOnly: true,
+		Permission:         authorization.PermissionRead,
+		RequestBody:        authorization.NewFilteredRequestBody(lp1),
+	}
+	isAuthorized, err := a.isAuthorized(ctx, attr, scope)
+	if err != nil {
+		return nil, err
+	}
+	if !isAuthorized {
+		return nil, errUnauthorized
+	}
+	return a.listAuthorizedDomains(ctx, lp1, scope)
 }
 
 func (a *apiHandler) ListFailoverHistory(ctx context.Context, lp1 *types.ListFailoverHistoryRequest) (lp2 *types.ListFailoverHistoryResponse, err error) {

--- a/service/frontend/wrappers/accesscontrolled/api_generated.go
+++ b/service/frontend/wrappers/accesscontrolled/api_generated.go
@@ -18,24 +18,33 @@ import (
 
 // apiHandler frontend handler wrapper for authentication and authorization
 type apiHandler struct {
-	handler    _sourceApi.Handler
-	authorizer authorization.Authorizer
+	handler       _sourceApi.Handler
+	authorizer    authorization.Authorizer
+	authenticator authorization.Authorizer
 	resource.Resource
 }
 
 // NewAPIHandler creates frontend handler with authentication support
-func NewAPIHandler(handler _sourceApi.Handler, resource resource.Resource, authorizer authorization.Authorizer, cfg config.Authorization) _sourceApi.Handler {
-	if authorizer == nil {
-		var err error
+func NewAPIHandler(handler _sourceApi.Handler, resource resource.Resource, authorizer authorization.Authorizer, authenticator authorization.Authorizer, cfg config.Authorization) _sourceApi.Handler {
+	// Built together so that they share one token validator, which matters when the
+	// configured scheme fetches verification keys from a remote endpoint.
+	var err error
+	switch {
+	case authorizer == nil && authenticator == nil:
+		authorizer, authenticator, err = authorization.NewAuthorizerAndAuthenticator(cfg, resource.GetLogger(), resource.GetDomainCache())
+	case authorizer == nil:
 		authorizer, err = authorization.NewAuthorizer(cfg, resource.GetLogger(), resource.GetDomainCache())
-		if err != nil {
-			resource.GetLogger().Fatal("Error when initiating the Authorizer", tag.Error(err))
-		}
+	case authenticator == nil:
+		authenticator, err = authorization.NewAuthenticator(cfg, resource.GetLogger())
+	}
+	if err != nil {
+		resource.GetLogger().Fatal("Unable to initialize access control", tag.Error(err))
 	}
 	return &apiHandler{
-		handler:    handler,
-		authorizer: authorizer,
-		Resource:   resource,
+		handler:       handler,
+		authorizer:    authorizer,
+		authenticator: authenticator,
+		Resource:      resource,
 	}
 }
 
@@ -326,19 +335,18 @@ func (a *apiHandler) ListClosedWorkflowExecutions(ctx context.Context, lp1 *type
 func (a *apiHandler) ListDomains(ctx context.Context, lp1 *types.ListDomainsRequest) (lp2 *types.ListDomainsResponse, err error) {
 	scope := a.GetMetricsClient().Scope(metrics.FrontendListDomainsScope).Tagged(metrics.NonDomainTag())
 	attr := &authorization.Attributes{
-		APIName:            "ListDomains",
-		AuthenticationOnly: true,
-		Permission:         authorization.PermissionRead,
-		RequestBody:        authorization.NewFilteredRequestBody(lp1),
+		APIName:     "ListDomains",
+		Permission:  authorization.PermissionRead,
+		RequestBody: authorization.NewFilteredRequestBody(lp1),
 	}
-	isAuthorized, err := a.isAuthorized(ctx, attr, scope)
+	isAuthorized, err := a.isAuthenticated(ctx, attr, scope)
 	if err != nil {
 		return nil, err
 	}
 	if !isAuthorized {
 		return nil, errUnauthorized
 	}
-	return a.listAuthorizedDomains(ctx, lp1, scope)
+	return a.listAuthorizedDomains(ctx, lp1)
 }
 
 func (a *apiHandler) ListFailoverHistory(ctx context.Context, lp1 *types.ListFailoverHistoryRequest) (lp2 *types.ListFailoverHistoryResponse, err error) {


### PR DESCRIPTION
**What changed?**

Added access-control handling for `ListDomains` to prevent unauthorized domain enumeration. Fixes https://github.com/cadence-workflow/cadence/issues/7823.

- Added an optional authentication-only `Authorizer` that checks caller credentials before fetching domains. The built-in OAuth implementation validates JWTs; the no-op implementation preserves behavior when authorization is disabled.
- Preserved the existing `Authorizer` interface. Existing custom-authorizer deployments are not required to implement or supply a new authenticator. The optional authenticator lets custom-authorizer deployments opt into authentication before fetching domains without making a new implementation mandatory for existing deployments.
- Added per-domain `PermissionRead` checks and filtered denied domains from responses, preserving `NextPageToken`.
- Shared one token validator between the built-in OAuth authorizer and authenticator, including one initial JWKS fetch and a shared key set. JWT verification still runs at the authentication gate and for each domain check.
- Regenerated the frontend access-controlled wrapper and added tests for authentication, filtering, pagination, error propagation, and shared validator construction.
- Request authentication and authorization checks record latency, unauthorized-request counts, and authorization-failure counts. Per-domain filtering uses a separate helper without those metrics; denied domains are filtered out and errors still propagate to the caller.

**Why?**

`ListDomains` previously bypassed access control and returned domain metadata without authorization checks. Because the request names no domain, OAuth credentials are checked through a separate authentication-only authorizer before fetching the page. Each domain is then checked against the caller's read permissions.

**How did you test it?**

Ran the focused authorization and wrapper tests:

```bash
go test -race -count=1 \
  ./common/authorization \
  ./service/frontend/wrappers/accesscontrolled
```

Also ran all frontend wrapper tests:

```bash
go test -count=1 ./service/frontend/wrappers/...
```

**Potential risks**

- OAuth-enabled Cadence Web deployments need a version containing https://github.com/cadence-workflow/cadence-web/pull/1524 before rolling out this server change. The affected domains page does not forward the user's JWT during server-side rendering, so it receives `AccessDenied` even when the user is authenticated in Web.
- Callers can receive an empty domains slice with a non-empty `NextPageToken`. Clients must continue pagination while a token is present to reach authorized domains on later pages.
- Deployments injecting `resource.Params.Authorizer` need to supply a matching `resource.Params.Authenticator` to reject unauthenticated requests before fetching domains. Supplying it is optional: nil falls back to configured authentication. With OAuth disabled, that fallback is a no-op. Per-domain checks still use the custom authorizer and filter denied domains. To enforce authentication, custom deployments can supply a matching resource.Params.Authenticator
- Each returned domain adds an authorization invocation and, with the built-in OAuth implementation, another JWT verification.
- Direct Go callers of the frontend access-controlled `NewAPIHandler` constructor need to pass the new authenticator argument; nil selects the configured fallback. No RPC/IDL or persistence schema changes are introduced.

**Release notes**

- `ListDomains` now returns only domains the caller is authorized to read. With built-in OAuth enabled, it also rejects unauthenticated requests before fetching domains. Fixes https://github.com/cadence-workflow/cadence/issues/7823.
- OAuth-enabled Cadence Web deployments must first upgrade to a version containing https://github.com/cadence-workflow/cadence-web/pull/1524.
- Custom-authorizer deployments can supply an optional matching authenticator to enforce authentication before fetching domains. Existing deployments can continue running without one.

**Documentation Changes**

Updated `common/authorization/README.md` to explain the authentication-only authorizer, shared OAuth validator, custom authenticator injection, and nil fallback behavior. Authenticating once per request and passing identity to authorization remains future work.

