### PR TITLE
feat(diagnostics): add timeout risks invariant

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -74,6 +74,7 @@ import (
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeoutrisk"
 )
 
 type (
@@ -303,7 +304,7 @@ func (s *server) startService() common.Daemon {
 	}
 
 	params.KafkaConfig = s.cfg.Kafka
-	params.DiagnosticsInvariants = []diagnosticsInvariant.Invariant{timeout.NewInvariant(timeout.Params{Client: params.PublicClient}), failure.NewInvariant(), retry.NewInvariant()}
+	params.DiagnosticsInvariants = []diagnosticsInvariant.Invariant{timeout.NewInvariant(timeout.Params{Client: params.PublicClient}), failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant()}
 	params.ShardDistributorMatchingConfig = s.cfg.ShardDistributorMatchingConfig
 
 	params.Logger.Info("Starting service " + s.name)

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	linkToTimeoutsRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
-	linkToFailuresRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/activity-failures/"
-	linkToRetriesRunbook  = "https://cadenceworkflow.io/docs/workflow-troubleshooting/retries"
-	WfDiagnosticsAppName  = "workflow-diagnostics"
+	linkToTimeoutsRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
+	linkToFailuresRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/activity-failures/"
+	linkToRetriesRunbook      = "https://cadenceworkflow.io/docs/workflow-troubleshooting/retries"
+	linkToTimeoutRisksRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
+	WfDiagnosticsAppName      = "workflow-diagnostics"
 
 	_maxPageSize           = 1000            // current maximum page size for fetching workflow history
 	_contextTimeout        = 1 * time.Minute // timeout to fetch the whole execution history

--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeoutrisk"
 )
 
 const (
@@ -140,7 +141,7 @@ func testDiagnosticWorkflow(t *testing.T, history *types.GetWorkflowExecutionHis
 	mockFrontendClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any()).Return(history, nil).AnyTimes()
 	return &dw{
 		clientBean: mockClientBean,
-		invariants: []invariant.Invariant{failure.NewInvariant(), retry.NewInvariant()},
+		invariants: []invariant.Invariant{failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant()},
 	}
 }
 

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package timeoutrisk
 
 import (
@@ -57,10 +35,9 @@ func (t *timeoutRisk) Check(ctx context.Context, params invariant.InvariantCheck
 		activityID := attr.GetActivityID()
 		activityType := attr.GetActivityType().GetName()
 
-		// The server caps activity timeouts at the workflow execution timeout before recording them
-		// (validateActivityScheduleAttributes in service/history/decision/checker.go), so a silently
-		// capped StartToClose surfaces as equality with the workflow timeout. ScheduleToStart and
-		// ScheduleToClose are excluded: the server inflates them to the cap under retry policies.
+		// Equality with workflow timeout means StartToClose was silently capped
+		// (validateActivityScheduleAttributes). ScheduleToStart/ScheduleToClose
+		// excluded: retries inflate them to the cap.
 		if workflowTimeoutSeconds > 0 && attr.GetStartToCloseTimeoutSeconds() == workflowTimeoutSeconds {
 			result = append(result, invariant.InvariantCheckResult{
 				IssueID:       issueID,

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
@@ -2,7 +2,6 @@ package timeoutrisk
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/uber/cadence/common/types"
@@ -70,31 +69,6 @@ func (t *timeoutRisk) Check(ctx context.Context, params invariant.InvariantCheck
 			})
 			issueID++
 		}
-
-		// Activity retries are invisible in history and replicate to standby clusters only via activity
-		// sync; the standby's activity timeout task is discarded after standbyTaskMissingEventsDiscardDelay
-		// (default 25m) with no replacement, so a failover during a retry sequence extending past that
-		// delay can orphan the activity until its workflow's tasks are refreshed.
-		policy := attr.RetryPolicy
-		if policy != nil && (policy.GetMaximumAttempts() == 0 || policy.GetMaximumAttempts() >= 2) {
-			estimatedRetryWindow := estimatedRetryWindowSeconds(policy, attr.GetStartToCloseTimeoutSeconds(), workflowTimeoutSeconds)
-			if estimatedRetryWindow > failoverOrphanRiskThresholdSeconds {
-				result = append(result, invariant.InvariantCheckResult{
-					IssueID:       issueID,
-					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
-					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
-					Metadata: invariant.MarshalData(ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
-						EventID:              event.ID,
-						ActivityID:           activityID,
-						ActivityType:         activityType,
-						EstimatedRetryWindow: time.Duration(estimatedRetryWindow) * time.Second,
-						Threshold:            time.Duration(failoverOrphanRiskThresholdSeconds) * time.Second,
-						RetryPolicy:          policy,
-					}),
-				})
-				issueID++
-			}
-		}
 	}
 
 	return result, nil
@@ -109,78 +83,6 @@ func fetchWorkflowExecutionTimeoutSeconds(events []*types.HistoryEvent) int32 {
 		}
 	}
 	return 0
-}
-
-// estimatedRetryWindowSeconds estimates how long an activity's retry sequence could keep extending, based
-// on its retry policy. Retries mutate mutable state and replicate to standby via activity sync without
-// emitting new history events, so this window cannot be read off the scheduled event directly -- it is
-// derived the same way the server would internally: an explicit expiration wins outright; an unlimited
-// attempt budget rides out to the workflow timeout; otherwise it is the cumulative estimate for a bounded
-// attempt budget. The result is always capped at the workflow timeout when one is known.
-func estimatedRetryWindowSeconds(policy *types.RetryPolicy, startToCloseSeconds int32, workflowTimeoutSeconds int32) int32 {
-	if policy == nil {
-		return 0
-	}
-
-	var windowSeconds int64
-	switch {
-	case policy.GetExpirationIntervalInSeconds() > 0:
-		windowSeconds = int64(policy.GetExpirationIntervalInSeconds())
-	case policy.GetMaximumAttempts() == 0:
-		if workflowTimeoutSeconds == 0 {
-			// No started event to establish a baseline against -- conservatively report no window,
-			// mirroring the guard on check 1.
-			return 0
-		}
-		windowSeconds = int64(workflowTimeoutSeconds)
-	default:
-		windowSeconds = cumulativeRetryWindowSeconds(policy, startToCloseSeconds, workflowTimeoutSeconds)
-	}
-
-	if workflowTimeoutSeconds > 0 && windowSeconds > int64(workflowTimeoutSeconds) {
-		windowSeconds = int64(workflowTimeoutSeconds)
-	}
-	if windowSeconds > math.MaxInt32 {
-		windowSeconds = math.MaxInt32
-	}
-	return int32(windowSeconds)
-}
-
-// cumulativeRetryWindowSeconds estimates the retry window for a bounded, non-expiring retry policy as the
-// sum of the backoff delays between attempts (each capped at MaximumIntervalInSeconds when configured) plus
-// one StartToCloseTimeout per attempt. The loop exits early once the running backoff total exceeds the
-// workflow timeout (or int32 range), since the estimate is already conclusive at that point.
-func cumulativeRetryWindowSeconds(policy *types.RetryPolicy, startToCloseSeconds int32, workflowTimeoutSeconds int32) int64 {
-	limit := int64(math.MaxInt32)
-	if workflowTimeoutSeconds > 0 {
-		limit = int64(workflowTimeoutSeconds)
-	}
-
-	coefficient := policy.GetBackoffCoefficient()
-	if coefficient < 1 {
-		coefficient = 1
-	}
-	maximumIntervalSeconds := int64(policy.GetMaximumIntervalInSeconds())
-
-	interval := float64(policy.GetInitialIntervalInSeconds())
-	var backoffTotal int64
-	for attempt := int32(1); attempt < policy.GetMaximumAttempts(); attempt++ {
-		step := interval
-		if maximumIntervalSeconds > 0 && step > float64(maximumIntervalSeconds) {
-			step = float64(maximumIntervalSeconds)
-		}
-		// exponential growth can exceed int64 range, where float-to-int conversion is implementation-defined
-		if step > float64(math.MaxInt32) {
-			step = float64(math.MaxInt32)
-		}
-		backoffTotal += int64(step)
-		if backoffTotal > limit {
-			return backoffTotal
-		}
-		interval *= coefficient
-	}
-
-	return backoffTotal + int64(policy.GetMaximumAttempts())*int64(startToCloseSeconds)
 }
 
 func (t *timeoutRisk) RootCause(ctx context.Context, params invariant.InvariantRootCauseInput) ([]invariant.InvariantRootCauseResult, error) {

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
@@ -1,0 +1,135 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package timeoutrisk
+
+import (
+	"context"
+	"time"
+
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+)
+
+// TimeoutRisk is an invariant that will be used to identify activity configurations in the workflow
+// execution history that put the workflow at risk of timing out, even though no timeout has occurred yet.
+type TimeoutRisk invariant.Invariant
+
+type timeoutRisk struct {
+}
+
+func NewInvariant() TimeoutRisk {
+	return &timeoutRisk{}
+}
+
+func (t *timeoutRisk) Check(ctx context.Context, params invariant.InvariantCheckInput) ([]invariant.InvariantCheckResult, error) {
+	result := make([]invariant.InvariantCheckResult, 0)
+	events := params.WorkflowExecutionHistory.GetHistory().GetEvents()
+	issueID := 0
+
+	workflowTimeoutSeconds := fetchWorkflowExecutionTimeoutSeconds(events)
+
+	for _, event := range events {
+		attr := event.GetActivityTaskScheduledEventAttributes()
+		if attr == nil {
+			continue
+		}
+
+		activityID := attr.GetActivityID()
+		activityType := attr.GetActivityType().GetName()
+
+		// The server caps activity timeouts at the workflow execution timeout before recording them
+		// (validateActivityScheduleAttributes in service/history/decision/checker.go), so a silently
+		// capped StartToClose surfaces as equality with the workflow timeout. ScheduleToStart and
+		// ScheduleToClose are excluded: the server inflates them to the cap under retry policies.
+		if workflowTimeoutSeconds > 0 && attr.GetStartToCloseTimeoutSeconds() == workflowTimeoutSeconds {
+			result = append(result, invariant.InvariantCheckResult{
+				IssueID:       issueID,
+				InvariantType: ActivityStartToCloseAtWorkflowTimeoutCap.String(),
+				Reason:        StartToCloseAtWorkflowTimeoutCap.String(),
+				Metadata: invariant.MarshalData(ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+					EventID:             event.ID,
+					ActivityID:          activityID,
+					ActivityType:        activityType,
+					StartToCloseTimeout: time.Duration(attr.GetStartToCloseTimeoutSeconds()) * time.Second,
+					WorkflowTimeout:     time.Duration(workflowTimeoutSeconds) * time.Second,
+				}),
+			})
+			issueID++
+		}
+
+		if attr.GetStartToCloseTimeoutSeconds() >= longRunningActivityThresholdSeconds && attr.GetHeartbeatTimeoutSeconds() == 0 {
+			result = append(result, invariant.InvariantCheckResult{
+				IssueID:       issueID,
+				InvariantType: ActivityMissingHeartbeatTimeout.String(),
+				Reason:        MissingHeartbeatTimeoutForLongActivity.String(),
+				Metadata: invariant.MarshalData(ActivityMissingHeartbeatTimeoutMetadata{
+					EventID:             event.ID,
+					ActivityID:          activityID,
+					ActivityType:        activityType,
+					StartToCloseTimeout: time.Duration(attr.GetStartToCloseTimeoutSeconds()) * time.Second,
+					Threshold:           time.Duration(longRunningActivityThresholdSeconds) * time.Second,
+				}),
+			})
+			issueID++
+		}
+
+		policy := attr.RetryPolicy
+		if attr.GetScheduleToStartTimeoutSeconds() >= longScheduleToStartThresholdSeconds &&
+			policy != nil && (policy.GetMaximumAttempts() == 0 || policy.GetMaximumAttempts() >= minRetryAttemptsForFailoverRisk) {
+			result = append(result, invariant.InvariantCheckResult{
+				IssueID:       issueID,
+				InvariantType: ActivityLongScheduleToStartWithRetries.String(),
+				Reason:        LongScheduleToStartWithMultipleRetries.String(),
+				Metadata: invariant.MarshalData(ActivityLongScheduleToStartWithRetriesMetadata{
+					EventID:                event.ID,
+					ActivityID:             activityID,
+					ActivityType:           activityType,
+					ScheduleToStartTimeout: time.Duration(attr.GetScheduleToStartTimeoutSeconds()) * time.Second,
+					Threshold:              time.Duration(longScheduleToStartThresholdSeconds) * time.Second,
+					RetryPolicy:            policy,
+				}),
+			})
+			issueID++
+		}
+	}
+
+	return result, nil
+}
+
+// fetchWorkflowExecutionTimeoutSeconds returns the workflow's configured ExecutionStartToCloseTimeout in
+// seconds, or 0 if the WorkflowExecutionStartedEventAttributes could not be found in the history.
+func fetchWorkflowExecutionTimeoutSeconds(events []*types.HistoryEvent) int32 {
+	for _, event := range events {
+		if startedAttr := event.GetWorkflowExecutionStartedEventAttributes(); startedAttr != nil {
+			return startedAttr.GetExecutionStartToCloseTimeoutSeconds()
+		}
+	}
+	return 0
+}
+
+func (t *timeoutRisk) RootCause(ctx context.Context, params invariant.InvariantRootCauseInput) ([]invariant.InvariantRootCauseResult, error) {
+	// Not implemented since this invariant does not have any root cause.
+	// The issues identified in Check() are static configuration risks that are actionable on their own.
+	result := make([]invariant.InvariantRootCauseResult, 0)
+	return result, nil
+}

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
@@ -2,6 +2,7 @@ package timeoutrisk
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/uber/cadence/common/types"
@@ -70,23 +71,29 @@ func (t *timeoutRisk) Check(ctx context.Context, params invariant.InvariantCheck
 			issueID++
 		}
 
