### PR TITLE
fix(cloudsql): Exclude unsupported connection attributes from dsn

### DIFF
--- a/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin.go
@@ -63,6 +63,12 @@ const (
 	driverFormat                 = "cloudsql-mysql-%d"
 )
 
+// Attributes that are used for driver options and should not be included in the DSN
+var excludedDSNAttrs = map[string]bool{
+	"iamAuthN": true,
+	"ipType":   true,
+}
+
 var dsnAttrOverrides = map[string]string{
 	"parseTime":       "true",
 	"clientFoundRows": "true",
@@ -246,6 +252,10 @@ func getServiceAccountUsername() (string, error) {
 func buildDSNAttrs(cfg *config.SQL) string {
 	attrs := make(map[string]string, len(dsnAttrOverrides)+len(cfg.ConnectAttributes)+1)
 	for k, v := range cfg.ConnectAttributes {
+		// Skip attributes that are used for driver options
+		if excludedDSNAttrs[k] {
+			continue
+		}
 		k1, v1 := sanitizeAttr(k, v)
 		attrs[k1] = v1
 	}

--- a/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin_test.go
+++ b/common/persistence/sql/sqlplugin/cloudsql-mysql/plugin_test.go
@@ -23,9 +23,12 @@ package cloudsqlmysql
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/config"
 )
 
 func TestGetServiceAccountUsername(t *testing.T) {
@@ -94,6 +97,58 @@ func TestGetServiceAccountUsername(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, username)
+		})
+	}
+}
+
+func TestBuildDSNAttrs(t *testing.T) {
+	tests := []struct {
+		name           string
+		connectAttrs   map[string]string
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:           "excludes iamAuthN",
+			connectAttrs:   map[string]string{"iamAuthN": "true"},
+			wantNotContain: []string{"iamAuthN"},
+			wantContains:   []string{"parseTime=true"},
+		},
+		{
+			name:           "excludes ipType",
+			connectAttrs:   map[string]string{"ipType": "private"},
+			wantNotContain: []string{"ipType"},
+			wantContains:   []string{"parseTime=true"},
+		},
+		{
+			name:           "excludes both driver options",
+			connectAttrs:   map[string]string{"iamAuthN": "true", "ipType": "private"},
+			wantNotContain: []string{"iamAuthN", "ipType"},
+			wantContains:   []string{"parseTime=true"},
+		},
+		{
+			name:           "includes regular attributes",
+			connectAttrs:   map[string]string{"iamAuthN": "true", "customAttr": "value"},
+			wantContains:   []string{"customAttr=value", "parseTime=true"},
+			wantNotContain: []string{"iamAuthN"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.SQL{
+				ConnectAttributes: tc.connectAttrs,
+			}
+			result := buildDSNAttrs(cfg)
+
+			for _, want := range tc.wantContains {
+				require.True(t, strings.Contains(result, want),
+					"DSN attrs should contain %q, got: %s", want, result)
+			}
+			for _, notWant := range tc.wantNotContain {
+				require.False(t, strings.Contains(result, notWant),
+					"DSN attrs should not contain %q, got: %s", notWant, result)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Exclude unsupported connection attributes from dsn

**Why?**
iamAuthN and ipType are not supported by mysql driver, and they could fail the connection

**How did you test it?**
manual verification

**Potential risks**
No. The feature is not deployed in production.

**Release notes**


**Documentation Changes**

