### PR TITLE
fix(persistence): Correct handling of no schema version row

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/schema.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/schema.go
@@ -64,7 +64,7 @@ func (db *CDB) GetSchemaVersion(ctx context.Context) (persistence.Version, error
 	var version string
 	if !iter.Scan(&version) {
 		err := iter.Close()
-		return persistence.Version{}, fmt.Errorf("reading schemaDB version: %w", err)
+		return persistence.Version{}, err
 	}
 	if err := iter.Close(); err != nil {
 		return persistence.Version{}, err

--- a/common/persistence/sql/schema.go
+++ b/common/persistence/sql/schema.go
@@ -2,6 +2,8 @@ package sql
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/uber/cadence/common/log"
@@ -47,6 +49,9 @@ func (s *sqlSchemaDB) SetupVersioning(_ context.Context) error {
 
 func (s *sqlSchemaDB) GetSchemaVersion(_ context.Context) (persistence.Version, error) {
 	stringVersion, err := s.crud.ReadSchemaVersion(s.db)
+	if errors.Is(err, sql.ErrNoRows) {
+		return persistence.Version{}, nil
+	}
 	if err != nil {
 		return persistence.Version{}, err
 	}


### PR DESCRIPTION
If there's no schema version row at all return the zero value of Version to indicate it.

Schema operation test coverage is in process, this scenario wasn't exercised by existing persistence tests

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Return a zero value if there are no schema version rows

**Why?**
- Fix schema setup

**How did you test it?**
- Manually running schema setup

**Potential risks**


**Release notes**


**Documentation Changes**