+		// Activity retries are invisible in history and replicate to standby clusters only via activity
+		// sync; the standby's activity timeout task is discarded after standbyTaskMissingEventsDiscardDelay
+		// (default 25m) with no replacement, so a failover during a retry sequence extending past that
+		// delay can orphan the activity until its workflow's tasks are refreshed.
 		policy := attr.RetryPolicy
-		if attr.GetScheduleToStartTimeoutSeconds() >= longScheduleToStartThresholdSeconds &&
-			policy != nil && (policy.GetMaximumAttempts() == 0 || policy.GetMaximumAttempts() >= minRetryAttemptsForFailoverRisk) {
-			result = append(result, invariant.InvariantCheckResult{
-				IssueID:       issueID,
-				InvariantType: ActivityLongScheduleToStartWithRetries.String(),
-				Reason:        LongScheduleToStartWithMultipleRetries.String(),
-				Metadata: invariant.MarshalData(ActivityLongScheduleToStartWithRetriesMetadata{
-					EventID:                event.ID,
-					ActivityID:             activityID,
-					ActivityType:           activityType,
-					ScheduleToStartTimeout: time.Duration(attr.GetScheduleToStartTimeoutSeconds()) * time.Second,
-					Threshold:              time.Duration(longScheduleToStartThresholdSeconds) * time.Second,
-					RetryPolicy:            policy,
-				}),
-			})
-			issueID++
+		if policy != nil && (policy.GetMaximumAttempts() == 0 || policy.GetMaximumAttempts() >= 2) {
+			estimatedRetryWindow := estimatedRetryWindowSeconds(policy, attr.GetStartToCloseTimeoutSeconds(), workflowTimeoutSeconds)
+			if estimatedRetryWindow > failoverOrphanRiskThresholdSeconds {
+				result = append(result, invariant.InvariantCheckResult{
+					IssueID:       issueID,
+					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
+					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
+					Metadata: invariant.MarshalData(ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
+						EventID:              event.ID,
+						ActivityID:           activityID,
+						ActivityType:         activityType,
+						EstimatedRetryWindow: time.Duration(estimatedRetryWindow) * time.Second,
+						Threshold:            time.Duration(failoverOrphanRiskThresholdSeconds) * time.Second,
+						RetryPolicy:          policy,
+					}),
+				})
+				issueID++
+			}
 		}
 	}
 
@@ -102,6 +109,78 @@ func fetchWorkflowExecutionTimeoutSeconds(events []*types.HistoryEvent) int32 {
 		}
 	}
 	return 0
+}
+
+// estimatedRetryWindowSeconds estimates how long an activity's retry sequence could keep extending, based
+// on its retry policy. Retries mutate mutable state and replicate to standby via activity sync without
+// emitting new history events, so this window cannot be read off the scheduled event directly -- it is
+// derived the same way the server would internally: an explicit expiration wins outright; an unlimited
+// attempt budget rides out to the workflow timeout; otherwise it is the cumulative estimate for a bounded
+// attempt budget. The result is always capped at the workflow timeout when one is known.
+func estimatedRetryWindowSeconds(policy *types.RetryPolicy, startToCloseSeconds int32, workflowTimeoutSeconds int32) int32 {
+	if policy == nil {
+		return 0
+	}
+
+	var windowSeconds int64
+	switch {
+	case policy.GetExpirationIntervalInSeconds() > 0:
+		windowSeconds = int64(policy.GetExpirationIntervalInSeconds())
+	case policy.GetMaximumAttempts() == 0:
+		if workflowTimeoutSeconds == 0 {
+			// No started event to establish a baseline against -- conservatively report no window,
+			// mirroring the guard on check 1.
+			return 0
+		}
+		windowSeconds = int64(workflowTimeoutSeconds)
+	default:
+		windowSeconds = cumulativeRetryWindowSeconds(policy, startToCloseSeconds, workflowTimeoutSeconds)
+	}
+
+	if workflowTimeoutSeconds > 0 && windowSeconds > int64(workflowTimeoutSeconds) {
+		windowSeconds = int64(workflowTimeoutSeconds)
+	}
+	if windowSeconds > math.MaxInt32 {
+		windowSeconds = math.MaxInt32
+	}
+	return int32(windowSeconds)
+}
+
+// cumulativeRetryWindowSeconds estimates the retry window for a bounded, non-expiring retry policy as the
+// sum of the backoff delays between attempts (each capped at MaximumIntervalInSeconds when configured) plus
+// one StartToCloseTimeout per attempt. The loop exits early once the running backoff total exceeds the
+// workflow timeout (or int32 range), since the estimate is already conclusive at that point.
+func cumulativeRetryWindowSeconds(policy *types.RetryPolicy, startToCloseSeconds int32, workflowTimeoutSeconds int32) int64 {
+	limit := int64(math.MaxInt32)
+	if workflowTimeoutSeconds > 0 {
+		limit = int64(workflowTimeoutSeconds)
+	}
+
+	coefficient := policy.GetBackoffCoefficient()
+	if coefficient < 1 {
+		coefficient = 1
+	}
+	maximumIntervalSeconds := int64(policy.GetMaximumIntervalInSeconds())
+
+	interval := float64(policy.GetInitialIntervalInSeconds())
+	var backoffTotal int64
+	for attempt := int32(1); attempt < policy.GetMaximumAttempts(); attempt++ {
+		step := interval
+		if maximumIntervalSeconds > 0 && step > float64(maximumIntervalSeconds) {
+			step = float64(maximumIntervalSeconds)
+		}
+		// exponential growth can exceed int64 range, where float-to-int conversion is implementation-defined
+		if step > float64(math.MaxInt32) {
+			step = float64(math.MaxInt32)
+		}
+		backoffTotal += int64(step)
+		if backoffTotal > limit {
+			return backoffTotal
+		}
+		interval *= coefficient
+	}
+
+	return backoffTotal + int64(policy.GetMaximumAttempts())*int64(startToCloseSeconds)
 }
 
 func (t *timeoutRisk) RootCause(ctx context.Context, params invariant.InvariantRootCauseInput) ([]invariant.InvariantRootCauseResult, error) {

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
@@ -34,40 +34,55 @@ func Test__Check(t *testing.T) {
 	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
 	require.NoError(t, err)
 
-	longScheduleToStartUnlimitedMetadata := ActivityLongScheduleToStartWithRetriesMetadata{
-		EventID:                2,
-		ActivityID:             "103",
-		ActivityType:           "test-activity",
-		ScheduleToStartTimeout: 600 * time.Second,
-		Threshold:              300 * time.Second,
+	explicitExpirationMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
+		EventID:              2,
+		ActivityID:           "201",
+		ActivityType:         "test-activity",
+		EstimatedRetryWindow: 1800 * time.Second,
+		Threshold:            1500 * time.Second,
 		RetryPolicy: &types.RetryPolicy{
-			InitialIntervalInSeconds: 1,
-			MaximumAttempts:          0,
+			ExpirationIntervalInSeconds: 1800,
+			MaximumAttempts:             0,
 		},
 	}
-	longScheduleToStartUnlimitedMetadataInBytes, err := json.Marshal(longScheduleToStartUnlimitedMetadata)
+	explicitExpirationMetadataInBytes, err := json.Marshal(explicitExpirationMetadata)
 	require.NoError(t, err)
 
-	longScheduleToStartFiveAttemptsMetadata := ActivityLongScheduleToStartWithRetriesMetadata{
-		EventID:                2,
-		ActivityID:             "104",
-		ActivityType:           "test-activity",
-		ScheduleToStartTimeout: 600 * time.Second,
-		Threshold:              300 * time.Second,
+	unlimitedRidesToWfTimeoutMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
+		EventID:              2,
+		ActivityID:           "202",
+		ActivityType:         "test-activity",
+		EstimatedRetryWindow: 3600 * time.Second,
+		Threshold:            1500 * time.Second,
 		RetryPolicy: &types.RetryPolicy{
-			InitialIntervalInSeconds: 1,
-			MaximumAttempts:          5,
+			MaximumAttempts: 0,
 		},
 	}
-	longScheduleToStartFiveAttemptsMetadataInBytes, err := json.Marshal(longScheduleToStartFiveAttemptsMetadata)
+	unlimitedRidesToWfTimeoutMetadataInBytes, err := json.Marshal(unlimitedRidesToWfTimeoutMetadata)
+	require.NoError(t, err)
+
+	boundedCumulativeMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
+		EventID:              2,
+		ActivityID:           "203",
+		ActivityType:         "test-activity",
+		EstimatedRetryWindow: 6900 * time.Second,
+		Threshold:            1500 * time.Second,
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 60,
+			BackoffCoefficient:       2,
+			MaximumIntervalInSeconds: 600,
+			MaximumAttempts:          10,
+		},
+	}
+	boundedCumulativeMetadataInBytes, err := json.Marshal(boundedCumulativeMetadata)
 	require.NoError(t, err)
 
 	allThreeAtCapMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
 		EventID:             2,
 		ActivityID:          "107",
 		ActivityType:        "test-activity",
