### PR TITLE
refactor(persistence): Move dynamic config out of config.Persistence

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -295,8 +295,6 @@ func (s *server) startService() common.Daemon {
 
 	params.ArchivalMetadata = s.archivalMetadata
 	params.ArchiverProvider = s.archiverProvider
-	params.PersistenceConfig.TransactionSizeLimit = s.dynamicCollection.GetIntProperty(dynamicproperties.TransactionSizeLimit)
-	params.PersistenceConfig.ErrorInjectionRate = s.dynamicCollection.GetFloat64Property(dynamicproperties.PersistenceErrorInjectionRate)
 	params.AuthorizationConfig = s.cfg.Authorization
 	params.BlobstoreClient, err = filestore.NewFilestoreClient(s.cfg.Blobstore.Filestore)
 	if err != nil {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -35,7 +35,6 @@ import (
 	"github.com/uber/cadence/common/config/yaml"
 	"github.com/uber/cadence/common/dynamicconfig"
 	c "github.com/uber/cadence/common/dynamicconfig/configstore/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	openfeatureclientconfig "github.com/uber/cadence/common/dynamicconfig/openfeatureclient/config"
 	"github.com/uber/cadence/common/metrics"
 	ringpopprovider "github.com/uber/cadence/common/peerprovider/ringpopprovider/config"
@@ -213,12 +212,6 @@ type (
 		NumHistoryShards int `yaml:"numHistoryShards" validate:"nonzero"`
 		// DataStores contains the configuration for all datastores
 		DataStores map[string]DataStore `yaml:"datastores"`
-		// TODO: move dynamic config out of static config
-		// TransactionSizeLimit is the largest allowed transaction size
-		TransactionSizeLimit dynamicproperties.IntPropertyFn `yaml:"-" json:"-"`
-		// TODO: move dynamic config out of static config
-		// ErrorInjectionRate is the the rate for injecting random error
-		ErrorInjectionRate dynamicproperties.FloatPropertyFn `yaml:"-" json:"-"`
 		// HostName for emitting per-host metrics
 		HostName string `yaml:"-" json:"-"`
 	}

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -187,7 +187,7 @@ func (f *factoryImpl) NewTaskManager() (p.TaskManager, error) {
 		return nil, err
 	}
 	result := p.NewTaskManager(store)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewTaskManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
@@ -207,7 +207,7 @@ func (f *factoryImpl) NewShardManager() (p.ShardManager, error) {
 		return nil, err
 	}
 	result := p.NewShardManager(store, f.dc)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewShardManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
@@ -226,8 +226,8 @@ func (f *factoryImpl) NewHistoryManager() (p.HistoryManager, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := p.NewHistoryV2ManagerImpl(store, f.logger, p.NewPayloadSerializer(), codec.NewThriftRWEncoder(), f.config.TransactionSizeLimit)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	result := p.NewHistoryV2ManagerImpl(store, f.logger, p.NewPayloadSerializer(), codec.NewThriftRWEncoder(), f.dc.TransactionSizeLimit)
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewHistoryManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
@@ -249,7 +249,7 @@ func (f *factoryImpl) NewDomainManager() (p.DomainManager, error) {
 		return nil, err
 	}
 	result := p.NewDomainManagerImpl(store, f.logger, p.NewPayloadSerializer(), f.dc)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewDomainManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
@@ -322,7 +322,7 @@ func (f *factoryImpl) NewExecutionManager() (p.ExecutionManager, error) {
 		return nil, err
 	}
 	result := p.NewExecutionManagerImpl(store, f.logger, p.NewPayloadSerializer(), f.dc)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewExecutionManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
@@ -517,7 +517,7 @@ func (f *factoryImpl) newDBVisibilityManager(
 		return nil, err
 	}
 	result := p.NewVisibilityManagerImpl(store, f.logger, f.dc)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewVisibilityManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
@@ -550,7 +550,7 @@ func (f *factoryImpl) NewDomainReplicationQueueManager() (p.QueueManager, error)
 		return nil, err
 	}
 	result := p.NewQueueManager(store)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewQueueManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
@@ -570,7 +570,7 @@ func (f *factoryImpl) NewConfigStoreManager() (p.ConfigStoreManager, error) {
 		return nil, err
 	}
 	result := p.NewConfigStoreManagerImpl(store, f.logger)
-	if errorRate := f.config.ErrorInjectionRate(); errorRate != 0 {
+	if errorRate := f.dc.ErrorInjectionRate(); errorRate != 0 {
 		result = errorinjectors.NewConfigStoreManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {

--- a/common/persistence/client/factory_test.go
+++ b/common/persistence/client/factory_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/IBM/sarama/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 
@@ -262,8 +263,9 @@ func makeFactoryWithMetrics(t *testing.T, withMetrics bool) Factory {
 	if withMetrics {
 		met = metrics.NewClient(tally.NewTestScope("", nil), service.GetMetricsServiceIdx(service.Frontend, logger), metrics.MigrationConfig{})
 	}
-	ctrl := gomock.NewController(t)
-	dc := dynamicconfig.NewCollection(dynamicconfig.NewMockClient(ctrl), logger)
+	client := dynamicconfig.NewInMemoryClient()
+	require.NoError(t, client.UpdateValue(dynamicproperties.PersistenceErrorInjectionRate, 0.5))
+	dc := dynamicconfig.NewCollection(client, logger)
 	pdc := persistence.NewDynamicConfiguration(dc)
 
 	cfg := &config.Persistence{
@@ -277,10 +279,6 @@ func makeFactoryWithMetrics(t *testing.T, withMetrics bool) Factory {
 				ElasticSearch: &config.ElasticSearchConfig{},   // fields are unused but must be non-nil
 				Pinot:         &config.PinotVisibilityConfig{}, // fields are unused but must be non-nil
 			},
-		},
-		TransactionSizeLimit: nil,
-		ErrorInjectionRate: func(opts ...dynamicproperties.FilterOption) float64 {
-			return 0.5 // half errors, unused in these tests beyond "nonzero" so it wraps with the error injector
 		},
 	}
 

--- a/common/persistence/config.go
+++ b/common/persistence/config.go
@@ -40,10 +40,12 @@ type (
 		DomainAuditLogTTL                        dynamicproperties.DurationPropertyFnWithDomainIDFilter
 		HistoryNodeDeleteBatchSize               dynamicproperties.IntPropertyFn
 		RateLimiterBypassCallerTypes             dynamicproperties.ListPropertyFn
+		TransactionSizeLimit                     dynamicproperties.IntPropertyFn
+		ErrorInjectionRate                       dynamicproperties.FloatPropertyFn
 	}
 )
 
-// NewDynamicConfiguration returns new config with default values
+// NewDynamicConfiguration returns new config backed by the specified collection
 func NewDynamicConfiguration(dc *dynamicconfig.Collection) *DynamicConfiguration {
 	return &DynamicConfiguration{
 		EnableWorkflowTimerTaskCleanup:           dc.GetBoolProperty(dynamicproperties.EnableWorkflowTimerTaskCleanup),
@@ -58,5 +60,12 @@ func NewDynamicConfiguration(dc *dynamicconfig.Collection) *DynamicConfiguration
 		DomainAuditLogTTL:                        dc.GetDurationPropertyFilteredByDomainID(dynamicproperties.DomainAuditLogTTL),
 		HistoryNodeDeleteBatchSize:               dc.GetIntProperty(dynamicproperties.HistoryNodeDeleteBatchSize),
 		RateLimiterBypassCallerTypes:             dc.GetListProperty(dynamicproperties.RateLimiterBypassCallerTypes),
+		TransactionSizeLimit:                     dc.GetIntProperty(dynamicproperties.TransactionSizeLimit),
+		ErrorInjectionRate:                       dc.GetFloat64Property(dynamicproperties.PersistenceErrorInjectionRate),
 	}
+}
+
+// NewDefaultDynamicConfiguration returns new config with default values
+func NewDefaultDynamicConfiguration() *DynamicConfiguration {
+	return NewDynamicConfiguration(dynamicconfig.NewNopCollection())
 }

--- a/common/persistence/domain_audit_manager_test.go
+++ b/common/persistence/domain_audit_manager_test.go
@@ -48,9 +48,7 @@ func setUpMocksForDomainAuditManager(t *testing.T) (*domainAuditManagerImpl, *Mo
 		timeSrc:     clock.NewMockedTimeSourceAt(testTimeNow),
 		serializer:  NewPayloadSerializer(),
 		logger:      log.NewNoop(),
-		dc: &DynamicConfiguration{
-			DomainAuditLogTTL: func(domainID string) time.Duration { return time.Hour * 24 * 365 },
-		},
+		dc:          NewDefaultDynamicConfiguration(),
 	}
 
 	return m, mockStore

--- a/common/persistence/domain_manager_test.go
+++ b/common/persistence/domain_manager_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/types"
 )
@@ -144,7 +143,7 @@ func setUpMocksForDomainManager(t *testing.T) (*domainManagerImpl, *MockDomainSt
 	mockSerializer := NewMockPayloadSerializer(ctrl)
 	logger := log.NewNoop()
 
-	domainManager := NewDomainManagerImpl(mockStore, logger, mockSerializer, &DynamicConfiguration{SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW))}).(*domainManagerImpl)
+	domainManager := NewDomainManagerImpl(mockStore, logger, mockSerializer, NewDefaultDynamicConfiguration()).(*domainManagerImpl)
 
 	return domainManager, mockStore, mockSerializer
 }

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -141,9 +141,7 @@ func TestExecutionManager_ProxyStoreMethods(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockedStore := NewMockExecutionStore(ctrl)
 			tc.prepareMocks(mockedStore)
-			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, NewDefaultDynamicConfiguration())
 			v := reflect.ValueOf(manager)
 			method := v.MethodByName(tc.method)
 			methodType := method.Type()
@@ -177,9 +175,7 @@ func TestExecutionManager_GetWorkflowExecution(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetWorkflowExecutionRequest{
 		DomainID: testDomainID,
@@ -269,9 +265,7 @@ func TestExecutionManager_GetWorkflowExecution_NoWorkflow(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetWorkflowExecutionRequest{
 		DomainID: "testDomain",
@@ -294,9 +288,7 @@ func TestExecutionManager_UpdateWorkflowExecution(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	expectedInfo := sampleInternalWorkflowMutation()
 
@@ -500,9 +492,7 @@ func TestSerializeWorkflowSnapshot(t *testing.T) {
 
 			mockedSerializer := NewMockPayloadSerializer(ctrl)
 			tc.prepareMocks(mockedSerializer)
-			manager := NewExecutionManagerImpl(nil, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			}).(*executionManagerImpl)
+			manager := NewExecutionManagerImpl(nil, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration()).(*executionManagerImpl)
 			res, err := manager.SerializeWorkflowSnapshot(tc.input, constants.EncodingTypeThriftRW)
 			tc.checkRes(t, res, err)
 		})
@@ -546,9 +536,7 @@ func TestDeserializeBufferedEvents(t *testing.T) {
 
 			tc.prepareMocks(mockedSerializer)
 
-			manager := NewExecutionManagerImpl(nil, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			}).(*executionManagerImpl)
+			manager := NewExecutionManagerImpl(nil, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration()).(*executionManagerImpl)
 
 			events := []*DataBlob{
 				sampleEventData(),
@@ -564,9 +552,7 @@ func TestDeserializeBufferedEvents(t *testing.T) {
 func TestPutReplicationTaskToDLQ(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), NewDefaultDynamicConfiguration())
 
 	now := time.Now().UTC()
 
@@ -598,9 +584,7 @@ func TestPutReplicationTaskToDLQ(t *testing.T) {
 func TestGetReplicationTasksFromDLQ(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), NewDefaultDynamicConfiguration())
 
 	request := &GetReplicationTasksFromDLQRequest{
 		SourceClusterName: "test-cluster",
@@ -639,9 +623,7 @@ func TestGetReplicationTasksFromDLQ_WithBlob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetReplicationTasksFromDLQRequest{
 		SourceClusterName: "test-cluster",
@@ -686,9 +668,7 @@ func TestGetReplicationTasksFromDLQ_CorruptBlob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetReplicationTasksFromDLQRequest{
 		SourceClusterName: "test-cluster",
@@ -970,9 +950,7 @@ func TestListConcreteExecutions(t *testing.T) {
 
 			tc.prepareMocks(mockedStore, mockedSerializer)
 
-			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			res, err := manager.ListConcreteExecutions(context.Background(), request)
 
@@ -1087,9 +1065,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 				WorkflowRequestMode:      CreateWorkflowRequestModeReplicated,
 			}
 
-			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			res, err := manager.CreateWorkflowExecution(context.Background(), request)
 
@@ -1255,9 +1231,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 
 			tc.prepareMocks(mockedStore, mockedSerializer)
 
-			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			res, err := manager.ConflictResolveWorkflowExecution(context.Background(), tc.request)
 
@@ -1269,9 +1243,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 func TestCreateFailoverMarkerTasks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, NewDefaultDynamicConfiguration())
 
 	req := &CreateFailoverMarkersRequest{
 		Markers: []*FailoverMarkerTask{{
@@ -1362,9 +1334,7 @@ func TestGetActiveClusterSelectionPolicy(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockedStore := NewMockExecutionStore(ctrl)
 			mockedSerializer := NewMockPayloadSerializer(ctrl)
-			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			test.prepareMocks(mockedStore, mockedSerializer)
 
@@ -1415,9 +1385,7 @@ func TestDeleteActiveClusterSelectionPolicy(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockedStore := NewMockExecutionStore(ctrl)
-			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, NewDefaultDynamicConfiguration())
 
 			test.prepareMocks(mockedStore)
 
@@ -1777,11 +1745,10 @@ func TestUpdateWorkflowExecution_TimerTaskTracking(t *testing.T) {
 	longLivedTS := time.Now().Add(48 * time.Hour)
 	shortLivedID := int64(888)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		EnableWorkflowTimerTaskCleanup: dynamicproperties.GetBoolPropertyFn(true),
-		WorkflowTimerTaskCleanupMinTTL: dynamicproperties.GetDurationPropertyFn(minTTL),
-	})
+	dc := NewDefaultDynamicConfiguration()
+	dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
+	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	mutation := sampleWorkflowMutation()
 	mutation.TasksByCategory = map[HistoryTaskCategory][]Task{
@@ -1840,11 +1807,10 @@ func TestCreateWorkflowExecution_TimerTaskTracking(t *testing.T) {
 	longLivedTS := time.Now().Add(24 * time.Hour)
 	shortLivedID := int64(777)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		EnableWorkflowTimerTaskCleanup: dynamicproperties.GetBoolPropertyFn(true),
-		WorkflowTimerTaskCleanupMinTTL: dynamicproperties.GetDurationPropertyFn(minTTL),
-	})
+	dc := NewDefaultDynamicConfiguration()
+	dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
+	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	snapshot := sampleWorkflowSnapshot()
 	snapshot.TasksByCategory = map[HistoryTaskCategory][]Task{
@@ -1897,10 +1863,8 @@ func TestUpdateWorkflowExecution_TimerTaskTrackingFlagOff(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		EnableWorkflowTimerTaskCleanup: dynamicproperties.GetBoolPropertyFn(false),
-	})
+	// EnableWorkflowTimerTaskCleanup is false by default
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	mutation := sampleWorkflowMutation()
 	mutation.TasksByCategory = map[HistoryTaskCategory][]Task{
@@ -1939,10 +1903,8 @@ func TestCreateWorkflowExecution_TimerTaskTrackingFlagOff(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		EnableWorkflowTimerTaskCleanup: dynamicproperties.GetBoolPropertyFn(false),
-	})
+	// EnableWorkflowTimerTaskCleanup is false by default
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	snapshot := sampleWorkflowSnapshot()
 	snapshot.TasksByCategory = map[HistoryTaskCategory][]Task{
@@ -1988,11 +1950,10 @@ func TestConflictResolveWorkflowExecution_TimerTaskTracking(t *testing.T) {
 	shortLivedID := int64(444)
 	visTS := time.Now().Add(48 * time.Hour)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		EnableWorkflowTimerTaskCleanup: dynamicproperties.GetBoolPropertyFn(true),
-		WorkflowTimerTaskCleanupMinTTL: dynamicproperties.GetDurationPropertyFn(minTTL),
-	})
+	dc := NewDefaultDynamicConfiguration()
+	dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
+	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	makeTimerTask := func(taskID int64) Task {
 		return &WorkflowTimeoutTask{
@@ -2064,10 +2025,7 @@ func TestConflictResolveWorkflowExecution_TimerTaskTrackingFlagOff(t *testing.T)
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		EnableWorkflowTimerTaskCleanup: dynamicproperties.GetBoolPropertyFn(false),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	makeTimerTask := func(taskID int64) Task {
 		return &WorkflowTimeoutTask{
@@ -2115,10 +2073,9 @@ func TestFetchWorkflowTimerTasksForCleanup_FiltersCorrectly(t *testing.T) {
 	pastID := int64(3)
 	pastTS := time.Now().Add(-5 * time.Minute) // already fired, should be excluded
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		WorkflowTimerTaskCleanupMinTTL: dynamicproperties.GetDurationPropertyFn(minTTL),
-	})
+	dc := NewDefaultDynamicConfiguration()
+	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	shardID := 0
 	mockedStore.EXPECT().SelectWorkflowTimerTasks(gomock.Any(), &SelectWorkflowTimerTasksRequest{
@@ -2149,10 +2106,9 @@ func TestFetchWorkflowTimerTasksForCleanup_EmptyMap(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		WorkflowTimerTaskCleanupMinTTL: dynamicproperties.GetDurationPropertyFn(time.Hour),
-	})
+	dc := NewDefaultDynamicConfiguration()
+	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(time.Hour)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	shardID := 0
 	mockedStore.EXPECT().SelectWorkflowTimerTasks(gomock.Any(), &SelectWorkflowTimerTasksRequest{
@@ -2180,9 +2136,7 @@ func TestCompleteHistoryTasks(t *testing.T) {
 	taskID := int64(1)
 	visTS := time.Now().Add(48 * time.Hour)
 
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	shardID := 0
 	mockedStore.EXPECT().CompleteHistoryTask(gomock.Any(), gomock.Cond(func(req *CompleteHistoryTaskRequest) bool {

--- a/common/persistence/nosql/admin.go
+++ b/common/persistence/nosql/admin.go
@@ -28,7 +28,7 @@ func (n *nosqlAdmin) Identifier() string {
 }
 
 func (n *nosqlAdmin) CreateSetupDB() (persistence.SetupDB, error) {
-	return n.plugin.SetupDB(n.cfg, n.logger, &persistence.DynamicConfiguration{})
+	return n.plugin.SetupDB(n.cfg, n.logger, persistence.NewDefaultDynamicConfiguration())
 }
 
 func (n *nosqlAdmin) SupportsSchema() bool {
@@ -36,5 +36,5 @@ func (n *nosqlAdmin) SupportsSchema() bool {
 }
 
 func (n *nosqlAdmin) CreateSchemaDB() (persistence.SchemaDB, error) {
-	return n.plugin.SchemaDB(n.dbType, n.cfg, n.logger, &persistence.DynamicConfiguration{})
+	return n.plugin.SchemaDB(n.dbType, n.cfg, n.logger, persistence.NewDefaultDynamicConfiguration())
 }

--- a/common/persistence/nosql/nosql_execution_store_test.go
+++ b/common/persistence/nosql/nosql_execution_store_test.go
@@ -329,9 +329,7 @@ func TestUpdateWorkflowExecution(t *testing.T) {
 			controller := gomock.NewController(t)
 			mockDB := nosqlplugin.NewMockDB(controller)
 			mockTaskSerializer := serialization.NewMockTaskSerializer(controller)
-			store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), mockTaskSerializer, &persistence.DynamicConfiguration{
-				EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return false },
-			})
+			store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), mockTaskSerializer, persistence.NewDefaultDynamicConfiguration())
 
 			tc.setupMock(mockDB, 1)
 
@@ -1129,9 +1127,7 @@ func TestCreateHistoryTasks(t *testing.T) {
 	t.Run("when tasks span multiple workflows it should prepare them by category with per-task owners", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		mockDB := nosqlplugin.NewMockDB(controller)
-		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, &persistence.DynamicConfiguration{
-			EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return false },
-		})
+		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, persistence.NewDefaultDynamicConfiguration())
 
 		now := time.Unix(0, 12345)
 
@@ -1185,9 +1181,7 @@ func TestCreateHistoryTasks(t *testing.T) {
 	t.Run("when the request has no tasks it should not error", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		mockDB := nosqlplugin.NewMockDB(controller)
-		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, &persistence.DynamicConfiguration{
-			EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return false },
-		})
+		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, persistence.NewDefaultDynamicConfiguration())
 		mockDB.EXPECT().
 			InsertHistoryTasks(ctx, gomock.Len(0), gomock.Any(), nosqlplugin.ShardCondition{ShardID: shardID, RangeID: 1}).
 			Return(nil)
@@ -1200,9 +1194,7 @@ func TestCreateHistoryTasks(t *testing.T) {
 	t.Run("when a category other than transfer or timer is provided it should return a BadRequestError without writing", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		mockDB := nosqlplugin.NewMockDB(controller)
-		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, &persistence.DynamicConfiguration{
-			EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return false },
-		})
+		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, persistence.NewDefaultDynamicConfiguration())
 		// InsertHistoryTasks must never be called for an unsupported category.
 
 		err := store.CreateHistoryTasks(ctx, &persistence.CreateHistoryTasksRequest{
@@ -1219,9 +1211,7 @@ func TestCreateHistoryTasks(t *testing.T) {
 	t.Run("when InsertHistoryTasks returns a shard condition failure it should return a ShardOwnershipLostError", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		mockDB := nosqlplugin.NewMockDB(controller)
-		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, &persistence.DynamicConfiguration{
-			EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return false },
-		})
+		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, persistence.NewDefaultDynamicConfiguration())
 		mockDB.EXPECT().
 			InsertHistoryTasks(ctx, gomock.Any(), gomock.Any(), nosqlplugin.ShardCondition{ShardID: shardID, RangeID: 7}).
 			Return(&nosqlplugin.ShardOperationConditionFailure{RangeID: 8, Details: "boom"})
@@ -1241,9 +1231,7 @@ func TestCreateHistoryTasks(t *testing.T) {
 	t.Run("when InsertHistoryTasks returns a non-condition error it should return that error unchanged", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		mockDB := nosqlplugin.NewMockDB(controller)
-		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, &persistence.DynamicConfiguration{
-			EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return false },
-		})
+		store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, persistence.NewDefaultDynamicConfiguration())
 		genericErr := errors.New("some generic db error")
 		mockDB.EXPECT().
 			InsertHistoryTasks(ctx, gomock.Any(), gomock.Any(), nosqlplugin.ShardCondition{ShardID: shardID, RangeID: 7}).
@@ -1333,9 +1321,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 
 	mockDB := nosqlplugin.NewMockDB(gomockController)
 	mockTaskSerializer := serialization.NewMockTaskSerializer(gomockController)
-	store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), mockTaskSerializer, &persistence.DynamicConfiguration{
-		EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return false },
-	})
+	store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), mockTaskSerializer, persistence.NewDefaultDynamicConfiguration())
 
 	tests := []struct {
 		name          string
@@ -2047,9 +2033,11 @@ func TestGetHistoryTasks(t *testing.T) {
 
 			mockDB := nosqlplugin.NewMockDB(controller)
 			mockTaskSerializer := serialization.NewMockTaskSerializer(controller)
-			store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), mockTaskSerializer, &persistence.DynamicConfiguration{ReadNoSQLHistoryTaskFromDataBlob: func(...dynamicproperties.FilterOption) bool {
+			dc := persistence.NewDefaultDynamicConfiguration()
+			dc.ReadNoSQLHistoryTaskFromDataBlob = func(...dynamicproperties.FilterOption) bool {
 				return tc.readNoSQLHistoryTaskFromDataBlob
-			}})
+			}
+			store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), mockTaskSerializer, dc)
 
 			tc.setupMock(mockDB, mockTaskSerializer)
 
@@ -2166,7 +2154,7 @@ func TestCompleteHistoryTask(t *testing.T) {
 			defer controller.Finish()
 
 			mockDB := nosqlplugin.NewMockDB(controller)
-			store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, &persistence.DynamicConfiguration{})
+			store := newTestNosqlExecutionStoreWithOptions(mockDB, log.NewNoop(), nil, persistence.NewDefaultDynamicConfiguration())
 
 			tc.setupMock(mockDB)
 

--- a/common/persistence/nosql/nosql_execution_store_test_helpers.go
+++ b/common/persistence/nosql/nosql_execution_store_test_helpers.go
@@ -79,7 +79,7 @@ func newTestNosqlExecutionStoreWithOptions(
 	dc *persistence.DynamicConfiguration,
 ) *nosqlExecutionStore {
 	if dc == nil {
-		dc = &persistence.DynamicConfiguration{}
+		dc = persistence.NewDefaultDynamicConfiguration()
 	}
 	store := nosqlStore{logger: logger, db: db, dc: dc}
 	return &nosqlExecutionStore{

--- a/common/persistence/nosql/nosql_execution_store_util_test.go
+++ b/common/persistence/nosql/nosql_execution_store_util_test.go
@@ -45,9 +45,9 @@ import (
 var FixedTime = time.Date(2025, 1, 6, 15, 0, 0, 0, time.UTC)
 
 func newTestNosqlExecutionStoreWithTaskSerializer(db nosqlplugin.DB, logger log.Logger, taskSerializer serialization.TaskSerializer) *nosqlExecutionStore {
-	return newTestNosqlExecutionStoreWithOptions(db, logger, taskSerializer, &persistence.DynamicConfiguration{
-		EnableHistoryTaskDualWriteMode: func(...dynamicproperties.FilterOption) bool { return true },
-	})
+	dc := persistence.NewDefaultDynamicConfiguration()
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
+	return newTestNosqlExecutionStoreWithOptions(db, logger, taskSerializer, dc)
 }
 
 func TestNosqlExecutionStoreUtils(t *testing.T) {

--- a/common/persistence/nosql/nosql_shard_store_test.go
+++ b/common/persistence/nosql/nosql_shard_store_test.go
@@ -211,9 +211,7 @@ func TestGetShard(t *testing.T) {
 		{
 			name: "success - no update",
 			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
-					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(true),
-				}}, nil).Times(1)
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: persistence.NewDefaultDynamicConfiguration()}, nil).Times(1)
 				shardInfo := testFixtureInternalShardInfo()
 				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(101), &nosqlplugin.ShardRow{
 					InternalShardInfo: shardInfo,
@@ -314,9 +312,9 @@ func TestGetShard(t *testing.T) {
 		{
 			name: "success - fix shard",
 			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
-					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(false),
-				}}, nil).Times(2)
+				dc := persistence.NewDefaultDynamicConfiguration()
+				dc.ReadNoSQLShardFromDataBlob = dynamicproperties.GetBoolPropertyFn(false)
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: dc}, nil).Times(2)
 				storeShardMock.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
 				storeShardMock.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).Times(1)
 				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), &nosqlplugin.ShardRow{
@@ -335,9 +333,9 @@ func TestGetShard(t *testing.T) {
 		{
 			name: "error fixing shard - shard ownership lost error",
 			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
-					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(false),
-				}}, nil).Times(2)
+				dc := persistence.NewDefaultDynamicConfiguration()
+				dc.ReadNoSQLShardFromDataBlob = dynamicproperties.GetBoolPropertyFn(false)
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: dc}, nil).Times(2)
 				storeShardMock.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
 				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), &nosqlplugin.ShardRow{
 					InternalShardInfo: testFixtureInternalShardInfo(),
@@ -356,9 +354,9 @@ func TestGetShard(t *testing.T) {
 		{
 			name: "error fixing shard - generic db error",
 			setupMock: func(dbMock *nosqlplugin.MockDB, storeShardMock *MockshardedNosqlStore, mockParser *serialization.MockParser) {
-				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: &persistence.DynamicConfiguration{
-					ReadNoSQLShardFromDataBlob: dynamicproperties.GetBoolPropertyFn(false),
-				}}, nil).Times(2)
+				dc := persistence.NewDefaultDynamicConfiguration()
+				dc.ReadNoSQLShardFromDataBlob = dynamicproperties.GetBoolPropertyFn(false)
+				storeShardMock.EXPECT().GetStoreShardByHistoryShard(1).Return(&nosqlStore{db: dbMock, dc: dc}, nil).Times(2)
 				storeShardMock.EXPECT().GetLogger().Return(log.NewNoop()).Times(1)
 				dbMock.EXPECT().SelectShard(gomock.Any(), 1, "test-cluster").Return(int64(100), &nosqlplugin.ShardRow{
 					InternalShardInfo: testFixtureInternalShardInfo(),

--- a/common/persistence/nosql/nosql_test_utils.go
+++ b/common/persistence/nosql/nosql_test_utils.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 )
 
 // TestClusterParams are params for test cluster initialization.
@@ -63,8 +61,6 @@ func NewTestCluster(_ *testing.T, params TestClusterParams) config.Persistence {
 		DataStores: map[string]config.DataStore{
 			"test": {NoSQL: &cfg},
 		},
-		TransactionSizeLimit: dynamicproperties.GetIntPropertyFn(constants.DefaultTransactionSizeLimit),
-		ErrorInjectionRate:   dynamicproperties.GetFloatPropertyFn(0),
 	}
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/db_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/db_test.go
@@ -39,7 +39,7 @@ func TestCDBBasics(t *testing.T) {
 	client := gocql.NewMockClient(ctrl)
 	cfg := &config.NoSQL{}
 	logger := testlogger.New(t)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 
 	db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -161,10 +161,9 @@ func TestExecuteWithConsistencyAll(t *testing.T) {
 			query := gocql.NewMockQuery(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{
-				EnableCassandraAllConsistencyLevelDelete: func(opts ...dynamicproperties.FilterOption) bool {
-					return tc.enableAllConsistencyLevelDelete
-				},
+			dc := persistence.NewDefaultDynamicConfiguration()
+			dc.EnableCassandraAllConsistencyLevelDelete = func(opts ...dynamicproperties.FilterOption) bool {
+				return tc.enableAllConsistencyLevelDelete
 			}
 
 			if tc.queryMockPrep != nil {
@@ -261,10 +260,9 @@ func TestExecuteBatchWithConsistencyAll(t *testing.T) {
 			batch := gocql.NewMockBatch(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{
-				EnableCassandraAllConsistencyLevelDelete: func(opts ...dynamicproperties.FilterOption) bool {
-					return tc.enableAllConsistencyLevelDelete
-				},
+			dc := persistence.NewDefaultDynamicConfiguration()
+			dc.EnableCassandraAllConsistencyLevelDelete = func(opts ...dynamicproperties.FilterOption) bool {
+				return tc.enableAllConsistencyLevelDelete
 			}
 
 			if tc.sessionMockPrep != nil {

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain_audit_log_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain_audit_log_test.go
@@ -95,7 +95,7 @@ func TestInsertDomainAuditLog(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -447,7 +447,7 @@ func TestSelectDomainAuditLogs(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
@@ -247,7 +246,7 @@ func TestInsertDomain(t *testing.T) {
 			}
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			err := db.InsertDomain(context.Background(), tc.row)
@@ -380,7 +379,7 @@ func TestUpdateDomain(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			err := db.UpdateDomain(context.Background(), tc.row)
@@ -504,7 +503,7 @@ func TestSelectDomain(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -751,7 +750,7 @@ func TestSelectDomainMetadata(t *testing.T) {
 			}
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -922,11 +921,8 @@ func TestDeleteDomain(t *testing.T) {
 			}
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{
-				EnableCassandraAllConsistencyLevelDelete: func(opts ...dynamicproperties.FilterOption) bool {
-					return false
-				},
-			}
+			// EnableCassandraAllConsistencyLevelDelete is false by default
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/history_task_dlq_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/history_task_dlq_test.go
@@ -87,7 +87,7 @@ func TestInsertHistoryDLQAckLevelIfNotExistsRow(t *testing.T) {
 			tc.queryMockFn(query)
 			session := &fakeSession{query: query}
 			client := gocql.NewMockClient(ctrl)
-			db := NewCassandraDBFromSession(&config.NoSQL{}, session, testlogger.New(t), &persistence.DynamicConfiguration{}, DbWithClient(client))
+			db := NewCassandraDBFromSession(&config.NoSQL{}, session, testlogger.New(t), persistence.NewDefaultDynamicConfiguration(), DbWithClient(client))
 
 			err := db.InsertHistoryDLQAckLevelIfNotExistsRow(context.Background(), row)
 
@@ -151,7 +151,7 @@ func TestInsertOrUpdateHistoryDLQAckLevelRow(t *testing.T) {
 			tc.queryMockFn(query)
 			session := &fakeSession{query: query}
 			client := gocql.NewMockClient(ctrl)
-			db := NewCassandraDBFromSession(&config.NoSQL{}, session, testlogger.New(t), &persistence.DynamicConfiguration{}, DbWithClient(client))
+			db := NewCassandraDBFromSession(&config.NoSQL{}, session, testlogger.New(t), persistence.NewDefaultDynamicConfiguration(), DbWithClient(client))
 
 			err := db.InsertOrUpdateHistoryDLQAckLevelRow(context.Background(), row)
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue_test.go
@@ -92,7 +92,7 @@ func TestInsertIntoQueue(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -160,7 +160,7 @@ func TestSelectLastEnqueuedMessageID(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			gotMsgID, err := db.SelectLastEnqueuedMessageID(context.Background(), tc.queueType)
@@ -261,7 +261,7 @@ func TestSelectQueueMetadata(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -333,7 +333,7 @@ func TestGetQueueSize(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			gotCount, err := db.GetQueueSize(context.Background(), tc.queueType)
@@ -824,7 +824,7 @@ func TestInsertQueueMetadata(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -913,7 +913,7 @@ func TestUpdateQueueMetadataCas(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/semaphore_metadata_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/semaphore_metadata_test.go
@@ -97,7 +97,7 @@ func TestInsertSemaphoreMetadata(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -176,7 +176,7 @@ func TestSelectSemaphoreMetadata(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -356,7 +356,7 @@ func TestSelectSemaphoreMetadataByDomain(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard_test.go
@@ -111,7 +111,7 @@ func TestInsertShard(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			err := db.InsertShard(context.Background(), tc.row)
@@ -264,7 +264,7 @@ func TestSelectShard(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			gotRangeID, gotShardInfo, err := db.SelectShard(context.Background(), tc.shardID, tc.cluster)
@@ -365,7 +365,7 @@ func TestUpdateRangeID(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			err := db.UpdateRangeID(context.Background(), tc.shardID, tc.rangeID, tc.prevRangeID)
@@ -481,7 +481,7 @@ func TestUpdateShard(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			err := db.UpdateShard(context.Background(), tc.row, tc.prevRangeID)

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks_test.go
@@ -184,7 +184,7 @@ func TestSelectTaskList(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -336,7 +336,7 @@ func TestInsertTaskList(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -448,7 +448,7 @@ func TestUpdateTaskList(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -549,7 +549,7 @@ func TestUpdateTaskListWithTTL(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 			err := db.UpdateTaskListWithTTL(context.Background(), tc.ttlSeconds, tc.row, tc.prevRangeID)
@@ -574,7 +574,7 @@ func TestListTaskList(t *testing.T) {
 	client := gocql.NewMockClient(ctrl)
 	cfg := &config.NoSQL{}
 	logger := testlogger.New(t)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	session := &fakeSession{}
 	db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -717,7 +717,7 @@ func TestDeleteTaskList(t *testing.T) {
 			}
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -828,7 +828,7 @@ func TestInsertTasks(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -913,7 +913,7 @@ func TestGetTasksCount(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/visibility_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/visibility_test.go
@@ -88,7 +88,7 @@ func TestInsertVisibility(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			err := db.InsertVisibility(context.Background(), test.ttlSeconds, test.row)
@@ -158,7 +158,7 @@ func TestUpdateVisibility(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 			err := db.UpdateVisibility(context.Background(), test.ttlSeconds, test.row)
 			if test.wantErr {
@@ -257,7 +257,7 @@ func TestSelectOneClosedWorkflow(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 			result, err := db.SelectOneClosedWorkflow(context.Background(), test.domainID, test.workflowID, test.runID)
 			if test.wantError {
@@ -299,7 +299,7 @@ func TestDeleteVisibility(t *testing.T) {
 			itrMockFunc:    nil,
 			queryMockFunc:  nil,
 			context:        context.Background(),
-			dc:             &persistence.DynamicConfiguration{},
+			dc:             persistence.NewDefaultDynamicConfiguration(),
 			clientMockFunc: nil,
 			wantQueries:    nil,
 			wantError:      false,
@@ -315,7 +315,7 @@ func TestDeleteVisibility(t *testing.T) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query)
 			},
 			context:        context.WithValue(context.Background(), persistence.VisibilityAdminDeletionKey("visibilityAdminDelete"), true),
-			dc:             &persistence.DynamicConfiguration{},
+			dc:             persistence.NewDefaultDynamicConfiguration(),
 			clientMockFunc: nil,
 			wantQueries:    []string{`SELECT  workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_list, is_cron, num_clusters, update_time, shard_id, execution_status, cron_schedule, scheduled_execution_time FROM open_executions WHERE domain_id = test-domain-id AND domain_partition = 0 AND run_id = test-run-id ALLOW FILTERING`},
 			wantError:      true,
@@ -333,7 +333,7 @@ func TestDeleteVisibility(t *testing.T) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query)
 			},
 			context:        context.WithValue(context.Background(), persistence.VisibilityAdminDeletionKey("visibilityAdminDelete"), true),
-			dc:             &persistence.DynamicConfiguration{},
+			dc:             persistence.NewDefaultDynamicConfiguration(),
 			clientMockFunc: nil,
 			wantQueries:    []string{`SELECT  workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_list, is_cron, num_clusters, update_time, shard_id, execution_status, cron_schedule, scheduled_execution_time FROM open_executions WHERE domain_id = test-domain-id AND domain_partition = 0 AND run_id = test-run-id ALLOW FILTERING`},
 			wantError:      false,
@@ -352,7 +352,7 @@ func TestDeleteVisibility(t *testing.T) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query)
 			},
 			context:        context.WithValue(context.Background(), persistence.VisibilityAdminDeletionKey("visibilityAdminDelete"), true),
-			dc:             &persistence.DynamicConfiguration{},
+			dc:             persistence.NewDefaultDynamicConfiguration(),
 			clientMockFunc: nil,
 			wantQueries:    []string{`SELECT  workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_list, is_cron, num_clusters, update_time, shard_id, execution_status, cron_schedule, scheduled_execution_time FROM open_executions WHERE domain_id = test-domain-id AND domain_partition = 0 AND run_id = test-run-id ALLOW FILTERING`},
 			wantError:      true,
@@ -395,10 +395,8 @@ func TestDeleteVisibility(t *testing.T) {
 				query.EXPECT().Consistency(gomock.Any()).Return(query)
 				query.EXPECT().Exec().Return(nil)
 			},
-			context: context.WithValue(context.Background(), persistence.VisibilityAdminDeletionKey("visibilityAdminDelete"), true),
-			dc: &persistence.DynamicConfiguration{EnableCassandraAllConsistencyLevelDelete: func(opts ...dynamicproperties.FilterOption) bool {
-				return true
-			}},
+			context:        context.WithValue(context.Background(), persistence.VisibilityAdminDeletionKey("visibilityAdminDelete"), true),
+			dc:             dcWithAllConsistencyLevelDelete(),
 			clientMockFunc: nil,
 			wantQueries: []string{
 				`SELECT  workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_list, is_cron, num_clusters, update_time, shard_id, execution_status, cron_schedule, scheduled_execution_time FROM open_executions WHERE domain_id = test-domain-id AND domain_partition = 0 AND run_id = test-run-id ALLOW FILTERING`,
@@ -424,9 +422,7 @@ func TestDeleteVisibility(t *testing.T) {
 				itr.EXPECT().Scan(generateMockParams(15)...).Return(true)
 				itr.EXPECT().Close().Return(nil)
 			},
-			dc: &persistence.DynamicConfiguration{
-				EnableCassandraAllConsistencyLevelDelete: func(opts ...dynamicproperties.FilterOption) bool { return true },
-			},
+			dc: dcWithAllConsistencyLevelDelete(),
 			clientMockFunc: func(client *gocql.MockClient) {
 				client.EXPECT().IsCassandraConsistencyError(gomock.Any()).Return(true)
 			},
@@ -452,9 +448,7 @@ func TestDeleteVisibility(t *testing.T) {
 				itr.EXPECT().Scan(generateMockParams(15)...).Return(true)
 				itr.EXPECT().Close().Return(nil)
 			},
-			dc: &persistence.DynamicConfiguration{
-				EnableCassandraAllConsistencyLevelDelete: func(opts ...dynamicproperties.FilterOption) bool { return true },
-			},
+			dc: dcWithAllConsistencyLevelDelete(),
 			clientMockFunc: func(client *gocql.MockClient) {
 				client.EXPECT().IsCassandraConsistencyError(gomock.Any()).Return(false)
 			},
@@ -883,7 +877,7 @@ func TestSelectVisibility(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 			result, err := db.SelectVisibility(context.Background(), test.filter)
 			if test.wantError {
@@ -907,4 +901,10 @@ func generateMockParams(count int) []interface{} {
 		params = append(params, gomock.Any())
 	}
 	return params
+}
+
+func dcWithAllConsistencyLevelDelete() *persistence.DynamicConfiguration {
+	dc := persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	return dc
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
@@ -152,7 +152,7 @@ func TestInsertWorkflowExecutionWithTasks(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -487,7 +487,7 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -614,7 +614,7 @@ func TestSelectWorkflowExecution(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
@@ -854,7 +854,7 @@ func TestSelectAllCurrentWorkflows(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			gotExecutions, gotPageToken, err := db.SelectAllCurrentWorkflows(context.Background(), tc.shardID, tc.pageToken, tc.pageSize)
@@ -976,7 +976,7 @@ func TestSelectAllWorkflowExecutions(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			gotExecutions, gotPageToken, err := db.SelectAllWorkflowExecutions(context.Background(), tc.shardID, tc.pageToken, tc.pageSize)
@@ -1063,7 +1063,7 @@ func TestIsWorkflowExecutionExists(t *testing.T) {
 
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			got, err := db.IsWorkflowExecutionExists(context.Background(), 1, "domain1", "wfi", "run1")
@@ -1183,7 +1183,7 @@ func TestSelectTransferTasksOrderByTaskID(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			gotTasks, gotPageToken, err := db.SelectTransferTasksOrderByTaskID(context.Background(), tc.shardID, tc.pageSize, tc.pageToken, tc.inclusiveMinTaskID, tc.exclusiveMaxTaskID)
@@ -1424,7 +1424,7 @@ func TestSelectTimerTasksOrderByVisibilityTime(t *testing.T) {
 			client := gocql.NewMockClient(ctrl)
 			cfg := &config.NoSQL{}
 			logger := testlogger.New(t)
-			dc := &persistence.DynamicConfiguration{}
+			dc := persistence.NewDefaultDynamicConfiguration()
 			db := NewCassandraDBFromSession(cfg, session, logger, dc, DbWithClient(client))
 
 			gotTasks, gotPageToken, err := db.SelectTimerTasksOrderByVisibilityTime(context.Background(), tc.shardID, tc.pageSize, tc.pageToken, tc.inclusiveMinTime, tc.exclusiveMaxTime)

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -153,18 +153,10 @@ func NewTestBaseWithNoSQL(t *testing.T, options *TestBaseOptions) *TestBase {
 	if metadata.GetCurrentClusterName() == "" {
 		metadata = cluster.GetTestClusterMetadata(false)
 	}
-	dc := persistence.DynamicConfiguration{
-		EnableSQLAsyncTransaction:                dynamicproperties.GetBoolPropertyFn(false),
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-		DomainAuditLogTTL:                        func(domainID string) time.Duration { return time.Hour * 24 * 365 }, // 1 year default
-		HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-		EnableWorkflowTimerTaskCleanup:           dynamicproperties.GetBoolPropertyFn(true),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
 	params := TestBaseParams{
 		PersistenceConfig:    testClusterCfg,
 		ClusterMetadata:      metadata,
@@ -186,18 +178,10 @@ func NewTestBaseWithSQL(t *testing.T, options *TestBaseOptions) *TestBase {
 	if metadata.GetCurrentClusterName() == "" {
 		metadata = cluster.GetTestClusterMetadata(false)
 	}
-	dc := persistence.DynamicConfiguration{
-		EnableSQLAsyncTransaction:                dynamicproperties.GetBoolPropertyFn(false),
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-		DomainAuditLogTTL:                        func(domainID string) time.Duration { return time.Hour * 24 * 365 }, // 1 year default
-		HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-		EnableWorkflowTimerTaskCleanup:           dynamicproperties.GetBoolPropertyFn(false),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
+	// EnableWorkflowTimerTaskCleanup is false by default
 	params := TestBaseParams{
 		PersistenceConfig:    testConfig,
 		ClusterMetadata:      metadata,

--- a/common/persistence/pinot/pinot_visibility_metric_clients_test.go
+++ b/common/persistence/pinot/pinot_visibility_metric_clients_test.go
@@ -32,7 +32,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/.gen/go/indexer"
-	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
@@ -40,7 +39,6 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	metricsClientMocks "github.com/uber/cadence/common/metrics/mocks"
 	"github.com/uber/cadence/common/mocks"
-	"github.com/uber/cadence/common/persistence"
 	p "github.com/uber/cadence/common/persistence"
 	pnt "github.com/uber/cadence/common/pinot"
 	"github.com/uber/cadence/common/service"
@@ -119,9 +117,7 @@ func TestMetricClientRecordWorkflowExecutionStarted(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -206,9 +202,7 @@ func TestMetricClientRecordWorkflowExecutionClosed(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -283,9 +277,7 @@ func TestMetricClientRecordWorkflowExecutionUninitialized(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -360,9 +352,7 @@ func TestMetricClientUpsertWorkflowExecution(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -435,9 +425,7 @@ func TestMetricClientListOpenWorkflowExecutions(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -510,9 +498,7 @@ func TestMetricClientListClosedWorkflowExecutions(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -586,9 +572,7 @@ func TestMetricClientListOpenWorkflowExecutionsByType(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -662,9 +646,7 @@ func TestMetricClientListClosedWorkflowExecutionsByType(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -737,9 +719,7 @@ func TestMetricClientListOpenWorkflowExecutionsByWorkflowID(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -812,9 +792,7 @@ func TestMetricClientListClosedWorkflowExecutionsByWorkflowID(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -891,9 +869,7 @@ func TestMetricClientListClosedWorkflowExecutionsByStatus(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -968,9 +944,7 @@ func TestMetricClientGetClosedWorkflowExecution(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -1041,9 +1015,7 @@ func TestMetricClientListWorkflowExecutions(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -1110,9 +1082,7 @@ func TestMetricClientScanWorkflowExecutions(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -1179,9 +1149,7 @@ func TestMetricClientCountWorkflowExecutions(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -1256,9 +1224,7 @@ func TestMetricClientDeleteWorkflowExecution(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -1329,9 +1295,7 @@ func TestMetricClientDeleteUninitializedWorkflowExecution(t *testing.T) {
 				ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 			}, mockProducer, testlogger.New(t))
 			visibilityStore := mgr.(*pinotVisibilityStore)
-			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 			visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 			metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -1362,9 +1326,7 @@ func TestMetricClientClose(t *testing.T) {
 		ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 	}, mockProducer, testlogger.New(t))
 	visibilityStore := mgr.(*pinotVisibilityStore)
-	pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 	visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 	metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 
@@ -1388,9 +1350,7 @@ func TestMetricClientGetName(t *testing.T) {
 		ESIndexMaxResultWindow: dynamicproperties.GetIntPropertyFn(3),
 	}, mockProducer, testlogger.New(t))
 	visibilityStore := mgr.(*pinotVisibilityStore)
-	pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	pinotVisibilityManager := p.NewVisibilityManagerImpl(visibilityStore, logger, p.NewDefaultDynamicConfiguration())
 	visibilityMgr := NewPinotVisibilityMetricsClient(pinotVisibilityManager, mockMetricClient, logger)
 	metricsClient := visibilityMgr.(*pinotVisibilityMetricsClient)
 

--- a/common/persistence/serialization/parser_test.go
+++ b/common/persistence/serialization/parser_test.go
@@ -32,17 +32,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
 
 func TestParserRoundTrip(t *testing.T) {
-	dc := &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	}
-	thriftParser, err := NewParser(dc)
+	thriftParser, err := NewParser(persistence.NewDefaultDynamicConfiguration())
 	assert.NoError(t, err)
 	now := time.Now().Round(time.Second)
 
@@ -359,10 +354,7 @@ func TestParser_WorkflowExecution_with_cron(t *testing.T) {
 		CronSchedule: "@every 1m",
 		IsCron:       true,
 	}
-	dc := &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	}
-	parser, err := NewParser(dc)
+	parser, err := NewParser(persistence.NewDefaultDynamicConfiguration())
 	require.NoError(t, err)
 	blob, err := parser.WorkflowExecutionInfoToBlob(info)
 	require.NoError(t, err)

--- a/common/persistence/serialization/snappy_thrift_decoder_test.go
+++ b/common/persistence/serialization/snappy_thrift_decoder_test.go
@@ -36,9 +36,8 @@ import (
 )
 
 func TestSnappyThriftDecoderRoundTrip(t *testing.T) {
-	dc := &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRWSnappy)),
-	}
+	dc := persistence.NewDefaultDynamicConfiguration()
+	dc.SerializationEncoding = dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRWSnappy))
 	parser, err := NewParser(dc)
 	require.NoError(t, err)
 

--- a/common/persistence/serialization/snappy_thrift_encoder_test.go
+++ b/common/persistence/serialization/snappy_thrift_encoder_test.go
@@ -404,9 +404,8 @@ func TestSnappyThriftRWEncode(t *testing.T) {
 }
 
 func TestSnappyThriftEncoderWithParser(t *testing.T) {
-	dc := &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRWSnappy)),
-	}
+	dc := persistence.NewDefaultDynamicConfiguration()
+	dc.SerializationEncoding = dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRWSnappy))
 	// Test encoder integration with parser
 	parser, err := NewParser(dc)
 	require.NoError(t, err)

--- a/common/persistence/serialization/task_serializer_test.go
+++ b/common/persistence/serialization/task_serializer_test.go
@@ -29,16 +29,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 )
 
 func TestTaskSerializerThriftRW(t *testing.T) {
-	dc := &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	}
-	parser, err := NewParser(dc)
+	parser, err := NewParser(persistence.NewDefaultDynamicConfiguration())
 	require.NoError(t, err)
 	taskSerializer := NewTaskSerializer(parser)
 

--- a/common/persistence/shard_manager_test.go
+++ b/common/persistence/shard_manager_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -42,9 +41,7 @@ func TestShardManagerGetName(t *testing.T) {
 	store := NewMockShardStore(ctrl)
 	store.EXPECT().GetName().Return("name")
 
-	manager := NewShardManager(store, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewShardManager(store, NewDefaultDynamicConfiguration())
 
 	assert.Equal(t, "name", manager.GetName())
 }
@@ -54,9 +51,7 @@ func TestShardManagerClose(t *testing.T) {
 	store := NewMockShardStore(ctrl)
 	store.EXPECT().Close().Times(1)
 
-	manager := NewShardManager(store, &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	manager := NewShardManager(store, NewDefaultDynamicConfiguration())
 	manager.Close()
 }
 
@@ -111,9 +106,7 @@ func TestShardManagerCreateShard(t *testing.T) {
 					}).Return(test.internalResponse)
 			}
 
-			manager := NewShardManager(store, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			}, WithSerializer(test.serializer))
+			manager := NewShardManager(store, NewDefaultDynamicConfiguration(), WithSerializer(test.serializer))
 
 			result := manager.CreateShard(context.Background(), test.request)
 
@@ -193,9 +186,7 @@ func TestShardManagerGetShard(t *testing.T) {
 				store.EXPECT().GetShard(gomock.Any(), gomock.Eq(test.internalRequest)).Return(test.internalResponse, test.internalErr)
 			}
 
-			manager := NewShardManager(store, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			}, WithSerializer(test.serializer))
+			manager := NewShardManager(store, NewDefaultDynamicConfiguration(), WithSerializer(test.serializer))
 
 			result, err := manager.GetShard(context.Background(), test.request)
 			assert.Equal(t, test.expected, result)
@@ -261,9 +252,7 @@ func TestShardManagerUpdateShard(t *testing.T) {
 					}).Return(test.internalResponse)
 			}
 
-			manager := NewShardManager(store, &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			}, WithSerializer(test.serializer))
+			manager := NewShardManager(store, NewDefaultDynamicConfiguration(), WithSerializer(test.serializer))
 
 			result := manager.UpdateShard(context.Background(), test.request)
 

--- a/common/persistence/sql/factory_test.go
+++ b/common/persistence/sql/factory_test.go
@@ -41,7 +41,7 @@ func TestNewFactory(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	assert.NotNil(t, factory)
 }
@@ -53,7 +53,7 @@ func TestFactoryNewTaskStore(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	taskStore, err := factory.NewTaskStore()
 	assert.Nil(t, taskStore)
@@ -75,7 +75,7 @@ func TestFactoryNewShardStore(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	shardStore, err := factory.NewShardStore()
 	assert.Nil(t, shardStore)
@@ -97,7 +97,7 @@ func TestFactoryNewHistoryV2Store(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	historyV2Store, err := factory.NewHistoryStore()
 	assert.Nil(t, historyV2Store)
@@ -119,7 +119,7 @@ func TestFactoryNewMetadataV2Store(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	metadataV2Store, err := factory.NewDomainStore()
 	assert.Nil(t, metadataV2Store)
@@ -141,7 +141,7 @@ func TestFactoryNewExecutionStore(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	executionStore, err := factory.NewExecutionStore()
 	assert.Nil(t, executionStore)
@@ -163,7 +163,7 @@ func TestFactoryNewVisibilityStore(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	visibilityStore, err := factory.NewVisibilityStore(true)
 	assert.Nil(t, visibilityStore)
@@ -185,7 +185,7 @@ func TestFactoryNewQueue(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	queueStore, err := factory.NewQueue(persistence.DomainReplicationQueueType)
 	assert.Nil(t, queueStore)
@@ -207,7 +207,7 @@ func TestFactoryNewConfigStore(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	configStore, err := factory.NewConfigStore()
 	assert.Nil(t, configStore)
@@ -229,7 +229,7 @@ func TestFactoryNewDomainAuditStore(t *testing.T) {
 	clusterName := "test"
 	logger := testlogger.New(t)
 	mockParser := serialization.NewMockParser(ctrl)
-	dc := &persistence.DynamicConfiguration{}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	factory := NewFactory(cfg, clusterName, logger, mockParser, dc)
 	domainAuditStore, err := factory.NewDomainAuditStore()
 	assert.Nil(t, domainAuditStore)

--- a/common/persistence/sql/sql_history_store_test.go
+++ b/common/persistence/sql/sql_history_store_test.go
@@ -1065,9 +1065,8 @@ func TestDeleteHistoryBranch_CustomBatchSize(t *testing.T) {
 	mockParser := serialization.NewMockParser(ctrl)
 
 	customBatchSize := 500
-	dc := &persistence.DynamicConfiguration{
-		HistoryNodeDeleteBatchSize: func(...dynamicproperties.FilterOption) int { return customBatchSize },
-	}
+	dc := persistence.NewDefaultDynamicConfiguration()
+	dc.HistoryNodeDeleteBatchSize = dynamicproperties.GetIntPropertyFn(customBatchSize)
 
 	store, err := NewHistoryV2Persistence(mockDB, nil, mockParser, dc)
 	require.NoError(t, err)
@@ -1122,9 +1121,8 @@ func TestDeleteHistoryBranch_UnboundedBatchSize(t *testing.T) {
 	mockTx := sqlplugin.NewMockTx(ctrl)
 	mockParser := serialization.NewMockParser(ctrl)
 
-	dc := &persistence.DynamicConfiguration{
-		HistoryNodeDeleteBatchSize: func(...dynamicproperties.FilterOption) int { return 0 },
-	}
+	dc := persistence.NewDefaultDynamicConfiguration()
+	dc.HistoryNodeDeleteBatchSize = dynamicproperties.GetIntPropertyFn(0)
 
 	store, err := NewHistoryV2Persistence(mockDB, nil, mockParser, dc)
 	require.NoError(t, err)
@@ -1179,9 +1177,8 @@ func TestDeleteHistoryBranch_NegativeBatchSize(t *testing.T) {
 	mockTx := sqlplugin.NewMockTx(ctrl)
 	mockParser := serialization.NewMockParser(ctrl)
 
-	dc := &persistence.DynamicConfiguration{
-		HistoryNodeDeleteBatchSize: func(...dynamicproperties.FilterOption) int { return -100 },
-	}
+	dc := persistence.NewDefaultDynamicConfiguration()
+	dc.HistoryNodeDeleteBatchSize = dynamicproperties.GetIntPropertyFn(-100)
 
 	store, err := NewHistoryV2Persistence(mockDB, nil, mockParser, dc)
 	require.NoError(t, err)

--- a/common/persistence/sql/sql_task_store_test.go
+++ b/common/persistence/sql/sql_task_store_test.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/serialization"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
@@ -1735,9 +1734,7 @@ func TestHelp(t *testing.T) {
 	shard := sqlplugin.GetDBShardIDFromDomainIDAndTasklist("c4b5cb22-c213-4812-bb4a-fc1ade5405ef", "pgtasklist", 16384)
 	println("shard: ", shard)
 	// BgAKAAAKAAwAAAAABQ+kWAoADgAAAAAAAAAACgAQGB6uFsU9cvEMABIKAAoAAAAAAAAAAQgADAAAAAAIAA4AAAAAAAA=
-	dc := &persistence.DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	}
+	dc := persistence.NewDefaultDynamicConfiguration()
 	parser, err := serialization.NewParser(dc)
 	require.NoError(t, err)
 	data, err := base64.StdEncoding.DecodeString("BgAKAAAKAAwAAAAABGGFYAoADgAAAAAAAAAACgAQGB6uGPaVqOUMABIKAAoAAAAAAAAAAQgADAAAAAIIAA4AAAACAAA=")

--- a/common/persistence/sql/sql_test_utils.go
+++ b/common/persistence/sql/sql_test_utils.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 )
 
 // NewTestCluster returns a new SQL test cluster
@@ -56,8 +54,6 @@ func NewTestCluster(pluginName, dbName, username, password, host string, port in
 		DataStores: map[string]config.DataStore{
 			"test": {SQL: &cfg},
 		},
-		TransactionSizeLimit: dynamicproperties.GetIntPropertyFn(constants.DefaultTransactionSizeLimit),
-		ErrorInjectionRate:   dynamicproperties.GetFloatPropertyFn(0),
-		NumHistoryShards:     cfg.NumShards,
+		NumHistoryShards: cfg.NumShards,
 	}, nil
 }

--- a/common/persistence/visibility_single_manager_test.go
+++ b/common/persistence/visibility_single_manager_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/types"
 )
@@ -50,9 +48,7 @@ func TestNewVisibilityManagerImpl(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
 			assert.NotPanics(t, func() {
-				NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-					SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-				})
+				NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 			})
 		})
 	}
@@ -71,9 +67,7 @@ func TestClose(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
 			mockVisibilityStore.EXPECT().Close().Return().Times(1)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 			assert.NotPanics(t, func() {
 				visibilityManager.Close()
 			})
@@ -94,9 +88,7 @@ func TestGetName(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
 			mockVisibilityStore.EXPECT().GetName().Return(testTableName).Times(1)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			assert.NotPanics(t, func() {
 				visibilityManager.GetName()
@@ -159,9 +151,7 @@ func TestRecordWorkflowExecutionStarted(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -225,9 +215,7 @@ func TestRecordWorkflowExecutionClosed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -281,9 +269,7 @@ func TestRecordWorkflowExecutionUninitialized(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -347,9 +333,7 @@ func TestUpsertWorkflowExecution(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -393,9 +377,7 @@ func TestDeleteWorkflowExecution(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -439,9 +421,7 @@ func TestDeleteUninitializedWorkflowExecution(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -485,9 +465,7 @@ func TestListOpenWorkflowExecutions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -531,9 +509,7 @@ func TestListClosedWorkflowExecutions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -577,9 +553,7 @@ func TestListOpenWorkflowExecutionsByType(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -623,9 +597,7 @@ func TestTestListClosedWorkflowExecutionsByType(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -669,9 +641,7 @@ func TestListOpenWorkflowExecutionsByWorkflowID(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -715,9 +685,7 @@ func TestListClosedWorkflowExecutionsByWorkflowID(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -761,9 +729,7 @@ func TestListClosedWorkflowExecutionsByStatus(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -814,9 +780,7 @@ func TestGetClosedWorkflowExecution(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -875,9 +839,7 @@ func TestListWorkflowExecutions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -921,9 +883,7 @@ func TestScanWorkflowExecutions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -967,9 +927,7 @@ func TestCountWorkflowExecutions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 
 			test.visibilityStoreAffordance(mockVisibilityStore)
 
@@ -1005,9 +963,7 @@ func TestGetSearchAttributes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 			visibilityManagerImpl := visibilityManager.(*visibilityManagerImpl)
 
 			actualOutput, actualErr := visibilityManagerImpl.getSearchAttributes(*test.input)
@@ -1057,9 +1013,7 @@ func TestConvertVisibilityWorkflowExecutionInfo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockVisibilityStore := NewMockVisibilityStore(ctrl)
-			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-				SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			})
+			visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 			visibilityManagerImpl := visibilityManager.(*visibilityManagerImpl)
 
 			actualOutput := visibilityManagerImpl.convertVisibilityWorkflowExecutionInfo(test.input)
@@ -1071,9 +1025,7 @@ func TestConvertVisibilityWorkflowExecutionInfo(t *testing.T) {
 func TestToInternalListWorkflowExecutionsRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockVisibilityStore := NewMockVisibilityStore(ctrl)
-	visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 	visibilityManagerImpl := visibilityManager.(*visibilityManagerImpl)
 
 	assert.Nil(t, visibilityManagerImpl.toInternalListWorkflowExecutionsRequest(nil))
@@ -1084,9 +1036,7 @@ func TestSerializeMemo(t *testing.T) {
 	mockVisibilityStore := NewMockVisibilityStore(ctrl)
 	mockPayloadSerializer := NewMockPayloadSerializer(ctrl)
 	mockPayloadSerializer.EXPECT().SerializeVisibilityMemo(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1)
-	visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), &DynamicConfiguration{
-		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	})
+	visibilityManager := NewVisibilityManagerImpl(mockVisibilityStore, log.NewNoop(), NewDefaultDynamicConfiguration())
 	visibilityManagerImpl := visibilityManager.(*visibilityManagerImpl)
 	visibilityManagerImpl.serializer = mockPayloadSerializer
 	assert.NotPanics(t, func() {

--- a/host/async_wf_test.go
+++ b/host/async_wf_test.go
@@ -52,7 +52,6 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
-	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
@@ -92,15 +91,9 @@ func (s *AsyncWFIntegrationSuite) SetupSuite() {
 
 	s.Logger.Info("Running integration test against test cluster")
 	clusterMetadata := NewClusterMetadata(s.T(), s.TestClusterConfig)
-	dc := persistence.DynamicConfiguration{
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-		HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
 	params := pt.TestBaseParams{
 		PersistenceConfig:    s.PersistenceConfig,
 		ClusterMetadata:      clusterMetadata,

--- a/host/cli/cassandra/cassandra_tool_version_test.go
+++ b/host/cli/cassandra/cassandra_tool_version_test.go
@@ -33,8 +33,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	cassandra_db "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/environment"
@@ -90,8 +88,6 @@ func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
 			"default":    {NoSQL: &defaultCfg},
 			"visibility": {NoSQL: &visibilityCfg},
 		},
-		TransactionSizeLimit: dynamicproperties.GetIntPropertyFn(constants.DefaultTransactionSizeLimit),
-		ErrorInjectionRate:   dynamicproperties.GetFloatPropertyFn(0),
 	}
 	s.NoError(cassandra.VerifyCompatibleVersion(cfg, gocql.All))
 }

--- a/host/cli/sql/versionTest.go
+++ b/host/cli/sql/versionTest.go
@@ -32,8 +32,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/environment"
 	"github.com/uber/cadence/tools/sql"
 )
@@ -120,8 +118,6 @@ func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
 			"default":    {SQL: &defaultCfg},
 			"visibility": {SQL: &visibilityCfg},
 		},
-		TransactionSizeLimit: dynamicproperties.GetIntPropertyFn(constants.DefaultTransactionSizeLimit),
-		ErrorInjectionRate:   dynamicproperties.GetFloatPropertyFn(0),
 	}
 	s.NoError(sql.VerifyCompatibleVersion(cfg))
 }

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -117,17 +117,10 @@ func (s *IntegrationBase) setupSuite() {
 	} else {
 		s.Logger.Info("Running integration test against test cluster")
 		clusterMetadata := NewClusterMetadata(s.T(), s.TestClusterConfig)
-		dc := persistence.DynamicConfiguration{
-			EnableSQLAsyncTransaction:                dynamicproperties.GetBoolPropertyFn(false),
-			EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-			EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-			EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-			ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-			SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-			ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-			HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-			EnableWorkflowTimerTaskCleanup:           dynamicproperties.GetBoolPropertyFn(true),
-		}
+		dc := *persistence.NewDefaultDynamicConfiguration()
+		dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+		dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
+		dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
 		params := pt.TestBaseParams{
 			PersistenceConfig:    s.PersistenceConfig,
 			ClusterMetadata:      clusterMetadata,

--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -100,15 +100,9 @@ func (s *NDCIntegrationTestSuite) SetupSuite() {
 	s.clusterConfigs[0].MockAdminClient = s.mockAdminClient
 
 	clusterMetadata := host.NewClusterMetadata(s.T(), s.clusterConfigs[0])
-	dc := persistence.DynamicConfiguration{
-		EnableSQLAsyncTransaction:                dynamicproperties.GetBoolPropertyFn(false),
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-		HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
 	params := pt.TestBaseParams{
 		PersistenceConfig:    s.persistenceConfig,
 		ClusterMetadata:      clusterMetadata,

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -56,7 +56,6 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
@@ -106,16 +105,9 @@ func (s *PinotIntegrationSuite) SetupSuite() {
 
 	s.Logger.Info("Running integration test against test cluster")
 	clusterMetadata := NewClusterMetadata(s.T(), s.TestClusterConfig)
-	dc := persistence.DynamicConfiguration{
-		EnableSQLAsyncTransaction:                dynamicproperties.GetBoolPropertyFn(false),
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-		HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
 	params := pt.TestBaseParams{
 		PersistenceConfig:    s.PersistenceConfig,
 		ClusterMetadata:      clusterMetadata,

--- a/host/workflowidratelimit_test.go
+++ b/host/workflowidratelimit_test.go
@@ -69,15 +69,9 @@ func (s *WorkflowIDRateLimitIntegrationSuite) SetupSuite() {
 
 	s.Logger.Info("Running integration test against test cluster")
 	clusterMetadata := NewClusterMetadata(s.T(), s.TestClusterConfig)
-	dc := persistence.DynamicConfiguration{
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-		HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
 	params := pt.TestBaseParams{
 		PersistenceConfig:    s.PersistenceConfig,
 		ClusterMetadata:      clusterMetadata,

--- a/host/workflowsidinternalratelimit_test.go
+++ b/host/workflowsidinternalratelimit_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
-	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
@@ -73,15 +72,9 @@ func (s *WorkflowIDInternalRateLimitIntegrationSuite) SetupSuite() {
 
 	s.Logger.Info("Running integration test against test cluster")
 	clusterMetadata := NewClusterMetadata(s.T(), s.TestClusterConfig)
-	dc := persistence.DynamicConfiguration{
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-		HistoryNodeDeleteBatchSize:               dynamicproperties.GetIntPropertyFn(1000),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
 	params := pt.TestBaseParams{
 		PersistenceConfig:    s.PersistenceConfig,
 		ClusterMetadata:      clusterMetadata,

--- a/simulation/history/history_simulation_test.go
+++ b/simulation/history/history_simulation_test.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/grpc"
 
-	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
@@ -70,14 +69,9 @@ func (s *HistorySimulationSuite) SetupSuite() {
 
 	s.Logger.Info("Running integration test against test cluster")
 	clusterMetadata := host.NewClusterMetadata(s.T(), s.TestClusterConfig)
-	dc := persistence.DynamicConfiguration{
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		ReadNoSQLHistoryTaskFromDataBlob:         dynamicproperties.GetBoolPropertyFn(false),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-		ReadNoSQLShardFromDataBlob:               dynamicproperties.GetBoolPropertyFn(true),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
 	params := pt.TestBaseParams{
 		PersistenceConfig:    s.PersistenceConfig,
 		ClusterMetadata:      clusterMetadata,

--- a/simulation/matching/matching_simulation_test.go
+++ b/simulation/matching/matching_simulation_test.go
@@ -162,12 +162,9 @@ func (s *MatchingSimulationSuite) SetupSuite() {
 
 	s.Logger.Info("Running integration test against test cluster")
 	clusterMetadata := host.NewClusterMetadata(s.T(), s.TestClusterConfig)
-	dc := persistence.DynamicConfiguration{
-		EnableCassandraAllConsistencyLevelDelete: dynamicproperties.GetBoolPropertyFn(true),
-		EnableShardIDMetrics:                     dynamicproperties.GetBoolPropertyFn(true),
-		EnableHistoryTaskDualWriteMode:           dynamicproperties.GetBoolPropertyFn(true),
-		SerializationEncoding:                    dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
-	}
+	dc := *persistence.NewDefaultDynamicConfiguration()
+	dc.EnableCassandraAllConsistencyLevelDelete = dynamicproperties.GetBoolPropertyFn(true)
+	dc.EnableHistoryTaskDualWriteMode = dynamicproperties.GetBoolPropertyFn(true)
 	params := pt.TestBaseParams{
 		PersistenceConfig:    s.PersistenceConfig,
 		ClusterMetadata:      clusterMetadata,

--- a/tools/cli/database.go
+++ b/tools/cli/database.go
@@ -29,8 +29,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/constants"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
@@ -250,9 +248,6 @@ func (f *defaultManagerFactory) initPersistenceFactory(c *cli.Context) (client.F
 	}
 	cfg.Persistence.DataStores[cfg.Persistence.DefaultStore] = defaultStore
 
-	cfg.Persistence.TransactionSizeLimit = dynamicproperties.GetIntPropertyFn(constants.DefaultTransactionSizeLimit)
-	cfg.Persistence.ErrorInjectionRate = dynamicproperties.GetFloatPropertyFn(0.0)
-
 	rps := c.Float64(FlagRPS)
 
 	return client.NewFactory(
@@ -261,9 +256,7 @@ func (f *defaultManagerFactory) initPersistenceFactory(c *cli.Context) (client.F
 		cfg.ClusterGroupMetadata.CurrentClusterName,
 		metrics.NewNoopMetricsClient(),
 		log.NewNoop(),
-		&persistence.DynamicConfiguration{
-			EnableSQLAsyncTransaction: dynamicproperties.GetBoolPropertyFn(false),
-		},
+		persistence.NewDefaultDynamicConfiguration(),
 	), nil
 }
 


### PR DESCRIPTION
Move TransactionSizeLimit and ErrorInjectionRate from the config where it's manually set in server startup to persistence.Config, representing the dynamicconfig settings for persistence. These are used only within the persistenceClient.Factory which wraps the returned implementations.

Replace all direct struct initialization of persistence.Config with a call to NewDefaultDynamicConfiguration(), which initializes the struct with default values according to each property. Remove any explicit property assignments that match the default, and maintain any that don't.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Move TransactionSizeLimit and ErrorInjectionRate from the config where it's manually set in server startup to persistence.Config, representing the dynamicconfig settings for persistence

**Why?**
- Cleanup and simplification during server startup.

**How did you test it?**
- Unit and integration tests. This is a non behavioral change

**Potential risks**
- Low. This is purely a refactoring change. If these fields aren't initialized correctly the server would either fail to build or immediately crash on startup.

**Release notes**


**Documentation Changes**

