### PR TITLE
feat(persistence): Add Generic Schema Verification

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/configstore"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/logfx"
 	"github.com/uber/cadence/common/log/tag"
@@ -163,6 +164,12 @@ func (a *App) Stop(ctx context.Context) error {
 }
 
 func (a *App) verifySchema(ctx context.Context) error {
+	if err := VerifySchema(ctx, a.cfg); err != nil {
+		if a.dynamicCollection.GetBoolProperty(dynamicproperties.EnforceSchemaVerificationV2)() {
+			return fmt.Errorf("schema verification failed: %w", err)
+		}
+		a.logger.Warn("SchemaVerificationV2 failed", tag.Error(err))
+	}
 	// cassandra schema version validation
 	if err := cassandra.VerifyCompatibleVersion(a.cfg.Persistence, gocql.Quorum); err != nil {
 		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)

--- a/cmd/server/cadence/update_schema.go
+++ b/cmd/server/cadence/update_schema.go
@@ -45,21 +45,15 @@ const setupTimeout = 2 * time.Minute
 const setupRetryInterval = 3 * time.Second
 
 type setupTask struct {
-	pluginName string
-	dbType     persistence.DBType
-	identifier string
-	setupDB    persistence.SetupDB
+	adminDB persistence.AdminDB
+	setupDB persistence.SetupDB
 }
 
 // schemaUpdateTask tracks a pending schema update and the SchemaDB it should be applied to.
 type schemaUpdateTask struct {
-	// pluginName/dbType groups updates so all DBs in the same group can be
-	// advanced version-by-version together.
-	pluginName string
-	dbType     persistence.DBType
-	identifier string
-	schemaDB   persistence.SchemaDB
-	update     *persistence.SchemaUpdate
+	adminDB  persistence.AdminDB
+	schemaDB persistence.SchemaDB
+	update   *persistence.SchemaUpdate
 }
 
 // newPersistenceFactory constructs a persistence factory from the provided config. It doesn't support dynamic config
@@ -133,10 +127,8 @@ func connectToDBs(ctx context.Context, logger log.Logger, timeSource clock.TimeS
 			return tasks, setupDBs, err
 		}
 		tasks = append(tasks, setupTask{
-			pluginName: adminDB.PluginName(),
-			dbType:     adminDB.DBType(),
-			identifier: adminDB.Identifier(),
-			setupDB:    setupDB,
+			adminDB: adminDB,
+			setupDB: setupDB,
 		})
 		setupDBs = append(setupDBs, setupDB)
 	}
