### PR TITLE
feat(queuev2): add LTrimBySize head-eviction to InMemQueue

### DIFF
--- a/service/history/queuev2/queue_mem.go
+++ b/service/history/queuev2/queue_mem.go
@@ -47,6 +47,10 @@ type InMemQueue interface {
 	// Returns the key just past the last kept task and true if any tasks were
 	// removed, or the zero key and false if the queue was already within bounds.
 	RTrimBySize(maxSize int) (persistence.HistoryTaskKey, bool)
+	// LTrimBySize drops the OLDEST tasks from the head until Len() <= maxSize.
+	// Returns the key of the new head (the new inclusive lower bound) and true if any
+	// tasks were removed, or the zero key and false if already within bounds.
+	LTrimBySize(maxSize int) (persistence.HistoryTaskKey, bool)
 	// Clear removes all tasks.
 	Clear()
 	// Len returns the number of tasks currently in the queue.
@@ -181,6 +185,43 @@ func (q *inMemQueueImpl) RTrimBySize(maxSize int) (persistence.HistoryTaskKey, b
 	}
 
 	return q.tasks[len(q.tasks)-1].GetTaskKey().Next(), trimmed
+}
+
+// LTrimBySize truncates the queue to at most maxSize elements by dropping
+// the oldest tasks from the head, keeping the newest.
+// Returns the key of the new head (the new inclusive lower bound) or
+// MinimumHistoryTaskKey if the queue ends up empty, and true if any tasks
+// were removed, or false if the queue was already within bounds.
+func (q *inMemQueueImpl) LTrimBySize(maxSize int) (persistence.HistoryTaskKey, bool) {
+	if len(q.tasks) == 0 {
+		return persistence.MinimumHistoryTaskKey, false
+	}
+
+	if maxSize <= 0 {
+		q.tasks = nil
+		return persistence.MinimumHistoryTaskKey, true
+	}
+
+	if len(q.tasks) <= maxSize {
+		return persistence.MinimumHistoryTaskKey, false
+	}
+
+	drop := len(q.tasks) - maxSize
+	// Nil out the dropped head elements so the backing array releases references to
+	// the removed Task interface values before reslicing past them.
+	for i := 0; i < drop; i++ {
+		q.tasks[i] = nil
+	}
+	// Reslice in place rather than copy-to-a-fresh-slice (as LTrim does): the cap
+	// guard runs on every write, so copying up to maxSize retained tasks per call
+	// would cost O(maxSize) per insert instead of O(drop) (usually 1). The nil loop
+	// above already makes the dropped entries GC-eligible, so the only price paid
+	// for skipping the copy is deferred capacity reuse: the freed head slots stay
+	// part of this backing array until a future append grows past its capacity,
+	// rather than being reclaimed immediately.
+	q.tasks = q.tasks[drop:]
+
+	return q.tasks[0].GetTaskKey(), true
 }
 
 // Clear removes all tasks from the queue.

--- a/service/history/queuev2/queue_mem_mock.go
+++ b/service/history/queuev2/queue_mem_mock.go
@@ -80,6 +80,21 @@ func (mr *MockInMemQueueMockRecorder) LTrim(newInclusiveMinTaskKey any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LTrim", reflect.TypeOf((*MockInMemQueue)(nil).LTrim), newInclusiveMinTaskKey)
 }
 
