### PR TITLE
fix(history): Bound History Task DLQ to the maximum read level of the task executor

### DIFF
--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -295,22 +295,13 @@ func NewEngineWithShardContext(
 	replicationMessageHandler := replication.NewDLQHandler(shard, replicationTaskExecutors)
 	historyEngImpl.replicationDLQHandler = replicationMessageHandler
 
-	dlqProcessor, err := taskdlq.NewProcessorFromShard(
+	historyEngImpl.dlqProcessor = taskdlq.NewProcessorFromShard(
 		shard,
 		100,
 		config.HistoryTaskDLQProcessorInterval,
 		config.HistoryTaskDLQMode,
 		config.HistoryTaskDLQProcessorEnabled,
 	)
-	if err != nil {
-		// Run the shard without a history task DLQ processor if construction fails
-		logger.Error("Failed to create history task DLQ processor; DLQ re-injection disabled for this shard",
-			tag.ShardID(shard.GetShardID()),
-			tag.Error(err),
-		)
-	} else {
-		historyEngImpl.dlqProcessor = dlqProcessor
-	}
 
 	shard.SetEngine(historyEngImpl)
 	return historyEngImpl
@@ -326,9 +317,7 @@ func (e *historyEngineImpl) Start() {
 	for _, processor := range e.queueProcessors {
 		processor.Start()
 	}
-	if e.dlqProcessor != nil {
-		e.dlqProcessor.Start()
-	}
+	e.dlqProcessor.Start()
 	e.replicationDLQHandler.Start()
 	e.replicationMetricsEmitter.Start()
 
@@ -356,9 +345,7 @@ func (e *historyEngineImpl) Stop() {
 	for _, processor := range e.queueProcessors {
 		processor.Stop()
 	}
-	if e.dlqProcessor != nil {
-		e.dlqProcessor.Stop()
-	}
+	e.dlqProcessor.Stop()
 	e.replicationDLQHandler.Stop()
 	e.replicationMetricsEmitter.Stop()
 

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -295,13 +295,23 @@ func NewEngineWithShardContext(
 	replicationMessageHandler := replication.NewDLQHandler(shard, replicationTaskExecutors)
 	historyEngImpl.replicationDLQHandler = replicationMessageHandler
 
-	historyEngImpl.dlqProcessor = taskdlq.NewProcessorFromShard(
+	dlqProcessor, err := taskdlq.NewProcessorFromShard(
 		shard,
 		100,
 		config.HistoryTaskDLQProcessorInterval,
 		config.HistoryTaskDLQMode,
 		config.HistoryTaskDLQProcessorEnabled,
 	)
+	if err != nil {
+		// The engine constructor cannot return an error. Run the shard without DLQ
+		// re-injection rather than failing it — writes to the DLQ are unaffected.
+		logger.Error("Failed to create history task DLQ processor; DLQ re-injection disabled for this shard",
+			tag.ShardID(shard.GetShardID()),
+			tag.Error(err),
+		)
+	} else {
+		historyEngImpl.dlqProcessor = dlqProcessor
+	}
 
 	shard.SetEngine(historyEngImpl)
 	return historyEngImpl
@@ -317,7 +327,9 @@ func (e *historyEngineImpl) Start() {
 	for _, processor := range e.queueProcessors {
 		processor.Start()
 	}
-	e.dlqProcessor.Start()
+	if e.dlqProcessor != nil {
+		e.dlqProcessor.Start()
+	}
 	e.replicationDLQHandler.Start()
 	e.replicationMetricsEmitter.Start()
 
@@ -345,7 +357,9 @@ func (e *historyEngineImpl) Stop() {
 	for _, processor := range e.queueProcessors {
 		processor.Stop()
 	}
-	e.dlqProcessor.Stop()
+	if e.dlqProcessor != nil {
+		e.dlqProcessor.Stop()
+	}
 	e.replicationDLQHandler.Stop()
 	e.replicationMetricsEmitter.Stop()
 

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -303,8 +303,7 @@ func NewEngineWithShardContext(
 		config.HistoryTaskDLQProcessorEnabled,
 	)
 	if err != nil {
-		// The engine constructor cannot return an error. Run the shard without DLQ
-		// re-injection rather than failing it — writes to the DLQ are unaffected.
+		// Run the shard without a history task DLQ processor if construction fails
 		logger.Error("Failed to create history task DLQ processor; DLQ re-injection disabled for this shard",
 			tag.ShardID(shard.GetShardID()),
 			tag.Error(err),

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -24,7 +24,6 @@ package taskdlq
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -41,10 +40,6 @@ import (
 	"github.com/uber/cadence/service/history/constants"
 	"github.com/uber/cadence/service/history/shard"
 )
-
-// ErrMaxReadLevelRequired is returned by NewProcessor when
-// ProcessorParams.MaxReadLevel is nil.
-var ErrMaxReadLevelRequired = errors.New("taskdlq: ProcessorParams.MaxReadLevel is required")
 
 type (
 	// Processor reads tasks from the history task DLQ and executes them synchronously.
@@ -123,7 +118,8 @@ type (
 		ShardID    int
 		Manager    persistence.HistoryTaskDLQManager
 		Reinjector TaskReinjector
-		// MaxReadLevelFn provides the exclusive upper bound for processing tasks in the current round.
+		// MaxReadLevel provides the exclusive upper bound for each processing round.
+		// Optional: defaults to an unbounded read (MaximumHistoryTaskKey) when nil.
 		MaxReadLevel  MaxReadLevelFn
 		PageSize      int
 		Interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
@@ -141,17 +137,19 @@ var _ Processor = (*ProcessorImpl)(nil)
 //
 // The processor will periodically process the DLQ for the entire shard,
 // and will process a domain/clusterAttribute pair on demand.
-//
-// Returns ErrMaxReadLevelRequired when params.MaxReadLevel is nil
-func NewProcessor(params ProcessorParams) (*ProcessorImpl, error) {
-	if params.MaxReadLevel == nil {
-		return nil, ErrMaxReadLevelRequired
+func NewProcessor(params ProcessorParams) *ProcessorImpl {
+	maxReadLevel := params.MaxReadLevel
+	if maxReadLevel == nil {
+		// Default to an unbounded read if no MaxReadLevelFn is provided.
+		maxReadLevel = func(persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return persistence.MaximumHistoryTaskKey
+		}
 	}
 	return &ProcessorImpl{
 		shardID:         params.ShardID,
 		mgr:             params.Manager,
 		reinjector:      params.Reinjector,
-		maxReadLevel:    params.MaxReadLevel,
+		maxReadLevel:    maxReadLevel,
 		pageSize:        params.PageSize,
 		interval:        params.Interval,
 		domainMode:      params.DomainMode,
@@ -163,7 +161,7 @@ func NewProcessor(params ProcessorParams) (*ProcessorImpl, error) {
 		cancel:          func() {}, // no-op until Start() sets the real cancel
 		pendingFailover: make(map[string]Partition),
 		failoverSignal:  make(chan struct{}, 1),
-	}, nil
+	}
 }
 
 // NewShardMaxReadLevelFn builds a MaxReadLevelFn from the shard context.
@@ -190,7 +188,7 @@ func NewProcessorFromShard(
 	interval dynamicproperties.DurationPropertyFnWithShardIDFilter,
 	domainMode dynamicproperties.StringPropertyFnWithDomainFilter,
 	enabled dynamicproperties.BoolPropertyFn,
-) (*ProcessorImpl, error) {
+) *ProcessorImpl {
 	return NewProcessor(ProcessorParams{
 		ShardID:       shard.GetShardID(),
 		Manager:       shard.GetService().GetHistoryTaskDLQManager(),
@@ -440,12 +438,8 @@ func (p *ProcessorImpl) processAckLevel(ctx context.Context, al persistence.Hist
 	)
 	// Start just past the current ack position.
 	minKey := persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next()
-	// Bound the round by the shard's max read level snapshot so we never reinject tasks
-	// beyond the shard's current max read level. Default to the maximum possible task key.
-	maxKey := persistence.MaximumHistoryTaskKey
-	if p.maxReadLevel != nil {
-		maxKey = p.maxReadLevel(al.TaskCategory)
-	}
+	// Bound by the shard's max read level so we don't race between the processor and shard executor.
+	maxKey := p.maxReadLevel(al.TaskCategory)
 	if minKey.Compare(maxKey) >= 0 {
 		return nil
 	}

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -24,6 +24,7 @@ package taskdlq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -40,6 +41,10 @@ import (
 	"github.com/uber/cadence/service/history/constants"
 	"github.com/uber/cadence/service/history/shard"
 )
+
+// ErrMaxReadLevelRequired is returned by NewProcessor when
+// ProcessorParams.MaxReadLevel is nil.
+var ErrMaxReadLevelRequired = errors.New("taskdlq: ProcessorParams.MaxReadLevel is required")
 
 type (
 	// Processor reads tasks from the history task DLQ and executes them synchronously.
@@ -118,7 +123,8 @@ type (
 		ShardID    int
 		Manager    persistence.HistoryTaskDLQManager
 		Reinjector TaskReinjector
-		// MaxReadLevel is required; NewProcessor panics when it is nil.
+		// MaxReadLevel bounds each processing round; NewProcessor returns
+		// ErrMaxReadLevelRequired when it is nil.
 		MaxReadLevel  MaxReadLevelFn
 		PageSize      int
 		Interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
@@ -136,12 +142,13 @@ var _ Processor = (*ProcessorImpl)(nil)
 //
 // The processor will periodically process the DLQ for the entire shard,
 // and will process a domain/clusterAttribute pair on demand.
-func NewProcessor(params ProcessorParams) *ProcessorImpl {
+//
+// Returns ErrMaxReadLevelRequired when params.MaxReadLevel is nil; the caller
+// decides whether that is fatal. (A processor running without a MaxReadLevelFn
+// would fall back to unbounded reads — see processAckLevel.)
+func NewProcessor(params ProcessorParams) (*ProcessorImpl, error) {
 	if params.MaxReadLevel == nil {
-		// Fail fast: a nil MaxReadLevel would otherwise nil-panic on the first sweep, and
-		// silently defaulting to an unbounded scan would reintroduce the churn this
-		// dependency exists to prevent.
-		panic("taskdlq.NewProcessor: ProcessorParams.MaxReadLevel is required")
+		return nil, ErrMaxReadLevelRequired
 	}
 	return &ProcessorImpl{
 		shardID:         params.ShardID,
@@ -159,7 +166,7 @@ func NewProcessor(params ProcessorParams) *ProcessorImpl {
 		cancel:          func() {}, // no-op until Start() sets the real cancel
 		pendingFailover: make(map[string]Partition),
 		failoverSignal:  make(chan struct{}, 1),
-	}
+	}, nil
 }
 
 // NewShardMaxReadLevelFn builds a MaxReadLevelFn from the shard context. It
@@ -188,7 +195,7 @@ func NewProcessorFromShard(
 	interval dynamicproperties.DurationPropertyFnWithShardIDFilter,
 	domainMode dynamicproperties.StringPropertyFnWithDomainFilter,
 	enabled dynamicproperties.BoolPropertyFn,
-) *ProcessorImpl {
+) (*ProcessorImpl, error) {
 	return NewProcessor(ProcessorParams{
 		ShardID:       shard.GetShardID(),
 		Manager:       shard.GetService().GetHistoryTaskDLQManager(),
@@ -439,8 +446,14 @@ func (p *ProcessorImpl) processAckLevel(ctx context.Context, al persistence.Hist
 	// Start just past the current ack position.
 	minKey := persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next()
 	// Bound the round by the shard's max read level snapshot so we never chase
-	// concurrent writes; later tasks are picked up by the next sweep.
-	maxKey := p.maxReadLevel(al.TaskCategory)
+	// concurrent writes; later tasks are picked up by the next sweep. A processor
+	// without a MaxReadLevelFn (constructed directly, bypassing NewProcessor's
+	// validation) degrades to the unbounded pre-snapshot behavior rather than
+	// panicking mid-sweep.
+	maxKey := persistence.MaximumHistoryTaskKey
+	if p.maxReadLevel != nil {
+		maxKey = p.maxReadLevel(al.TaskCategory)
+	}
 	if minKey.Compare(maxKey) >= 0 {
 		return nil
 	}

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -123,8 +123,7 @@ type (
 		ShardID    int
 		Manager    persistence.HistoryTaskDLQManager
 		Reinjector TaskReinjector
-		// MaxReadLevel bounds each processing round; NewProcessor returns
-		// ErrMaxReadLevelRequired when it is nil.
+		// MaxReadLevelFn provides the exclusive upper bound for processing tasks in the current round.
 		MaxReadLevel  MaxReadLevelFn
 		PageSize      int
 		Interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
@@ -143,9 +142,7 @@ var _ Processor = (*ProcessorImpl)(nil)
 // The processor will periodically process the DLQ for the entire shard,
 // and will process a domain/clusterAttribute pair on demand.
 //
-// Returns ErrMaxReadLevelRequired when params.MaxReadLevel is nil; the caller
-// decides whether that is fatal. (A processor running without a MaxReadLevelFn
-// would fall back to unbounded reads — see processAckLevel.)
+// Returns ErrMaxReadLevelRequired when params.MaxReadLevel is nil
 func NewProcessor(params ProcessorParams) (*ProcessorImpl, error) {
 	if params.MaxReadLevel == nil {
 		return nil, ErrMaxReadLevelRequired
@@ -169,10 +166,8 @@ func NewProcessor(params ProcessorParams) (*ProcessorImpl, error) {
 	}, nil
 }
 
-// NewShardMaxReadLevelFn builds a MaxReadLevelFn from the shard context. It
-// snapshots the shard's max read level for the current cluster and converts
-// it to an exclusive bound (the shard's immediate-task level is inclusive;
-// scheduled levels are already exclusive).
+// NewShardMaxReadLevelFn builds a MaxReadLevelFn from the shard context.
+// It converts the shard's max read level to an exclusive upper bound for processing.
 func NewShardMaxReadLevelFn(shard shard.Context) MaxReadLevelFn {
 	// The current cluster name is static for the process lifetime, so capture it once.
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
@@ -445,11 +440,8 @@ func (p *ProcessorImpl) processAckLevel(ctx context.Context, al persistence.Hist
 	)
 	// Start just past the current ack position.
 	minKey := persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next()
-	// Bound the round by the shard's max read level snapshot so we never chase
-	// concurrent writes; later tasks are picked up by the next sweep. A processor
-	// without a MaxReadLevelFn (constructed directly, bypassing NewProcessor's
-	// validation) degrades to the unbounded pre-snapshot behavior rather than
-	// panicking mid-sweep.
+	// Bound the round by the shard's max read level snapshot so we never reinject tasks
+	// beyond the shard's current max read level. Default to the maximum possible task key.
 	maxKey := persistence.MaximumHistoryTaskKey
 	if p.maxReadLevel != nil {
 		maxKey = p.maxReadLevel(al.TaskCategory)

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -115,9 +115,10 @@ type (
 
 	// ProcessorParams are the dependencies needed to build a Processor.
 	ProcessorParams struct {
-		ShardID       int
-		Manager       persistence.HistoryTaskDLQManager
-		Reinjector    TaskReinjector
+		ShardID    int
+		Manager    persistence.HistoryTaskDLQManager
+		Reinjector TaskReinjector
+		// MaxReadLevel is required; NewProcessor panics when it is nil.
 		MaxReadLevel  MaxReadLevelFn
 		PageSize      int
 		Interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
@@ -136,6 +137,12 @@ var _ Processor = (*ProcessorImpl)(nil)
 // The processor will periodically process the DLQ for the entire shard,
 // and will process a domain/clusterAttribute pair on demand.
 func NewProcessor(params ProcessorParams) *ProcessorImpl {
+	if params.MaxReadLevel == nil {
+		// Fail fast: a nil MaxReadLevel would otherwise nil-panic on the first sweep, and
+		// silently defaulting to an unbounded scan would reintroduce the churn this
+		// dependency exists to prevent.
+		panic("taskdlq.NewProcessor: ProcessorParams.MaxReadLevel is required")
+	}
 	return &ProcessorImpl{
 		shardID:         params.ShardID,
 		mgr:             params.Manager,

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -77,10 +77,15 @@ type (
 		ClusterAttributeName  string
 	}
 
+	// MaxReadLevelFn returns the exclusive upper bound key for reading DLQ tasks
+	// of the given category in the current processing round.
+	MaxReadLevelFn func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey
+
 	ProcessorImpl struct {
 		shardID       int
 		mgr           persistence.HistoryTaskDLQManager
 		reinjector    TaskReinjector
+		maxReadLevel  MaxReadLevelFn
 		pageSize      int
 		interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
 		domainMode    dynamicproperties.StringPropertyFnWithDomainFilter
@@ -113,6 +118,7 @@ type (
 		ShardID       int
 		Manager       persistence.HistoryTaskDLQManager
 		Reinjector    TaskReinjector
+		MaxReadLevel  MaxReadLevelFn
 		PageSize      int
 		Interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
 		DomainMode    dynamicproperties.StringPropertyFnWithDomainFilter
@@ -134,6 +140,7 @@ func NewProcessor(params ProcessorParams) *ProcessorImpl {
 		shardID:         params.ShardID,
 		mgr:             params.Manager,
 		reinjector:      params.Reinjector,
+		maxReadLevel:    params.MaxReadLevel,
 		pageSize:        params.PageSize,
 		interval:        params.Interval,
 		domainMode:      params.DomainMode,
@@ -145,6 +152,20 @@ func NewProcessor(params ProcessorParams) *ProcessorImpl {
 		cancel:          func() {}, // no-op until Start() sets the real cancel
 		pendingFailover: make(map[string]Partition),
 		failoverSignal:  make(chan struct{}, 1),
+	}
+}
+
+// NewShardMaxReadLevelFn builds a MaxReadLevelFn from the shard context. It
+// snapshots the shard's max read level for the current cluster and converts
+// it to an exclusive bound (the shard's immediate-task level is inclusive;
+// scheduled levels are already exclusive).
+func NewShardMaxReadLevelFn(shard shard.Context) MaxReadLevelFn {
+	return func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+		maxReadLevel := shard.UpdateIfNeededAndGetQueueMaxReadLevel(category, shard.GetClusterMetadata().GetCurrentClusterName())
+		if category.Type() == persistence.HistoryTaskCategoryTypeImmediate {
+			return persistence.NewImmediateTaskKey(maxReadLevel.GetTaskID() + 1)
+		}
+		return maxReadLevel
 	}
 }
 
@@ -163,6 +184,7 @@ func NewProcessorFromShard(
 		ShardID:       shard.GetShardID(),
 		Manager:       shard.GetService().GetHistoryTaskDLQManager(),
 		Reinjector:    shard,
+		MaxReadLevel:  NewShardMaxReadLevelFn(shard),
 		PageSize:      pageSize,
 		Interval:      interval,
 		DomainMode:    domainMode,
@@ -378,7 +400,7 @@ func (p *ProcessorImpl) processAckLevels(ctx context.Context, ackLevels []persis
 }
 
 // processAckLevel fetches and re-injects tasks for the given ack level.
-// It reads all tasks from the current ack position to the shards max read level, and re-injects them
+// It reads all tasks from the current ack position to the shard's max read level, and re-injects them
 // to the executions table.
 // Returns an error when the domain is not enabled or when the tasks cannot be fetched or re-injected.
 func (p *ProcessorImpl) processAckLevel(ctx context.Context, al persistence.HistoryDLQAckLevel) error {
@@ -407,8 +429,12 @@ func (p *ProcessorImpl) processAckLevel(ctx context.Context, al persistence.Hist
 	)
 	// Start just past the current ack position.
 	minKey := persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next()
-	// TODO(c-warren): Pass in max read level from the shard context.
-	maxKey := persistence.MaximumHistoryTaskKey
+	// Bound the round by the shard's max read level snapshot so we never chase
+	// concurrent writes; later tasks are picked up by the next sweep.
+	maxKey := p.maxReadLevel(al.TaskCategory)
+	if minKey.Compare(maxKey) >= 0 {
+		return nil
+	}
 
 	for {
 		// Preempt promptly between pages when the sweep is canceled; any pages already

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -160,8 +160,10 @@ func NewProcessor(params ProcessorParams) *ProcessorImpl {
 // it to an exclusive bound (the shard's immediate-task level is inclusive;
 // scheduled levels are already exclusive).
 func NewShardMaxReadLevelFn(shard shard.Context) MaxReadLevelFn {
+	// The current cluster name is static for the process lifetime, so capture it once.
+	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 	return func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
-		maxReadLevel := shard.UpdateIfNeededAndGetQueueMaxReadLevel(category, shard.GetClusterMetadata().GetCurrentClusterName())
+		maxReadLevel := shard.UpdateIfNeededAndGetQueueMaxReadLevel(category, currentClusterName)
 		if category.Type() == persistence.HistoryTaskCategoryTypeImmediate {
 			return persistence.NewImmediateTaskKey(maxReadLevel.GetTaskID() + 1)
 		}

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -77,13 +77,7 @@ func newProcessor(
 	params newProcessorParams,
 ) *ProcessorImpl {
 	t.Helper()
-	maxReadLevel := params.MaxReadLevel
-	if maxReadLevel == nil {
-		maxReadLevel = func(persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
-			return persistence.MaximumHistoryTaskKey
-		}
-	}
-	proc, err := NewProcessor(ProcessorParams{
+	return NewProcessor(ProcessorParams{
 		ShardID:       1,
 		Manager:       params.Manager,
 		Reinjector:    params.Reinjector,
@@ -94,10 +88,8 @@ func newProcessor(
 		TimeSource:    params.TimeSource,
 		MetricsClient: metrics.NewNoopMetricsClient(),
 		Logger:        testlogger.New(t),
-		MaxReadLevel:  maxReadLevel,
+		MaxReadLevel:  params.MaxReadLevel,
 	})
-	require.NoError(t, err)
-	return proc
 }
 
 func setupProcessor(t *testing.T, ctrl *gomock.Controller) (*ProcessorImpl, *persistence.MockHistoryTaskDLQManager, *MockTaskReinjector) {
@@ -319,38 +311,29 @@ func TestNewShardMaxReadLevelFn(t *testing.T) {
 	assert.Equal(t, timerLevel, fn(persistence.HistoryTaskCategoryTimer))
 }
 
-// TestNewProcessor_ErrorsWhenMaxReadLevelNil validates that a missing MaxReadLevel is
-// reported as an error the caller can act on (fail the process, or proceed without the
-// processor) rather than a panic or a silent default.
-func TestNewProcessor_ErrorsWhenMaxReadLevelNil(t *testing.T) {
-	proc, err := NewProcessor(ProcessorParams{})
-	assert.Nil(t, proc)
-	assert.ErrorIs(t, err, ErrMaxReadLevelRequired)
-}
-
-// TestProcessAckLevel_FallsBackToUnboundedReadWhenMaxReadLevelNil validates the defensive
-// fallback: a processor holding no MaxReadLevelFn reads up to MaximumHistoryTaskKey (the
-// pre-#8450 behavior) instead of panicking. NewProcessor reports a nil fn as an error, so
-// this state is only reachable when the processor is constructed directly.
-func TestProcessAckLevel_FallsBackToUnboundedReadWhenMaxReadLevelNil(t *testing.T) {
+// TestProcessShard_DefaultsToUnboundedReadWhenMaxReadLevelNil validates that NewProcessor
+// defaults a nil MaxReadLevel to an unbounded read (MaximumHistoryTaskKey): the processor
+// is never optional and never fails construction; a missing bound only means reading more
+// than strictly necessary.
+func TestProcessShard_DefaultsToUnboundedReadWhenMaxReadLevelNil(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
 	reinjector := NewMockTaskReinjector(ctrl)
-	p := &ProcessorImpl{
-		shardID:       1,
-		mgr:           mgr,
-		reinjector:    reinjector,
-		pageSize:      10,
-		domainMode:    dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
-		metricsClient: metrics.NewNoopMetricsClient(),
-		logger:        testlogger.New(t),
-		ctx:           context.Background(), // used by advanceAckLevel after a successful page
-	}
+	proc := newProcessor(t, newProcessorParams{
+		Manager:           mgr,
+		Reinjector:        reinjector,
+		DomainMode:        constants.HistoryTaskDLQModeEnabled,
+		ProcessingEnabled: true,
+		TimeSource:        clock.NewMockedTimeSource(),
+		// MaxReadLevel deliberately nil: NewProcessor must default it.
+	})
 
 	al := baseAckLevel(1)
 	tasks := []persistence.Task{newMockTask(ctrl, 10)}
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil)
 	mgr.EXPECT().GetHistoryDLQTasks(gomock.Any(), persistence.HistoryDLQGetTasksRequest{
 		ShardID:               al.ShardID,
 		DomainID:              al.DomainID,
@@ -365,7 +348,7 @@ func TestProcessAckLevel_FallsBackToUnboundedReadWhenMaxReadLevelNil(t *testing.
 	mgr.EXPECT().UpdateHistoryDLQAckLevel(gomock.Any(), gomock.Any()).Return(nil)
 	mgr.EXPECT().DeleteHistoryDLQTasks(gomock.Any(), gomock.Any()).Return(nil)
 
-	require.NoError(t, p.processAckLevel(context.Background(), al))
+	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
 func TestProcessShard_WhenNoAckLevels_ReturnsNil(t *testing.T) {

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -33,11 +33,13 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/constants"
+	"github.com/uber/cadence/service/history/shard"
 )
 
 const (
@@ -58,6 +60,7 @@ type newProcessorParams struct {
 	DomainMode        string
 	ProcessingEnabled bool
 	TimeSource        clock.TimeSource
+	MaxReadLevel      MaxReadLevelFn
 }
 
 // newProcessor builds a ProcessorImpl with the given dependencies and sensible test defaults.
@@ -66,6 +69,12 @@ func newProcessor(
 	params newProcessorParams,
 ) *ProcessorImpl {
 	t.Helper()
+	maxReadLevel := params.MaxReadLevel
+	if maxReadLevel == nil {
+		maxReadLevel = func(persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return persistence.MaximumHistoryTaskKey
+		}
+	}
 	return NewProcessor(ProcessorParams{
 		ShardID:       1,
 		Manager:       params.Manager,
@@ -77,6 +86,7 @@ func newProcessor(
 		TimeSource:    params.TimeSource,
 		MetricsClient: metrics.NewNoopMetricsClient(),
 		Logger:        testlogger.New(t),
+		MaxReadLevel:  maxReadLevel,
 	})
 }
 
@@ -104,6 +114,102 @@ func baseAckLevel(shardID int) persistence.HistoryDLQAckLevel {
 		AckLevelVisibilityTS:  time.Unix(0, 0).UTC(),
 		AckLevelTaskID:        -1,
 	}
+}
+
+// TestProcessShard_BoundsReadByMaxReadLevel verifies each processing round reads DLQ tasks
+// only up to the shard's max read level snapshot, not persistence.MaximumHistoryTaskKey.
+func TestProcessShard_BoundsReadByMaxReadLevel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	maxKey := persistence.NewImmediateTaskKey(500)
+	proc := newProcessor(t, newProcessorParams{
+		Manager:           mgr,
+		Reinjector:        reinjector,
+		DomainMode:        constants.HistoryTaskDLQModeEnabled,
+		ProcessingEnabled: true,
+		TimeSource:        clock.NewMockedTimeSource(),
+		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return maxKey
+		},
+	})
+
+	al := baseAckLevel(1)
+	tasks := []persistence.Task{newMockTask(ctrl, 10)}
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+	mgr.EXPECT().GetHistoryDLQTasks(gomock.Any(), persistence.HistoryDLQGetTasksRequest{
+		ShardID:               al.ShardID,
+		DomainID:              al.DomainID,
+		ClusterAttributeScope: al.ClusterAttributeScope,
+		ClusterAttributeName:  al.ClusterAttributeName,
+		TaskCategory:          al.TaskCategory,
+		InclusiveMinTaskKey:   persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next(),
+		ExclusiveMaxTaskKey:   maxKey,
+		PageSize:              10,
+	}).Return(persistence.HistoryDLQGetTasksResponse{Tasks: tasks}, nil)
+	reinjector.EXPECT().ReinjectHistoryTasks(gomock.Any(), tasks).Return(nil)
+	mgr.EXPECT().UpdateHistoryDLQAckLevel(gomock.Any(), gomock.Any()).Return(nil)
+	mgr.EXPECT().DeleteHistoryDLQTasks(gomock.Any(), gomock.Any()).Return(nil)
+
+	require.NoError(t, proc.ProcessShard(context.Background()))
+}
+
+// TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead verifies that a partition whose ack
+// level has already reached the max read level snapshot is skipped without a DB read (no
+// GetHistoryDLQTasks expectation is set, so gomock fails the test if it is called).
+func TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	al := baseAckLevel(1)
+	// baseAckLevel has AckLevelVisibilityTS=Unix(0,0), AckLevelTaskID=-1, so the
+	// inclusive min key is (Unix(0,0), 0). A max read level equal to it means
+	// there is nothing to read (min >= exclusive max).
+	minKey := persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next()
+	proc := newProcessor(t, newProcessorParams{
+		Manager:           mgr,
+		Reinjector:        reinjector,
+		DomainMode:        constants.HistoryTaskDLQModeEnabled,
+		ProcessingEnabled: true,
+		TimeSource:        clock.NewMockedTimeSource(),
+		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return minKey
+		},
+	})
+
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+
+	require.NoError(t, proc.ProcessShard(context.Background()))
+}
+
+// TestNewShardMaxReadLevelFn verifies the shard wiring: the immediate-task (transfer) level
+// is converted from inclusive to exclusive (+1), and the scheduled (timer) level passes
+// through unchanged, both resolved for the current cluster.
+func TestNewShardMaxReadLevelFn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockShard := shard.NewMockContext(ctrl)
+	mockShard.EXPECT().GetClusterMetadata().Return(cluster.TestActiveClusterMetadata).AnyTimes()
+
+	fn := NewShardMaxReadLevelFn(mockShard)
+
+	mockShard.EXPECT().
+		UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTransfer, cluster.TestCurrentClusterName).
+		Return(persistence.NewImmediateTaskKey(41))
+	assert.Equal(t, persistence.NewImmediateTaskKey(42), fn(persistence.HistoryTaskCategoryTransfer))
+
+	timerLevel := persistence.NewHistoryTaskKey(time.Unix(100, 0).UTC(), 0)
+	mockShard.EXPECT().
+		UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, cluster.TestCurrentClusterName).
+		Return(timerLevel)
+	assert.Equal(t, timerLevel, fn(persistence.HistoryTaskCategoryTimer))
 }
 
 func TestProcessShard_WhenNoAckLevels_ReturnsNil(t *testing.T) {

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -83,7 +83,7 @@ func newProcessor(
 			return persistence.MaximumHistoryTaskKey
 		}
 	}
-	return NewProcessor(ProcessorParams{
+	proc, err := NewProcessor(ProcessorParams{
 		ShardID:       1,
 		Manager:       params.Manager,
 		Reinjector:    params.Reinjector,
@@ -96,6 +96,8 @@ func newProcessor(
 		Logger:        testlogger.New(t),
 		MaxReadLevel:  maxReadLevel,
 	})
+	require.NoError(t, err)
+	return proc
 }
 
 func setupProcessor(t *testing.T, ctrl *gomock.Controller) (*ProcessorImpl, *persistence.MockHistoryTaskDLQManager, *MockTaskReinjector) {
@@ -317,13 +319,53 @@ func TestNewShardMaxReadLevelFn(t *testing.T) {
 	assert.Equal(t, timerLevel, fn(persistence.HistoryTaskCategoryTimer))
 }
 
-// TestNewProcessor_PanicsWhenMaxReadLevelNil validates that a missing MaxReadLevel fails
-// fast at construction rather than nil-panicking mid-sweep or silently falling back to an
-// unbounded scan.
-func TestNewProcessor_PanicsWhenMaxReadLevelNil(t *testing.T) {
-	assert.PanicsWithValue(t, "taskdlq.NewProcessor: ProcessorParams.MaxReadLevel is required", func() {
-		NewProcessor(ProcessorParams{})
-	})
+// TestNewProcessor_ErrorsWhenMaxReadLevelNil validates that a missing MaxReadLevel is
+// reported as an error the caller can act on (fail the process, or proceed without the
+// processor) rather than a panic or a silent default.
+func TestNewProcessor_ErrorsWhenMaxReadLevelNil(t *testing.T) {
+	proc, err := NewProcessor(ProcessorParams{})
+	assert.Nil(t, proc)
+	assert.ErrorIs(t, err, ErrMaxReadLevelRequired)
+}
+
+// TestProcessAckLevel_FallsBackToUnboundedReadWhenMaxReadLevelNil validates the defensive
+// fallback: a processor holding no MaxReadLevelFn reads up to MaximumHistoryTaskKey (the
+// pre-#8450 behavior) instead of panicking. NewProcessor reports a nil fn as an error, so
+// this state is only reachable when the processor is constructed directly.
+func TestProcessAckLevel_FallsBackToUnboundedReadWhenMaxReadLevelNil(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	p := &ProcessorImpl{
+		shardID:       1,
+		mgr:           mgr,
+		reinjector:    reinjector,
+		pageSize:      10,
+		domainMode:    dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		metricsClient: metrics.NewNoopMetricsClient(),
+		logger:        testlogger.New(t),
+		ctx:           context.Background(), // used by advanceAckLevel after a successful page
+	}
+
+	al := baseAckLevel(1)
+	tasks := []persistence.Task{newMockTask(ctrl, 10)}
+	mgr.EXPECT().GetHistoryDLQTasks(gomock.Any(), persistence.HistoryDLQGetTasksRequest{
+		ShardID:               al.ShardID,
+		DomainID:              al.DomainID,
+		ClusterAttributeScope: al.ClusterAttributeScope,
+		ClusterAttributeName:  al.ClusterAttributeName,
+		TaskCategory:          al.TaskCategory,
+		InclusiveMinTaskKey:   persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next(),
+		ExclusiveMaxTaskKey:   persistence.MaximumHistoryTaskKey,
+		PageSize:              10,
+	}).Return(persistence.HistoryDLQGetTasksResponse{Tasks: tasks}, nil)
+	reinjector.EXPECT().ReinjectHistoryTasks(gomock.Any(), tasks).Return(nil)
+	mgr.EXPECT().UpdateHistoryDLQAckLevel(gomock.Any(), gomock.Any()).Return(nil)
+	mgr.EXPECT().DeleteHistoryDLQTasks(gomock.Any(), gomock.Any()).Return(nil)
+
+	require.NoError(t, p.processAckLevel(context.Background(), al))
 }
 
 func TestProcessShard_WhenNoAckLevels_ReturnsNil(t *testing.T) {

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -135,7 +135,7 @@ func timerAckLevel(shardID int, ts time.Time, taskID int64) persistence.HistoryD
 }
 
 // TestProcessShard_BoundsReadByMaxReadLevel verifies each processing round reads DLQ tasks
-// only up to the shard's max read level snapshot, not persistence.MaximumHistoryTaskKey.
+// only up to the shard's max read level snapshot.
 func TestProcessShard_BoundsReadByMaxReadLevel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -175,9 +175,8 @@ func TestProcessShard_BoundsReadByMaxReadLevel(t *testing.T) {
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
-// TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead verifies that a partition whose ack
-// level has already reached the max read level snapshot is skipped without a DB read (no
-// GetHistoryDLQTasks expectation is set, so gomock fails the test if it is called).
+// TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead validates that a partition whose ack
+// level has already reached the max read level snapshot is skipped without a DB read.
 func TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -206,11 +205,8 @@ func TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead(t *testing.T) {
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
-// TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead verifies that a partition whose
-// ack level is already past the shard's max read level (e.g. right after a shard moved and
-// the new owner's snapshot lags the persisted ack level) is skipped without a DB read and
-// without touching the ack level. No GetHistoryDLQTasks/UpdateHistoryDLQAckLevel
-// expectations are set, so gomock fails the test if either is called.
+// TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead validates that a partition whose
+// ack level is already past the shard's max read level is skipped without a DB read.
 func TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -236,9 +232,7 @@ func TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead(t *testing.T) {
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
-// TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead verifies the zero/zero corner:
-// an ack level at task ID 0 and a max read level of 0 must skip (min key is task ID 1,
-// which is at or past the exclusive bound 0), not read or advance anything.
+// TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead validates the zero/zero edge case.
 func TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -264,10 +258,8 @@ func TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead(t *testing.T) {
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
-// TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead verifies timer
-// exclusive-bound semantics: a timer max read level key (T, 0) sorts below every real task
-// at timestamp T, so a partition whose ack level already sits at T must skip without a read
-// even though its ack task ID is greater than zero.
+// TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead validates that a timer
+// partition whose ack level already sits at the max read level timestamp is skipped without a DB read.
 func TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -293,9 +285,8 @@ func TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead(t 
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
-// TestProcessShard_TimerPartition_BoundsReadByTimerMaxReadLevel verifies a timer partition
-// reads with visibility-timestamp bounds — min key just past the ack position, exclusive max
-// key at the snapshot — and advances the ack level to the last reinjected timer key.
+// TestProcessShard_TimerPartition_BoundsReadByTimerMaxReadLevel validates that a timer partition
+// only reads up to the max read level timestamp.
 func TestProcessShard_TimerPartition_BoundsReadByTimerMaxReadLevel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -345,9 +336,7 @@ func TestProcessShard_TimerPartition_BoundsReadByTimerMaxReadLevel(t *testing.T)
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
-// TestNewShardMaxReadLevelFn verifies the shard wiring: the immediate-task (transfer) level
-// is converted from inclusive to exclusive (+1), and the scheduled (timer) level passes
-// through unchanged, both resolved for the current cluster.
+// TestNewShardMaxReadLevelFn validates that the dlq can pull the max read level for each task category from the shards context.
 func TestNewShardMaxReadLevelFn(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -53,6 +53,14 @@ func newMockTask(ctrl *gomock.Controller, taskID int64) *persistence.MockTask {
 	return t
 }
 
+// newMockTimerTask creates a mock persistence.Task whose GetTaskKey returns a
+// scheduled (timer) key at the given visibility timestamp and taskID.
+func newMockTimerTask(ctrl *gomock.Controller, ts time.Time, taskID int64) *persistence.MockTask {
+	task := persistence.NewMockTask(ctrl)
+	task.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(ts, taskID)).AnyTimes()
+	return task
+}
+
 type newProcessorParams struct {
 	ShardID           int
 	Manager           persistence.HistoryTaskDLQManager
@@ -114,6 +122,16 @@ func baseAckLevel(shardID int) persistence.HistoryDLQAckLevel {
 		AckLevelVisibilityTS:  time.Unix(0, 0).UTC(),
 		AckLevelTaskID:        -1,
 	}
+}
+
+// timerAckLevel returns a timer-category ack level for the given visibility timestamp and
+// task ID, on the same test partition as baseAckLevel.
+func timerAckLevel(shardID int, ts time.Time, taskID int64) persistence.HistoryDLQAckLevel {
+	al := baseAckLevel(shardID)
+	al.TaskCategory = persistence.HistoryTaskCategoryTimer
+	al.AckLevelVisibilityTS = ts
+	al.AckLevelTaskID = taskID
+	return al
 }
 
 // TestProcessShard_BoundsReadByMaxReadLevel verifies each processing round reads DLQ tasks
@@ -184,6 +202,145 @@ func TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead(t *testing.T) {
 
 	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
 		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+
+	require.NoError(t, proc.ProcessShard(context.Background()))
+}
+
+// TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead verifies that a partition whose
+// ack level is already past the shard's max read level (e.g. right after a shard moved and
+// the new owner's snapshot lags the persisted ack level) is skipped without a DB read and
+// without touching the ack level. No GetHistoryDLQTasks/UpdateHistoryDLQAckLevel
+// expectations are set, so gomock fails the test if either is called.
+func TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	al := baseAckLevel(1)
+	al.AckLevelTaskID = 100
+	proc := newProcessor(t, newProcessorParams{
+		Manager:           mgr,
+		Reinjector:        reinjector,
+		DomainMode:        constants.HistoryTaskDLQModeEnabled,
+		ProcessingEnabled: true,
+		TimeSource:        clock.NewMockedTimeSource(),
+		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return persistence.NewImmediateTaskKey(50)
+		},
+	})
+
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+
+	require.NoError(t, proc.ProcessShard(context.Background()))
+}
+
+// TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead verifies the zero/zero corner:
+// an ack level at task ID 0 and a max read level of 0 must skip (min key is task ID 1,
+// which is at or past the exclusive bound 0), not read or advance anything.
+func TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	al := baseAckLevel(1)
+	al.AckLevelTaskID = 0
+	proc := newProcessor(t, newProcessorParams{
+		Manager:           mgr,
+		Reinjector:        reinjector,
+		DomainMode:        constants.HistoryTaskDLQModeEnabled,
+		ProcessingEnabled: true,
+		TimeSource:        clock.NewMockedTimeSource(),
+		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return persistence.NewImmediateTaskKey(0)
+		},
+	})
+
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+
+	require.NoError(t, proc.ProcessShard(context.Background()))
+}
+
+// TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead verifies timer
+// exclusive-bound semantics: a timer max read level key (T, 0) sorts below every real task
+// at timestamp T, so a partition whose ack level already sits at T must skip without a read
+// even though its ack task ID is greater than zero.
+func TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	ackTS := time.Unix(100, 0).UTC()
+	al := timerAckLevel(1, ackTS, 7)
+	proc := newProcessor(t, newProcessorParams{
+		Manager:           mgr,
+		Reinjector:        reinjector,
+		DomainMode:        constants.HistoryTaskDLQModeEnabled,
+		ProcessingEnabled: true,
+		TimeSource:        clock.NewMockedTimeSource(),
+		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return persistence.NewHistoryTaskKey(ackTS, 0)
+		},
+	})
+
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+
+	require.NoError(t, proc.ProcessShard(context.Background()))
+}
+
+// TestProcessShard_TimerPartition_BoundsReadByTimerMaxReadLevel verifies a timer partition
+// reads with visibility-timestamp bounds — min key just past the ack position, exclusive max
+// key at the snapshot — and advances the ack level to the last reinjected timer key.
+func TestProcessShard_TimerPartition_BoundsReadByTimerMaxReadLevel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	ackTS := time.Unix(100, 0).UTC()
+	maxTS := time.Unix(200, 0).UTC()
+	maxKey := persistence.NewHistoryTaskKey(maxTS, 0)
+	al := timerAckLevel(1, ackTS, 7)
+	proc := newProcessor(t, newProcessorParams{
+		Manager:           mgr,
+		Reinjector:        reinjector,
+		DomainMode:        constants.HistoryTaskDLQModeEnabled,
+		ProcessingEnabled: true,
+		TimeSource:        clock.NewMockedTimeSource(),
+		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+			return maxKey
+		},
+	})
+
+	taskTS := time.Unix(150, 0).UTC()
+	tasks := []persistence.Task{newMockTimerTask(ctrl, taskTS, 9)}
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+	mgr.EXPECT().GetHistoryDLQTasks(gomock.Any(), persistence.HistoryDLQGetTasksRequest{
+		ShardID:               al.ShardID,
+		DomainID:              al.DomainID,
+		ClusterAttributeScope: al.ClusterAttributeScope,
+		ClusterAttributeName:  al.ClusterAttributeName,
+		TaskCategory:          persistence.HistoryTaskCategoryTimer,
+		InclusiveMinTaskKey:   persistence.NewHistoryTaskKey(ackTS, 7).Next(),
+		ExclusiveMaxTaskKey:   maxKey,
+		PageSize:              10,
+	}).Return(persistence.HistoryDLQGetTasksResponse{Tasks: tasks}, nil)
+	reinjector.EXPECT().ReinjectHistoryTasks(gomock.Any(), tasks).Return(nil)
+	mgr.EXPECT().UpdateHistoryDLQAckLevel(gomock.Any(), persistence.HistoryDLQUpdateAckLevelRequest{
+		ShardID:                   al.ShardID,
+		DomainID:                  al.DomainID,
+		ClusterAttributeScope:     al.ClusterAttributeScope,
+		ClusterAttributeName:      al.ClusterAttributeName,
+		TaskCategory:              persistence.HistoryTaskCategoryTimer,
+		UpdatedInclusiveReadLevel: persistence.NewHistoryTaskKey(taskTS, 9),
+	}).Return(nil)
+	mgr.EXPECT().DeleteHistoryDLQTasks(gomock.Any(), gomock.Any()).Return(nil)
 
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -175,114 +175,73 @@ func TestProcessShard_BoundsReadByMaxReadLevel(t *testing.T) {
 	require.NoError(t, proc.ProcessShard(context.Background()))
 }
 
-// TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead validates that a partition whose ack
-// level has already reached the max read level snapshot is skipped without a DB read.
-func TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
-	reinjector := NewMockTaskReinjector(ctrl)
-	al := baseAckLevel(1)
-	// baseAckLevel has AckLevelVisibilityTS=Unix(0,0), AckLevelTaskID=-1, so the
-	// inclusive min key is (Unix(0,0), 0). A max read level equal to it means
-	// there is nothing to read (min >= exclusive max).
-	minKey := persistence.NewHistoryTaskKey(al.AckLevelVisibilityTS, al.AckLevelTaskID).Next()
-	proc := newProcessor(t, newProcessorParams{
-		Manager:           mgr,
-		Reinjector:        reinjector,
-		DomainMode:        constants.HistoryTaskDLQModeEnabled,
-		ProcessingEnabled: true,
-		TimeSource:        clock.NewMockedTimeSource(),
-		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
-			return minKey
-		},
-	})
-
-	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
-		Return([]persistence.HistoryDLQAckLevel{al}, nil)
-
-	require.NoError(t, proc.ProcessShard(context.Background()))
-}
-
-// TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead validates that a partition whose
-// ack level is already past the shard's max read level is skipped without a DB read.
-func TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
-	reinjector := NewMockTaskReinjector(ctrl)
-	al := baseAckLevel(1)
-	al.AckLevelTaskID = 100
-	proc := newProcessor(t, newProcessorParams{
-		Manager:           mgr,
-		Reinjector:        reinjector,
-		DomainMode:        constants.HistoryTaskDLQModeEnabled,
-		ProcessingEnabled: true,
-		TimeSource:        clock.NewMockedTimeSource(),
-		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
-			return persistence.NewImmediateTaskKey(50)
-		},
-	})
-
-	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
-		Return([]persistence.HistoryDLQAckLevel{al}, nil)
-
-	require.NoError(t, proc.ProcessShard(context.Background()))
-}
-
-// TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead validates the zero/zero edge case.
-func TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
-	reinjector := NewMockTaskReinjector(ctrl)
-	al := baseAckLevel(1)
-	al.AckLevelTaskID = 0
-	proc := newProcessor(t, newProcessorParams{
-		Manager:           mgr,
-		Reinjector:        reinjector,
-		DomainMode:        constants.HistoryTaskDLQModeEnabled,
-		ProcessingEnabled: true,
-		TimeSource:        clock.NewMockedTimeSource(),
-		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
-			return persistence.NewImmediateTaskKey(0)
-		},
-	})
-
-	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
-		Return([]persistence.HistoryDLQAckLevel{al}, nil)
-
-	require.NoError(t, proc.ProcessShard(context.Background()))
-}
-
-// TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead validates that a timer
-// partition whose ack level already sits at the max read level timestamp is skipped without a DB read.
-func TestProcessShard_TimerPartition_WhenMaxReadLevelAtAckTimestamp_SkipsRead(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
-	reinjector := NewMockTaskReinjector(ctrl)
+// TestProcessShard_SkipsReadWhenAckLevelAtOrPastMaxReadLevel validates that a partition is
+// skipped without a DB read or ack-level write whenever its ack level has already reached
+// the max read level snapshot. No GetHistoryDLQTasks/UpdateHistoryDLQAckLevel expectations
+// are set, so gomock fails a case if either is called.
+func TestProcessShard_SkipsReadWhenAckLevelAtOrPastMaxReadLevel(t *testing.T) {
 	ackTS := time.Unix(100, 0).UTC()
-	al := timerAckLevel(1, ackTS, 7)
-	proc := newProcessor(t, newProcessorParams{
-		Manager:           mgr,
-		Reinjector:        reinjector,
-		DomainMode:        constants.HistoryTaskDLQModeEnabled,
-		ProcessingEnabled: true,
-		TimeSource:        clock.NewMockedTimeSource(),
-		MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
-			return persistence.NewHistoryTaskKey(ackTS, 0)
+	tests := []struct {
+		name         string
+		ackLevel     func() persistence.HistoryDLQAckLevel
+		maxReadLevel persistence.HistoryTaskKey
+	}{
+		{
+			name:     "transfer ack level at max read level",
+			ackLevel: func() persistence.HistoryDLQAckLevel { return baseAckLevel(1) },
+			// baseAckLevel's min key is (Unix(0,0), 0); an equal exclusive bound leaves nothing to read.
+			maxReadLevel: persistence.NewHistoryTaskKey(time.Unix(0, 0).UTC(), 0),
 		},
-	})
+		{
+			name: "transfer max read level below ack level",
+			ackLevel: func() persistence.HistoryDLQAckLevel {
+				al := baseAckLevel(1)
+				al.AckLevelTaskID = 100
+				return al
+			},
+			maxReadLevel: persistence.NewImmediateTaskKey(50),
+		},
+		{
+			name: "transfer ack level and max read level both zero",
+			ackLevel: func() persistence.HistoryDLQAckLevel {
+				al := baseAckLevel(1)
+				al.AckLevelTaskID = 0
+				return al
+			},
+			maxReadLevel: persistence.NewImmediateTaskKey(0),
+		},
+		{
+			name:     "timer max read level at ack timestamp",
+			ackLevel: func() persistence.HistoryDLQAckLevel { return timerAckLevel(1, ackTS, 7) },
+			// A timer bound (T, 0) sorts below every real task at T, so an ack level at T must skip.
+			maxReadLevel: persistence.NewHistoryTaskKey(ackTS, 0),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
-		Return([]persistence.HistoryDLQAckLevel{al}, nil)
+			mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+			reinjector := NewMockTaskReinjector(ctrl)
+			al := tc.ackLevel()
+			proc := newProcessor(t, newProcessorParams{
+				Manager:           mgr,
+				Reinjector:        reinjector,
+				DomainMode:        constants.HistoryTaskDLQModeEnabled,
+				ProcessingEnabled: true,
+				TimeSource:        clock.NewMockedTimeSource(),
+				MaxReadLevel: func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey {
+					return tc.maxReadLevel
+				},
+			})
 
-	require.NoError(t, proc.ProcessShard(context.Background()))
+			mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+				Return([]persistence.HistoryDLQAckLevel{al}, nil)
+
+			require.NoError(t, proc.ProcessShard(context.Background()))
+		})
+	}
 }
 
 // TestProcessShard_TimerPartition_BoundsReadByTimerMaxReadLevel validates that a timer partition
@@ -356,6 +315,15 @@ func TestNewShardMaxReadLevelFn(t *testing.T) {
 		UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryTimer, cluster.TestCurrentClusterName).
 		Return(timerLevel)
 	assert.Equal(t, timerLevel, fn(persistence.HistoryTaskCategoryTimer))
+}
+
+// TestNewProcessor_PanicsWhenMaxReadLevelNil validates that a missing MaxReadLevel fails
+// fast at construction rather than nil-panicking mid-sweep or silently falling back to an
+// unbounded scan.
+func TestNewProcessor_PanicsWhenMaxReadLevelNil(t *testing.T) {
+	assert.PanicsWithValue(t, "taskdlq.NewProcessor: ProcessorParams.MaxReadLevel is required", func() {
+		NewProcessor(ProcessorParams{})
+	})
 }
 
 func TestProcessShard_WhenNoAckLevels_ReturnsNil(t *testing.T) {


### PR DESCRIPTION
**What changed?**

Bounded each history task DLQ processing round by a snapshot of the shard's max read level instead of scanning to MaximumHistoryTaskKey. Fixes #8450.

- Added taskdlq.MaxReadLevelFn, injected via ProcessorParams and wired in NewProcessorFromShard through the new NewShardMaxReadLevelFn(shard), which resolves shard.UpdateIfNeededAndGetQueueMaxReadLevel for the current cluster and converts the inclusive immediate-task level to an exclusive bound (+1), matching the queuev2 convention.
- processAckLevel now snapshots the bound once per round and skips the partition entirely (no read, no ack-level write) when the ack level has already reached it.

**Why?**

The DLQ processor previously read each partition from the ack level to an unbounded upper key. A processing round could therefore chase concurrent writes causing redundant reinjection work and range-tombstone growth in the partition from the repeated read/delete cycles

**How did you test it?**

Unit tests:

go test -race -run 'TestProcessShard_BoundsReadByMaxReadLevel|TestProcessShard_WhenAckLevelAtMaxReadLevel_SkipsRead|TestNewShardMaxReadLevelFn|TestProcessShard_WhenMaxReadLevelBelowAckLevel_SkipsRead|TestProcessShard_WhenAckLevelAndMaxReadLevelZero_SkipsRead|TestProcessShard_TimerPartition' ./service/history/taskdlq/...
go test -race ./service/history/taskdlq/... ./service/history/engine/engineimpl/...

**Potential risks**

No API/IDL or schema changes. A sweep no longer drains tasks written after its snapshot, they wait for the next sweep (interval HistoryTaskDLQProcessorInterval), which marginally increases worst-case reinjection latency.

Release notes

N/A

Documentation Changes

N/A