### PR TITLE
refactor(queuev2): split scheduled cache prefetch options

### DIFF
--- a/service/history/queuev2/queue_reader_cached_base.go
+++ b/service/history/queuev2/queue_reader_cached_base.go
@@ -69,27 +69,8 @@ type cachedQueueReaderOptions struct {
 	// Mode controls cache behavior: "enabled" uses cache, anything else (including "disabled") disables.
 	Mode dynamicproperties.StringPropertyFnWithShardIDFilter
 	// MaxSize is the maximum number of tasks the cache may hold at once.
-	// Insertions that would exceed this limit trigger time-based eviction first.
+	// Insertions that would exceed this limit trigger eviction first.
 	MaxSize dynamicproperties.IntPropertyFn
-	// MaxLookAheadWindow is how far into the future from now the cache prefetches.
-	// Tasks with scheduled time beyond now+MaxLookAheadWindow are not fetched.
-	MaxLookAheadWindow dynamicproperties.DurationPropertyFn
-	// PrefetchTriggerWindow defines how close to the upper-bound a task must be
-	// before the next prefetch is scheduled. A prefetch fires when the nearest
-	// upcoming task is within PrefetchTriggerWindow of the current upper bound.
-	PrefetchTriggerWindow dynamicproperties.DurationPropertyFn
-	// PrefetchPageSize caps the number of tasks fetched per DB round-trip.
-	PrefetchPageSize dynamicproperties.IntPropertyFn
-	// TimeEvictionWindow is the lookback horizon: tasks older than
-	// now-TimeEvictionWindow are evicted to reclaim cache capacity.
-	TimeEvictionWindow dynamicproperties.DurationPropertyFn
-	// MinPrefetchInterval is the minimum time between consecutive prefetch attempts.
-	// It prevents the prefetch loop from hammering the database when the cache resets
-	// or gap detection fires repeatedly.
-	MinPrefetchInterval dynamicproperties.DurationPropertyFn
-	// PrefetchJitterCoefficient is passed to backoff.JitDuration when computing
-	// the next prefetch delay. Must be in [0, 1]. Zero disables jitter.
-	PrefetchJitterCoefficient dynamicproperties.FloatPropertyFn
 	// ShadowSampleInterval controls how often, at most, a GetTask call in "enabled" mode
 	// is diverted through the shadow comparison path for continuous regression detection.
 	// <= 0 disables sampling.

--- a/service/history/queuev2/queue_reader_cached_scheduled.go
+++ b/service/history/queuev2/queue_reader_cached_scheduled.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -39,11 +40,39 @@ import (
 	"github.com/uber/cadence/service/history/shard"
 )
 
+// scheduledCacheQueueReaderOptions holds the tuning knobs used only by the scheduled (timer)
+// cached reader. The immediate (transfer) reader uses none of them.
+type scheduledCacheQueueReaderOptions struct {
+	// MaxLookAheadWindow is how far into the future from now the cache prefetches.
+	// Tasks with scheduled time beyond now+MaxLookAheadWindow are not fetched.
+	MaxLookAheadWindow dynamicproperties.DurationPropertyFn
+	// PrefetchTriggerWindow defines how close to the upper-bound a task must be
+	// before the next prefetch is scheduled. A prefetch fires when the nearest
+	// upcoming task is within PrefetchTriggerWindow of the current upper bound.
+	PrefetchTriggerWindow dynamicproperties.DurationPropertyFn
+	// PrefetchPageSize caps the number of tasks fetched per DB round-trip.
+	PrefetchPageSize dynamicproperties.IntPropertyFn
+	// TimeEvictionWindow is the lookback horizon: tasks older than
+	// now-TimeEvictionWindow are evicted to reclaim cache capacity.
+	TimeEvictionWindow dynamicproperties.DurationPropertyFn
+	// MinPrefetchInterval is the minimum time between consecutive prefetch attempts.
+	// It prevents the prefetch loop from hammering the database when the cache resets
+	// or gap detection fires repeatedly.
+	MinPrefetchInterval dynamicproperties.DurationPropertyFn
+	// PrefetchJitterCoefficient is passed to backoff.JitDuration when computing
+	// the next prefetch delay. Must be in [0, 1]. Zero disables jitter.
+	PrefetchJitterCoefficient dynamicproperties.FloatPropertyFn
+}
+
 // cachedScheduledQueueReader is the scheduled (timer) cached queue reader. It embeds the shared
 // cachedQueueReaderBase and adds the prefetch cycle that keeps a look-ahead window of future
 // timer tasks warm in the cache.
 type cachedScheduledQueueReader struct {
 	*cachedQueueReaderBase
+
+	// scheduledOpts holds the look-ahead / time-eviction / prefetch tuning knobs, specific to the
+	// scheduled/timer reader.
+	scheduledOpts *scheduledCacheQueueReaderOptions
 
 	// prefetchTargetUpper is the new exclusive upper key the current in-flight prefetch is aiming
 	// to reach. Prefetch-only state, so it lives on the scheduled reader rather than the shared
@@ -81,15 +110,17 @@ func newCachedScheduledQueueReader(
 		shard.GetLogger().WithTags(tag.ComponentCachedQueueReader),
 		metricsScope,
 		&cachedQueueReaderOptions{
-			Mode:                      config.TimerProcessorCachedQueueReaderMode,
-			MaxSize:                   config.TimerProcessorCacheMaxSize,
+			Mode:                 config.TimerProcessorCachedQueueReaderMode,
+			MaxSize:              config.TimerProcessorCacheMaxSize,
+			ShadowSampleInterval: config.TimerProcessorCachedQueueReaderShadowSampleInterval,
+		},
+		&scheduledCacheQueueReaderOptions{
 			MaxLookAheadWindow:        config.TimerProcessorMaxPollInterval,
 			PrefetchTriggerWindow:     config.TimerProcessorCachePrefetchTriggerWindow,
 			PrefetchPageSize:          config.TimerTaskBatchSize,
 			TimeEvictionWindow:        config.TimerProcessorCacheTimeEvictionWindow,
 			MinPrefetchInterval:       config.TimerProcessorCacheMinPrefetchInterval,
 			PrefetchJitterCoefficient: config.TimerProcessorMaxPollIntervalJitterCoefficient,
-			ShadowSampleInterval:      config.TimerProcessorCachedQueueReaderShadowSampleInterval,
 		},
 	)
 }
@@ -102,6 +133,7 @@ func newCachedScheduledQueueReaderWithOptions(
 	logger log.Logger,
 	metricsScope metrics.Scope,
 	options *cachedQueueReaderOptions,
+	scheduledOpts *scheduledCacheQueueReaderOptions,
 ) *cachedScheduledQueueReader {
 	ctx, cancel := context.WithCancel(context.Background())
 	q := &cachedScheduledQueueReader{
@@ -114,6 +146,7 @@ func newCachedScheduledQueueReaderWithOptions(
 			metricsScope,
 			options,
 		),
+		scheduledOpts:       scheduledOpts,
 		prefetchTargetUpper: persistence.MinimumHistoryTaskKey,
 		prefetchCh:          make(chan struct{}, 1),
 		ctx:                 ctx,
@@ -177,7 +210,7 @@ func (q *cachedScheduledQueueReader) prefetchLoop() {
 			q.tryTimeEvictIfCacheFull()
 			if err := q.prefetch(); err != nil {
 				q.logger.Warn("prefetch failed, retrying shortly", tag.Error(err))
-				timer.Reset(q.options.MinPrefetchInterval())
+				timer.Reset(q.scheduledOpts.MinPrefetchInterval())
 			} else {
 				timer.Reset(q.nextPrefetchDelay())
 			}
@@ -201,16 +234,16 @@ func (q *cachedScheduledQueueReader) nextPrefetchDelay() time.Duration {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 
-	triggerTime := q.exclusiveUpperBound.GetScheduledTime().Add(-q.options.PrefetchTriggerWindow())
-	delay := max(q.options.MinPrefetchInterval(), triggerTime.Sub(q.clock.Now()))
-	jittered := backoff.JitDuration(delay, q.options.PrefetchJitterCoefficient())
+	triggerTime := q.exclusiveUpperBound.GetScheduledTime().Add(-q.scheduledOpts.PrefetchTriggerWindow())
+	delay := max(q.scheduledOpts.MinPrefetchInterval(), triggerTime.Sub(q.clock.Now()))
+	jittered := backoff.JitDuration(delay, q.scheduledOpts.PrefetchJitterCoefficient())
 
 	// Cap the jittered delay to the original delay: positive jitter must not push the
 	// prefetch past triggerTime, which would cause it to fire after the upper bound and
 	// produce cache misses. MinPrefetchInterval is re-applied as the floor because
 	// negative jitter on a delay already clamped to MinPrefetchInterval can otherwise
 	// return a value below it.
-	return max(q.options.MinPrefetchInterval(), min(delay, jittered))
+	return max(q.scheduledOpts.MinPrefetchInterval(), min(delay, jittered))
 }
 
 // LookAHead returns the next task at or after req.InclusiveMinTaskKey. Serves
@@ -284,7 +317,7 @@ func (q *cachedScheduledQueueReader) prefetch() error {
 	defer sw.Stop()
 
 	// Ceiling of the look-ahead window; tasks at or after this time aren't due yet.
-	exclusiveMaxTaskKey := persistence.NewHistoryTaskKey(now.Add(q.options.MaxLookAheadWindow()), 0)
+	exclusiveMaxTaskKey := persistence.NewHistoryTaskKey(now.Add(q.scheduledOpts.MaxLookAheadWindow()), 0)
 
 	// Start from the existing upper bound so pages don't overlap. On the first
 	// run (upperBound is MinimumHistoryTaskKey, nothing fetched yet), anchor to
@@ -292,12 +325,12 @@ func (q *cachedScheduledQueueReader) prefetch() error {
 	// that timeEvict would drop immediately.
 	inclusiveMinTaskKey := upperBound
 	if inclusiveMinTaskKey.Equal(persistence.MinimumHistoryTaskKey) {
-		inclusiveMinTaskKey = persistence.NewHistoryTaskKey(now.Add(-q.options.TimeEvictionWindow()), 0)
+		inclusiveMinTaskKey = persistence.NewHistoryTaskKey(now.Add(-q.scheduledOpts.TimeEvictionWindow()), 0)
 	}
 
 	// Cap the page to available space (so the insert won't spill into RTrimBySize)
 	// and to the configured page size (to bound each round-trip).
-	pageSize := min(availableCacheSize, q.options.PrefetchPageSize())
+	pageSize := min(availableCacheSize, q.scheduledOpts.PrefetchPageSize())
 
 	// Record the prefetch's target window so Inject can buffer tasks that arrive
 	// while the DB call is in-flight. Cleared inside the write lock after the call.
@@ -445,7 +478,7 @@ func (q *cachedScheduledQueueReader) tryTimeEvict(extraTasks int) {
 	if q.queue.Len()+extraTasks < q.options.MaxSize() {
 		return
 	}
-	evictBefore := persistence.NewHistoryTaskKey(q.clock.Now().Add(-q.options.TimeEvictionWindow()), 0)
+	evictBefore := persistence.NewHistoryTaskKey(q.clock.Now().Add(-q.scheduledOpts.TimeEvictionWindow()), 0)
 	q.advanceInclusiveLowerBound(evictBefore)
 }
 

--- a/service/history/queuev2/queue_reader_cached_scheduled_test.go
+++ b/service/history/queuev2/queue_reader_cached_scheduled_test.go
@@ -42,17 +42,30 @@ import (
 	"github.com/uber/cadence/service/history/shard"
 )
 
-func testOptions(overrides ...func(*cachedQueueReaderOptions)) *cachedQueueReaderOptions {
-	opts := &cachedQueueReaderOptions{
-		Mode:                      dynamicproperties.GetStringPropertyFnFilteredByShardID("enabled"),
-		MaxSize:                   dynamicproperties.GetIntPropertyFn(100),
-		MaxLookAheadWindow:        dynamicproperties.GetDurationPropertyFn(time.Hour),
-		PrefetchTriggerWindow:     dynamicproperties.GetDurationPropertyFn(5 * time.Minute),
-		PrefetchPageSize:          dynamicproperties.GetIntPropertyFn(10),
-		TimeEvictionWindow:        dynamicproperties.GetDurationPropertyFn(time.Minute),
-		MinPrefetchInterval:       dynamicproperties.GetDurationPropertyFn(100 * time.Millisecond),
-		PrefetchJitterCoefficient: dynamicproperties.GetFloatPropertyFn(0),
-		ShadowSampleInterval:      dynamicproperties.GetDurationPropertyFn(0),
+// testCachedQueueReaderOptions embeds both the common options and the scheduled/timer-only
+// prefetch options so existing test overrides can keep referencing fields from either
+// (e.g. o.MaxSize or o.PrefetchTriggerWindow) via field promotion, without needing to know
+// which struct each field now lives in.
+type testCachedQueueReaderOptions struct {
+	*cachedQueueReaderOptions
+	*scheduledCacheQueueReaderOptions
+}
+
+func testOptions(overrides ...func(*testCachedQueueReaderOptions)) *testCachedQueueReaderOptions {
+	opts := &testCachedQueueReaderOptions{
+		cachedQueueReaderOptions: &cachedQueueReaderOptions{
+			Mode:                 dynamicproperties.GetStringPropertyFnFilteredByShardID("enabled"),
+			MaxSize:              dynamicproperties.GetIntPropertyFn(100),
+			ShadowSampleInterval: dynamicproperties.GetDurationPropertyFn(0),
+		},
+		scheduledCacheQueueReaderOptions: &scheduledCacheQueueReaderOptions{
+			MaxLookAheadWindow:        dynamicproperties.GetDurationPropertyFn(time.Hour),
+			PrefetchTriggerWindow:     dynamicproperties.GetDurationPropertyFn(5 * time.Minute),
+			PrefetchPageSize:          dynamicproperties.GetIntPropertyFn(10),
+			TimeEvictionWindow:        dynamicproperties.GetDurationPropertyFn(time.Minute),
+			MinPrefetchInterval:       dynamicproperties.GetDurationPropertyFn(100 * time.Millisecond),
+			PrefetchJitterCoefficient: dynamicproperties.GetFloatPropertyFn(0),
+		},
 	}
 	for _, o := range overrides {
 		if o == nil {
@@ -74,7 +87,7 @@ type cachedQueueReaderMockDeps struct {
 func setupMocksForCachedQueueReader(
 	t *testing.T,
 	ctrl *gomock.Controller,
-	overrides ...func(*cachedQueueReaderOptions),
+	overrides ...func(*testCachedQueueReaderOptions),
 ) (*cachedScheduledQueueReader, *cachedQueueReaderMockDeps) {
 	t.Helper()
 	mockShard := shard.NewMockContext(ctrl)
@@ -90,6 +103,7 @@ func setupMocksForCachedQueueReader(
 		metricsScope: metricsScope,
 	}
 
+	opts := testOptions(overrides...)
 	r := newCachedScheduledQueueReaderWithOptions(
 		deps.mockBase,
 		deps.mockQueue,
@@ -97,7 +111,8 @@ func setupMocksForCachedQueueReader(
 		deps.clock,
 		testlogger.New(t),
 		metrics.NewClient(metricsScope, metrics.History, metrics.MigrationConfig{}).Scope(metrics.TimerQueueProcessorV2Scope),
-		testOptions(overrides...),
+		opts.cachedQueueReaderOptions,
+		opts.scheduledCacheQueueReaderOptions,
 	)
 
 	return r, deps
@@ -155,7 +170,7 @@ func TestCachedQueueReader_Modes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.mode, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			r, _ := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
+			r, _ := setupMocksForCachedQueueReader(t, ctrl, func(o *testCachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID(tc.mode)
 			})
 			assert.Equal(t, tc.enabled, r.isEnabled(), "mode %q: isEnabled", tc.mode)
@@ -286,7 +301,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 		name                string
 		tasks               []persistence.Task
 		initPrefetchTarget  persistence.HistoryTaskKey
-		optsOverride        func(*cachedQueueReaderOptions)
+		optsOverride        func(*testCachedQueueReaderOptions)
 		setupMocks          func(queue *MockInMemQueue)
 		wantUpper           persistence.HistoryTaskKey
 		wantBufferLen       int
@@ -299,7 +314,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 		{
 			name:  "disabled clears stale cache",
 			tasks: []persistence.Task{inside},
-			optsOverride: func(o *cachedQueueReaderOptions) {
+			optsOverride: func(o *testCachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("disabled")
 			},
 			setupMocks: func(queue *MockInMemQueue) {
@@ -363,7 +378,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			// RTrimBySize fires and the upper bound must shrink to the trim key.
 			name:  "trims when over capacity: upper bound updated",
 			tasks: []persistence.Task{inside},
-			optsOverride: func(o *cachedQueueReaderOptions) {
+			optsOverride: func(o *testCachedQueueReaderOptions) {
 				o.MaxSize = dynamicproperties.GetIntPropertyFn(1)
 			},
 			setupMocks: func(queue *MockInMemQueue) {
@@ -884,7 +899,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
+			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *testCachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID(tc.mode)
 			})
 			base, queue := deps.mockBase, deps.mockQueue
@@ -1125,7 +1140,7 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
+			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *testCachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("shadow")
 			})
 			setBounds(r, tc.lower, tc.upper)
@@ -1252,6 +1267,10 @@ func TestCachedQueueReader_GetTask_PeriodicShadowSample(t *testing.T) {
 				mockShard: mockShard,
 				clock:     clock.NewMockedTimeSource(),
 			}
+			opts := testOptions(func(o *testCachedQueueReaderOptions) {
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("enabled")
+				o.ShadowSampleInterval = dynamicproperties.GetDurationPropertyFn(tc.interval)
+			})
 			r := newCachedScheduledQueueReaderWithOptions(
 				deps.mockBase,
 				deps.mockQueue,
@@ -1259,10 +1278,8 @@ func TestCachedQueueReader_GetTask_PeriodicShadowSample(t *testing.T) {
 				deps.clock,
 				logger,
 				metrics.NoopScope,
-				testOptions(func(o *cachedQueueReaderOptions) {
-					o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("enabled")
-					o.ShadowSampleInterval = dynamicproperties.GetDurationPropertyFn(tc.interval)
-				}),
+				opts.cachedQueueReaderOptions,
+				opts.scheduledCacheQueueReaderOptions,
 			)
 			setBounds(r, lower, upper)
 			deps.mockQueue.EXPECT().Len().Return(0).AnyTimes()
@@ -1684,7 +1701,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
+			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *testCachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID(tc.mode)
 			})
 			base, queue := deps.mockBase, deps.mockQueue
@@ -1731,7 +1748,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 	t4 := newTask(4, now.Add(40*time.Minute))
 	tests := []struct {
 		name                  string
-		optsOverride          func(*cachedQueueReaderOptions)
+		optsOverride          func(*testCachedQueueReaderOptions)
 		initLower             persistence.HistoryTaskKey
 		initUpper             persistence.HistoryTaskKey
 		initBuffer            []persistence.Task
@@ -1745,7 +1762,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 	}{
 		{
 			name: "disabled: no-op when cache empty",
-			optsOverride: func(o *cachedQueueReaderOptions) {
+			optsOverride: func(o *testCachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("disabled")
 			},
 			initLower:  persistence.MinimumHistoryTaskKey,
@@ -1756,7 +1773,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 		},
 		{
 			name: "disabled: clears stale cache when not empty",
-			optsOverride: func(o *cachedQueueReaderOptions) {
+			optsOverride: func(o *testCachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("disabled")
 			},
 			initLower: someLower,
@@ -1866,7 +1883,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 		},
 		{
 			name: "subsequent prefetch, tasks returned, tasks inserted, trimmed by size",
-			optsOverride: func(o *cachedQueueReaderOptions) {
+			optsOverride: func(o *testCachedQueueReaderOptions) {
 				o.MaxSize = dynamicproperties.GetIntPropertyFn(1)
 			},
 			initLower: someLower,
@@ -1969,7 +1986,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var overrides []func(*cachedQueueReaderOptions)
+			var overrides []func(*testCachedQueueReaderOptions)
 			if tc.optsOverride != nil {
 				overrides = append(overrides, tc.optsOverride)
 			}
@@ -2027,7 +2044,7 @@ func TestCachedQueueReader_NextPrefetchDelay(t *testing.T) {
 	// 50% jitter: un-capped range would be [0.5*base, 1.5*base].
 	// The cap (min(delay, jittered)) keeps the result in [0.5*base, base],
 	// and the MinPrefetchInterval floor ensures the result is never below 1s.
-	r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
+	r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *testCachedQueueReaderOptions) {
 		o.PrefetchTriggerWindow = dynamicproperties.GetDurationPropertyFn(10 * time.Minute)
 		o.MinPrefetchInterval = dynamicproperties.GetDurationPropertyFn(time.Second)
 		o.PrefetchJitterCoefficient = dynamicproperties.GetFloatPropertyFn(0.5)


### PR DESCRIPTION
**What changed?**

Split the cached queue reader options into two structs:
- `cachedQueueReaderOptions` keeps the knobs shared by every cached reader: `Mode`, `MaxSize`, and `ShadowSampleInterval`.
- A new timer-only `scheduledCacheQueueReaderOptions` holds the six look-ahead, time-eviction, and prefetch-cadence knobs (`MaxLookAheadWindow`, `PrefetchTriggerWindow`, `PrefetchPageSize`, `TimeEvictionWindow`, `MinPrefetchInterval`, `PrefetchJitterCoefficient`).

The scheduled reader gains a `scheduledOpts` field and its prefetch and look-ahead call sites now read those knobs from `q.scheduledOpts.*`, while `MaxSize` continues to be read from the shared `q.options`. Tests wrap both structs in a small embedding helper so existing field overrides keep working via promotion.

**Why?**

An upcoming immediate (transfer) cached reader (#8432) will embed the same base but has no prefetch cycle, look-ahead window, or time-based eviction, so those knobs are meaningless to it. Keeping them on the shared options struct would force the transfer reader to carry and populate config it never uses. Moving them onto a scheduled-only struct keeps the shared options minimal and makes each reader populate only the config it actually consumes. Behavior is unchanged: this is a pure refactor, and no dynamic-config keys are added or renamed.

**How did you test it?**

- `go build ./service/history/queuev2/...`
- `go test -race ./service/history/queuev2/...`
- `make lint`

**Potential risks**

None. Internal refactor only; no config keys or behavior change.

**Release notes**

N/A

**Documentation Changes**

N/A