@@ -166,31 +158,20 @@ func retryUntilConnected(ctx context.Context, logger log.Logger, adminDB persist
 // ensureSetup calls Setup on any SetupDB that reports IsSetup() == false.
 func ensureSetup(ctx context.Context, logger log.Logger, tasks []setupTask) error {
 	for _, t := range tasks {
+		dbLogger := logger.WithTags(dbTags(t.adminDB)...)
 		isSetup, err := t.setupDB.IsSetup(ctx)
 		if err != nil {
-			return fmt.Errorf("checking setup status for %s: %w", setupTarget(t), err)
+			return fmt.Errorf("checking setup status for %s: %w", describeDB(t.adminDB), err)
 		}
 		if isSetup {
-			logger.Info("Database already set up",
-				tag.PersistencePluginName(t.pluginName),
-				tag.PersistenceDBType(string(t.dbType)),
-				tag.PersistenceDBIdentifier(t.identifier),
-			)
+			dbLogger.Info("Database already set up")
 			continue
 		}
-		logger.Info("Setting up database...",
-			tag.PersistencePluginName(t.pluginName),
-			tag.PersistenceDBType(string(t.dbType)),
-			tag.PersistenceDBIdentifier(t.identifier),
-		)
+		dbLogger.Info("Setting up database...")
 		if err = t.setupDB.Setup(ctx, nil); err != nil {
-			return fmt.Errorf("setting up %s: %w", setupTarget(t), err)
+			return fmt.Errorf("setting up %s: %w", describeDB(t.adminDB), err)
 		}
-		logger.Info("Database set up successfully",
-			tag.PersistencePluginName(t.pluginName),
-			tag.PersistenceDBType(string(t.dbType)),
-			tag.PersistenceDBIdentifier(t.identifier),
-		)
+		dbLogger.Info("Database set up successfully")
 	}
 	return nil
 }
@@ -206,7 +187,7 @@ func collectSchemaUpdates(ctx context.Context, adminDBs []persistence.AdminDB) (
 		if !adminDB.SupportsSchema() {
 			continue
 		}
-		adminDBID := adminDBIdentity(adminDB)
+		adminDBID := describeDB(adminDB)
 
 		schemaDB, err := adminDB.CreateSchemaDB()
 		if err != nil {
@@ -228,11 +209,9 @@ func collectSchemaUpdates(ctx context.Context, adminDBs []persistence.AdminDB) (
 				return schemaDBs, nil, fmt.Errorf("failed reading latest schema for %s: %w", adminDBID, err)
 			}
 			updates = append(updates, schemaUpdateTask{
-				pluginName: adminDB.PluginName(),
-				dbType:     adminDB.DBType(),
-				identifier: adminDB.Identifier(),
-				schemaDB:   schemaDB,
-				update:     skipToLatest,
+				adminDB:  adminDB,
+				schemaDB: schemaDB,
+				update:   skipToLatest,
 			})
 			continue
 		}
@@ -256,11 +235,9 @@ func collectSchemaUpdates(ctx context.Context, adminDBs []persistence.AdminDB) (
 		for _, u := range allUpdates {
 			if currentVersion.IsBefore(u.Version) {
 				updates = append(updates, schemaUpdateTask{
-					pluginName: adminDB.PluginName(),
-					dbType:     adminDB.DBType(),
-					identifier: adminDB.Identifier(),
-					schemaDB:   schemaDB,
-					update:     u,
+					adminDB:  adminDB,
+					schemaDB: schemaDB,
+					update:   u,
 				})
 			}
 		}
@@ -273,52 +250,46 @@ func applyUpdates(ctx context.Context, logger log.Logger, updates []schemaUpdate
 	// Sort by (PluginName, DBType, Version) so DBs in the same plugin/type group are
 	// advanced together version-by-version.
 	slices.SortStableFunc(updates, func(a, b schemaUpdateTask) int {
-		if pluginCmp := cmp.Compare(a.pluginName, b.pluginName); pluginCmp != 0 {
+		if pluginCmp := cmp.Compare(a.adminDB.PluginName(), b.adminDB.PluginName()); pluginCmp != 0 {
 			return pluginCmp
 		}
-		if dbTypeCmp := cmp.Compare(string(a.dbType), string(b.dbType)); dbTypeCmp != 0 {
+		if dbTypeCmp := cmp.Compare(string(a.adminDB.DBType()), string(b.adminDB.DBType())); dbTypeCmp != 0 {
 			return dbTypeCmp
 		}
 		if versionCmp := a.update.Version.Compare(b.update.Version); versionCmp != 0 {
 			return versionCmp
 		}
-		return cmp.Compare(a.identifier, b.identifier)
+		return cmp.Compare(a.adminDB.Identifier(), b.adminDB.Identifier())
 	})
 
 	for _, entry := range updates {
-		logger.Info(
+		dbLogger := logger.WithTags(dbTags(entry.adminDB)...)
+		dbLogger.Info(
 			"Applying schema update...",
-			tag.PersistencePluginName(entry.pluginName),
-			tag.PersistenceDBType(string(entry.dbType)),
-			tag.PersistenceDBIdentifier(entry.identifier),
 			tag.SchemaUpdateVersion(entry.update.Version.String()),
 		)
 		if err := entry.schemaDB.UpdateSchema(ctx, entry.update); err != nil {
-			return fmt.Errorf("failed applying schema update v%s to %s: %w", entry.update.Version, schemaUpdateTarget(entry), err)
+			return fmt.Errorf("failed applying schema update v%s to %s: %w", entry.update.Version, describeDB(entry.adminDB), err)
 		}
-		logger.Info(
+		dbLogger.Info(
 			"Applied schema update",
-			tag.PersistencePluginName(entry.pluginName),
-			tag.PersistenceDBType(string(entry.dbType)),
-			tag.PersistenceDBIdentifier(entry.identifier),
 			tag.SchemaUpdateVersion(entry.update.Version.String()),
 		)
+
 	}
 	return nil
 }
 
-// These three helper functions are for error messages to make it clear which DB is having issues.
-
-func adminDBIdentity(adminDB persistence.AdminDB) string {
-	return fmt.Sprintf("%s/%s/%s", adminDB.PluginName(), adminDB.DBType(), adminDB.Identifier())
+func describeDB(db persistence.AdminDB) string {
+	return fmt.Sprintf("%s/%s/%s", db.PluginName(), db.DBType(), db.Identifier())
 }
 
-func setupTarget(t setupTask) string {
-	return fmt.Sprintf("%s/%s/%s", t.pluginName, t.dbType, t.identifier)
-}
-
-func schemaUpdateTarget(entry schemaUpdateTask) string {
-	return fmt.Sprintf("%s/%s/%s", entry.pluginName, entry.dbType, entry.identifier)
+func dbTags(db persistence.AdminDB) []tag.Tag {
+	return []tag.Tag{
+		tag.PersistencePluginName(db.PluginName()),
+		tag.PersistenceDBType(string(db.DBType())),
+		tag.PersistenceDBIdentifier(db.Identifier()),
+	}
 }
 
 func closeSetupDBs(setupDBs []persistence.SetupDB) {

--- a/cmd/server/cadence/update_schema_test.go
+++ b/cmd/server/cadence/update_schema_test.go
@@ -42,9 +42,7 @@ func TestConnectToDBs(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, tasks, 1)
 				require.Len(t, setupDBs, 1)
-				assert.Equal(t, "mysql", tasks[0].pluginName)
-				assert.Equal(t, persistence.DBTypeDefault, tasks[0].dbType)
-				assert.Equal(t, "db-1", tasks[0].identifier)
+				assert.Same(t, adminDB, tasks[0].adminDB)
 				assert.Same(t, setupDB, tasks[0].setupDB)
 				assert.Same(t, setupDB, setupDBs[0])
 
@@ -161,10 +159,8 @@ func TestEnsureSetup(t *testing.T) {
 			}
 
 			tasks := []setupTask{{
-				pluginName: "mysql",
-				dbType:     persistence.DBTypeDefault,
-				identifier: "db-1",
-				setupDB:    setupDB,
+				adminDB: newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1"),
+				setupDB: setupDB,
 			}}
 
 			err := ensureSetup(context.Background(), logger, tasks)
@@ -271,10 +267,7 @@ func TestCollectSchemaUpdates(t *testing.T) {
 			},
 			wantSchemaDBs: 1,
 			expectedUpdates: []schemaUpdateTask{{
-				pluginName: "mysql",
-				dbType:     persistence.DBTypeDefault,
-				identifier: "db-1",
-				update:     updateV3,
+				update: updateV3,
 			}},
 		},
 		{
@@ -351,8 +344,8 @@ func TestCollectSchemaUpdates(t *testing.T) {
 			},
 			wantSchemaDBs: 1,
 			expectedUpdates: []schemaUpdateTask{
-				{pluginName: "cassandra", dbType: persistence.DBTypeVisibility, identifier: "shard-a", update: updateV2},
-				{pluginName: "cassandra", dbType: persistence.DBTypeVisibility, identifier: "shard-a", update: updateV3},
+				{update: updateV2},
+				{update: updateV3},
 			},
 		},
 	}
@@ -376,9 +369,6 @@ func TestCollectSchemaUpdates(t *testing.T) {
 			require.Len(t, schemaDBs, tt.wantSchemaDBs)
 			require.Len(t, updates, len(tt.expectedUpdates))
 			for i, want := range tt.expectedUpdates {
-				assert.Equal(t, want.pluginName, updates[i].pluginName)
-				assert.Equal(t, want.dbType, updates[i].dbType)
-				assert.Equal(t, want.identifier, updates[i].identifier)
 				assert.Same(t, want.update, updates[i].update)
 			}
 		})
@@ -424,12 +414,12 @@ func TestApplyUpdates(t *testing.T) {
 				return []schemaUpdateTask{
 					// This is the reverse of the expected order
 					// Plugin B
-					{pluginName: "b", dbType: persistence.DBTypeDefault, identifier: "id-2", schemaDB: db1, update: v2},
+					{adminDB: newMockAdminDB(ctrl, "b", persistence.DBTypeDefault, "id-2"), schemaDB: db1, update: v2},
 					// Plugin A, Visibility DB, update to v2
-					{pluginName: "a", dbType: persistence.DBTypeVisibility, identifier: "id-1", schemaDB: db2, update: v2},
+					{adminDB: newMockAdminDB(ctrl, "a", persistence.DBTypeVisibility, "id-1"), schemaDB: db2, update: v2},
 					// Plugin A, Default DB, update to v1, then v2
-					{pluginName: "a", dbType: persistence.DBTypeDefault, identifier: "id-0", schemaDB: db3, update: v2},
-					{pluginName: "a", dbType: persistence.DBTypeDefault, identifier: "id-0", schemaDB: db3, update: v1},
+					{adminDB: newMockAdminDB(ctrl, "a", persistence.DBTypeDefault, "id-0"), schemaDB: db3, update: v2},
+					{adminDB: newMockAdminDB(ctrl, "a", persistence.DBTypeDefault, "id-0"), schemaDB: db3, update: v1},
 				}
 			},
 			expected: []string{
@@ -451,8 +441,8 @@ func TestApplyUpdates(t *testing.T) {
 					return errors.New("update failed")
 				})
 				return []schemaUpdateTask{
-					{pluginName: "b", dbType: persistence.DBTypeDefault, identifier: "id-2", schemaDB: db2, update: v2},
-					{pluginName: "a", dbType: persistence.DBTypeDefault, identifier: "id-0", schemaDB: db1, update: v1},
+					{adminDB: newMockAdminDB(ctrl, "b", persistence.DBTypeDefault, "id-2"), schemaDB: db2, update: v2},
+					{adminDB: newMockAdminDB(ctrl, "a", persistence.DBTypeDefault, "id-0"), schemaDB: db1, update: v1},
 				}
 			},
 			wantErrContains: "failed applying schema update v1.0",

--- a/cmd/server/cadence/verify_schema.go
+++ b/cmd/server/cadence/verify_schema.go
@@ -1,0 +1,83 @@
+package cadence
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence"
+	persistenceClient "github.com/uber/cadence/common/persistence/client"
+)
+
+func VerifySchema(ctx context.Context, cfg config.Config) error {
+	logger := newUpdateSchemaLogger()
+	factory := newPersistenceFactory(cfg, logger)
+	defer factory.Close()
+
+	return checkSchemas(ctx, factory)
+}
+
+func checkSchemas(ctx context.Context, factory persistenceClient.Factory) error {
+	adminDBs, err := factory.NewAdminDBs()
+	if err != nil {
+		return fmt.Errorf("get admin DBs: %w", err)
+	}
+	// Sort them just for deterministic output and to group by plugin name and DB type.
+	slices.SortStableFunc(adminDBs, func(a, b persistence.AdminDB) int {
+		return cmp.Compare(describeDB(a), describeDB(b))
+	})
+	var result []error
+	for _, db := range adminDBs {
+		dbError := checkDB(ctx, db)
+		if dbError != nil {
+			result = append(result, fmt.Errorf("%s: %w", describeDB(db), dbError))
+		}
+	}
+	if len(result) > 0 {
+		return errors.Join(result...)
+	}
+	return nil
+}
+
+func checkDB(ctx context.Context, db persistence.AdminDB) error {
+	setupDB, err := db.CreateSetupDB()
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+	defer setupDB.Close()
+	ok, err := setupDB.IsSetup(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if setup: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("not setup")
+	}
+	// DB is setup and it doesn't support schema, so we're done
+	if !db.SupportsSchema() {
+		return nil
+	}
+	schemaDB, err := db.CreateSchemaDB()
+	if err != nil {
+		return fmt.Errorf("failed to create schema db: %w", err)
+	}
+	defer schemaDB.Close()
+	ok, err = schemaDB.HasSchemaVersioning(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check for schema versioning: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("schema versioning is not setup")
+	}
+	latestVersion := schemaDB.LatestSchema().LatestVersion()
+	currentVersion, err := schemaDB.GetSchemaVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current schema version: %w", err)
+	}
+	if currentVersion.IsBefore(latestVersion) {
+		return fmt.Errorf("current schema version %v is before latest version %v", currentVersion, latestVersion)
+	}
+	return nil
+}

--- a/cmd/server/cadence/verify_schema_test.go
+++ b/cmd/server/cadence/verify_schema_test.go
@@ -1,0 +1,365 @@
+package cadence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence"
+	persistenceClient "github.com/uber/cadence/common/persistence/client"
+)
+
+func TestCheckDB(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(*gomock.Controller) persistence.AdminDB
+		expectedError string
+	}{
+		{
+			name: "create setup db fails",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockAdminDB.EXPECT().CreateSetupDB().Return(nil, errors.New("connection failed"))
+				return mockAdminDB
+			},
+			expectedError: "failed to connect",
+		},
+		{
+			name: "is setup check fails",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(false, errors.New("connection error")),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "failed to check if setup",
+		},
+		{
+			name: "database not setup",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(false, nil),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "not setup",
+		},
+		{
+			name: "database does not support schema",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(false),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "",
+		},
+		{
+			name: "create schema db fails",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB.EXPECT().CreateSchemaDB().Return(nil, errors.New("db creation failed")),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "failed to create schema db",
+		},
+		{
+			name: "check schema versioning fails",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				mockSchemaDB := persistence.NewMockSchemaDB(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB.EXPECT().CreateSchemaDB().Return(mockSchemaDB, nil),
+					mockSchemaDB.EXPECT().HasSchemaVersioning(gomock.Any()).Return(false, errors.New("query failed")),
+					mockSchemaDB.EXPECT().Close(),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "failed to check for schema versioning",
+		},
+		{
+			name: "schema versioning not setup",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				mockSchemaDB := persistence.NewMockSchemaDB(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB.EXPECT().CreateSchemaDB().Return(mockSchemaDB, nil),
+					mockSchemaDB.EXPECT().HasSchemaVersioning(gomock.Any()).Return(false, nil),
+					mockSchemaDB.EXPECT().Close(),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "schema versioning is not setup",
+		},
+		{
+			name: "get current schema version fails",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				mockSchemaDB := persistence.NewMockSchemaDB(ctrl)
+				mockSchema := persistence.NewMockSchema(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB.EXPECT().CreateSchemaDB().Return(mockSchemaDB, nil),
+					mockSchemaDB.EXPECT().HasSchemaVersioning(gomock.Any()).Return(true, nil),
+					mockSchemaDB.EXPECT().LatestSchema().Return(mockSchema),
+					mockSchema.EXPECT().LatestVersion().Return(persistence.Version{Major: 1, Minor: 0}),
+					mockSchemaDB.EXPECT().GetSchemaVersion(gomock.Any()).Return(persistence.Version{}, errors.New("version query failed")),
+					mockSchemaDB.EXPECT().Close(),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "failed to get current schema version",
+		},
+		{
+			name: "current version before latest version",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				mockSchemaDB := persistence.NewMockSchemaDB(ctrl)
+				mockSchema := persistence.NewMockSchema(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB.EXPECT().CreateSchemaDB().Return(mockSchemaDB, nil),
+					mockSchemaDB.EXPECT().HasSchemaVersioning(gomock.Any()).Return(true, nil),
+					mockSchemaDB.EXPECT().LatestSchema().Return(mockSchema),
+					mockSchema.EXPECT().LatestVersion().Return(persistence.Version{Major: 2, Minor: 0}),
+					mockSchemaDB.EXPECT().GetSchemaVersion(gomock.Any()).Return(persistence.Version{Major: 1, Minor: 5}, nil),
+					mockSchemaDB.EXPECT().Close(),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "current schema version 1.5 is before latest version 2.0",
+		},
+		{
+			name: "schema version matches",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				mockSchemaDB := persistence.NewMockSchemaDB(ctrl)
+				mockSchema := persistence.NewMockSchema(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB.EXPECT().CreateSchemaDB().Return(mockSchemaDB, nil),
+					mockSchemaDB.EXPECT().HasSchemaVersioning(gomock.Any()).Return(true, nil),
+					mockSchemaDB.EXPECT().LatestSchema().Return(mockSchema),
+					mockSchema.EXPECT().LatestVersion().Return(persistence.Version{Major: 2, Minor: 0}),
+					mockSchemaDB.EXPECT().GetSchemaVersion(gomock.Any()).Return(persistence.Version{Major: 2, Minor: 0}, nil),
+					mockSchemaDB.EXPECT().Close(),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "",
+		},
+		{
+			name: "schema version newer than latest",
+			setup: func(ctrl *gomock.Controller) persistence.AdminDB {
+				mockAdminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockSetupDB := persistence.NewMockSetupDB(ctrl)
+				mockSchemaDB := persistence.NewMockSchemaDB(ctrl)
+				mockSchema := persistence.NewMockSchema(ctrl)
+				gomock.InOrder(
+					mockAdminDB.EXPECT().CreateSetupDB().Return(mockSetupDB, nil),
+					mockSetupDB.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB.EXPECT().CreateSchemaDB().Return(mockSchemaDB, nil),
+					mockSchemaDB.EXPECT().HasSchemaVersioning(gomock.Any()).Return(true, nil),
+					mockSchemaDB.EXPECT().LatestSchema().Return(mockSchema),
+					mockSchema.EXPECT().LatestVersion().Return(persistence.Version{Major: 2, Minor: 0}),
+					mockSchemaDB.EXPECT().GetSchemaVersion(gomock.Any()).Return(persistence.Version{Major: 2, Minor: 5}, nil),
+					mockSchemaDB.EXPECT().Close(),
+					mockSetupDB.EXPECT().Close(),
+				)
+				return mockAdminDB
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockAdminDB := tt.setup(ctrl)
+			err := checkDB(context.Background(), mockAdminDB)
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckSchemas(t *testing.T) {
+	tests := []struct {
+		name           string
+		setup          func(*gomock.Controller) persistenceClient.Factory
+		expectedErrors []string // substrings expected in the error message
+	}{
+		{
+			name: "factory.NewAdminDBs fails",
+			setup: func(ctrl *gomock.Controller) persistenceClient.Factory {
+				mockFactory := persistenceClient.NewMockFactory(ctrl)
+				mockFactory.EXPECT().NewAdminDBs().Return(nil, errors.New("db connection failed"))
+				return mockFactory
+			},
+			expectedErrors: []string{"get admin DBs"},
+		},
+		{
+			name: "all databases succeed",
+			setup: func(ctrl *gomock.Controller) persistenceClient.Factory {
+				mockFactory := persistenceClient.NewMockFactory(ctrl)
+				mockAdminDB1 := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockAdminDB2 := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-2")
+				mockSetupDB1 := persistence.NewMockSetupDB(ctrl)
+				mockSetupDB2 := persistence.NewMockSetupDB(ctrl)
+				mockSchemaDB1 := persistence.NewMockSchemaDB(ctrl)
+				mockSchemaDB2 := persistence.NewMockSchemaDB(ctrl)
+				mockSchema1 := persistence.NewMockSchema(ctrl)
+				mockSchema2 := persistence.NewMockSchema(ctrl)
+
+				gomock.InOrder(
+					mockFactory.EXPECT().NewAdminDBs().Return([]persistence.AdminDB{mockAdminDB1, mockAdminDB2}, nil),
+					// DB 1
+					mockAdminDB1.EXPECT().CreateSetupDB().Return(mockSetupDB1, nil),
+					mockSetupDB1.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB1.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB1.EXPECT().CreateSchemaDB().Return(mockSchemaDB1, nil),
+					mockSchemaDB1.EXPECT().HasSchemaVersioning(gomock.Any()).Return(true, nil),
+					mockSchemaDB1.EXPECT().LatestSchema().Return(mockSchema1),
+					mockSchema1.EXPECT().LatestVersion().Return(persistence.Version{Major: 1, Minor: 0}),
+					mockSchemaDB1.EXPECT().GetSchemaVersion(gomock.Any()).Return(persistence.Version{Major: 1, Minor: 0}, nil),
+					mockSchemaDB1.EXPECT().Close(),
+					mockSetupDB1.EXPECT().Close(),
+					// DB 2
+					mockAdminDB2.EXPECT().CreateSetupDB().Return(mockSetupDB2, nil),
+					mockSetupDB2.EXPECT().IsSetup(gomock.Any()).Return(true, nil),
+					mockAdminDB2.EXPECT().SupportsSchema().Return(true),
+					mockAdminDB2.EXPECT().CreateSchemaDB().Return(mockSchemaDB2, nil),
+					mockSchemaDB2.EXPECT().HasSchemaVersioning(gomock.Any()).Return(true, nil),
+					mockSchemaDB2.EXPECT().LatestSchema().Return(mockSchema2),
+					mockSchema2.EXPECT().LatestVersion().Return(persistence.Version{Major: 1, Minor: 0}),
+					mockSchemaDB2.EXPECT().GetSchemaVersion(gomock.Any()).Return(persistence.Version{Major: 1, Minor: 0}, nil),
+					mockSchemaDB2.EXPECT().Close(),
+					mockSetupDB2.EXPECT().Close(),
+				)
+				return mockFactory
+			},
+		},
+		{
+			name: "all databases fail",
+			setup: func(ctrl *gomock.Controller) persistenceClient.Factory {
+				mockFactory := persistenceClient.NewMockFactory(ctrl)
+				mockAdminDB1 := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockAdminDB2 := newMockAdminDB(ctrl, "cassandra", persistence.DBTypeVisibility, "db-2")
+
+				gomock.InOrder(
+					mockFactory.EXPECT().NewAdminDBs().Return([]persistence.AdminDB{mockAdminDB1, mockAdminDB2}, nil),
+					// Sorting by plugin name puts cassandra first
+					mockAdminDB2.EXPECT().CreateSetupDB().Return(nil, errors.New("connection failed")),
+					mockAdminDB1.EXPECT().CreateSetupDB().Return(nil, errors.New("connection failed")),
+				)
+				return mockFactory
+			},
+			expectedErrors: []string{
+				"cassandra/visibility/db-2: failed to connect",
+				"mysql/default/db-1: failed to connect",
+			},
+		},
+		{
+			name: "only some databases fail",
+			setup: func(ctrl *gomock.Controller) persistenceClient.Factory {
+				mockFactory := persistenceClient.NewMockFactory(ctrl)
+				mockAdminDB1 := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
+				mockAdminDB2 := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-2")
+				mockSetupDB2 := persistence.NewMockSetupDB(ctrl)
+
+				gomock.InOrder(
+					mockFactory.EXPECT().NewAdminDBs().Return([]persistence.AdminDB{mockAdminDB1, mockAdminDB2}, nil),
+					// DB 1 fails to connect
+					mockAdminDB1.EXPECT().CreateSetupDB().Return(nil, errors.New("connection failed")),
+					// DB 2 connects but isn't set up
+					mockAdminDB2.EXPECT().CreateSetupDB().Return(mockSetupDB2, nil),
+					mockSetupDB2.EXPECT().IsSetup(gomock.Any()).Return(false, nil),
+					mockSetupDB2.EXPECT().Close(),
+				)
+				return mockFactory
+			},
+			expectedErrors: []string{
+				"mysql/default/db-1: failed to connect",
+				"mysql/default/db-2: not setup",
+			},
+		},
+		{
+			name: "empty admin databases list",
+			setup: func(ctrl *gomock.Controller) persistenceClient.Factory {
+				mockFactory := persistenceClient.NewMockFactory(ctrl)
+				mockFactory.EXPECT().NewAdminDBs().Return([]persistence.AdminDB{}, nil)
+				return mockFactory
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockFactory := tt.setup(ctrl)
+			err := checkSchemas(context.Background(), mockFactory)
+
+			if len(tt.expectedErrors) == 0 {
+				require.NoError(t, err)
+				return
+			}
+			for _, expectedError := range tt.expectedErrors {
+				require.ErrorContains(t, err, expectedError)
+			}
+		})
+	}
+}

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2415,6 +2415,14 @@ const (
 	// Default value: false
 	HistoryTaskDLQProcessorEnabled
 
+	// EnforceSchemaVerificationV2 enables more detailed schema verification on server startup
+	// When enabled, the server will verify that the schema of the underlying database matches the expected schema.
+	// This includes persistence backends not previously checked, such as advanced visibility.
+	// KeyName: system.enforceSchemaVerificationV2
+	// Value type: Bool
+	// Default value: false
+	EnforceSchemaVerificationV2
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -5251,6 +5259,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	HistoryTaskDLQProcessorEnabled: {
 		KeyName:      "history.historyTaskDLQProcessorEnabled",
 		Description:  "HistoryTaskDLQProcessorEnabled enables processing HistoryTaskDLQ messages",
+		DefaultValue: false,
+	},
+	EnforceSchemaVerificationV2: {
+		KeyName:      "system.enforceSchemaVerificationV2",
+		Description:  "EnforceSchemaVerificationV2 enables more thorough schema verification, including advanced visibility",
 		DefaultValue: false,
 	},
 }

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -97,3 +97,6 @@ worker.enableScheduler:
 frontend.failoverCoolDown:
 - value: 1s
   constraints: {}
+system.enforceSchemaVerificationV2:
+- value: true
+  constraints: {}


### PR DESCRIPTION
Use the persistence AdminDB interface for validating that the backing DBs are correctly setup and have an appropriate schema version rather than explicit per-plugin checks.

This gives the backing persistence implementation full control over the checks.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Refactored updated_schema a bit to just use AdminDB rather than deconstructing relevant fields.
- Added support for schema verification backed by AdminDB

**Why?**
- More extensible and thorough schema verification on startup. Doesn't rely on arbitrary packages but rather the persistence backend.

**How did you test it?**
- Unit tests
- Started the Cadence server with and without the schema setup for Cassandra/Postgres/MySQL and this feature enabled.

**Potential risks**
- High, so added behind a feature flag with the intention of making this the default in the future.

**Release notes**


**Documentation Changes**