-		StartToCloseTimeout: 700 * time.Second,
-		WorkflowTimeout:     700 * time.Second,
+		StartToCloseTimeout: 1800 * time.Second,
+		WorkflowTimeout:     1800 * time.Second,
 	}
 	allThreeAtCapMetadataInBytes, err := json.Marshal(allThreeAtCapMetadata)
 	require.NoError(t, err)
@@ -76,24 +91,24 @@ func Test__Check(t *testing.T) {
 		EventID:             2,
 		ActivityID:          "107",
 		ActivityType:        "test-activity",
-		StartToCloseTimeout: 700 * time.Second,
+		StartToCloseTimeout: 1800 * time.Second,
 		Threshold:           600 * time.Second,
 	}
 	allThreeMissingHeartbeatMetadataInBytes, err := json.Marshal(allThreeMissingHeartbeatMetadata)
 	require.NoError(t, err)
 
-	allThreeLongScheduleToStartMetadata := ActivityLongScheduleToStartWithRetriesMetadata{
-		EventID:                2,
-		ActivityID:             "107",
-		ActivityType:           "test-activity",
-		ScheduleToStartTimeout: 400 * time.Second,
-		Threshold:              300 * time.Second,
+	allThreeRetryWindowMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
+		EventID:              2,
+		ActivityID:           "107",
+		ActivityType:         "test-activity",
+		EstimatedRetryWindow: 1800 * time.Second,
+		Threshold:            1500 * time.Second,
 		RetryPolicy: &types.RetryPolicy{
 			InitialIntervalInSeconds: 1,
 			MaximumAttempts:          0,
 		},
 	}
-	allThreeLongScheduleToStartMetadataInBytes, err := json.Marshal(allThreeLongScheduleToStartMetadata)
+	allThreeRetryWindowMetadataInBytes, err := json.Marshal(allThreeRetryWindowMetadata)
 	require.NoError(t, err)
 
 	secondActivityRiskyMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
