### PR TITLE
feat(schema): add new tasks table schema

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -363,8 +363,7 @@ CREATE TYPE checksum (
 CREATE TYPE semaphore_task (
     workflow_id  text,
     run_id       uuid,
-    hold_id      bigint,  -- identifies this specific hold
-    schedule_id  bigint
+    hold_id      bigint  -- identifies this hold
 );
 
 CREATE TABLE executions (

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -662,31 +662,28 @@ CREATE TABLE semaphore_tokens (
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
 };
 
--- Distributed semaphore: per-bucket FIFO waiter queue for ungranted acquires.
+-- Distributed semaphore: per-bucket FIFO queue of ungranted acquires. Each full bucket
+-- (domain_id, semaphore_name, bucket) enqueues acquires as waiters ordered by task_id; the bucket's
+-- single owning Matching host drains the head on each release, reusing the tasks range_id fence.
 --
--- When a bucket (domain_id, semaphore_name, bucket) has no free token, an acquire cannot be
--- granted immediately and is enqueued here as a waiter, ordered by task_id (arrival). The
--- bucket's single owning Matching host drains the head of this queue on each release. The
--- framing is "a semaphore is a special task type", so this reuses Matching's durable task
--- machinery: the range_id single-writer fence and the background task reader.
+-- `type` tells the two row kinds apart (ints match the tasks rowType convention):
+--   control row (type = 1): holds range_id, the fence every waiter write CAS-checks (rejects a
+--          stale host after an owner handoff).
+--   waiter row  (type = 0): one queued acquire.
 --
--- A partition holds TWO kinds of row, told apart by `type`:
---   type = TaskList (control row): carries range_id, the single-writer fence. Every waiter
---          write CAS-checks range_id, so a stale host (after an owner handoff) is rejected.
---   type = Task     (waiter row):  one queued, ungranted acquire, ordered by task_id.
---
--- Removal is an explicit delete at grant; a waiter past its acquire_deadline is skipped by the
--- reader and reaped by a per-row TTL (set at write time to acquire_deadline plus a margin). The
--- TTL is never table-level: that would also expire the control row and lose the fence.
+-- A waiter is removed on grant, or reaped by a per-row TTL. The TTL is never table-level, which
+-- would expire the control row and lose the fence.
 CREATE TABLE semaphore_tasks (
     domain_id         uuid,          -- domain that owns the semaphore
     semaphore_name    text,          -- user-chosen semaphore name
     bucket            int,           -- static bucket = f(owner_id); one queue per bucket
-    type              int,           -- rowType {Task, TaskList}: waiter row vs control row
+    type              int,           -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
     task_id           bigint,        -- FIFO order within the bucket (arrival)
     range_id          bigint,        -- single-writer fence, carried on the control row
     task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
-    acquire_deadline  timestamp,     -- waitTimeout; reader skips rows past it, per-row TTL is a backstop
+    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted. Past it,
+                                     -- the reader skips the row and a per-row TTL reaps it.
+                                     -- NULL = never gives up (a healing re-acquire; no TTL either).
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -670,20 +670,16 @@ CREATE TABLE semaphore_tokens (
 --   control row (type = 1): holds range_id, the fence every waiter write CAS-checks (rejects a
 --          stale host after an owner handoff).
 --   waiter row  (type = 0): one queued acquire.
---
--- A waiter is removed on grant, or reaped by a per-row TTL. The TTL is never table-level, which
--- would expire the control row and lose the fence.
 CREATE TABLE semaphore_tasks (
-    domain_id         uuid,          -- domain that owns the semaphore
-    semaphore_name    text,          -- user-chosen semaphore name
+    domain_id         uuid,          
+    semaphore_name    text,          
     bucket            int,           -- static bucket = f(owner_id); one queue per bucket
     type              int,           -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
-    task_id           bigint,        -- FIFO order within the bucket (arrival)
+    task_id           bigint,        
     range_id          bigint,        -- single-writer fence, carried on the control row
     task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
-    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted. Past it,
-                                     -- the reader skips the row and a per-row TTL reaps it.
-                                     -- NULL = never gives up (a healing re-acquire; no TTL either).
+    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted
+                                     -- No deadline meas no skip and no TTL
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -661,3 +661,34 @@ CREATE TABLE semaphore_tokens (
 ) WITH compaction = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
 };
+
+-- Distributed semaphore: per-bucket FIFO waiter queue for ungranted acquires.
+--
+-- When a bucket (domain_id, semaphore_name, bucket) has no free token, an acquire cannot be
+-- granted immediately and is enqueued here as a waiter, ordered by task_id (arrival). The
+-- bucket's single owning Matching host drains the head of this queue on each release. The
+-- framing is "a semaphore is a special task type", so this reuses Matching's durable task
+-- machinery: the range_id single-writer fence and the background task reader.
+--
+-- A partition holds TWO kinds of row, told apart by `type`:
+--   type = TaskList (control row): carries range_id, the single-writer fence. Every waiter
+--          write CAS-checks range_id, so a stale host (after an owner handoff) is rejected.
+--   type = Task     (waiter row):  one queued, ungranted acquire, ordered by task_id.
+--
+-- Removal is an explicit delete at grant; a waiter past its acquire_deadline is skipped by the
+-- reader and reaped by a per-row TTL (set at write time to acquire_deadline plus a margin). The
+-- TTL is never table-level: that would also expire the control row and lose the fence.
+CREATE TABLE semaphore_tasks (
+    domain_id         uuid,          -- domain that owns the semaphore
+    semaphore_name    text,          -- user-chosen semaphore name
+    bucket            int,           -- static bucket = f(owner_id); one queue per bucket
+    type              int,           -- rowType {Task, TaskList}: waiter row vs control row
+    task_id           bigint,        -- FIFO order within the bucket (arrival)
+    range_id          bigint,        -- single-writer fence, carried on the control row
+    task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
+    acquire_deadline  timestamp,     -- waitTimeout; reader skips rows past it, per-row TTL is a backstop
+    created_time      timestamp,
+    PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
+) WITH compaction = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+};

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -359,6 +359,14 @@ CREATE TYPE checksum (
   value   blob, -- checksum bytes
 );
 
+-- A queued semaphore acquire waiting for a token in a bucket
+CREATE TYPE semaphore_task (
+    workflow_id  text,
+    run_id       uuid,
+    hold_id      bigint,  -- identifies this specific hold
+    schedule_id  bigint
+);
+
 CREATE TABLE executions (
   shard_id                       int,
   type                           int, -- enum RowType { Shard, Execution, TransferTask, TimerTask, ReplicationTask, CrossClusterTask}
@@ -661,19 +669,21 @@ CREATE TABLE semaphore_tokens (
 -- single owning Matching host drains the head on each release, reusing the tasks range_id fence.
 --
 -- `type` tells the two row kinds apart (ints match the tasks rowType convention):
---   control row (type = 1): holds range_id, the fence every waiter write CAS-checks (rejects a
---          stale host after an owner handoff).
+--   control row (type = 1): holds range_id (the fence every waiter write CAS-checks, rejecting a
+--          stale host after an owner handoff) and ack_level (the completed-through read cursor).
 --   waiter row  (type = 0): one queued acquire.
 CREATE TABLE semaphore_tasks (
     domain_id         uuid,
     semaphore_name    text,
-    bucket            int,           -- static bucket = f(owner_id); one queue per bucket
-    type              int,           -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
+    bucket            int,                    -- static bucket = f(owner_id); one queue per bucket
+    type              int,                    -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
     task_id           bigint,
-    range_id          bigint,        -- single-writer fence, carried on the control row
-    task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
-    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted
-                                     -- No deadline means no skip and no TTL
+    range_id          bigint,                 -- single-writer fence, carried on the control row
+    ack_level         bigint,                 -- control row: waiters with task_id <= this are granted/expired and
+                                              -- range-deleted; the reader reads above it, never scanning acked tombstones
+    task              frozen<semaphore_task>, -- the queued acquire's identity (owner_id parts + acquire handle)
+    acquire_deadline  timestamp,              -- the time this waiter gives up if still not granted
+                                              -- No deadline means no skip and no TTL
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -615,8 +615,8 @@ CREATE TABLE history_task_dlq_ack_level (
 -- Partitioned by domain_id so all semaphores in a domain list together; clustered by semaphore_name.
 -- Source of truth for size and bucket_size (which derive N = ceil(size / bucket_size)).
 CREATE TABLE semaphore_metadata (
-    domain_id         uuid,      -- domain that owns the semaphore
-    semaphore_name    text,      -- user-chosen semaphore name
+    domain_id         uuid,
+    semaphore_name    text,
     size              int,       -- total capacity (max concurrent tokens)
     bucket_size       int,       -- tokens per bucket (per-host budget); sets N = ceil(size / bucket_size)
     created_time      timestamp,
@@ -627,36 +627,30 @@ CREATE TABLE semaphore_metadata (
 
 -- Distributed semaphore: per-token ownership with an inline reverse index.
 --
--- Each bucket (domain_id, semaphore_name, bucket) is its own Cassandra partition, written by a
--- single owning Matching host. A partition holds TWO kinds of row, told apart by `type`, and the
--- four columns token_id / owner_id / holder / held_token mean different things in each kind:
+-- Each bucket (domain_id, semaphore_name, bucket) is one Cassandra partition, written by its single
+-- owning Matching host. `type` splits the partition into two row kinds that reuse the same four
+-- columns (token_id / owner_id / holder / held_token) for opposite roles:
 --
---   type = token  (forward index, keyed by token_id): "who holds slot token_id?"
---       token_id   = slot id in [1, size]                    <- the key
---       holder     = current holder's owner_id, or FREE      (LWT-guarded on grant/release)
---       owner_id   = OWNER_NONE sentinel                     (not used by this kind)
---       held_token = TOKEN_NONE sentinel                     (not used by this kind)
+--   token row (type = token): forward index keyed by token_id — "who holds this slot?"
+--       token_id = slot id in [1, size] (the key); holder = holder's owner_id, or FREE (LWT-guarded).
+--       owner_id, held_token = unused sentinels (OWNER_NONE, TOKEN_NONE).
 --
---   type = owner  (reverse index, keyed by owner_id): "which slot does this hold own?"
---       owner_id   = the hold's identity, length-prefixed workflow_id:run_id:hold_id  <- the key
---       held_token = the token_id this owner currently holds
---       token_id   = TOKEN_NONE sentinel                     (not used by this kind)
---       holder     = OWNER_NONE sentinel                     (not used by this kind)
+--   owner row (type = owner): reverse index keyed by owner_id — "which slot does this hold own?"
+--       owner_id = hold identity, length-prefixed workflow_id:run_id:hold_id (the key); held_token = its token_id.
+--       token_id, holder = unused sentinels (TOKEN_NONE, OWNER_NONE).
 --
--- The roles flip between the two kinds: a token row keys on token_id and names its holder; an owner
--- row keys on owner_id and names its held_token. Grant and release write the token row and its
--- matching owner row in ONE atomic batch on the same partition, so the forward and reverse views
--- can never diverge.
+-- Grant and release write the paired token row and owner row in ONE atomic batch on the partition,
+-- so the forward and reverse views can never diverge.
 CREATE TABLE semaphore_tokens (
-    domain_id       uuid,       -- domain that owns the semaphore
-    semaphore_name  text,       -- user-chosen semaphore name
-    bucket          int,        -- static bucket = f(owner_id); one Cassandra partition per bucket
+    domain_id       uuid,
+    semaphore_name  text,
+    bucket          int,        -- static bucket = f(owner_id)
     type            int,        -- rowKind {token, owner}: forward row vs reverse-index row
     token_id        int,        -- token row: slot id [1,size]; owner row: TOKEN_NONE sentinel
     owner_id        text,       -- owner row: the holder's identity; token row: OWNER_NONE sentinel
     holder          text,       -- token row: current holder or FREE (LWT-guarded); owner row: OWNER_NONE sentinel
     held_token      int,        -- owner row: the token this owner holds; token row: TOKEN_NONE sentinel
-    updated_time    timestamp,  -- set on grant and on release (held-since / free-since)
+    updated_time    timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, token_id, owner_id)
 ) WITH compaction = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
@@ -671,15 +665,15 @@ CREATE TABLE semaphore_tokens (
 --          stale host after an owner handoff).
 --   waiter row  (type = 0): one queued acquire.
 CREATE TABLE semaphore_tasks (
-    domain_id         uuid,          
-    semaphore_name    text,          
+    domain_id         uuid,
+    semaphore_name    text,
     bucket            int,           -- static bucket = f(owner_id); one queue per bucket
     type              int,           -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
-    task_id           bigint,        
+    task_id           bigint,
     range_id          bigint,        -- single-writer fence, carried on the control row
     task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
     acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted
-                                     -- No deadline meas no skip and no TTL
+                                     -- No deadline means no skip and no TTL
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -664,14 +664,9 @@ CREATE TABLE semaphore_tokens (
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
 };
 
--- Distributed semaphore: per-bucket FIFO queue of ungranted acquires. Each full bucket
--- (domain_id, semaphore_name, bucket) enqueues acquires as waiters ordered by task_id; the bucket's
--- single owning Matching host drains the head on each release, reusing the tasks range_id fence.
---
--- `type` tells the two row kinds apart (ints match the tasks rowType convention):
---   control row (type = 1): holds range_id (the fence every waiter write CAS-checks, rejecting a
---          stale host after an owner handoff) and ack_level (the completed-through read cursor).
---   waiter row  (type = 0): one queued acquire.
+-- Distributed semaphore: per-bucket FIFO queue of ungranted acquires, ordered by task_id.
+-- Each bucket (domain_id, semaphore_name, bucket) is owned by a single Matching host that
+-- drains the head on each release, reusing the tasks range_id fence.
 CREATE TABLE semaphore_tasks (
     domain_id         uuid,
     semaphore_name    text,
@@ -681,7 +676,7 @@ CREATE TABLE semaphore_tasks (
     range_id          bigint,                 -- single-writer fence, carried on the control row
     ack_level         bigint,                 -- control row: waiters with task_id <= this are granted/expired and
                                               -- range-deleted; the reader reads above it, never scanning acked tombstones
-    task              frozen<semaphore_task>, -- the queued acquire's identity (owner_id parts + acquire handle)
+    task              frozen<semaphore_task>,
     acquire_deadline  timestamp,              -- the time this waiter gives up if still not granted
                                               -- No deadline means no skip and no TTL
     created_time      timestamp,

--- a/schema/cassandra/cadence/versioned/v0.50/semaphore_metadata.cql
+++ b/schema/cassandra/cadence/versioned/v0.50/semaphore_metadata.cql
@@ -2,8 +2,8 @@
 -- Partitioned by domain_id so all semaphores in a domain list together; clustered by semaphore_name.
 -- Source of truth for size and bucket_size (which derive N = ceil(size / bucket_size)).
 CREATE TABLE semaphore_metadata (
-    domain_id         uuid,      -- domain that owns the semaphore
-    semaphore_name    text,      -- user-chosen semaphore name
+    domain_id         uuid,
+    semaphore_name    text,
     size              int,       -- total capacity (max concurrent tokens)
     bucket_size       int,       -- tokens per bucket (per-host budget); sets N = ceil(size / bucket_size)
     created_time      timestamp,

--- a/schema/cassandra/cadence/versioned/v0.51/semaphore_tokens.cql
+++ b/schema/cassandra/cadence/versioned/v0.51/semaphore_tokens.cql
@@ -1,35 +1,29 @@
 -- Distributed semaphore: per-token ownership with an inline reverse index.
 --
--- Each bucket (domain_id, semaphore_name, bucket) is its own Cassandra partition, written by a
--- single owning Matching host. A partition holds TWO kinds of row, told apart by `type`, and the
--- four columns token_id / owner_id / holder / held_token mean different things in each kind:
+-- Each bucket (domain_id, semaphore_name, bucket) is one Cassandra partition, written by its single
+-- owning Matching host. `type` splits the partition into two row kinds that reuse the same four
+-- columns (token_id / owner_id / holder / held_token) for opposite roles:
 --
---   type = token  (forward index, keyed by token_id): "who holds slot token_id?"
---       token_id   = slot id in [1, size]                    <- the key
---       holder     = current holder's owner_id, or FREE      (LWT-guarded on grant/release)
---       owner_id   = OWNER_NONE sentinel                     (not used by this kind)
---       held_token = TOKEN_NONE sentinel                     (not used by this kind)
+--   token row (type = token): forward index keyed by token_id — "who holds this slot?"
+--       token_id = slot id in [1, size] (the key); holder = holder's owner_id, or FREE (LWT-guarded).
+--       owner_id, held_token = unused sentinels (OWNER_NONE, TOKEN_NONE).
 --
---   type = owner  (reverse index, keyed by owner_id): "which slot does this hold own?"
---       owner_id   = the hold's identity, length-prefixed workflow_id:run_id:hold_id  <- the key
---       held_token = the token_id this owner currently holds
---       token_id   = TOKEN_NONE sentinel                     (not used by this kind)
---       holder     = OWNER_NONE sentinel                     (not used by this kind)
+--   owner row (type = owner): reverse index keyed by owner_id — "which slot does this hold own?"
+--       owner_id = hold identity, length-prefixed workflow_id:run_id:hold_id (the key); held_token = its token_id.
+--       token_id, holder = unused sentinels (TOKEN_NONE, OWNER_NONE).
 --
--- The roles flip between the two kinds: a token row keys on token_id and names its holder; an owner
--- row keys on owner_id and names its held_token. Grant and release write the token row and its
--- matching owner row in ONE atomic batch on the same partition, so the forward and reverse views
--- can never diverge.
+-- Grant and release write the paired token row and owner row in ONE atomic batch on the partition,
+-- so the forward and reverse views can never diverge.
 CREATE TABLE semaphore_tokens (
-    domain_id       uuid,       -- domain that owns the semaphore
-    semaphore_name  text,       -- user-chosen semaphore name
-    bucket          int,        -- static bucket = f(owner_id); one Cassandra partition per bucket
+    domain_id       uuid,
+    semaphore_name  text,
+    bucket          int,        -- static bucket = f(owner_id)
     type            int,        -- rowKind {token, owner}: forward row vs reverse-index row
     token_id        int,        -- token row: slot id [1,size]; owner row: TOKEN_NONE sentinel
     owner_id        text,       -- owner row: the holder's identity; token row: OWNER_NONE sentinel
     holder          text,       -- token row: current holder or FREE (LWT-guarded); owner row: OWNER_NONE sentinel
     held_token      int,        -- owner row: the token this owner holds; token row: TOKEN_NONE sentinel
-    updated_time    timestamp,  -- set on grant and on release (held-since / free-since)
+    updated_time    timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, token_id, owner_id)
 ) WITH compaction = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'

--- a/schema/cassandra/cadence/versioned/v0.52/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.52/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.52",
+  "MinCompatibleVersion": "0.52",
+  "Description": "Add semaphore_tasks table",
+  "SchemaUpdateCqlFiles": [
+    "semaphore_tasks.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
+++ b/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
@@ -1,28 +1,25 @@
--- Distributed semaphore: per-bucket FIFO waiter queue for ungranted acquires.
+-- Distributed semaphore: per-bucket FIFO queue of ungranted acquires. Each full bucket
+-- (domain_id, semaphore_name, bucket) enqueues acquires as waiters ordered by task_id; the bucket's
+-- single owning Matching host drains the head on each release, reusing the tasks range_id fence.
 --
--- When a bucket (domain_id, semaphore_name, bucket) has no free token, an acquire cannot be
--- granted immediately and is enqueued here as a waiter, ordered by task_id (arrival). The
--- bucket's single owning Matching host drains the head of this queue on each release. The
--- framing is "a semaphore is a special task type", so this reuses Matching's durable task
--- machinery: the range_id single-writer fence and the background task reader.
+-- `type` tells the two row kinds apart (ints match the tasks rowType convention):
+--   control row (type = 1): holds range_id, the fence every waiter write CAS-checks (rejects a
+--          stale host after an owner handoff).
+--   waiter row  (type = 0): one queued acquire.
 --
--- A partition holds TWO kinds of row, told apart by `type`:
---   type = TaskList (control row): carries range_id, the single-writer fence. Every waiter
---          write CAS-checks range_id, so a stale host (after an owner handoff) is rejected.
---   type = Task     (waiter row):  one queued, ungranted acquire, ordered by task_id.
---
--- Removal is an explicit delete at grant; a waiter past its acquire_deadline is skipped by the
--- reader and reaped by a per-row TTL (set at write time to acquire_deadline plus a margin). The
--- TTL is never table-level: that would also expire the control row and lose the fence.
+-- A waiter is removed on grant, or reaped by a per-row TTL. The TTL is never table-level, which
+-- would expire the control row and lose the fence.
 CREATE TABLE semaphore_tasks (
     domain_id         uuid,          -- domain that owns the semaphore
     semaphore_name    text,          -- user-chosen semaphore name
     bucket            int,           -- static bucket = f(owner_id); one queue per bucket
-    type              int,           -- rowType {Task, TaskList}: waiter row vs control row
+    type              int,           -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
     task_id           bigint,        -- FIFO order within the bucket (arrival)
     range_id          bigint,        -- single-writer fence, carried on the control row
     task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
-    acquire_deadline  timestamp,     -- waitTimeout; reader skips rows past it, per-row TTL is a backstop
+    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted. Past it,
+                                     -- the reader skips the row and a per-row TTL reaps it.
+                                     -- NULL = never gives up (a healing re-acquire; no TTL either).
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
+++ b/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
@@ -6,20 +6,16 @@
 --   control row (type = 1): holds range_id, the fence every waiter write CAS-checks (rejects a
 --          stale host after an owner handoff).
 --   waiter row  (type = 0): one queued acquire.
---
--- A waiter is removed on grant, or reaped by a per-row TTL. The TTL is never table-level, which
--- would expire the control row and lose the fence.
 CREATE TABLE semaphore_tasks (
-    domain_id         uuid,          -- domain that owns the semaphore
-    semaphore_name    text,          -- user-chosen semaphore name
+    domain_id         uuid,
+    semaphore_name    text,
     bucket            int,           -- static bucket = f(owner_id); one queue per bucket
     type              int,           -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
-    task_id           bigint,        -- FIFO order within the bucket (arrival)
+    task_id           bigint,
     range_id          bigint,        -- single-writer fence, carried on the control row
     task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
-    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted. Past it,
-                                     -- the reader skips the row and a per-row TTL reaps it.
-                                     -- NULL = never gives up (a healing re-acquire; no TTL either).
+    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted
+                                     -- No deadline meas no skip and no TTL
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
+++ b/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
@@ -6,14 +6,9 @@ CREATE TYPE semaphore_task (
     schedule_id  bigint
 );
 
--- Distributed semaphore: per-bucket FIFO queue of ungranted acquires. Each full bucket
--- (domain_id, semaphore_name, bucket) enqueues acquires as waiters ordered by task_id; the bucket's
--- single owning Matching host drains the head on each release, reusing the tasks range_id fence.
---
--- `type` tells the two row kinds apart (ints match the tasks rowType convention):
---   control row (type = 1): holds range_id (the fence every waiter write CAS-checks, rejecting a
---          stale host after an owner handoff) and ack_level (the completed-through read cursor).
---   waiter row  (type = 0): one queued acquire.
+-- Distributed semaphore: per-bucket FIFO queue of ungranted acquires, ordered by task_id.
+-- Each bucket (domain_id, semaphore_name, bucket) is owned by a single Matching host that
+-- drains the head on each release, reusing the tasks range_id fence.
 CREATE TABLE semaphore_tasks (
     domain_id         uuid,
     semaphore_name    text,
@@ -23,7 +18,7 @@ CREATE TABLE semaphore_tasks (
     range_id          bigint,                 -- single-writer fence, carried on the control row
     ack_level         bigint,                 -- control row: waiters with task_id <= this are granted/expired and
                                               -- range-deleted; the reader reads above it, never scanning acked tombstones
-    task              frozen<semaphore_task>, -- the queued acquire's identity (owner_id parts + acquire handle)
+    task              frozen<semaphore_task>,
     acquire_deadline  timestamp,              -- the time this waiter gives up if still not granted
                                               -- No deadline means no skip and no TTL
     created_time      timestamp,

--- a/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
+++ b/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
@@ -1,0 +1,30 @@
+-- Distributed semaphore: per-bucket FIFO waiter queue for ungranted acquires.
+--
+-- When a bucket (domain_id, semaphore_name, bucket) has no free token, an acquire cannot be
+-- granted immediately and is enqueued here as a waiter, ordered by task_id (arrival). The
+-- bucket's single owning Matching host drains the head of this queue on each release. The
+-- framing is "a semaphore is a special task type", so this reuses Matching's durable task
+-- machinery: the range_id single-writer fence and the background task reader.
+--
+-- A partition holds TWO kinds of row, told apart by `type`:
+--   type = TaskList (control row): carries range_id, the single-writer fence. Every waiter
+--          write CAS-checks range_id, so a stale host (after an owner handoff) is rejected.
+--   type = Task     (waiter row):  one queued, ungranted acquire, ordered by task_id.
+--
+-- Removal is an explicit delete at grant; a waiter past its acquire_deadline is skipped by the
+-- reader and reaped by a per-row TTL (set at write time to acquire_deadline plus a margin). The
+-- TTL is never table-level: that would also expire the control row and lose the fence.
+CREATE TABLE semaphore_tasks (
+    domain_id         uuid,          -- domain that owns the semaphore
+    semaphore_name    text,          -- user-chosen semaphore name
+    bucket            int,           -- static bucket = f(owner_id); one queue per bucket
+    type              int,           -- rowType {Task, TaskList}: waiter row vs control row
+    task_id           bigint,        -- FIFO order within the bucket (arrival)
+    range_id          bigint,        -- single-writer fence, carried on the control row
+    task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
+    acquire_deadline  timestamp,     -- waitTimeout; reader skips rows past it, per-row TTL is a backstop
+    created_time      timestamp,
+    PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
+) WITH compaction = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+};

--- a/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
+++ b/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
@@ -15,7 +15,7 @@ CREATE TABLE semaphore_tasks (
     range_id          bigint,        -- single-writer fence, carried on the control row
     task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
     acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted
-                                     -- No deadline meas no skip and no TTL
+                                     -- No deadline means no skip and no TTL
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
+++ b/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
@@ -2,8 +2,7 @@
 CREATE TYPE semaphore_task (
     workflow_id  text,
     run_id       uuid,
-    hold_id      bigint,  -- identifies this specific hold
-    schedule_id  bigint
+    hold_id      bigint  -- identifies this hold
 );
 
 -- Distributed semaphore: per-bucket FIFO queue of ungranted acquires, ordered by task_id.

--- a/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
+++ b/schema/cassandra/cadence/versioned/v0.52/semaphore_tasks.cql
@@ -1,21 +1,31 @@
+-- A queued semaphore acquire waiting for a token in a bucket
+CREATE TYPE semaphore_task (
+    workflow_id  text,
+    run_id       uuid,
+    hold_id      bigint,  -- identifies this specific hold
+    schedule_id  bigint
+);
+
 -- Distributed semaphore: per-bucket FIFO queue of ungranted acquires. Each full bucket
 -- (domain_id, semaphore_name, bucket) enqueues acquires as waiters ordered by task_id; the bucket's
 -- single owning Matching host drains the head on each release, reusing the tasks range_id fence.
 --
 -- `type` tells the two row kinds apart (ints match the tasks rowType convention):
---   control row (type = 1): holds range_id, the fence every waiter write CAS-checks (rejects a
---          stale host after an owner handoff).
+--   control row (type = 1): holds range_id (the fence every waiter write CAS-checks, rejecting a
+--          stale host after an owner handoff) and ack_level (the completed-through read cursor).
 --   waiter row  (type = 0): one queued acquire.
 CREATE TABLE semaphore_tasks (
     domain_id         uuid,
     semaphore_name    text,
-    bucket            int,           -- static bucket = f(owner_id); one queue per bucket
-    type              int,           -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
+    bucket            int,                    -- static bucket = f(owner_id); one queue per bucket
+    type              int,                    -- rowType: 0 = waiter (queued acquire), 1 = control row (range_id fence)
     task_id           bigint,
-    range_id          bigint,        -- single-writer fence, carried on the control row
-    task              frozen<task>,  -- the queued acquire (reuses the Matching task UDT)
-    acquire_deadline  timestamp,     -- the time this waiter gives up if still not granted
-                                     -- No deadline means no skip and no TTL
+    range_id          bigint,                 -- single-writer fence, carried on the control row
+    ack_level         bigint,                 -- control row: waiters with task_id <= this are granted/expired and
+                                              -- range-deleted; the reader reads above it, never scanning acked tombstones
+    task              frozen<semaphore_task>, -- the queued acquire's identity (owner_id parts + acquire handle)
+    acquire_deadline  timestamp,              -- the time this waiter gives up if still not granted
+                                              -- No deadline means no skip and no TTL
     created_time      timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, task_id)
 ) WITH compaction = {

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -25,7 +25,7 @@ import "github.com/uber/cadence/schema/common"
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.51"
+const Version = "0.52"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.10"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49", "v0.50", "v0.51"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49", "v0.50", "v0.51", "v0.52"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**Detailed Description**
- Adds a new Cassandra table and bumps the Cassandra schema version 0.51 → 0.52. 
- The table is a per-bucket FIFO queue of ungranted acquires, partition key (domain_id, semaphore_name, bucket), clustering key (type, task_id). 
- It reuses the tasks table's single-writer fence pattern: a **type** discriminator separates a **control row (type = 1, carries range_id)** from **waiter rows (type = 0)**, and reuses the existing task UDT via task frozen<task>. 
- The only column beyond the base tasks schema is **acquire_deadline** timestamp (the time a waiter gives up if still not granted; enforced by a reader skip and a per-row TTL backstop). 

**Impact Analysis**
- **Backward Compatibility**: Fully backward compatible. The change is purely additive — one new table. 
- **Forward Compatibility**: Fully forward compatible. 

**Testing Plan**
- Unit Tests: Yes. schema/version_test.go &  tools/common/schema/updatetask_test.go 
- Persistence Tests: N/A. No persistence layer accompanies this PR. Persistence tests land with the follow-up manager/store PR.
- Integration Tests: Covered by CI schema-install
- Compatibility Tests: N/A beyond the above — an additive table with no readers/writers has no compatibility surface to exercise.

**Rollout Plan**
- Rollout plan: Apply the v0.52 schema migration 
- Order of deployment: Independent. 
- Rollback: Safe. The table is unused, so a binary rollback needs nothing. No data migration is involved.
- Kill switch: N/A — the change adds no runtime behavior; there is nothing to disable.
