### PR TITLE
ci(ci-checks): fail PR if go.mod deps were published within 14 days

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -18,25 +18,6 @@ jobs:
       - name: Check IDL submodule status (must point to master)
         run: make .idl-status
 
-  golang-check-fresh-dependencies:
-    name: Golang check fresh dependencies
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24.5'
-
-      - name: Check for too-fresh go module dependencies
-        run: ./scripts/github_actions/check_fresh_go_deps.sh
-
   golang-unit-test:
     name: Golang unit test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -18,10 +18,29 @@ jobs:
       - name: Check IDL submodule status (must point to master)
         run: make .idl-status
 
+  golang-check-fresh-dependencies:
+    name: Golang check fresh dependencies
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Check for too-fresh go module dependencies
+        run: ./scripts/github_actions/check_fresh_go_deps.sh
+
   golang-unit-test:
     name: Golang unit test
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/fresh-go-deps-check.yml
+++ b/.github/workflows/fresh-go-deps-check.yml
@@ -1,0 +1,25 @@
+name: Fresh Go Deps Check
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  golang-check-fresh-dependencies:
+    name: Golang check fresh dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Check for too-fresh go module dependencies
+        run: ./scripts/github_actions/check_fresh_go_deps.sh

--- a/.github/workflows/fresh-go-deps-check.yml
+++ b/.github/workflows/fresh-go-deps-check.yml
@@ -2,8 +2,8 @@ name: Fresh Go Deps Check
 on:
   pull_request:
     paths:
-      - 'go.mod'
-      - 'go.sum'
+      - '**/go.mod'
+      - '**/go.sum'
 
 jobs:
   golang-check-fresh-dependencies:

--- a/scripts/github_actions/check_fresh_go_deps.sh
+++ b/scripts/github_actions/check_fresh_go_deps.sh
@@ -6,19 +6,30 @@ EXEMPT_PREFIXES="${EXEMPT_PREFIXES:-github.com/uber/cadence-idl,github.com/caden
 
 exempt_json=$(jq -cn --arg s "$EXEMPT_PREFIXES" '$s | split(",") | map(select(length > 0))')
 