@@ -165,14 +180,14 @@ func Test__Check(t *testing.T) {
 			},
 		},
 		{
-			name: "long ScheduleToStart with unlimited retries",
+			name: "retry window: explicit expiration exceeds threshold",
 			testData: &types.GetWorkflowExecutionHistoryResponse{
 				History: &types.History{
 					Events: []*types.HistoryEvent{
-						startedEvent(1, 3600),
-						scheduledEvent(2, "103", "test-activity", 30, 600, 10, &types.RetryPolicy{
-							InitialIntervalInSeconds: 1,
-							MaximumAttempts:          0,
+						startedEvent(1, 7200),
+						scheduledEvent(2, "201", "test-activity", 30, 5, 10, &types.RetryPolicy{
+							ExpirationIntervalInSeconds: 1800,
+							MaximumAttempts:             0,
 						}),
 					},
 				},
@@ -180,21 +195,20 @@ func Test__Check(t *testing.T) {
 			expectedResult: []invariant.InvariantCheckResult{
 				{
 					IssueID:       0,
-					InvariantType: ActivityLongScheduleToStartWithRetries.String(),
-					Reason:        LongScheduleToStartWithMultipleRetries.String(),
-					Metadata:      longScheduleToStartUnlimitedMetadataInBytes,
+					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
+					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
+					Metadata:      explicitExpirationMetadataInBytes,
 				},
 			},
 		},
 		{
-			name: "long ScheduleToStart with 5 max attempts",
+			name: "retry window: unlimited attempts ride out to the workflow timeout",
 			testData: &types.GetWorkflowExecutionHistoryResponse{
 				History: &types.History{
 					Events: []*types.HistoryEvent{
 						startedEvent(1, 3600),
-						scheduledEvent(2, "104", "test-activity", 30, 600, 10, &types.RetryPolicy{
-							InitialIntervalInSeconds: 1,
-							MaximumAttempts:          5,
+						scheduledEvent(2, "202", "test-activity", 30, 5, 10, &types.RetryPolicy{
+							MaximumAttempts: 0,
 						}),
 					},
 				},
@@ -202,21 +216,104 @@ func Test__Check(t *testing.T) {
 			expectedResult: []invariant.InvariantCheckResult{
 				{
 					IssueID:       0,
-					InvariantType: ActivityLongScheduleToStartWithRetries.String(),
-					Reason:        LongScheduleToStartWithMultipleRetries.String(),
-					Metadata:      longScheduleToStartFiveAttemptsMetadataInBytes,
+					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
+					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
+					Metadata:      unlimitedRidesToWfTimeoutMetadataInBytes,
 				},
 			},
 		},
 		{
-			name: "long ScheduleToStart but too few max attempts to be risky",
+			name: "retry window: bounded attempts with large cumulative backoff",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 7200),
+						scheduledEvent(2, "203", "test-activity", 300, 5, 10, &types.RetryPolicy{
+							InitialIntervalInSeconds: 60,
+							BackoffCoefficient:       2,
+							MaximumIntervalInSeconds: 600,
+							MaximumAttempts:          10,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
+					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
+					Metadata:      boundedCumulativeMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "retry window: explicit expiration below threshold - no issue",
 			testData: &types.GetWorkflowExecutionHistoryResponse{
 				History: &types.History{
 					Events: []*types.HistoryEvent{
 						startedEvent(1, 3600),
-						scheduledEvent(2, "105", "test-activity", 30, 600, 10, &types.RetryPolicy{
+						scheduledEvent(2, "204", "test-activity", 30, 5, 10, &types.RetryPolicy{
+							ExpirationIntervalInSeconds: 600,
+							MaximumAttempts:             0,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "retry window: explicit expiration capped at workflow timeout - no issue",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 1200),
+						scheduledEvent(2, "205", "test-activity", 30, 5, 10, &types.RetryPolicy{
+							ExpirationIntervalInSeconds: 7200,
+							MaximumAttempts:             0,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "retry window: single attempt cannot retry - no issue",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 3600),
+						scheduledEvent(2, "206", "test-activity", 30, 5, 10, &types.RetryPolicy{
+							ExpirationIntervalInSeconds: 7200,
+							MaximumAttempts:             1,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "retry window: bounded attempts with small cumulative backoff - no issue",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 3600),
+						scheduledEvent(2, "207", "test-activity", 60, 5, 10, &types.RetryPolicy{
 							InitialIntervalInSeconds: 1,
+							BackoffCoefficient:       2,
 							MaximumAttempts:          2,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "retry window: unlimited attempts but no workflow started event - no issue",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						scheduledEvent(1, "208", "test-activity", 10, 5, 10, &types.RetryPolicy{
+							MaximumAttempts: 0,
 						}),
 					},
 				},
@@ -243,8 +340,8 @@ func Test__Check(t *testing.T) {
 			testData: &types.GetWorkflowExecutionHistoryResponse{
 				History: &types.History{
 					Events: []*types.HistoryEvent{
-						startedEvent(1, 700),
-						scheduledEvent(2, "107", "test-activity", 700, 400, 0, &types.RetryPolicy{
+						startedEvent(1, 1800),
+						scheduledEvent(2, "107", "test-activity", 1800, 5, 0, &types.RetryPolicy{
 							InitialIntervalInSeconds: 1,
 							MaximumAttempts:          0,
 						}),
@@ -266,9 +363,9 @@ func Test__Check(t *testing.T) {
 				},
 				{
 					IssueID:       2,
-					InvariantType: ActivityLongScheduleToStartWithRetries.String(),
-					Reason:        LongScheduleToStartWithMultipleRetries.String(),
-					Metadata:      allThreeLongScheduleToStartMetadataInBytes,
+					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
+					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
+					Metadata:      allThreeRetryWindowMetadataInBytes,
 				},
 			},
 		},

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package timeoutrisk
 
 import (

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
@@ -34,81 +34,24 @@ func Test__Check(t *testing.T) {
 	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
 	require.NoError(t, err)
 
-	explicitExpirationMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
-		EventID:              2,
-		ActivityID:           "201",
-		ActivityType:         "test-activity",
-		EstimatedRetryWindow: 1800 * time.Second,
-		Threshold:            1500 * time.Second,
-		RetryPolicy: &types.RetryPolicy{
-			ExpirationIntervalInSeconds: 1800,
-			MaximumAttempts:             0,
-		},
-	}
-	explicitExpirationMetadataInBytes, err := json.Marshal(explicitExpirationMetadata)
-	require.NoError(t, err)
-
-	unlimitedRidesToWfTimeoutMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
-		EventID:              2,
-		ActivityID:           "202",
-		ActivityType:         "test-activity",
-		EstimatedRetryWindow: 3600 * time.Second,
-		Threshold:            1500 * time.Second,
-		RetryPolicy: &types.RetryPolicy{
-			MaximumAttempts: 0,
-		},
-	}
-	unlimitedRidesToWfTimeoutMetadataInBytes, err := json.Marshal(unlimitedRidesToWfTimeoutMetadata)
-	require.NoError(t, err)
-
-	boundedCumulativeMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
-		EventID:              2,
-		ActivityID:           "203",
-		ActivityType:         "test-activity",
-		EstimatedRetryWindow: 6900 * time.Second,
-		Threshold:            1500 * time.Second,
-		RetryPolicy: &types.RetryPolicy{
-			InitialIntervalInSeconds: 60,
-			BackoffCoefficient:       2,
-			MaximumIntervalInSeconds: 600,
-			MaximumAttempts:          10,
-		},
-	}
-	boundedCumulativeMetadataInBytes, err := json.Marshal(boundedCumulativeMetadata)
-	require.NoError(t, err)
-
-	allThreeAtCapMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+	twoIssuesAtCapMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
 		EventID:             2,
 		ActivityID:          "107",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 1800 * time.Second,
 		WorkflowTimeout:     1800 * time.Second,
 	}
-	allThreeAtCapMetadataInBytes, err := json.Marshal(allThreeAtCapMetadata)
+	twoIssuesAtCapMetadataInBytes, err := json.Marshal(twoIssuesAtCapMetadata)
 	require.NoError(t, err)
 
-	allThreeMissingHeartbeatMetadata := ActivityMissingHeartbeatTimeoutMetadata{
+	twoIssuesMissingHeartbeatMetadata := ActivityMissingHeartbeatTimeoutMetadata{
 		EventID:             2,
 		ActivityID:          "107",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 1800 * time.Second,
 		Threshold:           600 * time.Second,
 	}
-	allThreeMissingHeartbeatMetadataInBytes, err := json.Marshal(allThreeMissingHeartbeatMetadata)
-	require.NoError(t, err)
-
-	allThreeRetryWindowMetadata := ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
-		EventID:              2,
-		ActivityID:           "107",
-		ActivityType:         "test-activity",
-		EstimatedRetryWindow: 1800 * time.Second,
-		Threshold:            1500 * time.Second,
-		RetryPolicy: &types.RetryPolicy{
-			InitialIntervalInSeconds: 1,
-			MaximumAttempts:          0,
-		},
-	}
-	allThreeRetryWindowMetadataInBytes, err := json.Marshal(allThreeRetryWindowMetadata)
+	twoIssuesMissingHeartbeatMetadataInBytes, err := json.Marshal(twoIssuesMissingHeartbeatMetadata)
 	require.NoError(t, err)
 
 	secondActivityRiskyMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
@@ -180,147 +123,6 @@ func Test__Check(t *testing.T) {
 			},
 		},
 		{
-			name: "retry window: explicit expiration exceeds threshold",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						startedEvent(1, 7200),
-						scheduledEvent(2, "201", "test-activity", 30, 5, 10, &types.RetryPolicy{
-							ExpirationIntervalInSeconds: 1800,
-							MaximumAttempts:             0,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{
-				{
-					IssueID:       0,
-					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
-					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
-					Metadata:      explicitExpirationMetadataInBytes,
-				},
-			},
-		},
-		{
-			name: "retry window: unlimited attempts ride out to the workflow timeout",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						startedEvent(1, 3600),
-						scheduledEvent(2, "202", "test-activity", 30, 5, 10, &types.RetryPolicy{
-							MaximumAttempts: 0,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{
-				{
-					IssueID:       0,
-					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
-					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
-					Metadata:      unlimitedRidesToWfTimeoutMetadataInBytes,
-				},
-			},
-		},
-		{
-			name: "retry window: bounded attempts with large cumulative backoff",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						startedEvent(1, 7200),
-						scheduledEvent(2, "203", "test-activity", 300, 5, 10, &types.RetryPolicy{
-							InitialIntervalInSeconds: 60,
-							BackoffCoefficient:       2,
-							MaximumIntervalInSeconds: 600,
-							MaximumAttempts:          10,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{
-				{
-					IssueID:       0,
-					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
-					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
-					Metadata:      boundedCumulativeMetadataInBytes,
-				},
-			},
-		},
-		{
-			name: "retry window: explicit expiration below threshold - no issue",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						startedEvent(1, 3600),
-						scheduledEvent(2, "204", "test-activity", 30, 5, 10, &types.RetryPolicy{
-							ExpirationIntervalInSeconds: 600,
-							MaximumAttempts:             0,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{},
-		},
-		{
-			name: "retry window: explicit expiration capped at workflow timeout - no issue",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						startedEvent(1, 1200),
-						scheduledEvent(2, "205", "test-activity", 30, 5, 10, &types.RetryPolicy{
-							ExpirationIntervalInSeconds: 7200,
-							MaximumAttempts:             0,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{},
-		},
-		{
-			name: "retry window: single attempt cannot retry - no issue",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						startedEvent(1, 3600),
-						scheduledEvent(2, "206", "test-activity", 30, 5, 10, &types.RetryPolicy{
-							ExpirationIntervalInSeconds: 7200,
-							MaximumAttempts:             1,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{},
-		},
-		{
-			name: "retry window: bounded attempts with small cumulative backoff - no issue",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						startedEvent(1, 3600),
-						scheduledEvent(2, "207", "test-activity", 60, 5, 10, &types.RetryPolicy{
-							InitialIntervalInSeconds: 1,
-							BackoffCoefficient:       2,
-							MaximumAttempts:          2,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{},
-		},
-		{
-			name: "retry window: unlimited attempts but no workflow started event - no issue",
-			testData: &types.GetWorkflowExecutionHistoryResponse{
-				History: &types.History{
-					Events: []*types.HistoryEvent{
-						scheduledEvent(1, "208", "test-activity", 10, 5, 10, &types.RetryPolicy{
-							MaximumAttempts: 0,
-						}),
-					},
-				},
-			},
-			expectedResult: []invariant.InvariantCheckResult{},
-		},
-		{
 			name: "well-configured activity",
 			testData: &types.GetWorkflowExecutionHistoryResponse{
 				History: &types.History{
@@ -336,15 +138,12 @@ func Test__Check(t *testing.T) {
 			expectedResult: []invariant.InvariantCheckResult{},
 		},
 		{
-			name: "all three risks fire on one scheduled event",
+			name: "both risks fire on one scheduled event",
 			testData: &types.GetWorkflowExecutionHistoryResponse{
 				History: &types.History{
 					Events: []*types.HistoryEvent{
 						startedEvent(1, 1800),
-						scheduledEvent(2, "107", "test-activity", 1800, 5, 0, &types.RetryPolicy{
-							InitialIntervalInSeconds: 1,
-							MaximumAttempts:          0,
-						}),
+						scheduledEvent(2, "107", "test-activity", 1800, 5, 0, nil),
 					},
 				},
 			},
@@ -353,19 +152,13 @@ func Test__Check(t *testing.T) {
 					IssueID:       0,
 					InvariantType: ActivityStartToCloseAtWorkflowTimeoutCap.String(),
 					Reason:        StartToCloseAtWorkflowTimeoutCap.String(),
-					Metadata:      allThreeAtCapMetadataInBytes,
+					Metadata:      twoIssuesAtCapMetadataInBytes,
 				},
 				{
 					IssueID:       1,
 					InvariantType: ActivityMissingHeartbeatTimeout.String(),
 					Reason:        MissingHeartbeatTimeoutForLongActivity.String(),
-					Metadata:      allThreeMissingHeartbeatMetadataInBytes,
-				},
-				{
-					IssueID:       2,
-					InvariantType: ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
-					Reason:        RetryWindowExceedsStandbyDiscardDelay.String(),
-					Metadata:      allThreeRetryWindowMetadataInBytes,
+					Metadata:      twoIssuesMissingHeartbeatMetadataInBytes,
 				},
 			},
 		},

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
@@ -1,0 +1,377 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package timeoutrisk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+)
+
+func Test__Check(t *testing.T) {
+	atCapMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+		EventID:             2,
+		ActivityID:          "101",
+		ActivityType:        "test-activity",
+		StartToCloseTimeout: 60 * time.Second,
+		WorkflowTimeout:     60 * time.Second,
+	}
+	atCapMetadataInBytes, err := json.Marshal(atCapMetadata)
+	require.NoError(t, err)
+
+	missingHeartbeatMetadata := ActivityMissingHeartbeatTimeoutMetadata{
+		EventID:             2,
+		ActivityID:          "102",
+		ActivityType:        "test-activity",
+		StartToCloseTimeout: 900 * time.Second,
+		Threshold:           600 * time.Second,
+	}
+	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
+	require.NoError(t, err)
+
+	longScheduleToStartUnlimitedMetadata := ActivityLongScheduleToStartWithRetriesMetadata{
+		EventID:                2,
+		ActivityID:             "103",
+		ActivityType:           "test-activity",
+		ScheduleToStartTimeout: 600 * time.Second,
+		Threshold:              300 * time.Second,
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 1,
+			MaximumAttempts:          0,
+		},
+	}
+	longScheduleToStartUnlimitedMetadataInBytes, err := json.Marshal(longScheduleToStartUnlimitedMetadata)
+	require.NoError(t, err)
+
+	longScheduleToStartFiveAttemptsMetadata := ActivityLongScheduleToStartWithRetriesMetadata{
+		EventID:                2,
+		ActivityID:             "104",
+		ActivityType:           "test-activity",
+		ScheduleToStartTimeout: 600 * time.Second,
+		Threshold:              300 * time.Second,
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 1,
+			MaximumAttempts:          5,
+		},
+	}
+	longScheduleToStartFiveAttemptsMetadataInBytes, err := json.Marshal(longScheduleToStartFiveAttemptsMetadata)
+	require.NoError(t, err)
+
+	allThreeAtCapMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+		EventID:             2,
+		ActivityID:          "107",
+		ActivityType:        "test-activity",
+		StartToCloseTimeout: 700 * time.Second,
+		WorkflowTimeout:     700 * time.Second,
+	}
+	allThreeAtCapMetadataInBytes, err := json.Marshal(allThreeAtCapMetadata)
+	require.NoError(t, err)
+
+	allThreeMissingHeartbeatMetadata := ActivityMissingHeartbeatTimeoutMetadata{
+		EventID:             2,
+		ActivityID:          "107",
+		ActivityType:        "test-activity",
+		StartToCloseTimeout: 700 * time.Second,
+		Threshold:           600 * time.Second,
+	}
+	allThreeMissingHeartbeatMetadataInBytes, err := json.Marshal(allThreeMissingHeartbeatMetadata)
+	require.NoError(t, err)
+
+	allThreeLongScheduleToStartMetadata := ActivityLongScheduleToStartWithRetriesMetadata{
+		EventID:                2,
+		ActivityID:             "107",
+		ActivityType:           "test-activity",
+		ScheduleToStartTimeout: 400 * time.Second,
+		Threshold:              300 * time.Second,
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 1,
+			MaximumAttempts:          0,
+		},
+	}
+	allThreeLongScheduleToStartMetadataInBytes, err := json.Marshal(allThreeLongScheduleToStartMetadata)
+	require.NoError(t, err)
+
+	secondActivityRiskyMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+		EventID:             3,
+		ActivityID:          "108b",
+		ActivityType:        "test-activity",
+		StartToCloseTimeout: 60 * time.Second,
+		WorkflowTimeout:     60 * time.Second,
+	}
+	secondActivityRiskyMetadataInBytes, err := json.Marshal(secondActivityRiskyMetadata)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		testData       *types.GetWorkflowExecutionHistoryResponse
+		expectedResult []invariant.InvariantCheckResult
+	}{
+		{
+			name: "activity StartToClose at workflow timeout cap (capped equality)",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 60),
+						scheduledEvent(2, "101", "test-activity", 60, 10, 30, nil),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityStartToCloseAtWorkflowTimeoutCap.String(),
+					Reason:        StartToCloseAtWorkflowTimeoutCap.String(),
+					Metadata:      atCapMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "activity StartToClose just below workflow timeout - no issue",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 60),
+						scheduledEvent(2, "111", "test-activity", 59, 10, 30, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          1,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "long-running activity missing heartbeat timeout",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 3600),
+						scheduledEvent(2, "102", "test-activity", 900, 10, 0, nil),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityMissingHeartbeatTimeout.String(),
+					Reason:        MissingHeartbeatTimeoutForLongActivity.String(),
+					Metadata:      missingHeartbeatMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "long ScheduleToStart with unlimited retries",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 3600),
+						scheduledEvent(2, "103", "test-activity", 30, 600, 10, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          0,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityLongScheduleToStartWithRetries.String(),
+					Reason:        LongScheduleToStartWithMultipleRetries.String(),
+					Metadata:      longScheduleToStartUnlimitedMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "long ScheduleToStart with 5 max attempts",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 3600),
+						scheduledEvent(2, "104", "test-activity", 30, 600, 10, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          5,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityLongScheduleToStartWithRetries.String(),
+					Reason:        LongScheduleToStartWithMultipleRetries.String(),
+					Metadata:      longScheduleToStartFiveAttemptsMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "long ScheduleToStart but too few max attempts to be risky",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 3600),
+						scheduledEvent(2, "105", "test-activity", 30, 600, 10, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          2,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "well-configured activity",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 110),
+						scheduledEvent(2, "106", "test-activity", 10, 5, 5, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          1,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "all three risks fire on one scheduled event",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 700),
+						scheduledEvent(2, "107", "test-activity", 700, 400, 0, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          0,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityStartToCloseAtWorkflowTimeoutCap.String(),
+					Reason:        StartToCloseAtWorkflowTimeoutCap.String(),
+					Metadata:      allThreeAtCapMetadataInBytes,
+				},
+				{
+					IssueID:       1,
+					InvariantType: ActivityMissingHeartbeatTimeout.String(),
+					Reason:        MissingHeartbeatTimeoutForLongActivity.String(),
+					Metadata:      allThreeMissingHeartbeatMetadataInBytes,
+				},
+				{
+					IssueID:       2,
+					InvariantType: ActivityLongScheduleToStartWithRetries.String(),
+					Reason:        LongScheduleToStartWithMultipleRetries.String(),
+					Metadata:      allThreeLongScheduleToStartMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "two activities, only the second is risky",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						startedEvent(1, 60),
+						scheduledEvent(2, "108a", "test-activity", 10, 5, 5, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          1,
+						}),
+						scheduledEvent(3, "108b", "test-activity", 60, 10, 30, nil),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityStartToCloseAtWorkflowTimeoutCap.String(),
+					Reason:        StartToCloseAtWorkflowTimeoutCap.String(),
+					Metadata:      secondActivityRiskyMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "no workflow started event in history - check 1 must not false-positive on a zero baseline",
+			testData: &types.GetWorkflowExecutionHistoryResponse{
+				History: &types.History{
+					Events: []*types.HistoryEvent{
+						scheduledEvent(1, "109", "test-activity", 10, 5, 5, &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumAttempts:          1,
+						}),
+					},
+				},
+			},
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := NewInvariant()
+			result, err := inv.Check(context.Background(), invariant.InvariantCheckInput{
+				WorkflowExecutionHistory: tc.testData,
+			})
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expectedResult), len(result))
+			require.ElementsMatch(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func Test__RootCause(t *testing.T) {
+	inv := NewInvariant()
+	result, err := inv.RootCause(context.Background(), invariant.InvariantRootCauseInput{})
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+func startedEvent(id int64, workflowTimeoutSeconds int32) *types.HistoryEvent {
+	return &types.HistoryEvent{
+		ID: id,
+		WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSeconds),
+		},
+	}
+}
+
+func scheduledEvent(id int64, activityID, activityType string, startToCloseSeconds, scheduleToStartSeconds, heartbeatSeconds int32, retryPolicy *types.RetryPolicy) *types.HistoryEvent {
+	return &types.HistoryEvent{
+		ID: id,
+		ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+			ActivityID:                    activityID,
+			ActivityType:                  &types.ActivityType{Name: activityType},
+			StartToCloseTimeoutSeconds:    common.Int32Ptr(startToCloseSeconds),
+			ScheduleToStartTimeoutSeconds: common.Int32Ptr(scheduleToStartSeconds),
+			HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatSeconds),
+			RetryPolicy:                   retryPolicy,
+		},
+	}
+}

--- a/service/worker/diagnostics/invariant/timeoutrisk/types.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/types.go
@@ -2,16 +2,13 @@ package timeoutrisk
 
 import (
 	"time"
-
-	"github.com/uber/cadence/common/types"
 )
 
 type TimeoutRiskType string
 
 const (
-	ActivityStartToCloseAtWorkflowTimeoutCap      TimeoutRiskType = "Activity StartToClose timeout at the workflow execution timeout cap"
-	ActivityMissingHeartbeatTimeout               TimeoutRiskType = "Long-running activity missing heartbeat timeout"
-	ActivityRetryWindowExceedsStandbyDiscardDelay TimeoutRiskType = "Activity retry window exceeds standby task discard delay (failover risk)"
+	ActivityStartToCloseAtWorkflowTimeoutCap TimeoutRiskType = "Activity StartToClose timeout at the workflow execution timeout cap"
+	ActivityMissingHeartbeatTimeout          TimeoutRiskType = "Long-running activity missing heartbeat timeout"
 )
 
 func (t TimeoutRiskType) String() string {
@@ -23,7 +20,6 @@ type IssueType string
 const (
 	StartToCloseAtWorkflowTimeoutCap       IssueType = "Activity StartToClose timeout may have been silently capped at the workflow execution timeout by the server, leaving no headroom for retrying."
 	MissingHeartbeatTimeoutForLongActivity IssueType = "Long-running activity without a HeartbeatTimeout will leave worker failures undetected until the activity times out."
-	RetryWindowExceedsStandbyDiscardDelay  IssueType = "Activity retries that can extend past the standby cluster's task discard delay (25 minutes) risk being orphaned by a failover; a workflow stuck this way needs its tasks refreshed to resume."
 )
 
 func (i IssueType) String() string {
@@ -34,10 +30,6 @@ const (
 	// longRunningActivityThresholdSeconds is the StartToCloseTimeout above which an activity is
 	// considered long-running and should be configured with a HeartbeatTimeout.
 	longRunningActivityThresholdSeconds int32 = 10 * 60
-
-	// failoverOrphanRiskThresholdSeconds mirrors the default of history.standbyTaskMissingEventsDiscardDelay.
-	// Retries extending past it can be orphaned by a failover (deployments overriding that config shift the real boundary).
-	failoverOrphanRiskThresholdSeconds int32 = 25 * 60
 )
 
 // ActivityStartToCloseAtWorkflowTimeoutCapMetadata is the metadata for an activity whose StartToCloseTimeout
@@ -64,22 +56,9 @@ type ActivityMissingHeartbeatTimeoutMetadata struct {
 	Threshold           time.Duration
 }
 
-// ActivityRetryWindowExceedsStandbyDiscardDelayMetadata is the metadata for an activity whose estimated
-// retry window -- how long its retry sequence could keep extending, per its retry policy -- exceeds the
-// standby cluster's task discard delay, putting it at risk of being orphaned by a failover.
-type ActivityRetryWindowExceedsStandbyDiscardDelayMetadata struct {
-	EventID              int64
-	ActivityID           string
-	ActivityType         string
-	EstimatedRetryWindow time.Duration
-	Threshold            time.Duration
-	RetryPolicy          *types.RetryPolicy
-}
-
 // TimeoutRiskIssuesMetadata is a discriminated union of the metadata for each timeout risk check,
 // with exactly one field populated per issue.
 type TimeoutRiskIssuesMetadata struct {
-	ActivityStartToCloseAtWorkflowTimeoutCap      *ActivityStartToCloseAtWorkflowTimeoutCapMetadata
-	ActivityMissingHeartbeatTimeout               *ActivityMissingHeartbeatTimeoutMetadata
-	ActivityRetryWindowExceedsStandbyDiscardDelay *ActivityRetryWindowExceedsStandbyDiscardDelayMetadata
+	ActivityStartToCloseAtWorkflowTimeoutCap *ActivityStartToCloseAtWorkflowTimeoutCapMetadata
+	ActivityMissingHeartbeatTimeout          *ActivityMissingHeartbeatTimeoutMetadata
 }

--- a/service/worker/diagnostics/invariant/timeoutrisk/types.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/types.go
@@ -1,0 +1,111 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package timeoutrisk
+
+import (
+	"time"
+
+	"github.com/uber/cadence/common/types"
+)
+
+type TimeoutRiskType string
+
+const (
+	ActivityStartToCloseAtWorkflowTimeoutCap TimeoutRiskType = "Activity StartToClose timeout at the workflow execution timeout cap"
+	ActivityMissingHeartbeatTimeout          TimeoutRiskType = "Long-running activity missing heartbeat timeout"
+	ActivityLongScheduleToStartWithRetries   TimeoutRiskType = "Long ScheduleToStart timeout with retry policy allowing multiple attempts"
+)
+
+func (t TimeoutRiskType) String() string {
+	return string(t)
+}
+
+type IssueType string
+
+const (
+	StartToCloseAtWorkflowTimeoutCap       IssueType = "Activity StartToClose timeout may have been silently capped at the workflow execution timeout by the server, leaving no headroom for retrying."
+	MissingHeartbeatTimeoutForLongActivity IssueType = "Long-running activity without a HeartbeatTimeout will leave worker failures undetected until the activity times out."
+	LongScheduleToStartWithMultipleRetries IssueType = "Long ScheduleToStartTimeout with a retry policy allowing multiple attempts can multiply recovery time during a failover or poller outage."
+)
+
+func (i IssueType) String() string {
+	return string(i)
+}
+
+const (
+	// longRunningActivityThresholdSeconds is the StartToCloseTimeout above which an activity is
+	// considered long-running and should be configured with a HeartbeatTimeout.
+	longRunningActivityThresholdSeconds int32 = 10 * 60
+
+	// longScheduleToStartThresholdSeconds is the ScheduleToStartTimeout above which, combined with a
+	// retry policy allowing multiple attempts, a failover or poller outage can significantly delay recovery.
+	longScheduleToStartThresholdSeconds int32 = 5 * 60
+
+	// minRetryAttemptsForFailoverRisk is the minimum number of configured retry attempts (or unlimited,
+	// represented by MaximumAttempts == 0) that is considered risky when combined with a long ScheduleToStartTimeout.
+	minRetryAttemptsForFailoverRisk int32 = 3
+)
+
+// ActivityStartToCloseAtWorkflowTimeoutCapMetadata is the metadata for an activity whose StartToCloseTimeout
+// sits exactly at the workflow's ExecutionStartToCloseTimeout. The server caps an activity's StartToClose at
+// the workflow timeout when validating ActivityTaskScheduled attributes (see validateActivityScheduleAttributes
+// in service/history/decision/checker.go), so this equality is the fingerprint of a client-configured value that
+// was silently capped -- or, if genuinely configured this way, an activity with zero headroom before the
+// workflow itself times out.
+type ActivityStartToCloseAtWorkflowTimeoutCapMetadata struct {
+	EventID             int64
+	ActivityID          string
+	ActivityType        string
+	StartToCloseTimeout time.Duration
+	WorkflowTimeout     time.Duration
+}
+
+// ActivityMissingHeartbeatTimeoutMetadata is the metadata for a long-running activity that has no
+// HeartbeatTimeout configured, meaning a dead worker would go undetected until the activity times out.
+type ActivityMissingHeartbeatTimeoutMetadata struct {
+	EventID             int64
+	ActivityID          string
+	ActivityType        string
+	StartToCloseTimeout time.Duration
+	Threshold           time.Duration
+}
+
+// ActivityLongScheduleToStartWithRetriesMetadata is the metadata for an activity with a long
+// ScheduleToStartTimeout combined with a retry policy that allows multiple attempts, which can
+// multiply recovery time during a failover or poller outage.
+type ActivityLongScheduleToStartWithRetriesMetadata struct {
+	EventID                int64
+	ActivityID             string
+	ActivityType           string
+	ScheduleToStartTimeout time.Duration
+	Threshold              time.Duration
+	RetryPolicy            *types.RetryPolicy
+}
+
+// TimeoutRiskIssuesMetadata is a discriminated union of the metadata for each timeout risk check,
+// with exactly one field populated per issue.
+type TimeoutRiskIssuesMetadata struct {
+	ActivityStartToCloseAtWorkflowTimeoutCap *ActivityStartToCloseAtWorkflowTimeoutCapMetadata
+	ActivityMissingHeartbeatTimeout          *ActivityMissingHeartbeatTimeoutMetadata
+	ActivityLongScheduleToStartWithRetries   *ActivityLongScheduleToStartWithRetriesMetadata
+}

--- a/service/worker/diagnostics/invariant/timeoutrisk/types.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/types.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package timeoutrisk
 
 import (

--- a/service/worker/diagnostics/invariant/timeoutrisk/types.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/types.go
@@ -9,9 +9,9 @@ import (
 type TimeoutRiskType string
 
 const (
-	ActivityStartToCloseAtWorkflowTimeoutCap TimeoutRiskType = "Activity StartToClose timeout at the workflow execution timeout cap"
-	ActivityMissingHeartbeatTimeout          TimeoutRiskType = "Long-running activity missing heartbeat timeout"
-	ActivityLongScheduleToStartWithRetries   TimeoutRiskType = "Long ScheduleToStart timeout with retry policy allowing multiple attempts"
+	ActivityStartToCloseAtWorkflowTimeoutCap      TimeoutRiskType = "Activity StartToClose timeout at the workflow execution timeout cap"
+	ActivityMissingHeartbeatTimeout               TimeoutRiskType = "Long-running activity missing heartbeat timeout"
+	ActivityRetryWindowExceedsStandbyDiscardDelay TimeoutRiskType = "Activity retry window exceeds standby task discard delay (failover risk)"
 )
 
 func (t TimeoutRiskType) String() string {
@@ -23,7 +23,7 @@ type IssueType string
 const (
 	StartToCloseAtWorkflowTimeoutCap       IssueType = "Activity StartToClose timeout may have been silently capped at the workflow execution timeout by the server, leaving no headroom for retrying."
 	MissingHeartbeatTimeoutForLongActivity IssueType = "Long-running activity without a HeartbeatTimeout will leave worker failures undetected until the activity times out."
-	LongScheduleToStartWithMultipleRetries IssueType = "Long ScheduleToStartTimeout with a retry policy allowing multiple attempts can multiply recovery time during a failover or poller outage."
+	RetryWindowExceedsStandbyDiscardDelay  IssueType = "Activity retries that can extend past the standby cluster's task discard delay (25 minutes) risk being orphaned by a failover; a workflow stuck this way needs its tasks refreshed to resume."
 )
 
 func (i IssueType) String() string {
@@ -35,13 +35,9 @@ const (
 	// considered long-running and should be configured with a HeartbeatTimeout.
 	longRunningActivityThresholdSeconds int32 = 10 * 60
 
-	// longScheduleToStartThresholdSeconds is the ScheduleToStartTimeout above which, combined with a
-	// retry policy allowing multiple attempts, a failover or poller outage can significantly delay recovery.
-	longScheduleToStartThresholdSeconds int32 = 5 * 60
-
-	// minRetryAttemptsForFailoverRisk is the minimum number of configured retry attempts (or unlimited,
-	// represented by MaximumAttempts == 0) that is considered risky when combined with a long ScheduleToStartTimeout.
-	minRetryAttemptsForFailoverRisk int32 = 3
+	// failoverOrphanRiskThresholdSeconds mirrors the default of history.standbyTaskMissingEventsDiscardDelay.
+	// Retries extending past it can be orphaned by a failover (deployments overriding that config shift the real boundary).
+	failoverOrphanRiskThresholdSeconds int32 = 25 * 60
 )
 
 // ActivityStartToCloseAtWorkflowTimeoutCapMetadata is the metadata for an activity whose StartToCloseTimeout
@@ -68,22 +64,22 @@ type ActivityMissingHeartbeatTimeoutMetadata struct {
 	Threshold           time.Duration
 }
 
-// ActivityLongScheduleToStartWithRetriesMetadata is the metadata for an activity with a long
-// ScheduleToStartTimeout combined with a retry policy that allows multiple attempts, which can
-// multiply recovery time during a failover or poller outage.
-type ActivityLongScheduleToStartWithRetriesMetadata struct {
-	EventID                int64
-	ActivityID             string
-	ActivityType           string
-	ScheduleToStartTimeout time.Duration
-	Threshold              time.Duration
-	RetryPolicy            *types.RetryPolicy
+// ActivityRetryWindowExceedsStandbyDiscardDelayMetadata is the metadata for an activity whose estimated
+// retry window -- how long its retry sequence could keep extending, per its retry policy -- exceeds the
+// standby cluster's task discard delay, putting it at risk of being orphaned by a failover.
+type ActivityRetryWindowExceedsStandbyDiscardDelayMetadata struct {
+	EventID              int64
+	ActivityID           string
+	ActivityType         string
+	EstimatedRetryWindow time.Duration
+	Threshold            time.Duration
+	RetryPolicy          *types.RetryPolicy
 }
 
 // TimeoutRiskIssuesMetadata is a discriminated union of the metadata for each timeout risk check,
 // with exactly one field populated per issue.
 type TimeoutRiskIssuesMetadata struct {
-	ActivityStartToCloseAtWorkflowTimeoutCap *ActivityStartToCloseAtWorkflowTimeoutCapMetadata
-	ActivityMissingHeartbeatTimeout          *ActivityMissingHeartbeatTimeoutMetadata
-	ActivityLongScheduleToStartWithRetries   *ActivityLongScheduleToStartWithRetriesMetadata
+	ActivityStartToCloseAtWorkflowTimeoutCap      *ActivityStartToCloseAtWorkflowTimeoutCapMetadata
+	ActivityMissingHeartbeatTimeout               *ActivityMissingHeartbeatTimeoutMetadata
+	ActivityRetryWindowExceedsStandbyDiscardDelay *ActivityRetryWindowExceedsStandbyDiscardDelayMetadata
 }

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -37,9 +37,10 @@ const (
 	emitUsageLogsActivity      = "emitUsageLogs"
 	queryDiagnosticsReport     = "query-diagnostics-report"
 
-	issueTypeTimeouts = "Timeout"
-	issueTypeFailures = "Failure"
-	issueTypeRetry    = "Retry"
+	issueTypeTimeouts     = "Timeout"
+	issueTypeFailures     = "Failure"
+	issueTypeRetry        = "Retry"
+	issueTypeTimeoutRisks = "TimeoutRisk"
 )
 
 type DiagnosticsStarterWorkflowInput struct {
@@ -125,6 +126,9 @@ func getIssueType(result DiagnosticsWorkflowResult) string {
 	}
 	if result.Retries != nil {
 		issueType = fmt.Sprintf("%s-%s", issueType, issueTypeRetry)
+	}
+	if result.TimeoutRisks != nil {
+		issueType = fmt.Sprintf("%s-%s", issueType, issueTypeTimeoutRisks)
 	}
 	return issueType
 }

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -430,8 +430,8 @@ func retrieveTimeoutRiskIssues(issues []invariant.InvariantCheckResult) ([]*time
 					ActivityMissingHeartbeatTimeout: &metadata,
 				},
 			})
-		case timeoutrisk.ActivityLongScheduleToStartWithRetries.String():
-			var metadata timeoutrisk.ActivityLongScheduleToStartWithRetriesMetadata
+		case timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelay.String():
+			var metadata timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelayMetadata
 			err := json.Unmarshal(issue.Metadata, &metadata)
 			if err != nil {
 				return nil, err
@@ -441,7 +441,7 @@ func retrieveTimeoutRiskIssues(issues []invariant.InvariantCheckResult) ([]*time
 				InvariantType: issue.InvariantType,
 				Reason:        issue.Reason,
 				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-					ActivityLongScheduleToStartWithRetries: &metadata,
+					ActivityRetryWindowExceedsStandbyDiscardDelay: &metadata,
 				},
 			})
 		}

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -430,20 +430,6 @@ func retrieveTimeoutRiskIssues(issues []invariant.InvariantCheckResult) ([]*time
 					ActivityMissingHeartbeatTimeout: &metadata,
 				},
 			})
-		case timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelay.String():
-			var metadata timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelayMetadata
-			err := json.Unmarshal(issue.Metadata, &metadata)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, &timeoutRiskIssuesResult{
-				IssueID:       issue.IssueID,
-				InvariantType: issue.InvariantType,
-				Reason:        issue.Reason,
-				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-					ActivityRetryWindowExceedsStandbyDiscardDelay: &metadata,
-				},
-			})
 		}
 	}
 	return result, nil

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeoutrisk"
 )
 
 const (
@@ -52,9 +53,10 @@ type DiagnosticsWorkflowInput struct {
 }
 
 type DiagnosticsWorkflowResult struct {
-	Timeouts *timeoutDiagnostics
-	Failures *failureDiagnostics
-	Retries  *retryDiagnostics
+	Timeouts     *timeoutDiagnostics
+	Failures     *failureDiagnostics
+	Retries      *retryDiagnostics
+	TimeoutRisks *timeoutRiskDiagnostics
 }
 
 type timeoutDiagnostics struct {
@@ -107,6 +109,18 @@ type retryIssuesResult struct {
 	Metadata      retry.RetryMetadata
 }
 
+type timeoutRiskDiagnostics struct {
+	Issues  []*timeoutRiskIssuesResult
+	Runbook string
+}
+
+type timeoutRiskIssuesResult struct {
+	IssueID       int
+	InvariantType string
+	Reason        string
+	Metadata      *timeoutrisk.TimeoutRiskIssuesMetadata
+}
+
 func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (*DiagnosticsWorkflowResult, error) {
 	scope := w.metricsClient.Scope(metrics.DiagnosticsWorkflowScope, metrics.DomainTag(params.Domain))
 	scope.IncCounter(metrics.DiagnosticsWorkflowStartedCount)
@@ -120,6 +134,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	var timeoutsResult *timeoutDiagnostics
 	var failureResult *failureDiagnostics
 	var retryResult *retryDiagnostics
+	var timeoutRiskResult *timeoutRiskDiagnostics
 	var checkResult []invariant.InvariantCheckResult
 	var rootCauseResult []invariant.InvariantRootCauseResult
 
@@ -195,11 +210,24 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		}
 	}
 
+	timeoutRiskIssues, err := retrieveTimeoutRiskIssues(checkResult)
+	if err != nil {
+		return nil, fmt.Errorf("RetrieveTimeoutRiskIssues: %w", err)
+	}
+
+	if len(timeoutRiskIssues) > 0 {
+		timeoutRiskResult = &timeoutRiskDiagnostics{
+			Issues:  timeoutRiskIssues,
+			Runbook: linkToTimeoutRisksRunbook,
+		}
+	}
+
 	scope.IncCounter(metrics.DiagnosticsWorkflowSuccess)
 	return &DiagnosticsWorkflowResult{
-		Timeouts: timeoutsResult,
-		Failures: failureResult,
-		Retries:  retryResult,
+		Timeouts:     timeoutsResult,
+		Failures:     failureResult,
+		Retries:      retryResult,
+		TimeoutRisks: timeoutRiskResult,
 	}, nil
 }
 
@@ -364,6 +392,57 @@ func retrieveRetryIssues(issues []invariant.InvariantCheckResult) ([]*retryIssue
 				InvariantType: issue.InvariantType,
 				Reason:        issue.Reason,
 				Metadata:      data,
+			})
+		}
+	}
+	return result, nil
+}
+
+func retrieveTimeoutRiskIssues(issues []invariant.InvariantCheckResult) ([]*timeoutRiskIssuesResult, error) {
+	result := make([]*timeoutRiskIssuesResult, 0)
+	for _, issue := range issues {
+		switch issue.InvariantType {
+		case timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCap.String():
+			var metadata timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCapMetadata
+			err := json.Unmarshal(issue.Metadata, &metadata)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, &timeoutRiskIssuesResult{
+				IssueID:       issue.IssueID,
+				InvariantType: issue.InvariantType,
+				Reason:        issue.Reason,
+				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
+					ActivityStartToCloseAtWorkflowTimeoutCap: &metadata,
+				},
+			})
+		case timeoutrisk.ActivityMissingHeartbeatTimeout.String():
+			var metadata timeoutrisk.ActivityMissingHeartbeatTimeoutMetadata
+			err := json.Unmarshal(issue.Metadata, &metadata)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, &timeoutRiskIssuesResult{
+				IssueID:       issue.IssueID,
+				InvariantType: issue.InvariantType,
+				Reason:        issue.Reason,
+				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
+					ActivityMissingHeartbeatTimeout: &metadata,
+				},
+			})
+		case timeoutrisk.ActivityLongScheduleToStartWithRetries.String():
+			var metadata timeoutrisk.ActivityLongScheduleToStartWithRetriesMetadata
+			err := json.Unmarshal(issue.Metadata, &metadata)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, &timeoutRiskIssuesResult{
+				IssueID:       issue.IssueID,
+				InvariantType: issue.InvariantType,
+				Reason:        issue.Reason,
+				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
+					ActivityLongScheduleToStartWithRetries: &metadata,
+				},
 			})
 		}
 	}

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -503,18 +503,18 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 	}
 	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
 	s.NoError(err)
-	longScheduleToStartMetadata := timeoutrisk.ActivityLongScheduleToStartWithRetriesMetadata{
-		EventID:                4,
-		ActivityID:             "103",
-		ActivityType:           "test-activity",
-		ScheduleToStartTimeout: 600 * time.Second,
-		Threshold:              300 * time.Second,
+	retryWindowMetadata := timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
+		EventID:              4,
+		ActivityID:           "103",
+		ActivityType:         "test-activity",
+		EstimatedRetryWindow: 1800 * time.Second,
+		Threshold:            1500 * time.Second,
 		RetryPolicy: &types.RetryPolicy{
 			InitialIntervalInSeconds: 1,
 			MaximumAttempts:          0,
 		},
 	}
-	longScheduleToStartMetadataInBytes, err := json.Marshal(longScheduleToStartMetadata)
+	retryWindowMetadataInBytes, err := json.Marshal(retryWindowMetadata)
 	s.NoError(err)
 	issues := []invariant.InvariantCheckResult{
 		{
@@ -531,9 +531,9 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 		},
 		{
 			IssueID:       2,
-			InvariantType: timeoutrisk.ActivityLongScheduleToStartWithRetries.String(),
-			Reason:        timeoutrisk.LongScheduleToStartWithMultipleRetries.String(),
-			Metadata:      longScheduleToStartMetadataInBytes,
+			InvariantType: timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
+			Reason:        timeoutrisk.RetryWindowExceedsStandbyDiscardDelay.String(),
+			Metadata:      retryWindowMetadataInBytes,
 		},
 	}
 	timeoutRiskIssues := []*timeoutRiskIssuesResult{
@@ -555,10 +555,10 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 		},
 		{
 			IssueID:       2,
-			InvariantType: timeoutrisk.ActivityLongScheduleToStartWithRetries.String(),
-			Reason:        timeoutrisk.LongScheduleToStartWithMultipleRetries.String(),
+			InvariantType: timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
+			Reason:        timeoutrisk.RetryWindowExceedsStandbyDiscardDelay.String(),
 			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-				ActivityLongScheduleToStartWithRetries: &longScheduleToStartMetadata,
+				ActivityRetryWindowExceedsStandbyDiscardDelay: &retryWindowMetadata,
 			},
 		},
 	}

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeoutrisk"
 )
 
 type diagnosticsWorkflowTestSuite struct {
@@ -67,7 +68,7 @@ func (s *diagnosticsWorkflowTestSuite) SetupTest() {
 		svcClient:     publicClient,
 		clientBean:    mockResource.ClientBean,
 		metricsClient: mockResource.GetMetricsClient(),
-		invariants:    []invariant.Invariant{timeout.NewInvariant(timeout.Params{Client: publicClient}), failure.NewInvariant(), retry.NewInvariant()},
+		invariants:    []invariant.Invariant{timeout.NewInvariant(timeout.Params{Client: publicClient}), failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant()},
 	}
 
 	s.T().Cleanup(func() {
@@ -481,4 +482,87 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveRetryIssues() {
 	result, err := retrieveRetryIssues(issues)
 	s.NoError(err)
 	s.ElementsMatch(retryIssues, result)
+}
+
+func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
+	atCapMetadata := timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+		EventID:             2,
+		ActivityID:          "101",
+		ActivityType:        "test-activity",
+		StartToCloseTimeout: 60 * time.Second,
+		WorkflowTimeout:     60 * time.Second,
+	}
+	atCapMetadataInBytes, err := json.Marshal(atCapMetadata)
+	s.NoError(err)
+	missingHeartbeatMetadata := timeoutrisk.ActivityMissingHeartbeatTimeoutMetadata{
+		EventID:             3,
+		ActivityID:          "102",
+		ActivityType:        "test-activity",
+		StartToCloseTimeout: 900 * time.Second,
+		Threshold:           600 * time.Second,
+	}
+	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
+	s.NoError(err)
+	longScheduleToStartMetadata := timeoutrisk.ActivityLongScheduleToStartWithRetriesMetadata{
+		EventID:                4,
+		ActivityID:             "103",
+		ActivityType:           "test-activity",
+		ScheduleToStartTimeout: 600 * time.Second,
+		Threshold:              300 * time.Second,
+		RetryPolicy: &types.RetryPolicy{
+			InitialIntervalInSeconds: 1,
+			MaximumAttempts:          0,
+		},
+	}
+	longScheduleToStartMetadataInBytes, err := json.Marshal(longScheduleToStartMetadata)
+	s.NoError(err)
+	issues := []invariant.InvariantCheckResult{
+		{
+			IssueID:       0,
+			InvariantType: timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCap.String(),
+			Reason:        timeoutrisk.StartToCloseAtWorkflowTimeoutCap.String(),
+			Metadata:      atCapMetadataInBytes,
+		},
+		{
+			IssueID:       1,
+			InvariantType: timeoutrisk.ActivityMissingHeartbeatTimeout.String(),
+			Reason:        timeoutrisk.MissingHeartbeatTimeoutForLongActivity.String(),
+			Metadata:      missingHeartbeatMetadataInBytes,
+		},
+		{
+			IssueID:       2,
+			InvariantType: timeoutrisk.ActivityLongScheduleToStartWithRetries.String(),
+			Reason:        timeoutrisk.LongScheduleToStartWithMultipleRetries.String(),
+			Metadata:      longScheduleToStartMetadataInBytes,
+		},
+	}
+	timeoutRiskIssues := []*timeoutRiskIssuesResult{
+		{
+			IssueID:       0,
+			InvariantType: timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCap.String(),
+			Reason:        timeoutrisk.StartToCloseAtWorkflowTimeoutCap.String(),
+			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
+				ActivityStartToCloseAtWorkflowTimeoutCap: &atCapMetadata,
+			},
+		},
+		{
+			IssueID:       1,
+			InvariantType: timeoutrisk.ActivityMissingHeartbeatTimeout.String(),
+			Reason:        timeoutrisk.MissingHeartbeatTimeoutForLongActivity.String(),
+			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
+				ActivityMissingHeartbeatTimeout: &missingHeartbeatMetadata,
+			},
+		},
+		{
+			IssueID:       2,
+			InvariantType: timeoutrisk.ActivityLongScheduleToStartWithRetries.String(),
+			Reason:        timeoutrisk.LongScheduleToStartWithMultipleRetries.String(),
+			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
+				ActivityLongScheduleToStartWithRetries: &longScheduleToStartMetadata,
+			},
+		},
+	}
+	result, err := retrieveTimeoutRiskIssues(issues)
+	s.NoError(err)
+	s.ElementsMatch(timeoutRiskIssues, result)
 }

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -503,19 +503,6 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 	}
 	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
 	s.NoError(err)
-	retryWindowMetadata := timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelayMetadata{
-		EventID:              4,
-		ActivityID:           "103",
-		ActivityType:         "test-activity",
-		EstimatedRetryWindow: 1800 * time.Second,
-		Threshold:            1500 * time.Second,
-		RetryPolicy: &types.RetryPolicy{
-			InitialIntervalInSeconds: 1,
-			MaximumAttempts:          0,
-		},
-	}
-	retryWindowMetadataInBytes, err := json.Marshal(retryWindowMetadata)
-	s.NoError(err)
 	issues := []invariant.InvariantCheckResult{
 		{
 			IssueID:       0,
@@ -528,12 +515,6 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 			InvariantType: timeoutrisk.ActivityMissingHeartbeatTimeout.String(),
 			Reason:        timeoutrisk.MissingHeartbeatTimeoutForLongActivity.String(),
 			Metadata:      missingHeartbeatMetadataInBytes,
-		},
-		{
-			IssueID:       2,
-			InvariantType: timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
-			Reason:        timeoutrisk.RetryWindowExceedsStandbyDiscardDelay.String(),
-			Metadata:      retryWindowMetadataInBytes,
 		},
 	}
 	timeoutRiskIssues := []*timeoutRiskIssuesResult{
@@ -551,14 +532,6 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 			Reason:        timeoutrisk.MissingHeartbeatTimeoutForLongActivity.String(),
 			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
 				ActivityMissingHeartbeatTimeout: &missingHeartbeatMetadata,
-			},
-		},
-		{
-			IssueID:       2,
-			InvariantType: timeoutrisk.ActivityRetryWindowExceedsStandbyDiscardDelay.String(),
-			Reason:        timeoutrisk.RetryWindowExceedsStandbyDiscardDelay.String(),
-			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-				ActivityRetryWindowExceedsStandbyDiscardDelay: &retryWindowMetadata,
 			},
 		},
 	}


