### PR TITLE
refactor(queuev2): rename cached timer reader to scheduled + extract base reader

### DIFF
--- a/service/history/queuev2/queue_reader_cached_base.go
+++ b/service/history/queuev2/queue_reader_cached_base.go
@@ -1,0 +1,768 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queuev2
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/service/history/shard"
+)
+
+//go:generate mockgen -package $GOPACKAGE -destination queue_reader_cached_mock.go github.com/uber/cadence/service/history/queuev2 CachedQueueReader
+
+// CachedQueueReader extends QueueReader with cache injection, read-level control, and a background
+// lifecycle. Both the scheduled (timer) and immediate (transfer) cached readers implement it; each
+// supplies its own Start/Stop. The timer reader runs a prefetch loop in a goroutine, while the
+// transfer reader only flips lifecycle state and logs, since it has no background work.
+type CachedQueueReader interface {
+	QueueReader
+	// Inject adds tasks that have just been persisted into the in-memory cache.
+	// Tasks outside the current cached window are silently dropped or buffered.
+	Inject(tasks []persistence.Task)
+	// Clear wipes all cached state.
+	// Call when the cache may be stale (e.g. after a persistence error).
+	Clear()
+	// UpdateReadLevel advances the eviction lower bound to readLevel,
+	// dropping tasks the processor has already passed.
+	UpdateReadLevel(readLevel persistence.HistoryTaskKey)
+	// Start begins the reader's lifecycle. Idempotent.
+	Start()
+	// Stop ends the reader's lifecycle. Idempotent.
+	Stop()
+}
+
+// cachedQueueReaderOptions is the configuration shared by both cached queue readers, held by the
+// base. Each concrete reader populates it from its own dynamic-config keys (timer vs transfer), so
+// the property names in the config file stay independent even though the code is shared.
+type cachedQueueReaderOptions struct {
+	// Mode controls cache behavior: "enabled" uses cache, anything else (including "disabled") disables.
+	Mode dynamicproperties.StringPropertyFnWithShardIDFilter
+	// MaxSize is the maximum number of tasks the cache may hold at once.
+	// Insertions that would exceed this limit trigger time-based eviction first.
+	MaxSize dynamicproperties.IntPropertyFn
+	// MaxLookAheadWindow is how far into the future from now the cache prefetches.
+	// Tasks with scheduled time beyond now+MaxLookAheadWindow are not fetched.
+	MaxLookAheadWindow dynamicproperties.DurationPropertyFn
+	// PrefetchTriggerWindow defines how close to the upper-bound a task must be
+	// before the next prefetch is scheduled. A prefetch fires when the nearest
+	// upcoming task is within PrefetchTriggerWindow of the current upper bound.
+	PrefetchTriggerWindow dynamicproperties.DurationPropertyFn
+	// PrefetchPageSize caps the number of tasks fetched per DB round-trip.
+	PrefetchPageSize dynamicproperties.IntPropertyFn
+	// TimeEvictionWindow is the lookback horizon: tasks older than
+	// now-TimeEvictionWindow are evicted to reclaim cache capacity.
+	TimeEvictionWindow dynamicproperties.DurationPropertyFn
+	// MinPrefetchInterval is the minimum time between consecutive prefetch attempts.
+	// It prevents the prefetch loop from hammering the database when the cache resets
+	// or gap detection fires repeatedly.
+	MinPrefetchInterval dynamicproperties.DurationPropertyFn
+	// PrefetchJitterCoefficient is passed to backoff.JitDuration when computing
+	// the next prefetch delay. Must be in [0, 1]. Zero disables jitter.
+	PrefetchJitterCoefficient dynamicproperties.FloatPropertyFn
+	// ShadowSampleInterval controls how often, at most, a GetTask call in "enabled" mode
+	// is diverted through the shadow comparison path for continuous regression detection.
+	// <= 0 disables sampling.
+	ShadowSampleInterval dynamicproperties.DurationPropertyFn
+}
+
+// cachedQueueReaderBase holds the state and behaviour shared by the scheduled (timer) and
+// immediate (transfer) cached queue readers: the cached window, coverage checks, range-ID
+// fencing, the read path (including shadow-mode comparison), and eviction bound bookkeeping.
+//
+// Both concrete readers embed *cachedQueueReaderBase and supply only their specific behaviour
+// (population via Inject, cap-guard direction, and lifecycle). Field/method promotion keeps
+// callers agnostic of which concrete reader they hold.
+type cachedQueueReaderBase struct {
+	base    QueueReader
+	shard   shard.Context
+	queue   InMemQueue
+	options *cachedQueueReaderOptions
+	clock   clock.TimeSource
+	logger  log.Logger
+	metrics metrics.Scope
+
+	mu sync.RWMutex
+
+	// inclusiveLowerBound is the inclusive start of the cached window. Tasks
+	// before this key have been evicted and are no longer served from cache.
+	// Invariant: inclusiveLowerBound <= exclusiveUpperBound.
+	inclusiveLowerBound persistence.HistoryTaskKey
+
+	// exclusiveUpperBound is the exclusive end of the cached window. Tasks with
+	// key < exclusiveUpperBound are covered by the cache if they exist in the DB.
+	// Invariant: inclusiveLowerBound <= exclusiveUpperBound.
+	// Always update via updateExclusiveUpperBound.
+	exclusiveUpperBound persistence.HistoryTaskKey
+
+	// lastRangeID is the shard rangeID observed when the cache was last valid.
+	// A change means the shard was re-acquired and the cache may be stale.
+	// Protected by mu.
+	lastRangeID int64
+
+	// lastShadowSampleUnixNano is the unix-nano timestamp of the last periodic shadow
+	// sample check performed while in "enabled" mode. When concurrent GetTask calls race
+	// on the same due window, only one of them wins the update, so at most one sample is
+	// taken per window. Zero value means no sample has been taken yet, so the first
+	// eligible call fires immediately.
+	lastShadowSampleUnixNano atomic.Int64
+
+	// onUpperBoundUpdatedLockedFn is called (under mu) after exclusiveUpperBound changes. The
+	// scheduled/timer reader wires this to notifyPrefetch so the prefetch loop recomputes its
+	// timer; the immediate/transfer reader leaves it nil (no background loop to notify).
+	onUpperBoundUpdatedLockedFn func()
+
+	// onClearLockedFn is called (under mu) at the end of clearLocked, after the shared window
+	// state has been reset. The scheduled/timer reader wires this to reset its prefetch-only
+	// state (in-flight target and pending inject buffer); the immediate/transfer reader leaves
+	// it nil (no prefetch state to reset).
+	onClearLockedFn func()
+
+	// status holds the daemon lifecycle state (DaemonStatusInitialized / Started / Stopped).
+	// It lives on the base so both concrete readers share the same lifecycle bookkeeping; each
+	// supplies its own Start/Stop, which flip it with an atomic compare-and-swap on this field.
+	status int32
+}
+
+func newCachedQueueReaderBase(
+	base QueueReader,
+	queue InMemQueue,
+	shard shard.Context,
+	clockSource clock.TimeSource,
+	logger log.Logger,
+	metricsScope metrics.Scope,
+	options *cachedQueueReaderOptions,
+) *cachedQueueReaderBase {
+	return &cachedQueueReaderBase{
+		base:                base,
+		shard:               shard,
+		queue:               queue,
+		options:             options,
+		clock:               clockSource,
+		logger:              logger,
+		metrics:             metricsScope,
+		inclusiveLowerBound: persistence.MinimumHistoryTaskKey,
+		exclusiveUpperBound: persistence.MinimumHistoryTaskKey,
+		lastRangeID:         shard.GetRangeID(),
+		status:              common.DaemonStatusInitialized,
+	}
+}
+
+// isEnabled returns true if the cache is fully enabled
+func (q *cachedQueueReaderBase) isEnabled() bool {
+	return q.options.Mode(q.shard.GetShardID()) == "enabled"
+}
+
+// isShadow returns true when cache runs in shadow mode — results are compared
+// against the DB but the DB result is returned to the processor.
+func (q *cachedQueueReaderBase) isShadow() bool {
+	return q.options.Mode(q.shard.GetShardID()) == "shadow"
+}
+
+// isCachedQueueReaderDisabled reports whether the given mode disables the cached queue reader.
+func isCachedQueueReaderDisabled(mode string) bool {
+	switch mode {
+	case "enabled", "shadow":
+		return false
+	default:
+		return true
+	}
+}
+
+// isDisabled returns true for the "disabled" mode and for any unrecognised value
+func (q *cachedQueueReaderBase) isDisabled() bool {
+	return isCachedQueueReaderDisabled(q.options.Mode(q.shard.GetShardID()))
+}
+
+// IsEmpty reports whether the cache queue reader is empty
+func (q *cachedQueueReaderBase) IsEmpty() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey)
+}
+
+// clearIfNotEmpty clears cached state only when the cache has data
+func (q *cachedQueueReaderBase) clearIfNotEmpty() {
+	if !q.IsEmpty() {
+		q.Clear()
+	}
+}
+
+// Clear wipes all cached state.
+func (q *cachedQueueReaderBase) Clear() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.logger.Info("cache fully cleared",
+		tag.Dynamic("cacheState", q.getState()),
+	)
+
+	q.clearLocked()
+}
+
+// clearLocked wipes all cached state. Caller must hold q.mu for writing.
+func (q *cachedQueueReaderBase) clearLocked() {
+	q.queue.Clear()
+	q.updateInclusiveLowerBound(persistence.MinimumHistoryTaskKey)
+	q.updateExclusiveUpperBound(persistence.MinimumHistoryTaskKey)
+	if q.onClearLockedFn != nil {
+		q.onClearLockedFn()
+	}
+}
+
+// isRangeIDChangedLocked reports whether the shard's current rangeID differs
+// from the last observed value. Caller must hold q.mu (read or write).
+func (q *cachedQueueReaderBase) isRangeIDChangedLocked() bool {
+	return q.shard.GetRangeID() != q.lastRangeID
+}
+
+// isRangeIDChanged reports whether the shard's current rangeID differs
+// from the last observed value.
+func (q *cachedQueueReaderBase) isRangeIDChanged() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.isRangeIDChangedLocked()
+}
+
+// fallbackIfRangeIDChanged clears cache if rangeID changed by more than 1
+// (shard moved away and was re-acquired). A change of exactly 1 means the same
+// host reacquired the shard — cache remains valid.
+// Returns true if cache was cleared.
+func (q *cachedQueueReaderBase) fallbackIfRangeIDChanged() bool {
+	if !q.isRangeIDChanged() {
+		return false
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if !q.isRangeIDChangedLocked() {
+		return false
+	}
+
+	newRangeID := q.shard.GetRangeID()
+	prevRangeID := q.lastRangeID
+	q.lastRangeID = newRangeID
+
+	if newRangeID == prevRangeID+1 {
+		// Same host reacquired the shard. Cache still valid.
+		q.logger.Info("rangeID changed on same host, cache not cleared",
+			tag.Dynamic("previousRangeID", prevRangeID),
+			tag.Dynamic("newRangeID", newRangeID),
+		)
+		return false
+	}
+
+	// rangeID changed by more than 1: possible stale cache.
+	q.logger.Info("rangeID changed, clearing cache",
+		tag.Dynamic("previousRangeID", prevRangeID),
+		tag.Dynamic("newRangeID", newRangeID),
+	)
+	q.clearLocked()
+	return true
+}
+
+// isRangeCovered reports whether [inclusiveMin, exclusiveMax) falls fully
+// within the cached window [inclusiveLowerBound, exclusiveUpperBound).
+// Caller must hold q.mu (read or write).
+func (q *cachedQueueReaderBase) isRangeCovered(inclusiveMin, exclusiveMax persistence.HistoryTaskKey) bool {
+	return !inclusiveMin.Less(q.inclusiveLowerBound) && !exclusiveMax.Greater(q.exclusiveUpperBound)
+}
+
+// isTaskCovered reports whether the given task key falls within the cached window.
+// Caller must hold q.mu (read or write).
+func (q *cachedQueueReaderBase) isTaskCovered(key persistence.HistoryTaskKey) bool {
+	return !key.Less(q.inclusiveLowerBound) && key.Less(q.exclusiveUpperBound)
+}
+
+// updateExclusiveUpperBound sets the upper bound and runs the onUpperBoundUpdatedLockedFn hook if set.
+// Caller must hold q.mu.
+func (q *cachedQueueReaderBase) updateExclusiveUpperBound(newKey persistence.HistoryTaskKey) {
+	if q.logger.DebugOn() {
+		q.logger.Debug("upper bound is updated",
+			tag.Dynamic("cacheState", q.getState()),
+			tag.Dynamic("newUpperBound", newKey),
+		)
+	}
+
+	q.exclusiveUpperBound = newKey
+	q.metrics.RecordHistogramValue(metrics.CachedQueueSizeHistogram, float64(q.queue.Len()))
+	if q.onUpperBoundUpdatedLockedFn != nil {
+		q.onUpperBoundUpdatedLockedFn()
+	}
+}
+
+// updateInclusiveLowerBound sets the lower bound
+// Caller must hold q.mu.
+func (q *cachedQueueReaderBase) updateInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
+	if q.logger.DebugOn() {
+		q.logger.Debug("lower bound is updated",
+			tag.Dynamic("cacheState", q.getState()),
+			tag.Dynamic("newLowerBound", newKey),
+		)
+	}
+
+	q.inclusiveLowerBound = newKey
+	q.metrics.RecordHistogramValue(metrics.CachedQueueSizeHistogram, float64(q.queue.Len()))
+}
+
+// advanceInclusiveLowerBound advances inclusiveLowerBound to newKey if it's
+// ahead, trimming evicted tasks. Caps at exclusiveUpperBound when set to
+// preserve the lower <= upper invariant.
+// Caller must hold q.mu (write).
+func (q *cachedQueueReaderBase) advanceInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
+	if !newKey.Greater(q.inclusiveLowerBound) {
+		return
+	}
+
+	if !newKey.Less(q.exclusiveUpperBound) {
+		newKey = q.exclusiveUpperBound
+	}
+
+	q.queue.LTrim(newKey)
+	q.updateInclusiveLowerBound(newKey)
+}
+
+// UpdateReadLevel advances the lower bound to the processor's ack position.
+// MaximumHistoryTaskKey means "no valid read level" and skipped
+func (q *cachedQueueReaderBase) UpdateReadLevel(readLevel persistence.HistoryTaskKey) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if readLevel.Equal(persistence.MaximumHistoryTaskKey) {
+		return
+	}
+
+	q.advanceInclusiveLowerBound(readLevel)
+}
+
+// inject status values reported via metrics.CachedQueueInjectAttemptCounter,
+// one per outcome branch of Inject.
+const (
+	injectStatusInjected     = "injected"
+	injectStatusBuffered     = "buffered"
+	injectStatusDroppedBelow = "dropped_below"
+	injectStatusDroppedUpper = "dropped_upper"
+)
+
+// emitInjectStatusCount records the number of injected tasks that took the given
+// outcome path, tagged by status. Zero counts are skipped to avoid emitting empty series.
+func (q *cachedQueueReaderBase) emitInjectStatusCount(status string, count int64) {
+	if count == 0 {
+		return
+	}
+	q.metrics.Tagged(metrics.StatusTag(status)).AddCounter(metrics.CachedQueueInjectAttemptCounter, count)
+}
+
+// resolveInclusiveMinTaskKey returns the effective InclusiveMinTaskKey for req, accounting for
+// the NextPageToken/NextTaskKey pagination-continuation override in GetTaskProgress. The second
+// return value is false only when NextPageToken is set but NextTaskKey was never populated — an
+// edge case callers should handle by delegating to the base reader.
+func resolveInclusiveMinTaskKey(req *GetTaskRequest) (persistence.HistoryTaskKey, bool) {
+	inclusiveMinTaskKey := req.Progress.Range.InclusiveMinTaskKey
+	if req.Progress.NextPageToken != nil {
+		if req.Progress.NextTaskKey.Equal(persistence.MinimumHistoryTaskKey) {
+			return persistence.HistoryTaskKey{}, false
+		}
+		inclusiveMinTaskKey = req.Progress.NextTaskKey
+	}
+	return inclusiveMinTaskKey, true
+}
+
+// LookAHead is the default look-ahead: it delegates straight to the underlying base reader. It
+// exists on the base so cached readers without cache-aware look-ahead (the immediate/transfer
+// reader) satisfy QueueReader purely by embedding, without re-implementing it. The scheduled/timer
+// reader overrides this with a cache-aware version, since look-ahead is a scheduled concern.
+func (q *cachedQueueReaderBase) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
+	return q.base.LookAHead(ctx, req)
+}
+
+// GetTask serves tasks from the cache when the starting key is covered.
+// Disabled mode bypasses the cache entirely.
+func (q *cachedQueueReaderBase) GetTask(ctx context.Context, req *GetTaskRequest) (*GetTaskResponse, error) {
+	if q.isDisabled() {
+		return q.base.GetTask(ctx, req)
+	}
+
+	if q.fallbackIfRangeIDChanged() {
+		q.logger.Info("GetTask falling back to base reader after rangeID change")
+		return q.base.GetTask(ctx, req)
+	}
+
+	inclusiveMinTaskKey, ok := resolveInclusiveMinTaskKey(req)
+	if !ok {
+		q.logger.Info("NextPageToken is set but NextTaskKey is not set, delegating to base reader", tag.Dynamic("getTaskRequest", req))
+		return q.base.GetTask(ctx, req)
+	}
+	exclusiveMaxTaskKey := req.Progress.Range.ExclusiveMaxTaskKey
+
+	q.mu.RLock()
+	covered := q.isRangeCovered(inclusiveMinTaskKey, exclusiveMaxTaskKey)
+
+	logTags := []tag.Tag{
+		tag.Dynamic("getTaskRequest", req),
+		tag.Dynamic("cacheState", q.getState()),
+		tag.Dynamic("inclusiveMinTaskKey", inclusiveMinTaskKey),
+	}
+
+	if !covered {
+		q.mu.RUnlock()
+		q.metrics.IncCounter(metrics.CachedQueueMissesCounter)
+		q.logger.Debug("cache miss", logTags...)
+		return q.base.GetTask(ctx, req)
+	}
+
+	tasks, nextTaskKey := q.queue.GetTasks(inclusiveMinTaskKey, exclusiveMaxTaskKey, req.Predicate, req.PageSize)
+	q.mu.RUnlock()
+
+	q.metrics.IncCounter(metrics.CachedQueueHitsCounter)
+	q.logger.Debug("cache hit", logTags...)
+
+	// cacheResp is constructed with Progress.Range starting at nextTaskKey and the same exclusiveMaxTaskKey as the request.
+	// This ensures that if the next page is fetched from the DB, Progress.Range will start at the correct position (nextTaskKey)
+	// and end at the same exclusiveMaxTaskKey. Since NextPageToken is not used when serving from the cache, Progress.Range
+	// is the sole source of truth for the next page's start and end. Using the request's original InclusiveMinTaskKey instead
+	// of nextTaskKey would cause the next page to start at the wrong position, leading to duplicate or skipped tasks.
+	cacheResp := &GetTaskResponse{
+		Tasks: tasks,
+		Progress: &GetTaskProgress{
+			Range: Range{
+				InclusiveMinTaskKey: nextTaskKey,
+				ExclusiveMaxTaskKey: req.Progress.Range.ExclusiveMaxTaskKey,
+			},
+			NextPageToken: nil,
+			NextTaskKey:   nextTaskKey,
+		},
+	}
+
+	if q.isShadow() || q.isPeriodicShadowSample() {
+		return q.getTaskInShadow(ctx, req, cacheResp, logTags)
+	}
+
+	return cacheResp, nil
+}
+
+// isPeriodicShadowSample reports whether this call should be diverted into a shadow
+// comparison as part of the periodic health check for "enabled" mode. Gated on elapsed
+// wall-clock time rather than a request counter, so the check cadence is independent of
+// request volume. When multiple callers race on the same due window, only one of them
+// wins and performs the sample; the timestamp is advanced before the comparison runs, so
+// the interval is measured from attempt to attempt rather than success to success.
+//
+// TODO: this periodic shadow sample check is temporary scaffolding for continuous
+// regression detection while "enabled" mode is being rolled out. It gives operators
+// an ongoing signal that the cache still agrees with the DB after promotion out of
+// "shadow" mode. Remove once CachedQueueReader is enabled by default and "shadow"
+// mode rollouts (and this periodic variant of it) are no longer needed.
+func (q *cachedQueueReaderBase) isPeriodicShadowSample() bool {
+	interval := q.options.ShadowSampleInterval()
+	if interval <= 0 {
+		return false
+	}
+
+	now := q.clock.Now().UnixNano()
+	last := q.lastShadowSampleUnixNano.Load()
+	if now-last < interval.Nanoseconds() {
+		return false
+	}
+	if !q.lastShadowSampleUnixNano.CompareAndSwap(last, now) {
+		return false
+	}
+	return true
+}
+
+// getState returns a snapshot of the cached queue reader's key state variables for logging and debugging.
+// Caller must hold q.mu (read or write).
+func (q *cachedQueueReaderBase) getState() cachedQueueReaderState {
+	return cachedQueueReaderState{
+		InclusiveLowerBound: q.inclusiveLowerBound,
+		ExclusiveUpperBound: q.exclusiveUpperBound,
+		CacheSize:           q.queue.Len(),
+	}
+}
+
+// cachedQueueReaderState is a snapshot of the cached queue reader's key state variables for logging and debugging.
+type cachedQueueReaderState struct {
+	InclusiveLowerBound persistence.HistoryTaskKey `json:"inclusiveLowerBound"`
+	ExclusiveUpperBound persistence.HistoryTaskKey `json:"exclusiveUpperBound"`
+	CacheSize           int                        `json:"cacheSize"`
+}
+
+// getTaskInShadow queries the DB for the same request, compares the result
+// against the cache snapshot, and returns the DB result. Mismatches are
+// logged but do not affect processing.
+func (q *cachedQueueReaderBase) getTaskInShadow(
+	ctx context.Context,
+	req *GetTaskRequest,
+	cacheResp *GetTaskResponse,
+	logTags []tag.Tag,
+) (*GetTaskResponse, error) {
+	dbResp, err := q.base.GetTask(ctx, req)
+	if err != nil {
+		q.logger.Error("shadow comparison skipped, base returned error",
+			append(logTags, tag.Error(err))...,
+		)
+		return dbResp, err
+	}
+	result := q.findMismatchesInShadow(cacheResp, dbResp, req)
+	q.reportShadowComparison(result, logTags)
+	return dbResp, nil
+}
+
+// shadowMismatchLogLimit caps the number of tasks logged
+const shadowMismatchLogLimit = 100
+
+// capShadowMismatchSlice returns the first shadowMismatchLogLimit elements of s, or s itself if shorter.
+func capShadowMismatchSlice[T any](s []T) []T {
+	if len(s) <= shadowMismatchLogLimit {
+		return s
+	}
+	return s[:shadowMismatchLogLimit]
+}
+
+// shadowMismatchTaskInfo holds identifying information about a task mismatch for logging purposes.
+type shadowMismatchTaskInfo struct {
+	TaskKey persistence.HistoryTaskKey `json:"taskKey"`
+	RunID   string                     `json:"runID"`
+}
+
+// toShadowMismatchTaskInfo extracts the identifying information from a persistence.Task for logging mismatches.
+func toShadowMismatchTaskInfo(t persistence.Task) shadowMismatchTaskInfo {
+	return shadowMismatchTaskInfo{
+		TaskKey: t.GetTaskKey(),
+		RunID:   t.GetRunID(),
+	}
+}
+
+// TaskMismatches groups the tasks found in one rangeID-relative bucket of a shadow comparison.
+type TaskMismatches struct {
+	// RangeIDs holds the distinct rangeIDs encoded in this bucket's tasks. Left unpopulated
+	// for the current-range bucket, where it would always equal CurrentRangeID.
+	RangeIDs []int64 `json:"rangeIDs,omitempty"`
+	// Extra holds tasks present in the cache snapshot but absent from the DB response.
+	Extra []shadowMismatchTaskInfo `json:"extra,omitempty"`
+	// Missed holds tasks present in the DB response but absent from the cache snapshot.
+	Missed []shadowMismatchTaskInfo `json:"missed,omitempty"`
+	// TaskIDBoundaryNoise holds DB-only tasks that are not real mismatches: Cassandra's timer
+	// task query range-filters only on scheduledTime, never taskID, so at a shared boundary
+	// timestamp the DB can return tasks below the requested floor's taskID that the (correctly,
+	// more strictly filtered) cache excludes. A task's rangeID is independent of this check, so
+	// it is bucketed the same way Missed/Extra are. Kept separate from Missed so it doesn't
+	// affect mismatch severity or CachedQueueShadowMismatchCounter, while remaining visible.
+	TaskIDBoundaryNoise []shadowMismatchTaskInfo `json:"taskIDBoundaryNoise,omitempty"`
+}
+
+func (m TaskMismatches) isEmpty() bool {
+	return len(m.Extra) == 0 && len(m.Missed) == 0
+}
+
+func (m TaskMismatches) cap() TaskMismatches {
+	m.RangeIDs = capShadowMismatchSlice(m.RangeIDs)
+	m.Extra = capShadowMismatchSlice(m.Extra)
+	m.Missed = capShadowMismatchSlice(m.Missed)
+	m.TaskIDBoundaryNoise = capShadowMismatchSlice(m.TaskIDBoundaryNoise)
+	return m
+}
+
+// findMismatchesInShadowResult holds the outcome of a shadow comparison, with tasks partitioned
+// by their encoded rangeID relative to the shard's CurrentRangeID at comparison time.
+type findMismatchesInShadowResult struct {
+	// NewRange holds tasks whose rangeID is greater than CurrentRangeID — proof this host is
+	// stale (a newer owner already created tasks, or a prefetch already pulled tasks from a
+	// just-renewed range). Its presence means the rest of the comparison isn't trustworthy.
+	NewRange TaskMismatches `json:"newRange,omitempty"`
+	// CurrentRange holds tasks whose rangeID equals CurrentRangeID.
+	CurrentRange TaskMismatches `json:"currentRange,omitempty"`
+	// PreviousRange holds tasks whose rangeID is less than CurrentRangeID — leftovers from
+	// before the current ownership period.
+	PreviousRange TaskMismatches `json:"previousRange,omitempty"`
+	// CurrentRangeID is the shard's rangeID at the time of comparison.
+	CurrentRangeID int64 `json:"currentRangeID"`
+	// CacheTaskCount is the number of tasks in the cache snapshot.
+	CacheTaskCount int `json:"cacheTaskCount"`
+	// DBTaskCount is the number of tasks in the DB response.
+	DBTaskCount int `json:"dbTaskCount"`
+}
+
+// getTaskRangeID extracts the rangeID encoded in taskID, which is assigned at task creation time and immutable.
+func (q *cachedQueueReaderBase) getTaskRangeID(taskID int64) int64 {
+	return taskID >> int64(q.shard.GetConfig().RangeSizeBits)
+}
+
+// reportShadowComparison logs exactly one line describing the outcome of a shadow comparison,
+// in order of decreasing severity:
+//  1. NewRange non-empty: this host is stale; nothing else is evaluated.
+//  2. CurrentRange.Missed non-empty: a task the queue processor may have skipped serving from cache.
+//  3. CurrentRange.Extra, or anything in PreviousRange: a benign or inconclusive finding, logged
+//     for visibility only.
+//  4. Otherwise: cache and DB agreed.
+func (q *cachedQueueReaderBase) reportShadowComparison(result findMismatchesInShadowResult, logTags []tag.Tag) {
+	// Metric emission must run before capping below: capping truncates the slices for
+	// logging, which would undercount the metric for large comparisons.
+	q.emitShadowMismatchMetrics(result)
+
+	// Cap the number of mismatched task keys logged to avoid excessively large logs.
+	result.NewRange = result.NewRange.cap()
+	result.CurrentRange = result.CurrentRange.cap()
+	result.PreviousRange = result.PreviousRange.cap()
+
+	logTags = append(logTags, tag.Dynamic("shadowComparison", result))
+
+	switch {
+	case !result.NewRange.isEmpty():
+		q.logger.Info("stale shard owner, no check for mismatches", logTags...)
+	case len(result.CurrentRange.Missed) > 0:
+		q.logger.Warn("potential severe mismatch between db and cache states", logTags...)
+	case len(result.CurrentRange.Extra) > 0 || !result.PreviousRange.isEmpty():
+		q.logger.Info("potential non-critical mismatch between db and cache states", logTags...)
+	default:
+		q.logger.Debug("shadow comparison matched", logTags...)
+	}
+}
+
+// emitShadowMismatchMetrics records CachedQueueShadowMismatchCounter for both the current-range
+// and previous-range missed-task buckets, tagged by which bucket they came from so the two never
+// mix into one series. Skipped entirely when NewRange is non-empty: a stale shard owner makes the
+// whole comparison untrustworthy, not just the log severity.
+func (q *cachedQueueReaderBase) emitShadowMismatchMetrics(result findMismatchesInShadowResult) {
+	if !result.NewRange.isEmpty() {
+		return
+	}
+	if len(result.CurrentRange.Missed) > 0 {
+		q.metrics.Tagged(metrics.Range("current")).
+			AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.CurrentRange.Missed)))
+	}
+	if len(result.PreviousRange.Missed) > 0 {
+		q.metrics.Tagged(metrics.Range("previous")).
+			AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.PreviousRange.Missed)))
+	}
+}
+
+// findMismatchesInShadow compares a cache snapshot response against the DB response.
+//
+// Task comparison uses taskID as the primary key. NextTaskKey is intentionally
+// not compared: Cassandra commonly returns a non-empty paging cursor even on
+// the last page, which causes the DB reader to report lastTask.Next() while
+// the cache (which knows its window is exhausted) reports exclusiveMaxTaskKey.
+// Comparing these would produce false-positive mismatches under normal
+// production traffic without indicating any real divergence in task data.
+//
+// Tasks missing from one side are bucketed by comparing their encoded rangeID (assigned
+// at creation and immutable) against the shard's CurrentRangeID: greater into NewRange,
+// equal into CurrentRange, less into PreviousRange. DB tasks missing from the cache land
+// in the bucket's Missed field; cache tasks missing from the DB response land in Extra.
+//
+// A DB task missing from the cache is first checked against req's effective InclusiveMinTaskKey
+// (resolved the same way GetTask resolves it, via resolveInclusiveMinTaskKey): Cassandra's timer
+// task query enforces scheduledTime >= that floor's scheduledTime as a hard bound but never
+// filters on taskID, so the only way a DB task's key can compare less than the floor is a shared
+// boundary timestamp with a lower taskID — the cache correctly excludes it under its own
+// (taskID-inclusive) filtering, and it is not a real mismatch. Such tasks land in the same
+// rangeID bucket's TaskIDBoundaryNoise field instead of its Missed field: the boundary-noise
+// check is orthogonal to which range the task's taskID encodes, so it can occur in any bucket.
+func (q *cachedQueueReaderBase) findMismatchesInShadow(
+	cacheResp *GetTaskResponse,
+	dbResp *GetTaskResponse,
+	req *GetTaskRequest,
+) findMismatchesInShadowResult {
+	inclusiveMinTaskKey, ok := resolveInclusiveMinTaskKey(req)
+	if !ok {
+		// Unreachable in practice: GetTask already returned early via the base reader for this
+		// same req before getTaskInShadow could be reached. Fall back to the safe default of
+		// never suppressing a mismatch as boundary noise.
+		inclusiveMinTaskKey = persistence.MinimumHistoryTaskKey
+	}
+
+	cacheTaskKeys := make(map[int64]struct{}, len(cacheResp.Tasks))
+	for _, t := range cacheResp.Tasks {
+		cacheTaskKeys[t.GetTaskID()] = struct{}{}
+	}
+	dbTaskKeys := make(map[int64]struct{}, len(dbResp.Tasks))
+	for _, t := range dbResp.Tasks {
+		dbTaskKeys[t.GetTaskID()] = struct{}{}
+	}
+
+	var (
+		result           findMismatchesInShadowResult
+		currentRangeID   = q.shard.GetRangeID()
+		newRangeIDs      = map[int64]struct{}{}
+		previousRangeIDs = map[int64]struct{}{}
+	)
+
+	// bucket returns the TaskMismatches this taskRangeID belongs to, relative to currentRangeID,
+	// recording the rangeID for later visibility when it isn't the current one.
+	bucket := func(taskRangeID int64) *TaskMismatches {
+		switch {
+		case taskRangeID > currentRangeID:
+			newRangeIDs[taskRangeID] = struct{}{}
+			return &result.NewRange
+		case taskRangeID < currentRangeID:
+			previousRangeIDs[taskRangeID] = struct{}{}
+			return &result.PreviousRange
+		default:
+			return &result.CurrentRange
+		}
+	}
+
+	for _, t := range dbResp.Tasks {
+		if _, ok := cacheTaskKeys[t.GetTaskID()]; ok {
+			// Task is present in both DB and cache
+			continue
+		}
+
+		b := bucket(q.getTaskRangeID(t.GetTaskID()))
+		if t.GetTaskKey().Less(inclusiveMinTaskKey) {
+			b.TaskIDBoundaryNoise = append(b.TaskIDBoundaryNoise, toShadowMismatchTaskInfo(t))
+			continue
+		}
+		b.Missed = append(b.Missed, toShadowMismatchTaskInfo(t))
+	}
+
+	for _, t := range cacheResp.Tasks {
+		if _, ok := dbTaskKeys[t.GetTaskID()]; ok {
+			// Task is present in DB
+			continue
+		}
+
+		b := bucket(q.getTaskRangeID(t.GetTaskID()))
+		b.Extra = append(b.Extra, toShadowMismatchTaskInfo(t))
+	}
+
+	result.NewRange.RangeIDs = slices.Collect(maps.Keys(newRangeIDs))
+	result.PreviousRange.RangeIDs = slices.Collect(maps.Keys(previousRangeIDs))
+	result.CurrentRangeID = currentRangeID
+	result.DBTaskCount = len(dbResp.Tasks)
+	result.CacheTaskCount = len(cacheResp.Tasks)
+
+	return result
+}