-fresh=$(go list -m -json all | jq -rs --argjson maxAgeDays "$MAX_AGE_DAYS" --argjson exempt "$exempt_json" '
-  def is_exempt($path): any($exempt[]; . as $p | $path | startswith($p));
-  .[]
-  | select(.Time)
-  | select(is_exempt(.Path) | not)
-  | (try (.Time|fromdateiso8601) catch null) as $t
-  | select($t != null)
-  | select((now-$t) < ($maxAgeDays*86400))
-  | "\(.Path) - published: \(.Time) - eligible: \(($t+$maxAgeDays*86400)|todateiso8601)"
-')
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+failed=0
 
-if [ -n "$fresh" ]; then
-  echo "Identified go modules which are too fresh (less than ${MAX_AGE_DAYS} days):"
-  echo "$fresh"
-  exit 1
-fi
+while IFS= read -r -d '' gomod; do
+  moddir="$(dirname "$gomod")"
+  modrel="${moddir#"$repo_root"/}"
+  [ "$moddir" = "$repo_root" ] && modrel="."
+
+  fresh=$(cd "$moddir" && go list -m -json all | jq -rs --argjson maxAgeDays "$MAX_AGE_DAYS" --argjson exempt "$exempt_json" '
+    def is_exempt($path): any($exempt[]; . as $p | $path | startswith($p));
+    .[]
+    | select(.Time)
+    | select(is_exempt(.Path) | not)
+    | (try (.Time|fromdateiso8601) catch null) as $t
+    | select($t != null)
+    | select((now-$t) < ($maxAgeDays*86400))
+    | "\(.Path) - published: \(.Time) - eligible: \(($t+$maxAgeDays*86400)|todateiso8601)"
+  ')
+
+  if [ -n "$fresh" ]; then
+    echo "[$modrel] Identified go modules which are too fresh (less than ${MAX_AGE_DAYS} days):"
+    echo "$fresh"
+    failed=1
+  fi
+done < <(find "$repo_root" -name go.mod -not -path "$repo_root/idls/*" -print0)
+
+exit "$failed"

--- a/scripts/github_actions/check_fresh_go_deps.sh
+++ b/scripts/github_actions/check_fresh_go_deps.sh
@@ -2,11 +2,17 @@
 set -euo pipefail
 
 MAX_AGE_DAYS="${MAX_AGE_DAYS:-14}"
+EXEMPT_PREFIXES="${EXEMPT_PREFIXES:-github.com/uber/cadence-idl,github.com/cadence-workflow}"
 
-fresh=$(go list -m -u -json all | jq -rs --argjson maxAgeDays "$MAX_AGE_DAYS" '
+exempt_json=$(jq -cn --arg s "$EXEMPT_PREFIXES" '$s | split(",") | map(select(length > 0))')
+
+fresh=$(go list -m -json all | jq -rs --argjson maxAgeDays "$MAX_AGE_DAYS" --argjson exempt "$exempt_json" '
+  def is_exempt($path): any($exempt[]; . as $p | $path | startswith($p));
   .[]
   | select(.Time)
-  | ((.Time|fromdateiso8601)) as $t
+  | select(is_exempt(.Path) | not)
+  | (try (.Time|fromdateiso8601) catch null) as $t
+  | select($t != null)
   | select((now-$t) < ($maxAgeDays*86400))
   | "\(.Path) - published: \(.Time) - eligible: \(($t+$maxAgeDays*86400)|todateiso8601)"
 ')

--- a/scripts/github_actions/check_fresh_go_deps.sh
+++ b/scripts/github_actions/check_fresh_go_deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_AGE_DAYS="${MAX_AGE_DAYS:-14}"
+
+fresh=$(go list -m -u -json all | jq -rs --argjson maxAgeDays "$MAX_AGE_DAYS" '
+  .[]
+  | select(.Time)
+  | ((.Time|fromdateiso8601)) as $t
+  | select((now-$t) < ($maxAgeDays*86400))
+  | "\(.Path) - published: \(.Time) - eligible: \(($t+$maxAgeDays*86400)|todateiso8601)"
+')
+
+if [ -n "$fresh" ]; then
+  echo "Identified go modules which are too fresh (less than ${MAX_AGE_DAYS} days):"
+  echo "$fresh"
+  exit 1
+fi


### PR DESCRIPTION
**What changed?**

Adds a new `fresh-go-deps-check.yml` workflow, plus `scripts/github_actions/check_fresh_go_deps.sh`, that fails a PR if any Go module dependency was published less than 14 days ago.

The check runs against every `go.mod` in the repo (root, `cmd/server`, `internal/tools`, `common/archiver/gcloud`, `common/dynamicconfig/openfeatureprovider/unleash`, `common/persistence/sql/sqlplugin/cloudsql-mysql`), since each is an independent module with its own dependency graph. The workflow only triggers on `pull_request` when `**/go.mod` or `**/go.sum` changes anywhere in the repo. `github.com/uber/cadence-idl` and `github.com/cadence-workflow/*` are exempted, since those are our own repos and get bumped frequently and intentionally.

**Why?**

Freshly-published dependency versions haven't had time to be widely vetted by the community, which raises supply-chain risk (e.g. a compromised release slipping in before it's caught and yanked). This adds a guard rail that blocks a PR from pulling in a dependency version published within the last 14 days, giving the ecosystem time to flag problems first.

**How did you test it?**

Ran the script locally against this repo's current `go.mod`s, across all three thresholds:
```
./scripts/github_actions/check_fresh_go_deps.sh                    # exit 0, no deps under 14 days
MAX_AGE_DAYS=28 ./scripts/github_actions/check_fresh_go_deps.sh     # exit 1, flags github.com/klauspost/compress in every module
MAX_AGE_DAYS=365 ./scripts/github_actions/check_fresh_go_deps.sh    # exit 1, flags the full long tail of deps per module
```

**Potential risks**

N/A — CI-only change, no runtime/production code paths affected. Worst case is a false-positive CI failure on a PR that bumps to a very recent dependency version, which is the intended behavior (bump can be re-attempted once the dependency ages past 14 days, or the threshold overridden via `MAX_AGE_DAYS`).

**Release notes**

N/A — internal CI tooling only.

**Documentation Changes**

N/A