### PR DESCRIPTION
## What changed?
New Workflow Diagnostics invariant, **Timeout Risks**, flagging risky timeout configuration found in workflow history:

1. Activity StartToClose equal to the workflow execution timeout — no headroom, and likely configured higher then silently capped by the server.
2. Activity with StartToClose ≥ 10 min and no HeartbeatTimeout — worker death goes undetected.

Results surface as a new `TimeoutRisks` section in the diagnostics report.

## Why?
The existing `timeout` invariant only fires after a timeout has happened; these are the same problems caught beforehand. `RootCause` for this invariant is a no-op, like the `retry` invariant.

## How did you test it?
```
make pr GEN_DIR=service/worker/diagnostics
make build && make test
go test -race -count=1 ./service/worker/diagnostics/...
```
New table tests cover each check, threshold boundaries (cap equality, just-below-cap), and degenerate histories.

### Screenshot from the Cadence UI
<img width="1666" height="1002" alt="Screenshot 2026-08-25 at 14 39 19" src="https://github.com/user-attachments/assets/8437e1d8-487b-45a0-8476-7f87ca0e76bf" />

## Potential risks
Low — additive change, no API/IDL/schema impact. Thresholds are hardcoded heuristics and may need tuning.

## Release notes
Workflow diagnostics now flags risky timeout configurations in addition to timeouts that already occurred.

## Documentation Changes
Runbook page https://cadenceworkflow.io/docs/workflow-troubleshooting/timeout-risks/ needs adding to cadence-docs.