+// LTrimBySize mocks base method.
+func (m *MockInMemQueue) LTrimBySize(maxSize int) (persistence.HistoryTaskKey, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LTrimBySize", maxSize)
+	ret0, _ := ret[0].(persistence.HistoryTaskKey)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// LTrimBySize indicates an expected call of LTrimBySize.
+func (mr *MockInMemQueueMockRecorder) LTrimBySize(maxSize any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LTrimBySize", reflect.TypeOf((*MockInMemQueue)(nil).LTrimBySize), maxSize)
+}
+
 // Len mocks base method.
 func (m *MockInMemQueue) Len() int {
 	m.ctrl.T.Helper()

--- a/service/history/queuev2/queue_mem_test.go
+++ b/service/history/queuev2/queue_mem_test.go
@@ -582,6 +582,130 @@ func TestInMemQueue_RTrimBySize_NilsTail(t *testing.T) {
 	}
 }
 
+func TestInMemQueue_LTrimBySize(t *testing.T) {
+	tests := []struct {
+		name        string
+		tasks       []persistence.Task
+		maxSize     int
+		wantLen     int
+		wantTaskIDs []int64
+		wantKey     persistence.HistoryTaskKey
+		wantTrimmed bool
+	}{
+		{
+			name: "queue larger than maxSize - drops oldest, keeps newest",
+			tasks: []persistence.Task{
+				newTestTask(time.Unix(10, 0), 1),
+				newTestTask(time.Unix(20, 0), 2),
+				newTestTask(time.Unix(30, 0), 3),
+				newTestTask(time.Unix(40, 0), 4),
+			},
+			maxSize:     2,
+			wantLen:     2,
+			wantTaskIDs: []int64{3, 4},
+			wantKey:     newTestTask(time.Unix(30, 0), 3).GetTaskKey(),
+			wantTrimmed: true,
+		},
+		{
+			name: "queue smaller than maxSize - no-op",
+			tasks: []persistence.Task{
+				newTestTask(time.Unix(10, 0), 1),
+				newTestTask(time.Unix(20, 0), 2),
+			},
+			maxSize:     5,
+			wantLen:     2,
+			wantTaskIDs: []int64{1, 2},
+			wantKey:     persistence.MinimumHistoryTaskKey,
+			wantTrimmed: false,
+		},
+		{
+			name: "queue exactly maxSize - no-op",
+			tasks: []persistence.Task{
+				newTestTask(time.Unix(10, 0), 1),
+				newTestTask(time.Unix(20, 0), 2),
+			},
+			maxSize:     2,
+			wantLen:     2,
+			wantTaskIDs: []int64{1, 2},
+			wantKey:     persistence.MinimumHistoryTaskKey,
+			wantTrimmed: false,
+		},
+		{
+			name:        "empty queue returns MinimumHistoryTaskKey",
+			tasks:       nil,
+			maxSize:     5,
+			wantLen:     0,
+			wantTaskIDs: nil,
+			wantKey:     persistence.MinimumHistoryTaskKey,
+			wantTrimmed: false,
+		},
+		{
+			name: "maxSize 0 empties queue",
+			tasks: []persistence.Task{
+				newTestTask(time.Unix(10, 0), 1),
+				newTestTask(time.Unix(20, 0), 2),
+			},
+			maxSize:     0,
+			wantLen:     0,
+			wantTaskIDs: nil,
+			wantKey:     persistence.MinimumHistoryTaskKey,
+			wantTrimmed: true,
+		},
+		{
+			name: "negative maxSize empties queue",
+			tasks: []persistence.Task{
+				newTestTask(time.Unix(10, 0), 1),
+			},
+			maxSize:     -1,
+			wantLen:     0,
+			wantTaskIDs: nil,
+			wantKey:     persistence.MinimumHistoryTaskKey,
+			wantTrimmed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := newInMemQueue()
+			q.PutTasks(tt.tasks)
+
+			gotKey, gotTrimmed := q.LTrimBySize(tt.maxSize)
+
+			assert.Equal(t, tt.wantLen, q.Len())
+			var gotIDs []int64
+			for _, task := range q.tasks {
+				gotIDs = append(gotIDs, task.GetTaskID())
+			}
+			assert.Equal(t, tt.wantTaskIDs, gotIDs)
+			assert.Equal(t, 0, tt.wantKey.Compare(gotKey), "expected key %v, got %v", tt.wantKey, gotKey)
+			assert.Equal(t, tt.wantTrimmed, gotTrimmed, "trimmed flag")
+		})
+	}
+}
+
+// TestInMemQueue_LTrimBySize_NilsHead verifies that LTrimBySize nils out the
+// dropped head elements of the backing array so removed Task interface values
+// are eligible for GC.
+func TestInMemQueue_LTrimBySize_NilsHead(t *testing.T) {
+	q := newInMemQueue()
+	q.PutTasks([]persistence.Task{
+		newTestTask(time.Unix(1, 0), 1),
+		newTestTask(time.Unix(2, 0), 2),
+		newTestTask(time.Unix(3, 0), 3),
+	})
+	full := q.tasks
+
+	_, trimmed := q.LTrimBySize(1)
+	assert.True(t, trimmed)
+	assert.Equal(t, 1, q.Len())
+
+	// The dropped head slots of the original backing array must be nil so the GC can
+	// collect the Task interface values they held.
+	for i := 0; i < 2; i++ {
+		assert.Nil(t, full[i], "backing array slot %d should be nil after LTrimBySize", i)
+	}
+}
+
 func TestInMemQueue_PutTasks_AppendFastPath(t *testing.T) {
 	q := newInMemQueue()
 	// Insert tasks in ascending order — all should use fast path.


### PR DESCRIPTION
**What changed?**
Adds an LTrimBySize method to the in-memory queue cache used by the history queue readers. It drops the oldest tasks from the head of the queue until the size is at or below a given limit, returning the new head key so callers can advance their lower bound.

**Why?**
This is the foundational piece for the Transfer Task Read Optimization (#8432 ) (an in-memory cached queue reader for the Transfer queue, mirroring the existing Timer queue cache). 

The Transfer cache has no prefetch cycle, so its size cap guard needs a way to evict entries overflow-safe on every write. Eviction direction is opposite to the timer cache's tail-trim: newest tasks are kept because healthy, high-volume domains keep producing new tasks while stalled domains simply fall through to persistence reads, so evicting from the head (oldest) rather than the tail keeps the cache useful for active work. This method is unused by production code paths until the cached reader and its wiring land in follow-up changes.

**How did you test it?**
```
go test ./service/history/queuev2/...
```

**Potential risks**
None. This change only adds a new method to an existing interface and its implementation; nothing in production code calls it yet.

**Release notes**
N/A - internal implementation detail, not user facing.

**Documentation Changes**
N/A
