### PR TITLE
chore: Move blank imports to main.go or *_test.go files

### DIFF
--- a/.gitar/rules/blank-imports-library.md
+++ b/.gitar/rules/blank-imports-library.md
@@ -1,0 +1,178 @@
+---
+title: Blank Imports in Library Code
+description: Prevents blank imports (side-effect imports) in library code to avoid registration conflicts and initialization issues
+when: PR adds or modifies Go files with blank imports
+actions: Detect blank imports in common/*, service/*, and plugin packages; recommend moving to main.go
+---
+
+# Blank Imports in Library Code
+
+Blank imports (`import _`) execute `init()` functions with global side effects. When used in library code that gets imported transitively, they cause:
+
+1. **Registration conflicts** - "driver already registered" panics when multiple libraries register the same driver
+2. **Order-of-initialization bugs** - unpredictable execution order across packages
+3. **Implicit dependencies** - side effects that are hard to track and debug
+4. **Custom build issues** - proprietary builds may need different initialization
+
+See `AGENTS.md` Coding Best Practices section for full context.
+
+## Overview
+
+When evaluating a pull request:
+
+1. **Check for blank imports in library code** - `common/**/*.go`, `service/**/*.go`, plugin packages
+2. **Verify blank imports are only in allowed locations** - `cmd/**/main.go`, `*_test.go`, `internal/tools.go`
+3. **Recommend moving to main.go** when violations are found
+
+## Detection Logic
+
+### Step 1: Identify Go files with blank imports
+
+Scan the PR diff for files matching `**/*.go` (excluding `*_test.go` for now) that contain:
+
+```go
+import (
+    _ "some/package"
+)
+```
+
+or
+
+```go
+import _ "some/package"
+```
+
+Look for the blank identifier `_` followed by a quoted import path.
+
+### Step 2: Categorize by location
+
+For each file with blank imports, determine if it's in:
+
+**Prohibited locations (flag these):**
+- `common/**/*.go` - shared library code
+- `service/**/*.go` - business logic
+- Plugin packages: `common/persistence/sql/sqlplugin/**/*.go`, `common/persistence/nosql/nosqlplugin/**/*.go`
+- Any other non-main package under the repository root
+
+**Allowed locations (don't flag):**
+- `cmd/**/main.go` - entry points with explicit initialization control
+- `internal/tools.go` - build tool dependencies
+- `*_test.go` - test files (allow but note in summary if excessive)
+
+### Step 3: Identify common violating patterns
+
+**Common blank imports that violate the rule:**
+
+Database drivers:
+- `_ "github.com/lib/pq"` (PostgreSQL)
+- `_ "github.com/go-sql-driver/mysql"`
+- `_ "github.com/ncruces/go-sqlite3/driver"`
+- `_ "github.com/ncruces/go-sqlite3/embed"`
+- Any package under `database/sql` driver path
+
+Profilers:
+- `_ "net/http/pprof"`
+
+Observability:
+- `_ "go.uber.org/automaxprocs"`
+
+Any other package that calls `sql.Register()`, `http.Handle()`, or mutates global state in `init()`.
+
+### Step 4: Check if moved to main.go
+
+If a blank import was removed from library code in this PR, check if it was added to the appropriate `cmd/**/main.go`.
+
+**Good pattern:**
+```diff
+// common/persistence/sql/sqlplugin/sqlite/db.go
+- import _ "github.com/ncruces/go-sqlite3/driver"
+
+// cmd/server/main.go
++ import _ "github.com/ncruces/go-sqlite3/driver"
+```
+
+## Report Format
+
+When violations are detected, provide:
+
+1. **List of files and line numbers** with prohibited blank imports
+2. **Type of import** (driver, profiler, etc.)
+3. **Recommended fix**: where to move the import
+
+### Example Report
+
+> ⚠️ **Blank imports in library code**
+>
+> **Blank imports with global side effects are prohibited in library code**
+>
+> The following files contain blank imports that should be moved to entry points:
+>
+> **common/persistence/sql/sqlplugin/postgres/db.go:15**
+> ```go
+> import _ "github.com/lib/pq"  // PostgreSQL driver
+> ```
+> - **Problem:** Driver registration in library code causes "driver already registered" panics when custom builds also import this driver
+> - **Fix:** Remove this import and add it to `cmd/server/main.go` instead
+>
+> **common/metrics/reporter.go:8**
+> ```go
+> import _ "net/http/pprof"  // profiler registration
+> ```
+> - **Problem:** Automatically registers pprof handlers on import, affecting all builds
+> - **Fix:** Remove this import and add it to `cmd/server/main.go` (or make it opt-in via explicit initialization)
+>
+> **service/history/engine.go:12**
+> ```go
+> import _ "go.uber.org/automaxprocs"
+> ```
+> - **Problem:** Global side effect in business logic package
+> - **Fix:** Move to `cmd/server/main.go`
+>
+> **Why this matters:**
+> - Blank imports execute `init()` functions with global side effects
+> - Library code should be side-effect free to support multiple builds and prevent conflicts
+> - Entry points (`cmd/**/main.go`) have explicit control over initialization order
+> - See `AGENTS.md` Coding Best Practices → Blank Imports section
+>
+> **Allowed locations for blank imports:**
+> - ✅ `cmd/**/main.go` - entry points
+> - ✅ `internal/tools.go` - build tool dependencies
+> - ⚠️ `*_test.go` - test setup (use sparingly)
+
+### Example for tests with many blank imports
+
+> 📊 **Note: Test files with blank imports**
+>
+> The following test files use blank imports (allowed, but consider explicit setup):
+>
+> - `service/history/engine_test.go:10` - imports test driver
+> - `common/persistence/sql/sql_test.go:15` - imports multiple drivers
+>
+> Consider: Explicit setup in `TestMain()` or test helpers for better control over initialization.
+
+## Skip Conditions
+
+Skip this rule when **ANY** of these is true:
+
+### 1. No Go files modified
+- PR only changes non-Go files (markdown, yaml, proto, etc.)
+
+### 2. Only allowed files modified
+- All Go files with blank imports are `cmd/**/main.go`, `internal/tools.go`, or `*_test.go`
+
+### 3. Blank imports being removed
+- PR removes blank imports from library code (this is good!)
+- Still report if they weren't moved to appropriate location
+
+## Integration with Development Workflow
+
+This rule complements:
+- `AGENTS.md` Coding Best Practices - provides the full pattern
+- `make lint` - catches some import issues
+- Code review - maintainers verify initialization boundaries
+
+## References
+
+- `AGENTS.md` - Coding Best Practices → Blank Imports section
+- Go best practice: blank imports should only be in main packages or for tools
+- Database driver registration: https://go.dev/doc/database/open-handle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,22 @@ go test -race -run TestFoo ./path/to/pkg/...  # run a specific test
   - Files in `.gen/` are generated from IDL — do not edit manually.
   - Never use yarpcerrors directly in handler logic; instead, create an new Error type in IDL and map to internal ones under common/type/errors.go.
 
+- **Blank Imports (Side-Effect Imports)**:
+  - **NEVER** use blank imports (`import _`) in library code under `common/`, `service/`, or any package that gets imported transitively.
+  - Blank imports execute `init()` functions with global side effects (driver registration, flag registration, global state mutation).
+  - These cause problems: registration conflicts ("driver already registered"), order-of-initialization bugs, implicit dependencies, and issues in custom builds.
+  - **Blank imports are ONLY allowed in:**
+    - `cmd/**/main.go` — entry points with explicit control over initialization
+    - `*_test.go` — test setup (use sparingly, prefer explicit setup)
+    - `internal/tools.go` — build tool dependencies pinned in `go.mod`
+  - **Examples of prohibited blank imports in library code:**
+    - Database drivers: `_ "github.com/lib/pq"`, `_ "github.com/ncruces/go-sqlite3/driver"`
+    - Profilers: `_ "net/http/pprof"`
+    - Flag packages: `_ "github.com/some/flags"`
+    - Any package that registers global state in `init()`
+  - **What to do instead:** Move the blank import to `cmd/server/main.go` or the appropriate entry point.
+  - **Example:** `common/persistence/sql/sqlplugin/sqlite/db.go` should NOT import drivers. Instead, `cmd/server/main.go` imports both the plugin package AND the driver.
+
 ## Architecture Guidelines
 
 **Core Principle**: Cadence must support both the standard open-source build and custom builds from a single codebase. Different builds may use different libraries (e.g., open-source Kafka client vs. company-internal Kafka library). This requires strict separation between core logic and proprietary implementations.

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -52,6 +52,9 @@ import (
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/rpc"
 	"github.com/uber/cadence/common/service"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 type ServerSuite struct {

--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -69,6 +69,7 @@ require (
 
 require (
 	github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802
+	github.com/ncruces/go-sqlite3 v0.23.3
 	github.com/uber/cadence v0.0.0-00010101000000-000000000000
 	github.com/uber/cadence/common/archiver/gcloud v0.0.0-00010101000000-000000000000
 	github.com/uber/cadence/common/dynamicconfig/openfeatureprovider/unleash v0.0.0-00010101000000-000000000000
@@ -103,7 +104,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/ncruces/go-sqlite3 v0.23.3 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/open-feature/go-sdk v1.17.1 // indirect
 	github.com/open-feature/go-sdk-contrib/providers/unleash v0.1.1-alpha // indirect

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,6 +27,8 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/tools/common/commoncli"
 
+	_ "github.com/ncruces/go-sqlite3/driver"                                                // register sqlite3 driver
+	_ "github.com/ncruces/go-sqlite3/embed"                                                 // embed sqlite db
 	_ "github.com/uber/cadence/common/archiver/gcloud"                                      // needed to load the optional gcloud archiver plugin
 	_ "github.com/uber/cadence/common/asyncworkflow/queue/kafka"                            // needed to load kafka asyncworkflow queue
 	_ "github.com/uber/cadence/common/dynamicconfig/openfeatureprovider/unleash"            // needed to load the optional unleash openfeature provider plugin
@@ -36,6 +38,7 @@ import (
 	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"                      // needed to load mysql plugin
 	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/postgres"                   // needed to load postgres plugin
 	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"                     // needed to load sqlite plugin
+	_ "net/http/pprof"                                                                      // register pprof HTTP handlers
 )
 
 // main entry point for the cadence server

--- a/common/config/pprof.go
+++ b/common/config/pprof.go
@@ -28,9 +28,6 @@ import (
 
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
-
-	// DO NOT REMOVE THE LINE BELOW
-	_ "net/http/pprof"
 )
 
 type (

--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -46,6 +46,9 @@ import (
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/common/types"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 type (

--- a/common/domain/handler_NotMasterCluster_test.go
+++ b/common/domain/handler_NotMasterCluster_test.go
@@ -46,6 +46,9 @@ import (
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/common/types"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 type (

--- a/common/domain/handler_integration_test.go
+++ b/common/domain/handler_integration_test.go
@@ -49,6 +49,9 @@ import (
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/common/types"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 type (

--- a/common/domain/replication_task_executor_integration_test.go
+++ b/common/domain/replication_task_executor_integration_test.go
@@ -36,6 +36,9 @@ import (
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/common/types"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 type (

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/public/testdata.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/public/testdata.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
-
-	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra" // needed to load cassandra plugin
 )
 
 // NewTestBaseWithPublicCassandra returns a persistence test base backed by cassandra datastore

--- a/common/persistence/sql/sqlplugin/sqlite/db.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db.go
@@ -28,11 +28,6 @@ import (
 	"github.com/uber/cadence/common/persistence/sql/sqldriver"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"
-
-	// import sqlite driver
-	_ "github.com/ncruces/go-sqlite3/driver"
-	// import embed sqlite db
-	_ "github.com/ncruces/go-sqlite3/embed"
 )
 
 var (

--- a/common/persistence/sql/sqlplugin/sqlite/plugin_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/plugin_test.go
@@ -31,6 +31,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/cadence/common/config"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 func TestPlugin_CreateDB(t *testing.T) {

--- a/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 func TestSQLiteHistoryV2PersistenceSuite(t *testing.T) {

--- a/host/cassandra_lwt_test.go
+++ b/host/cassandra_lwt_test.go
@@ -88,6 +88,8 @@ import (
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/testflags"
+
+	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra" // register cassandra plugin
 )
 
 const (

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -44,6 +44,10 @@ import (
 	"github.com/uber/cadence/service/history/engine/engineimpl"
 	"github.com/uber/cadence/service/history/execution"
 	"github.com/uber/cadence/service/matching/tasklist"
+
+	_ "github.com/ncruces/go-sqlite3/driver"                                   // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"                                    // embed sqlite db for tests
+	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra" // register cassandra plugin for tests
 )
 
 func TestIntegrationSuite(t *testing.T) {

--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -46,6 +46,10 @@ import (
 	test "github.com/uber/cadence/common/testing"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/host"
+
+	_ "github.com/ncruces/go-sqlite3/driver"                                   // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"                                    // embed sqlite db for tests
+	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra" // register cassandra plugin for tests
 )
 
 var (

--- a/host/persistence/cassandra/cassandra_persistence_test.go
+++ b/host/persistence/cassandra/cassandra_persistence_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/testflags"
+
+	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra" // register cassandra plugin
 )
 
 func TestCassandraHistoryPersistence(t *testing.T) {

--- a/simulation/history/history_simulation_test.go
+++ b/simulation/history/history_simulation_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/host"
 	"github.com/uber/cadence/simulation/history/workflow"
+
+	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra" // register cassandra plugin for tests
 )
 
 const (

--- a/tools/sql/sqlite/sqlite_test.go
+++ b/tools/sql/sqlite/sqlite_test.go
@@ -37,6 +37,9 @@ import (
 	"github.com/uber/cadence/schema/sqlite"
 	"github.com/uber/cadence/tools/common/schema"
 	"github.com/uber/cadence/tools/sql"
+
+	_ "github.com/ncruces/go-sqlite3/driver" // register sqlite3 driver for tests
+	_ "github.com/ncruces/go-sqlite3/embed"  // embed sqlite db for tests
 )
 
 // Test_SetupSchema test that setup schema works for all database sqlite schemas


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Move blank imports to main.go or *_test.go files
- Update AGENTS.md to follow the rule disallowing blank imports in other places
- Create a gitar rule to catch incorrect blank imports

**Why?**
Limiting blank imports to main.go (and test files) is a widely accepted best practice in Go because it keeps side effects like driver registrations centralized and prevents lower-level packages from being tightly coupled to global states.

**How did you test it?**
make test

**Potential risks**
No.

**Release notes**
We move blank imports to `main.go`, if a customer is building their own main.go, they need to add corresponding blank imports in their `main.go` file

**Documentation Changes**
N/A
