### PR TITLE
feat(cloudsql): Infer user from service account email if not specified

### DIFF
--- a/common/persistence/sql/sqlplugin/cloudsql-mysql/go.mod
+++ b/common/persistence/sql/sqlplugin/cloudsql-mysql/go.mod
@@ -13,6 +13,7 @@ replace github.com/uber/cadence => ../../../../..
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.18.0
+	cloud.google.com/go/compute/metadata v0.9.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/jmoiron/sqlx v1.2.1-0.20200615141059-0794cb1f47ee
 	github.com/stretchr/testify v1.11.1
@@ -23,7 +24,6 @@ require (
 require (
 	cloud.google.com/go/auth v0.16.4 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
-	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/VividCortex/mysqlerr v1.0.0 // indirect

--- a/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin.go
@@ -22,6 +22,7 @@ package cloudsqlmysql
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -30,6 +31,7 @@ import (
 
 	"cloud.google.com/go/cloudsqlconn"
 	cloudmysqldriver "cloud.google.com/go/cloudsqlconn/mysql/mysql"
+	"cloud.google.com/go/compute/metadata"
 	"github.com/iancoleman/strcase"
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/multierr"
@@ -176,8 +178,12 @@ func getDialOptions(cfg *config.SQL) (cloudsqlconn.DialOption, error) {
 }
 
 func createSingleDBConn(cfg *config.SQL, driverName string) (*sqlx.DB, error) {
+	dsn, err := buildDSN(cfg, driverName)
+	if err != nil {
+		return nil, err
+	}
 	// Can use either mysql or the DriverName, since the DSN also encodes the DriverName
-	db, err := sqlx.Connect(driverName, buildDSN(cfg, driverName))
+	db, err := sqlx.Connect(driverName, dsn)
 	if err != nil {
 		return nil, err
 	}
@@ -196,9 +202,16 @@ func createSingleDBConn(cfg *config.SQL, driverName string) (*sqlx.DB, error) {
 	return db, nil
 }
 
-func buildDSN(cfg *config.SQL, driverName string) string {
+func buildDSN(cfg *config.SQL, driverName string) (string, error) {
 	attrs := buildDSNAttrs(cfg)
 	userAndPassword := cfg.User
+	if userAndPassword == "" {
+		serviceAccount, err := getServiceAccountUsername()
+		if err != nil {
+			return "", err
+		}
+		userAndPassword = serviceAccount
+	}
 	if cfg.Password != "" {
 		userAndPassword += ":" + cfg.Password
 	}
@@ -206,7 +219,28 @@ func buildDSN(cfg *config.SQL, driverName string) string {
 	if attrs != "" {
 		dsn = dsn + "?" + attrs
 	}
-	return dsn
+	return dsn, nil
+}
+
+// Indirection to allow tests to stub out the GCE metadata server.
+var (
+	onGCE           = metadata.OnGCE
+	getMetadataUser = metadata.EmailWithContext
+)
+
+func getServiceAccountUsername() (string, error) {
+	if !onGCE() {
+		return "", errors.New("missing User")
+	}
+	serviceAccountEmail, err := getMetadataUser(context.Background(), "default")
+	if err != nil {
+		return "", err
+	}
+	username, _, _ := strings.Cut(serviceAccountEmail, "@")
+	if username == "" {
+		return "", errors.New("missing User")
+	}
+	return username, nil
 }
 
 func buildDSNAttrs(cfg *config.SQL) string {

--- a/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin_test.go
+++ b/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cloudsqlmysql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetServiceAccountUsername(t *testing.T) {
+	tests := []struct {
+		name      string
+		onGCE     bool
+		email     string
+		emailErr  error
+		expected  string
+		expectErr string
+	}{
+		{
+			name:      "not on GCE",
+			onGCE:     false,
+			expectErr: "missing User",
+		},
+		{
+			name:      "metadata server error",
+			onGCE:     true,
+			emailErr:  errors.New("metadata server unavailable"),
+			expectErr: "metadata server unavailable",
+		},
+		{
+			name:      "empty email",
+			onGCE:     true,
+			email:     "",
+			expectErr: "missing User",
+		},
+		{
+			name:      "email with empty username",
+			onGCE:     true,
+			email:     "@project.iam.gserviceaccount.com",
+			expectErr: "missing User",
+		},
+		{
+			name:     "service account email",
+			onGCE:    true,
+			email:    "my-sa@project.iam.gserviceaccount.com",
+			expected: "my-sa",
+		},
+		{
+			name:     "email without domain",
+			onGCE:    true,
+			email:    "my-sa",
+			expected: "my-sa",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreOnGCE, restoreGetMetadataUser := onGCE, getMetadataUser
+			t.Cleanup(func() {
+				onGCE, getMetadataUser = restoreOnGCE, restoreGetMetadataUser
+			})
+
+			onGCE = func() bool { return tc.onGCE }
+			getMetadataUser = func(ctx context.Context, suffix string) (string, error) {
+				require.Equal(t, "default", suffix)
+				return tc.email, tc.emailErr
+			}
+
+			username, err := getServiceAccountUsername()
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, username)
+		})
+	}
+}


### PR DESCRIPTION
When using IAM auth (the default and recommended option for cloudsql) the credentials and MySQL username should match. The default credentials will generally be for the service account. If the config doesn't include the user, we try using the service account as a default. CloudSQL's MySQL support uses the portion of the service account email without the domain name.

We could alternatively obtain a token and then try and parse the email out of the token's claim. This would let us infer the email directly from the credentials and allow for non-GCE usage to benefit from this default. The implementation however seems much more error prone and complex.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Use service account as default GCP CloudSQL username

**Why?**
- Simplifies configuration

**How did you test it?**
- Unit tests
- Manually tested on GCE containers

**Potential risks**
- Low. These configs are currently non functional

**Release notes**


**Documentation Changes**

