### PR TITLE
fix: Fix MinCompatibleVersion of versioned schemas' manifests

### DIFF
--- a/schema/cassandra/visibility/versioned/v0.10/manifest.json
+++ b/schema/cassandra/visibility/versioned/v0.10/manifest.json
@@ -1,6 +1,6 @@
 {
   "CurrVersion": "0.10",
-  "MinCompatibleVersion": "0.1",
+  "MinCompatibleVersion": "0.10",
   "Description": "add cron_schedule, execution_status, and scheduled_execution_time to visibility",
   "SchemaUpdateCqlFiles": [
     "add_execution_fields.cql"

--- a/schema/mysql/v8/visibility/versioned/v0.8/manifest.json
+++ b/schema/mysql/v8/visibility/versioned/v0.8/manifest.json
@@ -1,6 +1,6 @@
 {
   "CurrVersion": "0.8",
-  "MinCompatibleVersion": "0.1",
+  "MinCompatibleVersion": "0.8",
   "Description": "add cron_schedule, execution_status, and scheduled_execution_time to visibility",
   "SchemaUpdateCqlFiles": [
     "add_execution_fields.sql"

--- a/schema/postgres/visibility/versioned/v0.9/manifest.json
+++ b/schema/postgres/visibility/versioned/v0.9/manifest.json
@@ -1,6 +1,6 @@
 {
   "CurrVersion": "0.9",
-  "MinCompatibleVersion": "0.1",
+  "MinCompatibleVersion": "0.9",
   "Description": "add cron_schedule, execution_status, and scheduled_execution_time to visibility",
   "SchemaUpdateCqlFiles": [
     "add_execution_fields.sql"

--- a/schema/version_test.go
+++ b/schema/version_test.go
@@ -142,6 +142,29 @@ func TestSchema(t *testing.T) {
 				expected := tt.schema.LatestVersion().Minor + tt.schema.LatestVersion().Major
 				assert.Equal(t, expected, len(updates), "unexpected number of updates")
 			})
+			t.Run("minCompatibleVersion is non-decreasing", func(t *testing.T) {
+				for i := 1; i < len(updates); i++ {
+					prev := updates[i-1]
+					curr := updates[i]
+					// MinCompatibleVersion should never decrease across sequential updates
+					if curr.MinCompatibleVersion.Compare(prev.MinCompatibleVersion) < 0 {
+						t.Errorf(
+							"MinCompatibleVersion decreased from %s to %s (version %s to %s)\n"+
+								"  Previous update: v%s has MinCompatibleVersion=%s\n"+
+								"  Current update:  v%s has MinCompatibleVersion=%s\n"+
+								"  MinCompatibleVersion must be non-decreasing across schema updates",
+							prev.MinCompatibleVersion.String(),
+							curr.MinCompatibleVersion.String(),
+							prev.Version.String(),
+							curr.Version.String(),
+							prev.Version.String(),
+							prev.MinCompatibleVersion.String(),
+							curr.Version.String(),
+							curr.MinCompatibleVersion.String(),
+						)
+					}
+				}
+			})
 			// Validate each version as a test case
 			for _, update := range updates {
 				t.Run(update.Version.String(), func(t *testing.T) {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Fix MinCompatibleVersion of versioned schemas' manifests 

**Why?**
MinCompatibleVersion should be non-decreasing

**How did you test it?**
go test ./schema/...

**Potential risks**
This data is not actually being used, so there is no risk.

**Release notes**


**Documentation Changes**

**Detailed Description**
Fix MinCompatibleVersion of versioned schemas' manifests 

**Impact Analysis**
- **Backward Compatibility**: yes
- **Forward Compatibility**: yes

**Testing Plan**
- **Unit Tests**: yes
- **Persistence Tests**: N/A
- **Integration Tests**: yes
- **Compatibility Tests**: N/A

**Rollout Plan**
- What is the rollout plan? N/A
- Does the order of deployment matter? No.
- Is it safe to rollback? Does the order of rollback matter? Yes. No.
- Is there a kill switch to mitigate the impact immediately? No.
