### PR TITLE
chore(history): Add logs for the execution of activity retry timer tasks

### DIFF
--- a/service/history/ndc/activity_replicator.go
+++ b/service/history/ndc/activity_replicator.go
@@ -82,8 +82,8 @@ func (r *activityReplicatorImpl) SyncActivity(
 	// sync activity info will only be sent from active side, when
 	// 1. activity has retry policy and activity got started
 	// 2. activity heart beat
-	// no sync activity task will be sent when active side fail / timeout activity,
-	// since standby side does not have activity retry timer
+	// 3. activity fails with a retriable error (triggers retry backoff)
+	// Terminal failures and timeouts are replicated as history events instead.
 	domainID := request.GetDomainID()
 	workflowExecution := types.WorkflowExecution{
 		WorkflowID: request.WorkflowID,

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -753,12 +753,6 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 		return err
 	}
 	if !shouldPush {
-		t.logger.Warn("Activity retry timer task skipped: not pushing to matching",
-			tag.WorkflowID(task.WorkflowID),
-			tag.WorkflowRunID(task.RunID),
-			tag.WorkflowDomainID(task.DomainID),
-			tag.WorkflowScheduleID(scheduledID),
-		)
 		return nil
 	}
 

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -705,6 +705,14 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 	}
 	ok, err = verifyTaskVersion(t.shard, t.logger, task.DomainID, activityInfo.Version, task.Version, task)
 	if err != nil || !ok {
+		if err == nil {
+			t.logger.Debug("Activity retry timer task skipped: version mismatch",
+				tag.WorkflowID(task.WorkflowID),
+				tag.WorkflowRunID(task.RunID),
+				tag.WorkflowDomainID(task.DomainID),
+				tag.WorkflowScheduleID(scheduledID),
+			)
+		}
 		return err
 	}
 
@@ -745,6 +753,12 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 		return err
 	}
 	if !shouldPush {
+		t.logger.Warn("Activity retry timer task skipped: not pushing to matching",
+			tag.WorkflowID(task.WorkflowID),
+			tag.WorkflowRunID(task.RunID),
+			tag.WorkflowDomainID(task.DomainID),
+			tag.WorkflowScheduleID(scheduledID),
+		)
 		return nil
 	}
 

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -125,8 +125,15 @@ func (t *timerStandbyTaskExecutor) Execute(task Task) (ExecuteResponse, error) {
 		defer cancel()
 		return executeResponse, t.executeWorkflowTimeoutTask(ctx, timerTask)
 	case *persistence.ActivityRetryTimerTask:
-		// retry backoff timer should not get created on passive cluster
-		// TODO: add error logs
+		t.logger.Warn("Activity retry timer task on standby cluster will be dropped",
+			tag.WorkflowDomainID(timerTask.DomainID),
+			tag.WorkflowID(timerTask.WorkflowID),
+			tag.WorkflowRunID(timerTask.RunID),
+			tag.WorkflowScheduleID(timerTask.EventID),
+			tag.ScheduleAttempt(timerTask.Attempt),
+			tag.TaskVisibilityTimestamp(timerTask.VisibilityTimestamp.UnixNano()),
+		)
+		scope.IncCounter(metrics.TaskDiscarded)
 		return executeResponse, nil
 	case *persistence.WorkflowBackoffTimerTask:
 		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)


### PR DESCRIPTION
**What changed?**

Added warn-level logging and a TaskDiscarded counter metric when the standby timer executor drops an ActivityRetryTimerTask, added logging for two other silent skip paths in the active retry-timer executor. 

**Why?**

During domain failover, it is possible for an activity retry to be permanently lost when the standby cluster's timer executor silently drops an ActivityRetryTimerTask. Diagnosis required inferring the cause from the absence of logs. 

Three improvements:

1. Emit a warn log carrying and increment the TaskDiscarded counter on the when the timer is dropped.
2. Added a debug log when verifyTaskVersion skips a retry timer due to version mismatch, and a warn log when shouldPushToMatching returns false. The retry-dispatch path is now fully accounted for in logs.

How did you test it?

go build ./service/history/task/... ./service/history/ndc/...
go test -race -count=1 -run "TestTimerStandbyTaskExecutorSuite|TestTimerActiveTaskExecutorSuite" ./service/history/task/...

Potential risks

N/A All changes are metrics/logging related. 

Release notes

N/A

Documentation Changes

N/A