--- a/service/history/queuev2/queue_reader_cached_scheduled.go
+++ b/service/history/queuev2/queue_reader_cached_scheduled.go
@@ -95,7 +95,7 @@ type cachedQueueReaderOptions struct {
 	ShadowSampleInterval dynamicproperties.DurationPropertyFn
 }
 
-type cachedQueueReader struct {
+type cachedScheduledQueueReader struct {
 	status  int32 // DaemonStatusInitialized / Started / Stopped
 	base    QueueReader
 	shard   shard.Context
@@ -157,14 +157,14 @@ type cachedQueueReader struct {
 	lastShadowSampleUnixNano atomic.Int64
 }
 
-func newCachedQueueReader(
+func newCachedScheduledQueueReader(
 	base QueueReader,
 	queue InMemQueue,
 	shard shard.Context,
 	metricsScope metrics.Scope,
-) *cachedQueueReader {
+) *cachedScheduledQueueReader {
 	config := shard.GetConfig()
-	return newCachedQueueReaderWithOptions(
+	return newCachedScheduledQueueReaderWithOptions(
 		base,
 		queue,
 		shard,
@@ -185,7 +185,7 @@ func newCachedQueueReader(
 	)
 }
 
-func newCachedQueueReaderWithOptions(
+func newCachedScheduledQueueReaderWithOptions(
 	base QueueReader,
 	queue InMemQueue,
 	shard shard.Context,
@@ -193,9 +193,9 @@ func newCachedQueueReaderWithOptions(
 	logger log.Logger,
 	metricsScope metrics.Scope,
 	options *cachedQueueReaderOptions,
-) *cachedQueueReader {
+) *cachedScheduledQueueReader {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &cachedQueueReader{
+	return &cachedScheduledQueueReader{
 		status:              common.DaemonStatusInitialized,
 		base:                base,
 		shard:               shard,
@@ -214,7 +214,7 @@ func newCachedQueueReaderWithOptions(
 }
 
 // Start anchors the initial eviction window and launches the background loops.
-func (q *cachedQueueReader) Start() {
+func (q *cachedScheduledQueueReader) Start() {
 	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
@@ -224,7 +224,7 @@ func (q *cachedQueueReader) Start() {
 }
 
 // Stop cancels background goroutines and waits for them to finish.
-func (q *cachedQueueReader) Stop() {
+func (q *cachedScheduledQueueReader) Stop() {
 	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
@@ -237,7 +237,7 @@ func (q *cachedQueueReader) Stop() {
 // prefetchLoop fetches tasks into the look-ahead window on a timer. It fires
 // shortly after Start, then re-arms based on the result or when the upper
 // bound changes via notifyPrefetch.
-func (q *cachedQueueReader) prefetchLoop() {
+func (q *cachedScheduledQueueReader) prefetchLoop() {
 	defer q.wg.Done()
 
 	timer := q.clock.NewTimer(time.Millisecond)
@@ -266,7 +266,7 @@ func (q *cachedQueueReader) prefetchLoop() {
 
 // notifyPrefetch signals the prefetchLoop to recompute its timer. Non-blocking;
 // drops the signal if one is already pending, the loop reads current state on wake.
-func (q *cachedQueueReader) notifyPrefetch() {
+func (q *cachedScheduledQueueReader) notifyPrefetch() {
 	select {
 	case q.prefetchCh <- struct{}{}:
 	default:
@@ -276,7 +276,7 @@ func (q *cachedQueueReader) notifyPrefetch() {
 // nextPrefetchDelay returns how long to wait before the next prefetch. It
 // computes the trigger window relative to exclusiveUpperBound, clamped to
 // MinPrefetchInterval.
-func (q *cachedQueueReader) nextPrefetchDelay() time.Duration {
+func (q *cachedScheduledQueueReader) nextPrefetchDelay() time.Duration {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 
@@ -293,13 +293,15 @@ func (q *cachedQueueReader) nextPrefetchDelay() time.Duration {
 }
 
 // isEnabled returns true if the cache is fully enabled
-func (q *cachedQueueReader) isEnabled() bool {
+func (q *cachedScheduledQueueReader) isEnabled() bool {
 	return q.options.Mode(q.shard.GetShardID()) == "enabled"
 }
 
 // isShadow returns true when cache runs in shadow mode — results are compared
 // against the DB but the DB result is returned to the processor.
-func (q *cachedQueueReader) isShadow() bool { return q.options.Mode(q.shard.GetShardID()) == "shadow" }
+func (q *cachedScheduledQueueReader) isShadow() bool {
+	return q.options.Mode(q.shard.GetShardID()) == "shadow"
+}
 
 // isCachedQueueReaderDisabled reports whether the given mode disables the cached queue reader.
 func isCachedQueueReaderDisabled(mode string) bool {
@@ -312,26 +314,26 @@ func isCachedQueueReaderDisabled(mode string) bool {
 }
 
 // isDisabled returns true for the "disabled" mode and for any unrecognised value
-func (q *cachedQueueReader) isDisabled() bool {
+func (q *cachedScheduledQueueReader) isDisabled() bool {
 	return isCachedQueueReaderDisabled(q.options.Mode(q.shard.GetShardID()))
 }
 
 // IsEmpty reports whether the cache queue reader is empty
-func (q *cachedQueueReader) IsEmpty() bool {
+func (q *cachedScheduledQueueReader) IsEmpty() bool {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 	return q.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey)
 }
 
 // clearIfNotEmpty clears cached state only when the cache has data
-func (q *cachedQueueReader) clearIfNotEmpty() {
+func (q *cachedScheduledQueueReader) clearIfNotEmpty() {
 	if !q.IsEmpty() {
 		q.Clear()
 	}
 }
 
 // Clear wipes all cached state and triggers a fresh prefetch from the DB.
-func (q *cachedQueueReader) Clear() {
+func (q *cachedScheduledQueueReader) Clear() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -343,7 +345,7 @@ func (q *cachedQueueReader) Clear() {
 }
 
 // clearLocked wipes all cached state. Caller must hold q.mu for writing.
-func (q *cachedQueueReader) clearLocked() {
+func (q *cachedScheduledQueueReader) clearLocked() {
 	q.queue.Clear()
 	q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
 	q.prefetchTargetUpper = persistence.MinimumHistoryTaskKey
@@ -353,13 +355,13 @@ func (q *cachedQueueReader) clearLocked() {
 
 // isRangeIDChangedLocked reports whether the shard's current rangeID differs
 // from the last observed value. Caller must hold q.mu (read or write).
-func (q *cachedQueueReader) isRangeIDChangedLocked() bool {
+func (q *cachedScheduledQueueReader) isRangeIDChangedLocked() bool {
 	return q.shard.GetRangeID() != q.lastRangeID
 }
 
 // isRangeIDChanged reports whether the shard's current rangeID differs
 // from the last observed value.
-func (q *cachedQueueReader) isRangeIDChanged() bool {
+func (q *cachedScheduledQueueReader) isRangeIDChanged() bool {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 	return q.isRangeIDChangedLocked()
@@ -369,7 +371,7 @@ func (q *cachedQueueReader) isRangeIDChanged() bool {
 // (shard moved away and was re-acquired). A change of exactly 1 means the same
 // host reacquired the shard — cache remains valid.
 // Returns true if cache was cleared.
-func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
+func (q *cachedScheduledQueueReader) fallbackIfRangeIDChanged() bool {
 	if !q.isRangeIDChanged() {
 		return false
 	}
@@ -406,7 +408,7 @@ func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 // prefetch fetches one page of tasks into the look-ahead window. Returns nil
 // on success (including no-op cases); non-nil on any failure. The caller
 // (prefetchLoop) schedules the next attempt.
-func (q *cachedQueueReader) prefetch() error {
+func (q *cachedScheduledQueueReader) prefetch() error {
 	if q.isDisabled() {
 		// Clear stale cache so re-enabling starts with a fresh prefetch
 		// instead of serving outdated boundaries that cause cache misses.
@@ -533,20 +535,20 @@ func (q *cachedQueueReader) prefetch() error {
 // isRangeCovered reports whether [inclusiveMin, exclusiveMax) falls fully
 // within the cached window [inclusiveLowerBound, exclusiveUpperBound).
 // Caller must hold q.mu (read or write).
-func (q *cachedQueueReader) isRangeCovered(inclusiveMin, exclusiveMax persistence.HistoryTaskKey) bool {
+func (q *cachedScheduledQueueReader) isRangeCovered(inclusiveMin, exclusiveMax persistence.HistoryTaskKey) bool {
 	return !inclusiveMin.Less(q.inclusiveLowerBound) && !exclusiveMax.Greater(q.exclusiveUpperBound)
 }
 
 // isTaskCovered reports whether the given task key falls within the cached window.
 // Caller must hold q.mu (read or write).
-func (q *cachedQueueReader) isTaskCovered(key persistence.HistoryTaskKey) bool {
+func (q *cachedScheduledQueueReader) isTaskCovered(key persistence.HistoryTaskKey) bool {
 	return !key.Less(q.inclusiveLowerBound) && key.Less(q.exclusiveUpperBound)
 }
 
 // isToBufferTask reports whether the given task key should be placed in pendingInjectBuffer
 // and within [exclusiveUpperBound, prefetchTargetUpper) and if a prefetch is in-flight
 // Caller must hold q.mu (read or write).
-func (q *cachedQueueReader) isToBufferTask(key persistence.HistoryTaskKey) bool {
+func (q *cachedScheduledQueueReader) isToBufferTask(key persistence.HistoryTaskKey) bool {
 	// there is no in-flight prefetch, so no tasks should be buffered.
 	if q.prefetchTargetUpper.Equal(persistence.MinimumHistoryTaskKey) {
 		return false
@@ -559,7 +561,7 @@ func (q *cachedQueueReader) isToBufferTask(key persistence.HistoryTaskKey) bool 
 // Returns true if RTrimBySize fired and updated exclusiveUpperBound,
 // meaning the caller must not re-advance the bound.
 // Caller must hold q.mu.
-func (q *cachedQueueReader) putTasks(tasks []persistence.Task) bool {
+func (q *cachedScheduledQueueReader) putTasks(tasks []persistence.Task) bool {
 	if len(tasks) == 0 {
 		return false
 	}
@@ -585,7 +587,7 @@ func (q *cachedQueueReader) putTasks(tasks []persistence.Task) bool {
 
 // insertBufferedTasks drains pendingInjectBuffer into the cache for tasks now
 // covered by the updated exclusiveUpperBound. Must be called under q.mu (write lock).
-func (q *cachedQueueReader) insertBufferedTasks() {
+func (q *cachedScheduledQueueReader) insertBufferedTasks() {
 	if len(q.pendingInjectBuffer) == 0 {
 		return
 	}
@@ -601,7 +603,7 @@ func (q *cachedQueueReader) insertBufferedTasks() {
 
 // updateExclusiveUpperBound sets the upper bound and trigger prefetch if needed.
 // Caller must hold q.mu.
-func (q *cachedQueueReader) updateExclusiveUpperBound(newKey persistence.HistoryTaskKey) {
+func (q *cachedScheduledQueueReader) updateExclusiveUpperBound(newKey persistence.HistoryTaskKey) {
 	if q.logger.DebugOn() {
 		q.logger.Debug("upper bound is updated",
 			tag.Dynamic("cacheState", q.getState()),
@@ -616,7 +618,7 @@ func (q *cachedQueueReader) updateExclusiveUpperBound(newKey persistence.History
 
 // updateInclusiveLowerBound sets the lower bound
 // Caller must hold q.mu.
-func (q *cachedQueueReader) updateInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
+func (q *cachedScheduledQueueReader) updateInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
 	if q.logger.DebugOn() {
 		q.logger.Debug("lower bound is updated",
 			tag.Dynamic("cacheState", q.getState()),
@@ -632,7 +634,7 @@ func (q *cachedQueueReader) updateInclusiveLowerBound(newKey persistence.History
 // ahead, trimming evicted tasks. Caps at exclusiveUpperBound when set to
 // preserve the lower <= upper invariant.
 // Caller must hold q.mu (write).
-func (q *cachedQueueReader) advanceInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
+func (q *cachedScheduledQueueReader) advanceInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
 	if !newKey.Greater(q.inclusiveLowerBound) {
 		return
 	}
@@ -648,7 +650,7 @@ func (q *cachedQueueReader) advanceInclusiveLowerBound(newKey persistence.Histor
 // tryTimeEvict evicts tasks older than TimeEvictionWindow if adding extraTasks
 // would exceed MaxSize.
 // Caller must hold q.mu (write).
-func (q *cachedQueueReader) tryTimeEvict(extraTasks int) {
+func (q *cachedScheduledQueueReader) tryTimeEvict(extraTasks int) {
 	if q.queue.Len()+extraTasks < q.options.MaxSize() {
 		return
 	}
@@ -657,7 +659,7 @@ func (q *cachedQueueReader) tryTimeEvict(extraTasks int) {
 }
 
 // tryTimeEvictIfCacheFull evicts tasks older than TimeEvictionWindow if the cache is full
-func (q *cachedQueueReader) tryTimeEvictIfCacheFull() {
+func (q *cachedScheduledQueueReader) tryTimeEvictIfCacheFull() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -666,7 +668,7 @@ func (q *cachedQueueReader) tryTimeEvictIfCacheFull() {
 
 // UpdateReadLevel advances the lower bound to the processor's ack position.
 // MaximumHistoryTaskKey means "no valid read level" and skipped
-func (q *cachedQueueReader) UpdateReadLevel(readLevel persistence.HistoryTaskKey) {
+func (q *cachedScheduledQueueReader) UpdateReadLevel(readLevel persistence.HistoryTaskKey) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -691,7 +693,7 @@ const (
 // fall in [exclusiveUpperBound, prefetchTargetUpper) while a prefetch is
 // in-flight are buffered and drained once the prefetch completes. All other
 // tasks are dropped. No-op when the cache is off.
-func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
+func (q *cachedScheduledQueueReader) Inject(tasks []persistence.Task) {
 	if q.isDisabled() {
 		// Clear stale cache so re-enabling starts with a fresh prefetch
 		// instead of serving outdated boundaries that cause cache misses.
@@ -775,7 +777,7 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 
 // emitInjectStatusCount records the number of injected tasks that took the given
 // outcome path, tagged by status. Zero counts are skipped to avoid emitting empty series.
-func (q *cachedQueueReader) emitInjectStatusCount(status string, count int64) {
+func (q *cachedScheduledQueueReader) emitInjectStatusCount(status string, count int64) {
 	if count == 0 {
 		return
 	}
@@ -799,7 +801,7 @@ func resolveInclusiveMinTaskKey(req *GetTaskRequest) (persistence.HistoryTaskKey
 
 // GetTask serves tasks from the cache when the starting key is covered.
 // Disabled mode bypasses the cache entirely.
-func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*GetTaskResponse, error) {
+func (q *cachedScheduledQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*GetTaskResponse, error) {
 	if q.isDisabled() {
 		return q.base.GetTask(ctx, req)
 	}
@@ -874,7 +876,7 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 // an ongoing signal that the cache still agrees with the DB after promotion out of
 // "shadow" mode. Remove once CachedQueueReader is enabled by default and "shadow"
 // mode rollouts (and this periodic variant of it) are no longer needed.
-func (q *cachedQueueReader) isPeriodicShadowSample() bool {
+func (q *cachedScheduledQueueReader) isPeriodicShadowSample() bool {
 	interval := q.options.ShadowSampleInterval()
 	if interval <= 0 {
 		return false
@@ -895,7 +897,7 @@ func (q *cachedQueueReader) isPeriodicShadowSample() bool {
 // from cache when the request falls within the prefetched window. Bypasses
 // cache when disabled or in shadow mode. Shadow mode bypasses because in-flight
 // inject notifications make cache/DB comparison unreliable for look-ahead.
-func (q *cachedQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
+func (q *cachedScheduledQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
 	if q.isDisabled() || q.isShadow() {
 		return q.base.LookAHead(ctx, req)
 	}
@@ -931,7 +933,7 @@ func (q *cachedQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest
 
 // getState returns a snapshot of the cached queue reader's key state variables for logging and debugging.
 // Caller must hold q.mu (read or write).
-func (q *cachedQueueReader) getState() cachedQueueReaderState {
+func (q *cachedScheduledQueueReader) getState() cachedQueueReaderState {
 	return cachedQueueReaderState{
 		InclusiveLowerBound: q.inclusiveLowerBound,
 		ExclusiveUpperBound: q.exclusiveUpperBound,
@@ -951,7 +953,7 @@ type cachedQueueReaderState struct {
 // getTaskInShadow queries the DB for the same request, compares the result
 // against the cache snapshot, and returns the DB result. Mismatches are
 // logged but do not affect processing.
-func (q *cachedQueueReader) getTaskInShadow(
+func (q *cachedScheduledQueueReader) getTaskInShadow(
 	ctx context.Context,
 	req *GetTaskRequest,
 	cacheResp *GetTaskResponse,
@@ -1045,7 +1047,7 @@ type findMismatchesInShadowResult struct {
 }
 
 // getTaskRangeID extracts the rangeID encoded in taskID, which is assigned at task creation time and immutable.
-func (q *cachedQueueReader) getTaskRangeID(taskID int64) int64 {
+func (q *cachedScheduledQueueReader) getTaskRangeID(taskID int64) int64 {
 	return taskID >> int64(q.shard.GetConfig().RangeSizeBits)
 }
 
@@ -1056,7 +1058,7 @@ func (q *cachedQueueReader) getTaskRangeID(taskID int64) int64 {
 //  3. CurrentRange.Extra, or anything in PreviousRange: a benign or inconclusive finding, logged
 //     for visibility only.
 //  4. Otherwise: cache and DB agreed.
-func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadowResult, logTags []tag.Tag) {
+func (q *cachedScheduledQueueReader) reportShadowComparison(result findMismatchesInShadowResult, logTags []tag.Tag) {
 	// Metric emission must run before capping below: capping truncates the slices for
 	// logging, which would undercount the metric for large comparisons.
 	q.emitShadowMismatchMetrics(result)
@@ -1084,7 +1086,7 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 // and previous-range missed-task buckets, tagged by which bucket they came from so the two never
 // mix into one series. Skipped entirely when NewRange is non-empty: a stale shard owner makes the
 // whole comparison untrustworthy, not just the log severity.
-func (q *cachedQueueReader) emitShadowMismatchMetrics(result findMismatchesInShadowResult) {
+func (q *cachedScheduledQueueReader) emitShadowMismatchMetrics(result findMismatchesInShadowResult) {
 	if !result.NewRange.isEmpty() {
 		return
 	}
@@ -1120,7 +1122,7 @@ func (q *cachedQueueReader) emitShadowMismatchMetrics(result findMismatchesInSha
 // (taskID-inclusive) filtering, and it is not a real mismatch. Such tasks land in the same
 // rangeID bucket's TaskIDBoundaryNoise field instead of its Missed field: the boundary-noise
 // check is orthogonal to which range the task's taskID encodes, so it can occur in any bucket.
-func (q *cachedQueueReader) findMismatchesInShadow(
+func (q *cachedScheduledQueueReader) findMismatchesInShadow(
 	cacheResp *GetTaskResponse,
 	dbResp *GetTaskResponse,
 	req *GetTaskRequest,

--- a/service/history/queuev2/queue_reader_cached_scheduled.go
+++ b/service/history/queuev2/queue_reader_cached_scheduled.go
@@ -25,8 +25,6 @@ package queuev2
 import (
 	"context"
 	"fmt"
-	"maps"
-	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,7 +32,6 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/clock"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -42,97 +39,21 @@ import (
 	"github.com/uber/cadence/service/history/shard"
 )
 
-//go:generate mockgen -package $GOPACKAGE -destination queue_reader_cached_mock.go github.com/uber/cadence/service/history/queuev2 CachedQueueReader
-
-// CachedQueueReader extends QueueReader with cache injection and lifecycle control.
-type CachedQueueReader interface {
-	QueueReader
-	// Inject adds tasks that have just been persisted into the in-memory cache.
-	// Tasks outside the current prefetch window are silently dropped or buffered.
-	Inject(tasks []persistence.Task)
-	// Clear wipes all cached state and triggers a fresh prefetch from the DB.
-	// Call when the cache may be stale (e.g. after a persistence error).
-	Clear()
-	// UpdateReadLevel advances the eviction lower bound to readLevel,
-	// dropping tasks the processor has already passed.
-	UpdateReadLevel(readLevel persistence.HistoryTaskKey)
-	// Start anchors the eviction window and launches background loops.
-	Start()
-	// Stop cancels background goroutines and waits for them to finish.
-	Stop()
-}
-
-// cachedQueueReaderOptions is the dynamic configuration for the cached queue reader.
-// populated from shard.Context
-type cachedQueueReaderOptions struct {
-	// Mode controls cache behavior: "enabled" uses cache, anything else (including "disabled") disables.
-	Mode dynamicproperties.StringPropertyFnWithShardIDFilter
-	// MaxSize is the maximum number of tasks the cache may hold at once.
-	// Insertions that would exceed this limit trigger time-based eviction first.
-	MaxSize dynamicproperties.IntPropertyFn
-	// MaxLookAheadWindow is how far into the future from now the cache prefetches.
-	// Tasks with scheduled time beyond now+MaxLookAheadWindow are not fetched.
-	MaxLookAheadWindow dynamicproperties.DurationPropertyFn
-	// PrefetchTriggerWindow defines how close to the upper-bound a task must be
-	// before the next prefetch is scheduled. A prefetch fires when the nearest
-	// upcoming task is within PrefetchTriggerWindow of the current upper bound.
-	PrefetchTriggerWindow dynamicproperties.DurationPropertyFn
-	// PrefetchPageSize caps the number of tasks fetched per DB round-trip.
-	PrefetchPageSize dynamicproperties.IntPropertyFn
-	// TimeEvictionWindow is the lookback horizon: tasks older than
-	// now-TimeEvictionWindow are evicted to reclaim cache capacity.
-	TimeEvictionWindow dynamicproperties.DurationPropertyFn
-	// MinPrefetchInterval is the minimum time between consecutive prefetch attempts.
-	// It prevents the prefetch loop from hammering the database when the cache resets
-	// or gap detection fires repeatedly.
-	MinPrefetchInterval dynamicproperties.DurationPropertyFn
-	// PrefetchJitterCoefficient is passed to backoff.JitDuration when computing
-	// the next prefetch delay. Must be in [0, 1]. Zero disables jitter.
-	PrefetchJitterCoefficient dynamicproperties.FloatPropertyFn
-	// ShadowSampleInterval controls how often, at most, a GetTask call in "enabled" mode
-	// is diverted through the shadow comparison path for continuous regression detection.
-	// <= 0 disables sampling.
-	ShadowSampleInterval dynamicproperties.DurationPropertyFn
-}
-
+// cachedScheduledQueueReader is the scheduled (timer) cached queue reader. It embeds the shared
+// cachedQueueReaderBase and adds the prefetch cycle that keeps a look-ahead window of future
+// timer tasks warm in the cache.
 type cachedScheduledQueueReader struct {
-	status  int32 // DaemonStatusInitialized / Started / Stopped
-	base    QueueReader
-	shard   shard.Context
-	queue   InMemQueue
-	options *cachedQueueReaderOptions
-	clock   clock.TimeSource
-	logger  log.Logger
-	metrics metrics.Scope
+	*cachedQueueReaderBase
 
-	mu sync.RWMutex
-
-	// inclusiveLowerBound is the inclusive start of the cached window. Tasks
-	// before this key have been evicted and are no longer served from cache.
-	// Invariant: inclusiveLowerBound <= exclusiveUpperBound.
-	inclusiveLowerBound persistence.HistoryTaskKey
-
-	// exclusiveUpperBound is the exclusive end of the prefetched window. Tasks with
-	// key < exclusiveUpperBound are covered by the cache if they exist in the DB.
-	// Invariant: inclusiveLowerBound <= exclusiveUpperBound.
-	// Always update via updateExclusiveUpperBound to keep the prefetch loop in sync.
-	exclusiveUpperBound persistence.HistoryTaskKey
-
-	// prefetchTargetUpper is the new exclusive upper key the current in-flight prefetch
-	// is aiming to reach. Set under mu before the DB call; cleared to
-	// MinimumHistoryTaskKey after the call completes
+	// prefetchTargetUpper is the new exclusive upper key the current in-flight prefetch is aiming
+	// to reach. Prefetch-only state, so it lives on the scheduled reader rather than the shared
+	// base. Reset to MinimumHistoryTaskKey when no prefetch is in flight and on clearLocked.
 	prefetchTargetUpper persistence.HistoryTaskKey
 
-	// pendingInjectBuffer holds tasks that arrive via Inject while a prefetch is in-flight
-	// with keys in [exclusiveUpperBound, prefetchTargetUpper).
-	//
-	// Without this buffer, a task saved to DB during a prefetch may be missed: its key is
-	// beyond the current exclusiveUpperBound, so it is not injected into the cache, and the
-	// prefetch may not see it due to a race between reading from DB and the task being saved.
-	// When the prefetch completes, it advances exclusiveUpperBound past the task's key,
-	// leaving the task permanently dropped from the cache.
-	//
-	// These tasks are drained into the cache after the prefetch extends the window.
+	// pendingInjectBuffer holds tasks that arrive via Inject while a prefetch is in-flight with
+	// keys in [exclusiveUpperBound, prefetchTargetUpper). Prefetch-only state, so it lives on the
+	// scheduled reader rather than the shared base. Drained into the cache once the prefetch
+	// completes and reset on clearLocked.
 	pendingInjectBuffer []persistence.Task
 
 	ctx    context.Context
@@ -143,18 +64,6 @@ type cachedScheduledQueueReader struct {
 	// senders never block; duplicate signals are dropped, the loop reads current
 	// state on each wake.
 	prefetchCh chan struct{}
-
-	// lastRangeID is the shard rangeID observed when the cache was last valid.
-	// A change means the shard was re-acquired and the cache may be stale.
-	// Protected by mu.
-	lastRangeID int64
-
-	// lastShadowSampleUnixNano is the unix-nano timestamp of the last periodic shadow
-	// sample check performed while in "enabled" mode. When concurrent GetTask calls race
-	// on the same due window, only one of them wins the update, so at most one sample is
-	// taken per window. Zero value means no sample has been taken yet, so the first
-	// eligible call fires immediately.
-	lastShadowSampleUnixNano atomic.Int64
 }
 
 func newCachedScheduledQueueReader(
@@ -195,22 +104,34 @@ func newCachedScheduledQueueReaderWithOptions(
 	options *cachedQueueReaderOptions,
 ) *cachedScheduledQueueReader {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &cachedScheduledQueueReader{
-		status:              common.DaemonStatusInitialized,
-		base:                base,
-		shard:               shard,
-		queue:               queue,
-		options:             options,
-		clock:               clockSource,
-		logger:              logger,
-		metrics:             metricsScope,
-		inclusiveLowerBound: persistence.MinimumHistoryTaskKey,
-		exclusiveUpperBound: persistence.MinimumHistoryTaskKey,
+	q := &cachedScheduledQueueReader{
+		cachedQueueReaderBase: newCachedQueueReaderBase(
+			base,
+			queue,
+			shard,
+			clockSource,
+			logger,
+			metricsScope,
+			options,
+		),
+		prefetchTargetUpper: persistence.MinimumHistoryTaskKey,
 		prefetchCh:          make(chan struct{}, 1),
-		lastRangeID:         shard.GetRangeID(),
 		ctx:                 ctx,
 		cancel:              cancel,
 	}
+	// Wake the prefetch loop whenever the upper bound moves so it can recompute its timer.
+	q.cachedQueueReaderBase.onUpperBoundUpdatedLockedFn = q.notifyPrefetch
+	// Reset the prefetch-only state whenever the shared cache is cleared.
+	q.cachedQueueReaderBase.onClearLockedFn = q.resetPrefetchState
+	return q
+}
+
+// resetPrefetchState clears the in-flight prefetch target and pending inject buffer. Wired as the
+// base's onClearLockedFn hook so a shared clearLocked also discards prefetch-only state.
+// Caller must hold q.mu (write), which clearLocked guarantees.
+func (q *cachedScheduledQueueReader) resetPrefetchState() {
+	q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
+	q.prefetchTargetUpper = persistence.MinimumHistoryTaskKey
 }
 
 // Start anchors the initial eviction window and launches the background loops.
@@ -292,117 +213,46 @@ func (q *cachedScheduledQueueReader) nextPrefetchDelay() time.Duration {
 	return max(q.options.MinPrefetchInterval(), min(delay, jittered))
 }
 
-// isEnabled returns true if the cache is fully enabled
-func (q *cachedScheduledQueueReader) isEnabled() bool {
-	return q.options.Mode(q.shard.GetShardID()) == "enabled"
-}
-
-// isShadow returns true when cache runs in shadow mode — results are compared
-// against the DB but the DB result is returned to the processor.
-func (q *cachedScheduledQueueReader) isShadow() bool {
-	return q.options.Mode(q.shard.GetShardID()) == "shadow"
-}
-
-// isCachedQueueReaderDisabled reports whether the given mode disables the cached queue reader.
-func isCachedQueueReaderDisabled(mode string) bool {
-	switch mode {
-	case "enabled", "shadow":
-		return false
-	default:
-		return true
+// LookAHead returns the next task at or after req.InclusiveMinTaskKey. Serves
+// from cache when the request falls within the cached window. Bypasses
+// cache when disabled or in shadow mode. Shadow mode bypasses because in-flight
+// inject notifications make cache/DB comparison unreliable for look-ahead.
+//
+// Look-ahead is a scheduled/timer concern: only the scheduled queue's event loop calls it, to
+// learn when the next future timer fires. The immediate/transfer reader never uses cached
+// look-ahead (its wrapper delegates straight to the base reader).
+func (q *cachedScheduledQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
+	if q.isDisabled() || q.isShadow() {
+		return q.base.LookAHead(ctx, req)
 	}
-}
 
-// isDisabled returns true for the "disabled" mode and for any unrecognised value
-func (q *cachedScheduledQueueReader) isDisabled() bool {
-	return isCachedQueueReaderDisabled(q.options.Mode(q.shard.GetShardID()))
-}
+	if q.fallbackIfRangeIDChanged() {
+		q.logger.Info("LookAHead falling back to base reader after rangeID change")
+		return q.base.LookAHead(ctx, req)
+	}
 
-// IsEmpty reports whether the cache queue reader is empty
-func (q *cachedScheduledQueueReader) IsEmpty() bool {
 	q.mu.RLock()
-	defer q.mu.RUnlock()
-	return q.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey)
-}
 
-// clearIfNotEmpty clears cached state only when the cache has data
-func (q *cachedScheduledQueueReader) clearIfNotEmpty() {
-	if !q.IsEmpty() {
-		q.Clear()
-	}
-}
-
-// Clear wipes all cached state and triggers a fresh prefetch from the DB.
-func (q *cachedScheduledQueueReader) Clear() {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	q.logger.Info("cache fully cleared",
+	logTags := []tag.Tag{
+		tag.Dynamic("lookAHeadRequest", req),
 		tag.Dynamic("cacheState", q.getState()),
-	)
-
-	q.clearLocked()
-}
-
-// clearLocked wipes all cached state. Caller must hold q.mu for writing.
-func (q *cachedScheduledQueueReader) clearLocked() {
-	q.queue.Clear()
-	q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
-	q.prefetchTargetUpper = persistence.MinimumHistoryTaskKey
-	q.updateInclusiveLowerBound(persistence.MinimumHistoryTaskKey)
-	q.updateExclusiveUpperBound(persistence.MinimumHistoryTaskKey)
-}
-
-// isRangeIDChangedLocked reports whether the shard's current rangeID differs
-// from the last observed value. Caller must hold q.mu (read or write).
-func (q *cachedScheduledQueueReader) isRangeIDChangedLocked() bool {
-	return q.shard.GetRangeID() != q.lastRangeID
-}
-
-// isRangeIDChanged reports whether the shard's current rangeID differs
-// from the last observed value.
-func (q *cachedScheduledQueueReader) isRangeIDChanged() bool {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	return q.isRangeIDChangedLocked()
-}
-
-// fallbackIfRangeIDChanged clears cache if rangeID changed by more than 1
-// (shard moved away and was re-acquired). A change of exactly 1 means the same
-// host reacquired the shard — cache remains valid.
-// Returns true if cache was cleared.
-func (q *cachedScheduledQueueReader) fallbackIfRangeIDChanged() bool {
-	if !q.isRangeIDChanged() {
-		return false
 	}
 
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	if !q.isRangeIDChangedLocked() {
-		return false
+	if !q.isTaskCovered(req.InclusiveMinTaskKey) {
+		q.mu.RUnlock()
+		q.logger.Debug("look-ahead cache miss", logTags...)
+		return q.base.LookAHead(ctx, req)
 	}
 
-	newRangeID := q.shard.GetRangeID()
-	prevRangeID := q.lastRangeID
-	q.lastRangeID = newRangeID
+	cacheTask := q.queue.LookAHead(req.InclusiveMinTaskKey)
+	lookAHeadMaxTime := q.exclusiveUpperBound.GetScheduledTime()
 
-	if newRangeID == prevRangeID+1 {
-		// Same host reacquired the shard. Cache still valid.
-		q.logger.Info("rangeID changed on same host, cache not cleared",
-			tag.Dynamic("previousRangeID", prevRangeID),
-			tag.Dynamic("newRangeID", newRangeID),
-		)
-		return false
-	}
+	q.mu.RUnlock()
 
-	// rangeID changed by more than 1: possible stale cache.
-	q.logger.Info("rangeID changed, clearing cache",
-		tag.Dynamic("previousRangeID", prevRangeID),
-		tag.Dynamic("newRangeID", newRangeID),
-	)
-	q.clearLocked()
-	return true
+	return &LookAHeadResponse{
+		Task:             cacheTask,
+		LookAheadMaxTime: lookAHeadMaxTime,
+	}, nil
 }
 
 // prefetch fetches one page of tasks into the look-ahead window. Returns nil
@@ -532,19 +382,6 @@ func (q *cachedScheduledQueueReader) prefetch() error {
 	return nil
 }
 
-// isRangeCovered reports whether [inclusiveMin, exclusiveMax) falls fully
-// within the cached window [inclusiveLowerBound, exclusiveUpperBound).
-// Caller must hold q.mu (read or write).
-func (q *cachedScheduledQueueReader) isRangeCovered(inclusiveMin, exclusiveMax persistence.HistoryTaskKey) bool {
-	return !inclusiveMin.Less(q.inclusiveLowerBound) && !exclusiveMax.Greater(q.exclusiveUpperBound)
-}
-
-// isTaskCovered reports whether the given task key falls within the cached window.
-// Caller must hold q.mu (read or write).
-func (q *cachedScheduledQueueReader) isTaskCovered(key persistence.HistoryTaskKey) bool {
-	return !key.Less(q.inclusiveLowerBound) && key.Less(q.exclusiveUpperBound)
-}
-
 // isToBufferTask reports whether the given task key should be placed in pendingInjectBuffer
 // and within [exclusiveUpperBound, prefetchTargetUpper) and if a prefetch is in-flight
 // Caller must hold q.mu (read or write).
@@ -601,52 +438,6 @@ func (q *cachedScheduledQueueReader) insertBufferedTasks() {
 	q.putTasks(covered)
 }
 
-// updateExclusiveUpperBound sets the upper bound and trigger prefetch if needed.
-// Caller must hold q.mu.
-func (q *cachedScheduledQueueReader) updateExclusiveUpperBound(newKey persistence.HistoryTaskKey) {
-	if q.logger.DebugOn() {
-		q.logger.Debug("upper bound is updated",
-			tag.Dynamic("cacheState", q.getState()),
-			tag.Dynamic("newUpperBound", newKey),
-		)
-	}
-
-	q.exclusiveUpperBound = newKey
-	q.metrics.RecordHistogramValue(metrics.CachedQueueSizeHistogram, float64(q.queue.Len()))
-	q.notifyPrefetch()
-}
-
-// updateInclusiveLowerBound sets the lower bound
-// Caller must hold q.mu.
-func (q *cachedScheduledQueueReader) updateInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
-	if q.logger.DebugOn() {
-		q.logger.Debug("lower bound is updated",
-			tag.Dynamic("cacheState", q.getState()),
-			tag.Dynamic("newLowerBound", newKey),
-		)
-	}
-
-	q.inclusiveLowerBound = newKey
-	q.metrics.RecordHistogramValue(metrics.CachedQueueSizeHistogram, float64(q.queue.Len()))
-}
-
-// updateInclusiveLowerBound advances inclusiveLowerBound to newKey if it's
-// ahead, trimming evicted tasks. Caps at exclusiveUpperBound when set to
-// preserve the lower <= upper invariant.
-// Caller must hold q.mu (write).
-func (q *cachedScheduledQueueReader) advanceInclusiveLowerBound(newKey persistence.HistoryTaskKey) {
-	if !newKey.Greater(q.inclusiveLowerBound) {
-		return
-	}
-
-	if !newKey.Less(q.exclusiveUpperBound) {
-		newKey = q.exclusiveUpperBound
-	}
-
-	q.queue.LTrim(newKey)
-	q.updateInclusiveLowerBound(newKey)
-}
-
 // tryTimeEvict evicts tasks older than TimeEvictionWindow if adding extraTasks
 // would exceed MaxSize.
 // Caller must hold q.mu (write).
@@ -665,28 +456,6 @@ func (q *cachedScheduledQueueReader) tryTimeEvictIfCacheFull() {
 
 	q.tryTimeEvict(1)
 }
-
-// UpdateReadLevel advances the lower bound to the processor's ack position.
-// MaximumHistoryTaskKey means "no valid read level" and skipped
-func (q *cachedScheduledQueueReader) UpdateReadLevel(readLevel persistence.HistoryTaskKey) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	if readLevel.Equal(persistence.MaximumHistoryTaskKey) {
-		return
-	}
-
-	q.advanceInclusiveLowerBound(readLevel)
-}
-
-// inject status values reported via metrics.CachedQueueInjectAttemptCounter,
-// one per outcome branch of Inject.
-const (
-	injectStatusInjected     = "injected"
-	injectStatusBuffered     = "buffered"
-	injectStatusDroppedBelow = "dropped_below"
-	injectStatusDroppedUpper = "dropped_upper"
-)
 
 // Inject adds tasks that have just been persisted into the in-memory cache.
 // Tasks within the current cache window are inserted immediately. Tasks that
@@ -730,6 +499,7 @@ func (q *cachedScheduledQueueReader) Inject(tasks []persistence.Task) {
 				q.logger.Debug("buffering task",
 					tag.Dynamic("taskKey", t.GetTaskKey()),
 					tag.Dynamic("cacheState", q.getState()),
+					tag.Dynamic("prefetchTargetUpper", q.prefetchTargetUpper),
 				)
 			}
 			q.pendingInjectBuffer = append(q.pendingInjectBuffer, t)
@@ -773,428 +543,4 @@ func (q *cachedScheduledQueueReader) Inject(tasks []persistence.Task) {
 	q.emitInjectStatusCount(injectStatusDroppedUpper, droppedUpper)
 
 	q.putTasks(covered)
-}
-
-// emitInjectStatusCount records the number of injected tasks that took the given
-// outcome path, tagged by status. Zero counts are skipped to avoid emitting empty series.
-func (q *cachedScheduledQueueReader) emitInjectStatusCount(status string, count int64) {
-	if count == 0 {
-		return
-	}
-	q.metrics.Tagged(metrics.StatusTag(status)).AddCounter(metrics.CachedQueueInjectAttemptCounter, count)
-}
-
-// resolveInclusiveMinTaskKey returns the effective InclusiveMinTaskKey for req, accounting for
-// the NextPageToken/NextTaskKey pagination-continuation override in GetTaskProgress. The second
-// return value is false only when NextPageToken is set but NextTaskKey was never populated — an
-// edge case callers should handle by delegating to the base reader.
-func resolveInclusiveMinTaskKey(req *GetTaskRequest) (persistence.HistoryTaskKey, bool) {
-	inclusiveMinTaskKey := req.Progress.Range.InclusiveMinTaskKey
-	if req.Progress.NextPageToken != nil {
-		if req.Progress.NextTaskKey.Equal(persistence.MinimumHistoryTaskKey) {
-			return persistence.HistoryTaskKey{}, false
-		}
-		inclusiveMinTaskKey = req.Progress.NextTaskKey
-	}
-	return inclusiveMinTaskKey, true
-}
-
-// GetTask serves tasks from the cache when the starting key is covered.
-// Disabled mode bypasses the cache entirely.
-func (q *cachedScheduledQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*GetTaskResponse, error) {
-	if q.isDisabled() {
-		return q.base.GetTask(ctx, req)
-	}
-
-	if q.fallbackIfRangeIDChanged() {
-		q.logger.Info("GetTask falling back to base reader after rangeID change")
-		return q.base.GetTask(ctx, req)
-	}
-
-	inclusiveMinTaskKey, ok := resolveInclusiveMinTaskKey(req)
-	if !ok {
-		q.logger.Info("NextPageToken is set but NextTaskKey is not set, delegating to base reader", tag.Dynamic("getTaskRequest", req))
-		return q.base.GetTask(ctx, req)
-	}
-	exclusiveMaxTaskKey := req.Progress.Range.ExclusiveMaxTaskKey
-
-	q.mu.RLock()
-	covered := q.isRangeCovered(inclusiveMinTaskKey, exclusiveMaxTaskKey)
-
-	logTags := []tag.Tag{
-		tag.Dynamic("getTaskRequest", req),
-		tag.Dynamic("cacheState", q.getState()),
-		tag.Dynamic("inclusiveMinTaskKey", inclusiveMinTaskKey),
-	}
-
-	if !covered {
-		q.mu.RUnlock()
-		q.metrics.IncCounter(metrics.CachedQueueMissesCounter)
-		q.logger.Debug("cache miss", logTags...)
-		return q.base.GetTask(ctx, req)
-	}
-
-	tasks, nextTaskKey := q.queue.GetTasks(inclusiveMinTaskKey, exclusiveMaxTaskKey, req.Predicate, req.PageSize)
-	q.mu.RUnlock()
-
-	q.metrics.IncCounter(metrics.CachedQueueHitsCounter)
-	q.logger.Debug("cache hit", logTags...)
-
-	// cacheResp is constructed with Progress.Range starting at nextTaskKey and the same exclusiveMaxTaskKey as the request.
-	// This ensures that if the next page is fetched from the DB, Progress.Range will start at the correct position (nextTaskKey)
-	// and end at the same exclusiveMaxTaskKey. Since NextPageToken is not used when serving from the cache, Progress.Range
-	// is the sole source of truth for the next page's start and end. Using the request's original InclusiveMinTaskKey instead
-	// of nextTaskKey would cause the next page to start at the wrong position, leading to duplicate or skipped tasks.
-	cacheResp := &GetTaskResponse{
-		Tasks: tasks,
-		Progress: &GetTaskProgress{
-			Range: Range{
-				InclusiveMinTaskKey: nextTaskKey,
-				ExclusiveMaxTaskKey: req.Progress.Range.ExclusiveMaxTaskKey,
-			},
-			NextPageToken: nil,
-			NextTaskKey:   nextTaskKey,
-		},
-	}
-
-	if q.isShadow() || q.isPeriodicShadowSample() {
-		return q.getTaskInShadow(ctx, req, cacheResp, logTags)
-	}
-
-	return cacheResp, nil
-}
-
-// isPeriodicShadowSample reports whether this call should be diverted into a shadow
-// comparison as part of the periodic health check for "enabled" mode. Gated on elapsed
-// wall-clock time rather than a request counter, so the check cadence is independent of
-// request volume. When multiple callers race on the same due window, only one of them
-// wins and performs the sample; the timestamp is advanced before the comparison runs, so
-// the interval is measured from attempt to attempt rather than success to success.
-//
-// TODO: this periodic shadow sample check is temporary scaffolding for continuous
-// regression detection while "enabled" mode is being rolled out. It gives operators
-// an ongoing signal that the cache still agrees with the DB after promotion out of
-// "shadow" mode. Remove once CachedQueueReader is enabled by default and "shadow"
-// mode rollouts (and this periodic variant of it) are no longer needed.
-func (q *cachedScheduledQueueReader) isPeriodicShadowSample() bool {
-	interval := q.options.ShadowSampleInterval()
-	if interval <= 0 {
-		return false
-	}
-
-	now := q.clock.Now().UnixNano()
-	last := q.lastShadowSampleUnixNano.Load()
-	if now-last < interval.Nanoseconds() {
-		return false
-	}
-	if !q.lastShadowSampleUnixNano.CompareAndSwap(last, now) {
-		return false
-	}
-	return true
-}
-
-// LookAHead returns the next task at or after req.InclusiveMinTaskKey. Serves
-// from cache when the request falls within the prefetched window. Bypasses
-// cache when disabled or in shadow mode. Shadow mode bypasses because in-flight
-// inject notifications make cache/DB comparison unreliable for look-ahead.
-func (q *cachedScheduledQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
-	if q.isDisabled() || q.isShadow() {
-		return q.base.LookAHead(ctx, req)
-	}
-
-	if q.fallbackIfRangeIDChanged() {
-		q.logger.Info("LookAHead falling back to base reader after rangeID change")
-		return q.base.LookAHead(ctx, req)
-	}
-
-	q.mu.RLock()
-
-	logTags := []tag.Tag{
-		tag.Dynamic("lookAHeadRequest", req),
-		tag.Dynamic("cacheState", q.getState()),
-	}
-
-	if !q.isTaskCovered(req.InclusiveMinTaskKey) {
-		q.mu.RUnlock()
-		q.logger.Debug("look-ahead cache miss", logTags...)
-		return q.base.LookAHead(ctx, req)
-	}
-
-	cacheTask := q.queue.LookAHead(req.InclusiveMinTaskKey)
-	lookAHeadMaxTime := q.exclusiveUpperBound.GetScheduledTime()
-
-	q.mu.RUnlock()
-
-	return &LookAHeadResponse{
-		Task:             cacheTask,
-		LookAheadMaxTime: lookAHeadMaxTime,
-	}, nil
-}
-
-// getState returns a snapshot of the cached queue reader's key state variables for logging and debugging.
-// Caller must hold q.mu (read or write).
-func (q *cachedScheduledQueueReader) getState() cachedQueueReaderState {
-	return cachedQueueReaderState{
-		InclusiveLowerBound: q.inclusiveLowerBound,
-		ExclusiveUpperBound: q.exclusiveUpperBound,
-		CacheSize:           q.queue.Len(),
-		TargetUpperBound:    q.prefetchTargetUpper,
-	}
-}
-
-// cachedQueueReaderState is a snapshot of the cached queue reader's key state variables for logging and debugging.
-type cachedQueueReaderState struct {
-	InclusiveLowerBound persistence.HistoryTaskKey `json:"inclusiveLowerBound"`
-	ExclusiveUpperBound persistence.HistoryTaskKey `json:"exclusiveUpperBound"`
-	CacheSize           int                        `json:"cacheSize"`
-	TargetUpperBound    persistence.HistoryTaskKey `json:"targetUpperBound"`
-}
-
-// getTaskInShadow queries the DB for the same request, compares the result
-// against the cache snapshot, and returns the DB result. Mismatches are
-// logged but do not affect processing.
-func (q *cachedScheduledQueueReader) getTaskInShadow(
-	ctx context.Context,
-	req *GetTaskRequest,
-	cacheResp *GetTaskResponse,
-	logTags []tag.Tag,
-) (*GetTaskResponse, error) {
-	dbResp, err := q.base.GetTask(ctx, req)
-	if err != nil {
-		q.logger.Error("shadow comparison skipped, base returned error",
-			append(logTags, tag.Error(err))...,
-		)
-		return dbResp, err
-	}
-	result := q.findMismatchesInShadow(cacheResp, dbResp, req)
-	q.reportShadowComparison(result, logTags)
-	return dbResp, nil
-}
-
-// shadowMismatchLogLimit caps the number of tasks logged
-const shadowMismatchLogLimit = 100
-
-// capShadowMismatchSlice returns the first shadowMismatchLogLimit elements of s, or s itself if shorter.
-func capShadowMismatchSlice[T any](s []T) []T {
-	if len(s) <= shadowMismatchLogLimit {
-		return s
-	}
-	return s[:shadowMismatchLogLimit]
-}
-
-// shadowMismatchTaskInfo holds identifying information about a task mismatch for logging purposes.
-type shadowMismatchTaskInfo struct {
-	TaskKey persistence.HistoryTaskKey `json:"taskKey"`
-	RunID   string                     `json:"runID"`
-}
-
-// toShadowMismatchTaskInfo extracts the identifying information from a persistence.Task for logging mismatches.
-func toShadowMismatchTaskInfo(t persistence.Task) shadowMismatchTaskInfo {
-	return shadowMismatchTaskInfo{
-		TaskKey: t.GetTaskKey(),
-		RunID:   t.GetRunID(),
-	}
-}
-
-// TaskMismatches groups the tasks found in one rangeID-relative bucket of a shadow comparison.
-type TaskMismatches struct {
-	// RangeIDs holds the distinct rangeIDs encoded in this bucket's tasks. Left unpopulated
-	// for the current-range bucket, where it would always equal CurrentRangeID.
-	RangeIDs []int64 `json:"rangeIDs,omitempty"`
-	// Extra holds tasks present in the cache snapshot but absent from the DB response.
-	Extra []shadowMismatchTaskInfo `json:"extra,omitempty"`
-	// Missed holds tasks present in the DB response but absent from the cache snapshot.
-	Missed []shadowMismatchTaskInfo `json:"missed,omitempty"`
-	// TaskIDBoundaryNoise holds DB-only tasks that are not real mismatches: Cassandra's timer
-	// task query range-filters only on scheduledTime, never taskID, so at a shared boundary
-	// timestamp the DB can return tasks below the requested floor's taskID that the (correctly,
-	// more strictly filtered) cache excludes. A task's rangeID is independent of this check, so
-	// it is bucketed the same way Missed/Extra are. Kept separate from Missed so it doesn't
-	// affect mismatch severity or CachedQueueShadowMismatchCounter, while remaining visible.
-	TaskIDBoundaryNoise []shadowMismatchTaskInfo `json:"taskIDBoundaryNoise,omitempty"`
-}
-
-func (m TaskMismatches) isEmpty() bool {
-	return len(m.Extra) == 0 && len(m.Missed) == 0
-}
-
-func (m TaskMismatches) cap() TaskMismatches {
-	m.RangeIDs = capShadowMismatchSlice(m.RangeIDs)
-	m.Extra = capShadowMismatchSlice(m.Extra)
-	m.Missed = capShadowMismatchSlice(m.Missed)
-	m.TaskIDBoundaryNoise = capShadowMismatchSlice(m.TaskIDBoundaryNoise)
-	return m
-}
-
-// findMismatchesInShadowResult holds the outcome of a shadow comparison, with tasks partitioned
-// by their encoded rangeID relative to the shard's CurrentRangeID at comparison time.
-type findMismatchesInShadowResult struct {
-	// NewRange holds tasks whose rangeID is greater than CurrentRangeID — proof this host is
-	// stale (a newer owner already created tasks, or a prefetch already pulled tasks from a
-	// just-renewed range). Its presence means the rest of the comparison isn't trustworthy.
-	NewRange TaskMismatches `json:"newRange,omitempty"`
-	// CurrentRange holds tasks whose rangeID equals CurrentRangeID.
-	CurrentRange TaskMismatches `json:"currentRange,omitempty"`
-	// PreviousRange holds tasks whose rangeID is less than CurrentRangeID — leftovers from
-	// before the current ownership period.
-	PreviousRange TaskMismatches `json:"previousRange,omitempty"`
-	// CurrentRangeID is the shard's rangeID at the time of comparison.
-	CurrentRangeID int64 `json:"currentRangeID"`
-	// CacheTaskCount is the number of tasks in the cache snapshot.
-	CacheTaskCount int `json:"cacheTaskCount"`
-	// DBTaskCount is the number of tasks in the DB response.
-	DBTaskCount int `json:"dbTaskCount"`
-}
-
-// getTaskRangeID extracts the rangeID encoded in taskID, which is assigned at task creation time and immutable.
-func (q *cachedScheduledQueueReader) getTaskRangeID(taskID int64) int64 {
-	return taskID >> int64(q.shard.GetConfig().RangeSizeBits)
-}
-
-// reportShadowComparison logs exactly one line describing the outcome of a shadow comparison,
-// in order of decreasing severity:
-//  1. NewRange non-empty: this host is stale; nothing else is evaluated.
-//  2. CurrentRange.Missed non-empty: a task the queue processor may have skipped serving from cache.
-//  3. CurrentRange.Extra, or anything in PreviousRange: a benign or inconclusive finding, logged
-//     for visibility only.
-//  4. Otherwise: cache and DB agreed.
-func (q *cachedScheduledQueueReader) reportShadowComparison(result findMismatchesInShadowResult, logTags []tag.Tag) {
-	// Metric emission must run before capping below: capping truncates the slices for
-	// logging, which would undercount the metric for large comparisons.
-	q.emitShadowMismatchMetrics(result)
-
-	// Cap the number of mismatched task keys logged to avoid excessively large logs.
-	result.NewRange = result.NewRange.cap()
-	result.CurrentRange = result.CurrentRange.cap()
-	result.PreviousRange = result.PreviousRange.cap()
-
-	logTags = append(logTags, tag.Dynamic("shadowComparison", result))
-
-	switch {
-	case !result.NewRange.isEmpty():
-		q.logger.Info("stale shard owner, no check for mismatches", logTags...)
-	case len(result.CurrentRange.Missed) > 0:
-		q.logger.Warn("potential severe mismatch between db and cache states", logTags...)
-	case len(result.CurrentRange.Extra) > 0 || !result.PreviousRange.isEmpty():
-		q.logger.Info("potential non-critical mismatch between db and cache states", logTags...)
-	default:
-		q.logger.Debug("shadow comparison matched", logTags...)
-	}
-}
-
-// emitShadowMismatchMetrics records CachedQueueShadowMismatchCounter for both the current-range
-// and previous-range missed-task buckets, tagged by which bucket they came from so the two never
-// mix into one series. Skipped entirely when NewRange is non-empty: a stale shard owner makes the
-// whole comparison untrustworthy, not just the log severity.
-func (q *cachedScheduledQueueReader) emitShadowMismatchMetrics(result findMismatchesInShadowResult) {
-	if !result.NewRange.isEmpty() {
-		return
-	}
-	if len(result.CurrentRange.Missed) > 0 {
-		q.metrics.Tagged(metrics.Range("current")).
-			AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.CurrentRange.Missed)))
-	}
-	if len(result.PreviousRange.Missed) > 0 {
-		q.metrics.Tagged(metrics.Range("previous")).
-			AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.PreviousRange.Missed)))
-	}
-}
-
-// findMismatchesInShadow compares a cache snapshot response against the DB response.
-//
-// Task comparison uses taskID as the primary key. NextTaskKey is intentionally
-// not compared: Cassandra commonly returns a non-empty paging cursor even on
-// the last page, which causes the DB reader to report lastTask.Next() while
-// the cache (which knows its window is exhausted) reports exclusiveMaxTaskKey.
-// Comparing these would produce false-positive mismatches under normal
-// production traffic without indicating any real divergence in task data.
-//
-// Tasks missing from one side are bucketed by comparing their encoded rangeID (assigned
-// at creation and immutable) against the shard's CurrentRangeID: greater into NewRange,
-// equal into CurrentRange, less into PreviousRange. DB tasks missing from the cache land
-// in the bucket's Missed field; cache tasks missing from the DB response land in Extra.
-//
-// A DB task missing from the cache is first checked against req's effective InclusiveMinTaskKey
-// (resolved the same way GetTask resolves it, via resolveInclusiveMinTaskKey): Cassandra's timer
-// task query enforces scheduledTime >= that floor's scheduledTime as a hard bound but never
-// filters on taskID, so the only way a DB task's key can compare less than the floor is a shared
-// boundary timestamp with a lower taskID — the cache correctly excludes it under its own
-// (taskID-inclusive) filtering, and it is not a real mismatch. Such tasks land in the same
-// rangeID bucket's TaskIDBoundaryNoise field instead of its Missed field: the boundary-noise
-// check is orthogonal to which range the task's taskID encodes, so it can occur in any bucket.
-func (q *cachedScheduledQueueReader) findMismatchesInShadow(
-	cacheResp *GetTaskResponse,
-	dbResp *GetTaskResponse,
-	req *GetTaskRequest,
-) findMismatchesInShadowResult {
-	inclusiveMinTaskKey, ok := resolveInclusiveMinTaskKey(req)
-	if !ok {
-		// Unreachable in practice: GetTask already returned early via the base reader for this
-		// same req before getTaskInShadow could be reached. Fall back to the safe default of
-		// never suppressing a mismatch as boundary noise.
-		inclusiveMinTaskKey = persistence.MinimumHistoryTaskKey
-	}
-
-	cacheTaskKeys := make(map[int64]struct{}, len(cacheResp.Tasks))
-	for _, t := range cacheResp.Tasks {
-		cacheTaskKeys[t.GetTaskID()] = struct{}{}
-	}
-	dbTaskKeys := make(map[int64]struct{}, len(dbResp.Tasks))
-	for _, t := range dbResp.Tasks {
-		dbTaskKeys[t.GetTaskID()] = struct{}{}
-	}
-
-	var (
-		result           findMismatchesInShadowResult
-		currentRangeID   = q.shard.GetRangeID()
-		newRangeIDs      = map[int64]struct{}{}
-		previousRangeIDs = map[int64]struct{}{}
-	)
-
-	// bucket returns the TaskMismatches this taskRangeID belongs to, relative to currentRangeID,
-	// recording the rangeID for later visibility when it isn't the current one.
-	bucket := func(taskRangeID int64) *TaskMismatches {
-		switch {
-		case taskRangeID > currentRangeID:
-			newRangeIDs[taskRangeID] = struct{}{}
-			return &result.NewRange
-		case taskRangeID < currentRangeID:
-			previousRangeIDs[taskRangeID] = struct{}{}
-			return &result.PreviousRange
-		default:
-			return &result.CurrentRange
-		}
-	}
-
-	for _, t := range dbResp.Tasks {
-		if _, ok := cacheTaskKeys[t.GetTaskID()]; ok {
-			// Task is present in both DB and cache
-			continue
-		}
-
-		b := bucket(q.getTaskRangeID(t.GetTaskID()))
-		if t.GetTaskKey().Less(inclusiveMinTaskKey) {
-			b.TaskIDBoundaryNoise = append(b.TaskIDBoundaryNoise, toShadowMismatchTaskInfo(t))
-			continue
-		}
-		b.Missed = append(b.Missed, toShadowMismatchTaskInfo(t))
-	}
-
-	for _, t := range cacheResp.Tasks {
-		if _, ok := dbTaskKeys[t.GetTaskID()]; ok {
-			// Task is present in DB
-			continue
-		}
-
-		b := bucket(q.getTaskRangeID(t.GetTaskID()))
-		b.Extra = append(b.Extra, toShadowMismatchTaskInfo(t))
-	}
-
-	result.NewRange.RangeIDs = slices.Collect(maps.Keys(newRangeIDs))
-	result.PreviousRange.RangeIDs = slices.Collect(maps.Keys(previousRangeIDs))
-	result.CurrentRangeID = currentRangeID
-	result.DBTaskCount = len(dbResp.Tasks)
-	result.CacheTaskCount = len(cacheResp.Tasks)
-
-	return result
 }

--- a/service/history/queuev2/queue_reader_cached_scheduled_test.go
+++ b/service/history/queuev2/queue_reader_cached_scheduled_test.go
@@ -75,7 +75,7 @@ func setupMocksForCachedQueueReader(
 	t *testing.T,
 	ctrl *gomock.Controller,
 	overrides ...func(*cachedQueueReaderOptions),
-) (*cachedQueueReader, *cachedQueueReaderMockDeps) {
+) (*cachedScheduledQueueReader, *cachedQueueReaderMockDeps) {
 	t.Helper()
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetRangeID().Return(int64(0)).AnyTimes()
@@ -90,7 +90,7 @@ func setupMocksForCachedQueueReader(
 		metricsScope: metricsScope,
 	}
 
-	r := newCachedQueueReaderWithOptions(
+	r := newCachedScheduledQueueReaderWithOptions(
 		deps.mockBase,
 		deps.mockQueue,
 		deps.mockShard,
@@ -103,7 +103,7 @@ func setupMocksForCachedQueueReader(
 	return r, deps
 }
 
-func setBounds(r *cachedQueueReader, lower, upper persistence.HistoryTaskKey) {
+func setBounds(r *cachedScheduledQueueReader, lower, upper persistence.HistoryTaskKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.inclusiveLowerBound = lower
@@ -1252,7 +1252,7 @@ func TestCachedQueueReader_GetTask_PeriodicShadowSample(t *testing.T) {
 				mockShard: mockShard,
 				clock:     clock.NewMockedTimeSource(),
 			}
-			r := newCachedQueueReaderWithOptions(
+			r := newCachedScheduledQueueReaderWithOptions(
 				deps.mockBase,
 				deps.mockQueue,
 				deps.mockShard,
@@ -1735,7 +1735,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 		initLower             persistence.HistoryTaskKey
 		initUpper             persistence.HistoryTaskKey
 		initBuffer            []persistence.Task
-		setupMocks            func(base *MockQueueReader, queue *MockInMemQueue, r *cachedQueueReader)
+		setupMocks            func(base *MockQueueReader, queue *MockInMemQueue, r *cachedScheduledQueueReader)
 		wantErr               bool
 		wantLower             persistence.HistoryTaskKey
 		wantUpper             persistence.HistoryTaskKey
@@ -1750,7 +1750,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			},
 			initLower:  persistence.MinimumHistoryTaskKey,
 			initUpper:  persistence.MinimumHistoryTaskKey,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {},
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {},
 			wantLower:  persistence.MinimumHistoryTaskKey,
 			wantUpper:  persistence.MinimumHistoryTaskKey,
 		},
@@ -1761,7 +1761,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			},
 			initLower: someLower,
 			initUpper: someUpper,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Clear()
 				queue.EXPECT().Len().Return(0).AnyTimes()
 			},
@@ -1772,7 +1772,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			name:      "cache full: skips DB fetch, bounds unchanged",
 			initLower: someLower,
 			initUpper: someUpper,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(maxSize).AnyTimes()
 			},
 			wantLower: someLower,
@@ -1782,7 +1782,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			name:      "DB error: returns error, bounds unchanged",
 			initLower: someLower,
 			initUpper: someUpper,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
@@ -1796,7 +1796,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			name:      "clear cache, first prefetch, no tasks",
 			initLower: persistence.MinimumHistoryTaskKey,
 			initUpper: persistence.MinimumHistoryTaskKey,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Tasks:    nil,
@@ -1813,7 +1813,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			name:      "clear cache, first prefetch, tasks returned",
 			initLower: persistence.MinimumHistoryTaskKey,
 			initUpper: persistence.MinimumHistoryTaskKey,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Tasks:    []persistence.Task{t1, t2},
@@ -1832,7 +1832,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			name:      "subsequent prefetch, no tasks",
 			initLower: someLower,
 			initUpper: someUpper,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Tasks:    nil,
@@ -1849,7 +1849,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			name:      "subsequent prefetch, tasks returned, tasks inserted",
 			initLower: someLower,
 			initUpper: someUpper,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Tasks:    []persistence.Task{t3, t4},
@@ -1871,7 +1871,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			},
 			initLower: someLower,
 			initUpper: someUpper,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Tasks:    []persistence.Task{t3},
@@ -1893,7 +1893,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			name:      "gap detected: upper changed during fetch, returns error, bounds unchanged",
 			initLower: someLower,
 			initUpper: someUpper,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, r *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, r *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ *GetTaskRequest) (*GetTaskResponse, error) {
@@ -1925,7 +1925,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				// scheduled at someUpper+1min; will fall within [someUpper, maxKey) after prefetch
 				newTask(99, someUpper.GetScheduledTime().Add(time.Minute)),
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedScheduledQueueReader) {
 				tBuf := newTask(99, someUpper.GetScheduledTime().Add(time.Minute))
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
@@ -1949,7 +1949,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			initBuffer: []persistence.Task{
 				newTask(99, someUpper.GetScheduledTime().Add(time.Minute)),
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, r *cachedQueueReader) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, r *cachedScheduledQueueReader) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ *GetTaskRequest) (*GetTaskResponse, error) {

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -160,7 +160,7 @@ func (f *timerQueueFactory) createQueuev2(
 		options.MaxPollIntervalJitterCoefficient,
 	)
 	if !isCachedQueueReaderDisabled(config.TimerProcessorCachedQueueReaderMode(shard.GetShardID())) {
-		cachedReader = newCachedQueueReader(reader, newInMemQueue(), shard, metricsScope)
+		cachedReader = newCachedScheduledQueueReader(reader, newInMemQueue(), shard, metricsScope)
 		reader = cachedReader
 	}
 


### PR DESCRIPTION
**What changed?**

Pure rename of the cached timer queue reader for symmetry with an upcoming transfer-specific cached reader:
- type `cachedQueueReader` -> `cachedScheduledQueueReader`
- constructors `newCachedQueueReader*` -> `newCachedScheduledQueueReader*`
- reader source and test files renamed to match
- updated the timer queue factory call site

Then extracting the common base functionality into an embeddable `cachedQueueReaderBase`.

**Why?**

The existing `cachedQueueReader` caches tasks keyed by `scheduledTime`, so it is specific to scheduled tasks, but its name did not reflect that. Renaming it to `cachedScheduledQueueReader` makes that explicit and avoids a confusing mixed-naming state once a cached reader for immediate tasks exists (#8432).

Next steps: split the timer-only prefetch knobs into `scheduledCacheQueueReaderOptions`, leaving `Mode`/`MaxSize`/`ShadowSampleInterval` on the shared base.

**How did you test it?**

- `go build ./service/history/queuev2/...`
- `go test -race ./service/history/queuev2/...`

**Potential risks**

None. Internal rename only.

**Release notes**

N/A

**Documentation Changes**

N/A
