### PR TITLE
feat(schema): add new token-ownership table schema

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -624,3 +624,40 @@ CREATE TABLE semaphore_metadata (
 ) WITH compaction = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
 };
+
+-- Distributed semaphore: per-token ownership with an inline reverse index.
+--
+-- Each bucket (domain_id, semaphore_name, bucket) is its own Cassandra partition, written by a
+-- single owning Matching host. A partition holds TWO kinds of row, told apart by `type`, and the
+-- four columns token_id / owner_id / holder / held_token mean different things in each kind:
+--
+--   type = token  (forward index, keyed by token_id): "who holds slot token_id?"
+--       token_id   = slot id in [1, size]                    <- the key
+--       holder     = current holder's owner_id, or FREE      (LWT-guarded on grant/release)
+--       owner_id   = OWNER_NONE sentinel                     (not used by this kind)
+--       held_token = TOKEN_NONE sentinel                     (not used by this kind)
+--
+--   type = owner  (reverse index, keyed by owner_id): "which slot does this hold own?"
+--       owner_id   = the hold's identity, length-prefixed workflow_id:run_id:hold_id  <- the key
+--       held_token = the token_id this owner currently holds
+--       token_id   = TOKEN_NONE sentinel                     (not used by this kind)
+--       holder     = OWNER_NONE sentinel                     (not used by this kind)
+--
+-- The roles flip between the two kinds: a token row keys on token_id and names its holder; an owner
+-- row keys on owner_id and names its held_token. Grant and release write the token row and its
+-- matching owner row in ONE atomic batch on the same partition, so the forward and reverse views
+-- can never diverge.
+CREATE TABLE semaphore_tokens (
+    domain_id       uuid,       -- domain that owns the semaphore
+    semaphore_name  text,       -- user-chosen semaphore name
+    bucket          int,        -- static bucket = f(owner_id); one Cassandra partition per bucket
+    type            int,        -- rowKind {token, owner}: forward row vs reverse-index row
+    token_id        int,        -- token row: slot id [1,size]; owner row: TOKEN_NONE sentinel
+    owner_id        text,       -- owner row: the holder's identity; token row: OWNER_NONE sentinel
+    holder          text,       -- token row: current holder or FREE (LWT-guarded); owner row: OWNER_NONE sentinel
+    held_token      int,        -- owner row: the token this owner holds; token row: TOKEN_NONE sentinel
+    updated_time    timestamp,  -- set on grant and on release (held-since / free-since)
+    PRIMARY KEY ((domain_id, semaphore_name, bucket), type, token_id, owner_id)
+) WITH compaction = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+};

--- a/schema/cassandra/cadence/versioned/v0.51/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.51/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.51",
+  "MinCompatibleVersion": "0.51",
+  "Description": "Add semaphore_tokens table",
+  "SchemaUpdateCqlFiles": [
+    "semaphore_tokens.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.51/semaphore_tokens.cql
+++ b/schema/cassandra/cadence/versioned/v0.51/semaphore_tokens.cql
@@ -1,0 +1,36 @@
+-- Distributed semaphore: per-token ownership with an inline reverse index.
+--
+-- Each bucket (domain_id, semaphore_name, bucket) is its own Cassandra partition, written by a
+-- single owning Matching host. A partition holds TWO kinds of row, told apart by `type`, and the
+-- four columns token_id / owner_id / holder / held_token mean different things in each kind:
+--
+--   type = token  (forward index, keyed by token_id): "who holds slot token_id?"
+--       token_id   = slot id in [1, size]                    <- the key
+--       holder     = current holder's owner_id, or FREE      (LWT-guarded on grant/release)
+--       owner_id   = OWNER_NONE sentinel                     (not used by this kind)
+--       held_token = TOKEN_NONE sentinel                     (not used by this kind)
+--
+--   type = owner  (reverse index, keyed by owner_id): "which slot does this hold own?"
+--       owner_id   = the hold's identity, length-prefixed workflow_id:run_id:hold_id  <- the key
+--       held_token = the token_id this owner currently holds
+--       token_id   = TOKEN_NONE sentinel                     (not used by this kind)
+--       holder     = OWNER_NONE sentinel                     (not used by this kind)
+--
+-- The roles flip between the two kinds: a token row keys on token_id and names its holder; an owner
+-- row keys on owner_id and names its held_token. Grant and release write the token row and its
+-- matching owner row in ONE atomic batch on the same partition, so the forward and reverse views
+-- can never diverge.
+CREATE TABLE semaphore_tokens (
+    domain_id       uuid,       -- domain that owns the semaphore
+    semaphore_name  text,       -- user-chosen semaphore name
+    bucket          int,        -- static bucket = f(owner_id); one Cassandra partition per bucket
+    type            int,        -- rowKind {token, owner}: forward row vs reverse-index row
+    token_id        int,        -- token row: slot id [1,size]; owner row: TOKEN_NONE sentinel
+    owner_id        text,       -- owner row: the holder's identity; token row: OWNER_NONE sentinel
+    holder          text,       -- token row: current holder or FREE (LWT-guarded); owner row: OWNER_NONE sentinel
+    held_token      int,        -- owner row: the token this owner holds; token row: TOKEN_NONE sentinel
+    updated_time    timestamp,  -- set on grant and on release (held-since / free-since)
+    PRIMARY KEY ((domain_id, semaphore_name, bucket), type, token_id, owner_id)
+) WITH compaction = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+};

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -25,7 +25,7 @@ import "github.com/uber/cadence/schema/common"
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.50"
+const Version = "0.51"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.10"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49", "v0.50"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49", "v0.50", "v0.51"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**Detailed Description**
Adds a new Cassandra table as a `v0.51` schema migration: a per-token ownership table with an inline reverse index. 

**Impact Analysis**
- **Backward Compatibility**: Fully backward compatible. The change is a purely additive `CREATE TABLE`; existing tables, reads, and writes are untouched. 
- **Forward Compatibility**: Safe. Additive and reversible. Future persistence layer code will read/write this table, so the v0.51 migration must be applied before that code is enabled. The migration can be reverted by dropping the table while it is empty.

**Testing Plan**
- **Unit Tests**: Yes. `go test ./schema/... ./tools/common/schema/...` covers version_test and updatetask_test with the new v0.51 entry.
- **Persistence Tests**: N/A for this PR. This is schema-only
- **Integration Tests**: N/A. No runtime code path touches the table, so there is no end-to-end behavior to integration-test in this PR.
- **Compatibility Tests**:  No data migration or column change means there is no read/write compatibility surface to test.

**Rollout Plan**
- Rollout plan: Apply the v0.51 schema migration to the Cassandra cluster. No server code reads or writes the table yet, so the table is inert after the migration.
- Does deployment order matter?: Not for this PR (nothing consumes the table). Going forward, apply the schema migration before deploying any code that uses the table — schema first, then binaries.
- Is it safe to rollback? Does order matter?: Yes, safe. Rolling back binaries leaves an empty, unused additive table behind (harmless). The table can be dropped while empty. Rollback order does not matter because no code depends on it.
- Kill switch: The new feature will be gated by a dynamic-config flag (shipped off) with its consumers; until that lands the table is inert regardless of deployment state, so nothing needs mitigating.