### PR TITLE
ci(history-simulation): make scheduled_cache_enabled scenario required

### DIFF
--- a/.github/workflows/history-simulation.yml
+++ b/.github/workflows/history-simulation.yml
@@ -17,9 +17,6 @@ jobs:
           - queuev2
           - queuev2_scheduled_cache_enabled
           - queuev2_split
-        include:
-          - scenario: queuev2_scheduled_cache_enabled
-            experimental: true
     continue-on-error: ${{ matrix.experimental == true }}
 
     steps:


### PR DESCRIPTION
**What changed?**

Removes `queuev2_scheduled_cache_enabled` from the `experimental` matrix include in `history-simulation.yml`, so the scenario runs like the other three (no `continue-on-error`).

**Why?**

This scenario exercises the `CachedQueueReader` timer-task-read optimization from #7953. It was marked experimental when history simulation CI coverage was first added (#8152), since the cache feature was new at the time. It has passed consistently on every run since (checked runs from 2026-08-04 through 2026-08-13), so it should gate CI like the other scenarios instead of silently continuing on failure.

**How did you test it?**

Reviewed recent workflow runs on master and feature branches with `gh run view <id> --json jobs -q '.jobs[] | select(.name | contains("scheduled_cache_enabled"))'` — the job has been green every time. This PR's own CI run will exercise all four scenarios non-experimentally.

**Potential risks**

N/A — CI-only change, no production code touched.

**Release notes**

N/A — internal CI configuration change.

**Documentation Changes**

N/A
