### PR TITLE
feat(diagnostics): add antipatterns invariant

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -71,6 +71,7 @@ import (
 	"github.com/uber/cadence/service/matching"
 	"github.com/uber/cadence/service/worker"
 	diagnosticsInvariant "github.com/uber/cadence/service/worker/diagnostics/invariant"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/antipatterns"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
@@ -309,7 +310,7 @@ func (s *server) startService() common.Daemon {
 	}
 
 	params.KafkaConfig = s.cfg.Kafka
-	params.DiagnosticsInvariants = []diagnosticsInvariant.Invariant{timeout.NewInvariant(timeout.Params{Client: params.PublicClient}), failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant()}
+	params.DiagnosticsInvariants = []diagnosticsInvariant.Invariant{timeout.NewInvariant(timeout.Params{Client: params.PublicClient}), failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant(), antipatterns.NewInvariant()}
 	params.ShardDistributorMatchingConfig = s.cfg.ShardDistributorMatchingConfig
 
 	params.Logger.Info("Starting service " + s.name)

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -39,6 +39,7 @@ const (
 	linkToFailuresRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/activity-failures/"
 	linkToRetriesRunbook      = "https://cadenceworkflow.io/docs/workflow-troubleshooting/retries"
 	linkToTimeoutRisksRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
+	linkToAntipatternsRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/antipatterns/"
 	WfDiagnosticsAppName      = "workflow-diagnostics"
 
 	_maxPageSize           = 1000            // current maximum page size for fetching workflow history

--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/antipatterns"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeoutrisk"
@@ -141,7 +142,7 @@ func testDiagnosticWorkflow(t *testing.T, history *types.GetWorkflowExecutionHis
 	mockFrontendClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any()).Return(history, nil).AnyTimes()
 	return &dw{
 		clientBean: mockClientBean,
-		invariants: []invariant.Invariant{failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant()},
+		invariants: []invariant.Invariant{failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant(), antipatterns.NewInvariant()},
 	}
 }
 

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
@@ -1,0 +1,142 @@
+package antipatterns
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+)
+
+// Antipatterns is an invariant that identifies workflow implementation patterns that are known to
+// cause operational problems even though they are not failures on their own.
+type Antipatterns invariant.Invariant
+
+type antipatterns struct {
+}
+
+func NewInvariant() Antipatterns {
+	return &antipatterns{}
+}
+
+func (a *antipatterns) Check(ctx context.Context, params invariant.InvariantCheckInput) ([]invariant.InvariantCheckResult, error) {
+	result := make([]invariant.InvariantCheckResult, 0)
+	events := params.WorkflowExecutionHistory.GetHistory().GetEvents()
+
+	if burst := detectActivityScheduleBurst(events); burst != nil {
+		result = append(result, invariant.InvariantCheckResult{
+			IssueID:       len(result),
+			InvariantType: ActivityScheduleBurst.String(),
+			Reason:        ActivityScheduleBurstDetected.String(),
+			Metadata:      invariant.MarshalData(burst),
+		})
+	}
+
+	if issue := detectContinueAsNewInCronWorkflow(events); issue != nil {
+		result = append(result, invariant.InvariantCheckResult{
+			IssueID:       len(result),
+			InvariantType: ContinueAsNewInCronWorkflow.String(),
+			Reason:        ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
+			Metadata:      invariant.MarshalData(issue),
+		})
+	}
+
+	return result, nil
+}
+
+// detectActivityScheduleBurst finds the densest window of activityBurstWindowInSeconds among the
+// timestamped ActivityTaskScheduled events and returns its stats if it contains at least
+// activityBurstCountThreshold events. Events without a timestamp are excluded: a nil timestamp is
+// unknown, not time zero, and treating it as zero would collapse unrelated events into a phantom
+// burst.
+func detectActivityScheduleBurst(events []*types.HistoryEvent) *ActivityScheduleBurstMetadata {
+	type scheduledEvent struct {
+		eventID   int64
+		timestamp int64
+	}
+
+	scheduled := make([]scheduledEvent, 0, len(events))
+	for _, event := range events {
+		if event.GetActivityTaskScheduledEventAttributes() == nil || event.Timestamp == nil {
+			continue
+		}
+		scheduled = append(scheduled, scheduledEvent{eventID: event.ID, timestamp: *event.Timestamp})
+	}
+	if len(scheduled) < activityBurstCountThreshold {
+		return nil
+	}
+
+	sort.SliceStable(scheduled, func(i, j int) bool {
+		return scheduled[i].timestamp < scheduled[j].timestamp
+	})
+
+	windowNanos := (time.Duration(activityBurstWindowInSeconds) * time.Second).Nanoseconds()
+
+	var peak *ActivityScheduleBurstMetadata
+	left := 0
+	for right := 0; right < len(scheduled); right++ {
+		for scheduled[right].timestamp-scheduled[left].timestamp > windowNanos {
+			left++
+		}
+		count := right - left + 1
+		if count >= activityBurstCountThreshold && (peak == nil || count > peak.EventCount) {
+			peak = &ActivityScheduleBurstMetadata{
+				FirstEventID:    scheduled[left].eventID,
+				LastEventID:     scheduled[right].eventID,
+				EventCount:      count,
+				WindowStart:     time.Unix(0, scheduled[left].timestamp).UTC(),
+				WindowEnd:       time.Unix(0, scheduled[right].timestamp).UTC(),
+				WindowInSeconds: activityBurstWindowInSeconds,
+				Threshold:       activityBurstCountThreshold,
+			}
+		}
+	}
+	return peak
+}
+
+// detectContinueAsNewInCronWorkflow flags a workflow that was started with a cron schedule and
+// continued-as-new from workflow code. A nil Initiator reads as ContinueAsNewInitiatorDecider,
+// which is correct: the server only sets the initiator explicitly for its own cron- and
+// retry-driven continuations, and passes decisions from workflow code through unmodified.
+func detectContinueAsNewInCronWorkflow(events []*types.HistoryEvent) *ContinueAsNewInCronWorkflowMetadata {
+	startedEvent := fetchWfStartedEvent(events)
+	if startedEvent == nil {
+		return nil
+	}
+	cronSchedule := startedEvent.GetWorkflowExecutionStartedEventAttributes().GetCronSchedule()
+	if cronSchedule == "" {
+		return nil
+	}
+
+	for _, event := range events {
+		attr := event.GetWorkflowExecutionContinuedAsNewEventAttributes()
+		if attr == nil {
+			continue
+		}
+		if attr.GetInitiator() == types.ContinueAsNewInitiatorDecider {
+			return &ContinueAsNewInCronWorkflowMetadata{
+				StartedEventID:        startedEvent.ID,
+				CronSchedule:          cronSchedule,
+				ContinuedAsNewEventID: event.ID,
+			}
+		}
+	}
+	return nil
+}
+
+func fetchWfStartedEvent(events []*types.HistoryEvent) *types.HistoryEvent {
+	for _, event := range events {
+		if event.GetWorkflowExecutionStartedEventAttributes() != nil {
+			return event
+		}
+	}
+	return nil
+}
+
+func (a *antipatterns) RootCause(ctx context.Context, params invariant.InvariantRootCauseInput) ([]invariant.InvariantRootCauseResult, error) {
+	// Not implemented since this invariant does not have any root cause.
+	// Issues identified in Check() are self-explanatory.
+	result := make([]invariant.InvariantRootCauseResult, 0)
+	return result, nil
+}

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
@@ -24,7 +24,7 @@ func (a *antipatterns) Check(ctx context.Context, params invariant.InvariantChec
 	result := make([]invariant.InvariantCheckResult, 0)
 	events := params.WorkflowExecutionHistory.GetHistory().GetEvents()
 
-	if burst := detectActivityScheduleBurst(events); burst != nil {
+	for _, burst := range detectActivityScheduleBursts(events) {
 		result = append(result, invariant.InvariantCheckResult{
 			IssueID:       len(result),
 			InvariantType: ActivityScheduleBurst.String(),
@@ -45,12 +45,15 @@ func (a *antipatterns) Check(ctx context.Context, params invariant.InvariantChec
 	return result, nil
 }
 
-// detectActivityScheduleBurst finds the densest window of activityBurstWindowInSeconds among the
-// timestamped ActivityTaskScheduled events and returns its stats if it contains at least
-// activityBurstCountThreshold events. Events without a timestamp are excluded: a nil timestamp is
-// unknown, not time zero, and treating it as zero would collapse unrelated events into a phantom
-// burst.
-func detectActivityScheduleBurst(events []*types.HistoryEvent) *ActivityScheduleBurstMetadata {
+// detectActivityScheduleBursts finds every maximal cluster of timestamped ActivityTaskScheduled
+// events in which a sliding window of activityBurstWindowInSeconds always contains at least
+// activityBurstCountThreshold events, and reports each cluster once as a single span covering all
+// of its events. Clusters are only split where the scheduling density genuinely drops below the
+// threshold between them; a single sustained burst that runs longer than the window itself is
+// still reported as one span rather than being cut at an arbitrary window boundary. Events without
+// a timestamp are excluded: a nil timestamp is unknown, not time zero, and treating it as zero
+// would collapse unrelated events into a phantom burst.
+func detectActivityScheduleBursts(events []*types.HistoryEvent) []*ActivityScheduleBurstMetadata {
 	type scheduledEvent struct {
 		eventID   int64
 		timestamp int64
@@ -73,26 +76,42 @@ func detectActivityScheduleBurst(events []*types.HistoryEvent) *ActivitySchedule
 
 	windowNanos := (time.Duration(activityBurstWindowInSeconds) * time.Second).Nanoseconds()
 
-	var peak *ActivityScheduleBurstMetadata
+	newBurst := func(clusterStart, clusterEnd int) *ActivityScheduleBurstMetadata {
+		return &ActivityScheduleBurstMetadata{
+			FirstEventID:    scheduled[clusterStart].eventID,
+			LastEventID:     scheduled[clusterEnd].eventID,
+			EventCount:      clusterEnd - clusterStart + 1,
+			WindowStart:     time.Unix(0, scheduled[clusterStart].timestamp).UTC(),
+			WindowEnd:       time.Unix(0, scheduled[clusterEnd].timestamp).UTC(),
+			WindowInSeconds: activityBurstWindowInSeconds,
+			Threshold:       activityBurstCountThreshold,
+		}
+	}
+
+	var bursts []*ActivityScheduleBurstMetadata
+	clusterStart := -1
+	clusterEnd := -1
 	left := 0
 	for right := 0; right < len(scheduled); right++ {
 		for scheduled[right].timestamp-scheduled[left].timestamp > windowNanos {
 			left++
 		}
-		count := right - left + 1
-		if count >= activityBurstCountThreshold && (peak == nil || count > peak.EventCount) {
-			peak = &ActivityScheduleBurstMetadata{
-				FirstEventID:    scheduled[left].eventID,
-				LastEventID:     scheduled[right].eventID,
-				EventCount:      count,
-				WindowStart:     time.Unix(0, scheduled[left].timestamp).UTC(),
-				WindowEnd:       time.Unix(0, scheduled[right].timestamp).UTC(),
-				WindowInSeconds: activityBurstWindowInSeconds,
-				Threshold:       activityBurstCountThreshold,
+		if right-left+1 >= activityBurstCountThreshold {
+			if clusterStart == -1 {
+				clusterStart = left
 			}
+			clusterEnd = right
+			continue
+		}
+		if clusterStart != -1 {
+			bursts = append(bursts, newBurst(clusterStart, clusterEnd))
+			clusterStart, clusterEnd = -1, -1
 		}
 	}
-	return peak
+	if clusterStart != -1 {
+		bursts = append(bursts, newBurst(clusterStart, clusterEnd))
+	}
+	return bursts
 }
 
 // detectContinueAsNewInCronWorkflow flags a workflow that was started with a cron schedule and

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
@@ -24,21 +24,23 @@ func (a *antipatterns) Check(ctx context.Context, params invariant.InvariantChec
 	result := make([]invariant.InvariantCheckResult, 0)
 	events := params.WorkflowExecutionHistory.GetHistory().GetEvents()
 
-	for _, burst := range detectActivityScheduleBursts(events) {
-		result = append(result, invariant.InvariantCheckResult{
-			IssueID:       len(result),
-			InvariantType: ActivityScheduleBurst.String(),
-			Reason:        ActivityScheduleBurstDetected.String(),
-			Metadata:      invariant.MarshalData(burst),
-		})
-	}
-
+	// The continue-as-new check yields at most one issue, so it goes first: the number of issues
+	// reported per invariant is capped, and a workflow with many bursts would otherwise push it out.
 	if issue := detectContinueAsNewInCronWorkflow(events); issue != nil {
 		result = append(result, invariant.InvariantCheckResult{
 			IssueID:       len(result),
 			InvariantType: ContinueAsNewInCronWorkflow.String(),
 			Reason:        ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
 			Metadata:      invariant.MarshalData(issue),
+		})
+	}
+
+	for _, burst := range detectActivityScheduleBursts(events) {
+		result = append(result, invariant.InvariantCheckResult{
+			IssueID:       len(result),
+			InvariantType: ActivityScheduleBurst.String(),
+			Reason:        ActivityScheduleBurstDetected.String(),
+			Metadata:      invariant.MarshalData(burst),
 		})
 	}
 

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
@@ -48,11 +48,13 @@ func (a *antipatterns) Check(ctx context.Context, params invariant.InvariantChec
 // detectActivityScheduleBursts finds every maximal cluster of timestamped ActivityTaskScheduled
 // events in which a sliding window of activityBurstWindowInSeconds always contains at least
 // activityBurstCountThreshold events, and reports each cluster once as a single span covering all
-// of its events. Clusters are only split where the scheduling density genuinely drops below the
-// threshold between them; a single sustained burst that runs longer than the window itself is
-// still reported as one span rather than being cut at an arbitrary window boundary. Events without
-// a timestamp are excluded: a nil timestamp is unknown, not time zero, and treating it as zero
-// would collapse unrelated events into a phantom burst.
+// of its events. A single sustained burst that runs longer than the window itself is still
+// reported as one span rather than being cut at an arbitrary window boundary. Two qualifying
+// windows are merged into one cluster whenever they share an event — otherwise the shared event
+// would be double-counted as the tail of one cluster and the head of the next — and are only
+// treated as separate clusters once the scheduling density has genuinely dropped enough that the
+// windows no longer overlap. Events without a timestamp are excluded: a nil timestamp is unknown,
+// not time zero, and treating it as zero would collapse unrelated events into a phantom burst.
 func detectActivityScheduleBursts(events []*types.HistoryEvent) []*ActivityScheduleBurstMetadata {
 	type scheduledEvent struct {
 		eventID   int64
@@ -89,27 +91,26 @@ func detectActivityScheduleBursts(events []*types.HistoryEvent) []*ActivitySched
 	}
 
 	var bursts []*ActivityScheduleBurstMetadata
-	clusterStart := -1
-	clusterEnd := -1
+	pendingStart, pendingEnd := -1, -1
 	left := 0
 	for right := 0; right < len(scheduled); right++ {
 		for scheduled[right].timestamp-scheduled[left].timestamp > windowNanos {
 			left++
 		}
-		if right-left+1 >= activityBurstCountThreshold {
-			if clusterStart == -1 {
-				clusterStart = left
-			}
-			clusterEnd = right
+		if right-left+1 < activityBurstCountThreshold {
 			continue
 		}
-		if clusterStart != -1 {
-			bursts = append(bursts, newBurst(clusterStart, clusterEnd))
-			clusterStart, clusterEnd = -1, -1
+		if pendingStart != -1 && left <= pendingEnd {
+			pendingEnd = right
+			continue
 		}
+		if pendingStart != -1 {
+			bursts = append(bursts, newBurst(pendingStart, pendingEnd))
+		}
+		pendingStart, pendingEnd = left, right
 	}
-	if clusterStart != -1 {
-		bursts = append(bursts, newBurst(clusterStart, clusterEnd))
+	if pendingStart != -1 {
+		bursts = append(bursts, newBurst(pendingStart, pendingEnd))
 	}
 	return bursts
 }

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
@@ -46,7 +46,7 @@ func Test__Check(t *testing.T) {
 	burstAtWindowEdgeMetadataInBytes, err := json.Marshal(burstAtWindowEdgeMetadata)
 	require.NoError(t, err)
 
-	peakClusterMetadata := ActivityScheduleBurstMetadata{
+	secondBurstMetadata := ActivityScheduleBurstMetadata{
 		FirstEventID:    100,
 		LastEventID:     100 + int64(activityBurstCountThreshold) + 4,
 		EventCount:      activityBurstCountThreshold + 5,
@@ -55,7 +55,21 @@ func Test__Check(t *testing.T) {
 		WindowInSeconds: activityBurstWindowInSeconds,
 		Threshold:       activityBurstCountThreshold,
 	}
-	peakClusterMetadataInBytes, err := json.Marshal(peakClusterMetadata)
+	secondBurstMetadataInBytes, err := json.Marshal(secondBurstMetadata)
+	require.NoError(t, err)
+
+	const sustainedBurstCount = 100
+	const sustainedBurstStepNanos = int64(150 * time.Millisecond)
+	sustainedBurstMetadata := ActivityScheduleBurstMetadata{
+		FirstEventID:    2,
+		LastEventID:     2 + int64(sustainedBurstCount) - 1,
+		EventCount:      sustainedBurstCount,
+		WindowStart:     time.Unix(0, testTimestamp).UTC(),
+		WindowEnd:       time.Unix(0, testTimestamp+int64(sustainedBurstCount-1)*sustainedBurstStepNanos).UTC(),
+		WindowInSeconds: activityBurstWindowInSeconds,
+		Threshold:       activityBurstCountThreshold,
+	}
+	sustainedBurstMetadataInBytes, err := json.Marshal(sustainedBurstMetadata)
 	require.NoError(t, err)
 
 	cronCaNMetadata := ContinueAsNewInCronWorkflowMetadata{
@@ -119,7 +133,7 @@ func Test__Check(t *testing.T) {
 			},
 		},
 		{
-			name: "peak window is reported when multiple clusters cross the threshold",
+			name: "each independent burst cluster is reported as its own issue",
 			testData: wfHistory(
 				startedEvent(1, ""),
 				activityScheduleBurst(activityBurstCountThreshold, 2, testTimestamp, testStepNanos),
@@ -130,7 +144,28 @@ func Test__Check(t *testing.T) {
 					IssueID:       0,
 					InvariantType: ActivityScheduleBurst.String(),
 					Reason:        ActivityScheduleBurstDetected.String(),
-					Metadata:      peakClusterMetadataInBytes,
+					Metadata:      burstMetadataInBytes,
+				},
+				{
+					IssueID:       1,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      secondBurstMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "a sustained burst longer than the window is reported as a single issue",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				activityScheduleBurst(sustainedBurstCount, 2, testTimestamp, sustainedBurstStepNanos),
+			),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      sustainedBurstMetadataInBytes,
 				},
 			},
 		},

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
@@ -216,6 +216,14 @@ func Test__Check(t *testing.T) {
 			expectedResult: []invariant.InvariantCheckResult{},
 		},
 		{
+			name: "cron workflow with retry-initiated continue-as-new",
+			testData: wfHistory(
+				startedEvent(1, testCronSchedule),
+				continuedAsNewEvent(2, types.ContinueAsNewInitiatorRetryPolicy),
+			),
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
 			name: "non-cron workflow with decider-initiated continue-as-new",
 			testData: wfHistory(
 				startedEvent(1, ""),
@@ -239,7 +247,7 @@ func Test__Check(t *testing.T) {
 			},
 		},
 		{
-			name: "both issues fire with consecutive issue IDs",
+			name: "both issues fire with continue-as-new reported first",
 			testData: wfHistory(
 				startedEvent(1, testCronSchedule),
 				activityScheduleBurst(activityBurstCountThreshold, 2, testTimestamp, testStepNanos),
@@ -248,15 +256,15 @@ func Test__Check(t *testing.T) {
 			expectedResult: []invariant.InvariantCheckResult{
 				{
 					IssueID:       0,
-					InvariantType: ActivityScheduleBurst.String(),
-					Reason:        ActivityScheduleBurstDetected.String(),
-					Metadata:      burstMetadataInBytes,
-				},
-				{
-					IssueID:       1,
 					InvariantType: ContinueAsNewInCronWorkflow.String(),
 					Reason:        ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
 					Metadata:      cronCaNAfterBurstMetadataInBytes,
+				},
+				{
+					IssueID:       1,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      burstMetadataInBytes,
 				},
 			},
 		},

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
@@ -72,6 +72,20 @@ func Test__Check(t *testing.T) {
 	sustainedBurstMetadataInBytes, err := json.Marshal(sustainedBurstMetadata)
 	require.NoError(t, err)
 
+	group1LastTimestamp := testTimestamp + int64(activityBurstCountThreshold-1)*testStepNanos
+	sharedBoundaryGroup2Start := group1LastTimestamp + windowNanos
+	sharedBoundaryMetadata := ActivityScheduleBurstMetadata{
+		FirstEventID:    2,
+		LastEventID:     2 * int64(activityBurstCountThreshold),
+		EventCount:      2*activityBurstCountThreshold - 1,
+		WindowStart:     time.Unix(0, testTimestamp).UTC(),
+		WindowEnd:       time.Unix(0, sharedBoundaryGroup2Start).UTC(),
+		WindowInSeconds: activityBurstWindowInSeconds,
+		Threshold:       activityBurstCountThreshold,
+	}
+	sharedBoundaryMetadataInBytes, err := json.Marshal(sharedBoundaryMetadata)
+	require.NoError(t, err)
+
 	cronCaNMetadata := ContinueAsNewInCronWorkflowMetadata{
 		StartedEventID:        1,
 		CronSchedule:          testCronSchedule,
@@ -166,6 +180,22 @@ func Test__Check(t *testing.T) {
 					InvariantType: ActivityScheduleBurst.String(),
 					Reason:        ActivityScheduleBurstDetected.String(),
 					Metadata:      sustainedBurstMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "two windows sharing a boundary event merge instead of double-counting it",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				activityScheduleBurst(activityBurstCountThreshold, 2, testTimestamp, testStepNanos),
+				activityScheduleBurst(activityBurstCountThreshold-1, 2+int64(activityBurstCountThreshold), sharedBoundaryGroup2Start, 0),
+			),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      sharedBoundaryMetadataInBytes,
 				},
 			},
 		},

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
@@ -1,0 +1,291 @@
+package antipatterns
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+)
+
+const (
+	testTimestamp    = int64(1700000000000000000)
+	testCronSchedule = "*/5 * * * *"
+	testStepNanos    = int64(time.Millisecond)
+)
+
+func Test__Check(t *testing.T) {
+	windowNanos := activityBurstWindowInSeconds * int64(time.Second)
+
+	burstMetadata := ActivityScheduleBurstMetadata{
+		FirstEventID:    2,
+		LastEventID:     2 + int64(activityBurstCountThreshold) - 1,
+		EventCount:      activityBurstCountThreshold,
+		WindowStart:     time.Unix(0, testTimestamp).UTC(),
+		WindowEnd:       time.Unix(0, testTimestamp+int64(activityBurstCountThreshold-1)*testStepNanos).UTC(),
+		WindowInSeconds: activityBurstWindowInSeconds,
+		Threshold:       activityBurstCountThreshold,
+	}
+	burstMetadataInBytes, err := json.Marshal(burstMetadata)
+	require.NoError(t, err)
+
+	burstAtWindowEdgeMetadata := ActivityScheduleBurstMetadata{
+		FirstEventID:    2,
+		LastEventID:     2 + int64(activityBurstCountThreshold) - 1,
+		EventCount:      activityBurstCountThreshold,
+		WindowStart:     time.Unix(0, testTimestamp).UTC(),
+		WindowEnd:       time.Unix(0, testTimestamp+windowNanos).UTC(),
+		WindowInSeconds: activityBurstWindowInSeconds,
+		Threshold:       activityBurstCountThreshold,
+	}
+	burstAtWindowEdgeMetadataInBytes, err := json.Marshal(burstAtWindowEdgeMetadata)
+	require.NoError(t, err)
+
+	peakClusterMetadata := ActivityScheduleBurstMetadata{
+		FirstEventID:    100,
+		LastEventID:     100 + int64(activityBurstCountThreshold) + 4,
+		EventCount:      activityBurstCountThreshold + 5,
+		WindowStart:     time.Unix(0, testTimestamp+int64(time.Hour)).UTC(),
+		WindowEnd:       time.Unix(0, testTimestamp+int64(time.Hour)+int64(activityBurstCountThreshold+4)*testStepNanos).UTC(),
+		WindowInSeconds: activityBurstWindowInSeconds,
+		Threshold:       activityBurstCountThreshold,
+	}
+	peakClusterMetadataInBytes, err := json.Marshal(peakClusterMetadata)
+	require.NoError(t, err)
+
+	cronCaNMetadata := ContinueAsNewInCronWorkflowMetadata{
+		StartedEventID:        1,
+		CronSchedule:          testCronSchedule,
+		ContinuedAsNewEventID: 2,
+	}
+	cronCaNMetadataInBytes, err := json.Marshal(cronCaNMetadata)
+	require.NoError(t, err)
+
+	cronCaNAfterBurstMetadata := ContinueAsNewInCronWorkflowMetadata{
+		StartedEventID:        1,
+		CronSchedule:          testCronSchedule,
+		ContinuedAsNewEventID: 90,
+	}
+	cronCaNAfterBurstMetadataInBytes, err := json.Marshal(cronCaNAfterBurstMetadata)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		testData       *types.GetWorkflowExecutionHistoryResponse
+		expectedResult []invariant.InvariantCheckResult
+	}{
+		{
+			name: "activity schedule burst",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				activityScheduleBurst(activityBurstCountThreshold, 2, testTimestamp, testStepNanos),
+			),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      burstMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "activity schedule burst one below threshold",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				activityScheduleBurst(activityBurstCountThreshold-1, 2, testTimestamp, testStepNanos),
+			),
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "activity schedule burst spanning exactly the window",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				activityScheduleBurst(activityBurstCountThreshold-1, 2, testTimestamp, 0),
+				activityScheduleBurst(1, 2+int64(activityBurstCountThreshold)-1, testTimestamp+windowNanos, 0),
+			),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      burstAtWindowEdgeMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "peak window is reported when multiple clusters cross the threshold",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				activityScheduleBurst(activityBurstCountThreshold, 2, testTimestamp, testStepNanos),
+				activityScheduleBurst(activityBurstCountThreshold+5, 100, testTimestamp+int64(time.Hour), testStepNanos),
+			),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      peakClusterMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "scheduled events without timestamps are excluded",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				untimestampedActivityScheduledEvents(activityBurstCountThreshold+10, 2),
+			),
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "cron workflow with cron-initiated continue-as-new",
+			testData: wfHistory(
+				startedEvent(1, testCronSchedule),
+				continuedAsNewEvent(2, types.ContinueAsNewInitiatorCronSchedule),
+			),
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "non-cron workflow with decider-initiated continue-as-new",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				continuedAsNewEvent(2, types.ContinueAsNewInitiatorDecider),
+			),
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "cron workflow with decider-initiated continue-as-new",
+			testData: wfHistory(
+				startedEvent(1, testCronSchedule),
+				continuedAsNewEvent(2, types.ContinueAsNewInitiatorDecider),
+			),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ContinueAsNewInCronWorkflow.String(),
+					Reason:        ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
+					Metadata:      cronCaNMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "both issues fire with consecutive issue IDs",
+			testData: wfHistory(
+				startedEvent(1, testCronSchedule),
+				activityScheduleBurst(activityBurstCountThreshold, 2, testTimestamp, testStepNanos),
+				continuedAsNewEvent(90, types.ContinueAsNewInitiatorDecider),
+			),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: ActivityScheduleBurst.String(),
+					Reason:        ActivityScheduleBurstDetected.String(),
+					Metadata:      burstMetadataInBytes,
+				},
+				{
+					IssueID:       1,
+					InvariantType: ContinueAsNewInCronWorkflow.String(),
+					Reason:        ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
+					Metadata:      cronCaNAfterBurstMetadataInBytes,
+				},
+			},
+		},
+		{
+			name: "well-behaved workflow",
+			testData: wfHistory(
+				startedEvent(1, ""),
+				activityScheduleBurst(5, 2, testTimestamp, int64(5*time.Minute)),
+			),
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+		{
+			name: "history without started event",
+			testData: wfHistory(
+				activityScheduleBurst(3, 1, testTimestamp, testStepNanos),
+			),
+			expectedResult: []invariant.InvariantCheckResult{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := NewInvariant()
+			result, err := inv.Check(context.Background(), invariant.InvariantCheckInput{
+				WorkflowExecutionHistory: tc.testData,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func Test__RootCause(t *testing.T) {
+	inv := NewInvariant()
+	result, err := inv.RootCause(context.Background(), invariant.InvariantRootCauseInput{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Empty(t, result)
+}
+
+func wfHistory(eventGroups ...[]*types.HistoryEvent) *types.GetWorkflowExecutionHistoryResponse {
+	events := make([]*types.HistoryEvent, 0)
+	for _, group := range eventGroups {
+		events = append(events, group...)
+	}
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History: &types.History{Events: events},
+	}
+}
+
+func startedEvent(id int64, cronSchedule string) []*types.HistoryEvent {
+	return []*types.HistoryEvent{
+		{
+			ID: id,
+			WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+				CronSchedule: cronSchedule,
+			},
+		},
+	}
+}
+
+func continuedAsNewEvent(id int64, initiator types.ContinueAsNewInitiator) []*types.HistoryEvent {
+	return []*types.HistoryEvent{
+		{
+			ID: id,
+			WorkflowExecutionContinuedAsNewEventAttributes: &types.WorkflowExecutionContinuedAsNewEventAttributes{
+				Initiator: initiator.Ptr(),
+			},
+		},
+	}
+}
+
+func activityScheduledEvent(id int64, timestamp *int64) *types.HistoryEvent {
+	return &types.HistoryEvent{
+		ID:        id,
+		Timestamp: timestamp,
+		ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+			ActivityID:   "101",
+			ActivityType: &types.ActivityType{Name: "test-activity"},
+		},
+	}
+}
+
+func activityScheduleBurst(count int, startID, startTimestamp, stepNanos int64) []*types.HistoryEvent {
+	events := make([]*types.HistoryEvent, 0, count)
+	for i := 0; i < count; i++ {
+		events = append(events, activityScheduledEvent(startID+int64(i), common.Int64Ptr(startTimestamp+int64(i)*stepNanos)))
+	}
+	return events
+}
+
+func untimestampedActivityScheduledEvents(count int, startID int64) []*types.HistoryEvent {
+	events := make([]*types.HistoryEvent, 0, count)
+	for i := 0; i < count; i++ {
+		events = append(events, activityScheduledEvent(startID+int64(i), nil))
+	}
+	return events
+}

--- a/service/worker/diagnostics/invariant/antipatterns/types.go
+++ b/service/worker/diagnostics/invariant/antipatterns/types.go
@@ -1,0 +1,65 @@
+package antipatterns
+
+import (
+	"time"
+)
+
+type AntipatternType string
+
+const (
+	ActivityScheduleBurst       AntipatternType = "Activities scheduled in quick succession"
+	ContinueAsNewInCronWorkflow AntipatternType = "Continue-As-New used in cron workflow"
+)
+
+func (a AntipatternType) String() string {
+	return string(a)
+}
+
+type IssueType string
+
+const (
+	ActivityScheduleBurstDetected                 IssueType = "A burst of activities was scheduled within a short time window, which can be an early-warning signal of hot-shard contention."
+	ContinueAsNewInitiatedByDeciderInCronWorkflow IssueType = "The workflow continued-as-new from workflow code while running under a cron schedule, which can interfere with server-managed cron scheduling."
+)
+
+func (i IssueType) String() string {
+	return string(i)
+}
+
+const (
+	// activityBurstWindowInSeconds is the width of the sliding window used to look for a burst of
+	// scheduled activities.
+	activityBurstWindowInSeconds int64 = 10
+
+	// activityBurstCountThreshold is the minimum number of ActivityTaskScheduled events within
+	// activityBurstWindowInSeconds for a burst to be flagged as a hot-shard risk.
+	activityBurstCountThreshold = 50
+)
+
+// ActivityScheduleBurstMetadata describes the densest window of scheduled activities found in the
+// history. Only the peak window is reported, not every window that crossed the threshold.
+// FirstEventID anchors the issue to the first ActivityTaskScheduled event of that window.
+type ActivityScheduleBurstMetadata struct {
+	FirstEventID    int64
+	LastEventID     int64
+	EventCount      int
+	WindowStart     time.Time
+	WindowEnd       time.Time
+	WindowInSeconds int64
+	Threshold       int
+}
+
+// ContinueAsNewInCronWorkflowMetadata identifies the started event carrying the cron schedule and
+// the continue-as-new event that was initiated by workflow code.
+type ContinueAsNewInCronWorkflowMetadata struct {
+	StartedEventID        int64
+	CronSchedule          string
+	ContinuedAsNewEventID int64
+}
+
+// AntipatternIssuesMetadata is a discriminated union of the metadata for each antipattern check,
+// with exactly one field populated per issue.
+type AntipatternIssuesMetadata struct {
+	ActivityScheduleBurst       *ActivityScheduleBurstMetadata
+	ContinueAsNewInCronWorkflow *ContinueAsNewInCronWorkflowMetadata
+}

--- a/service/worker/diagnostics/invariant/antipatterns/types.go
+++ b/service/worker/diagnostics/invariant/antipatterns/types.go
@@ -51,9 +51,11 @@ const (
 	activityBurstCountThreshold = 50
 )
 
-// ActivityScheduleBurstMetadata describes the densest window of scheduled activities found in the
-// history. Only the peak window is reported, not every window that crossed the threshold.
-// FirstEventID anchors the issue to the first ActivityTaskScheduled event of that window.
+// ActivityScheduleBurstMetadata describes one cluster of tightly-packed scheduled activities.
+// Every cluster that crosses the threshold is reported as its own issue, and a single sustained
+// burst spanning more than WindowInSeconds is still reported as one span rather than being split
+// at a window boundary. FirstEventID/LastEventID bound the full cluster, not just the densest
+// sub-window within it.
 type ActivityScheduleBurstMetadata struct {
 	FirstEventID    int64
 	LastEventID     int64

--- a/service/worker/diagnostics/invariant/antipatterns/types.go
+++ b/service/worker/diagnostics/invariant/antipatterns/types.go
@@ -1,29 +1,44 @@
 package antipatterns
 
 import (
+	"fmt"
 	"time"
 )
 
-type AntipatternType string
+type AntipatternType int32
 
 const (
-	ActivityScheduleBurst       AntipatternType = "Activities scheduled in quick succession"
-	ContinueAsNewInCronWorkflow AntipatternType = "Continue-As-New used in cron workflow"
+	AntipatternTypeInvalid AntipatternType = iota
+	ActivityScheduleBurst
+	ContinueAsNewInCronWorkflow
 )
 
 func (a AntipatternType) String() string {
-	return string(a)
+	switch a {
+	case ActivityScheduleBurst:
+		return "Activities scheduled in quick succession"
+	case ContinueAsNewInCronWorkflow:
+		return "Continue-As-New used in cron workflow"
+	}
+	return fmt.Sprintf("AntipatternType(%d)", int32(a))
 }
 
-type IssueType string
+type IssueType int32
 
 const (
-	ActivityScheduleBurstDetected                 IssueType = "A burst of activities was scheduled within a short time window, which can be an early-warning signal of hot-shard contention."
-	ContinueAsNewInitiatedByDeciderInCronWorkflow IssueType = "The workflow continued-as-new from workflow code while running under a cron schedule, which can interfere with server-managed cron scheduling."
+	IssueTypeInvalid IssueType = iota
+	ActivityScheduleBurstDetected
+	ContinueAsNewInitiatedByDeciderInCronWorkflow
 )
 
 func (i IssueType) String() string {
-	return string(i)
+	switch i {
+	case ActivityScheduleBurstDetected:
+		return "A burst of activities was scheduled within a short time window, which can cause hot-shard contention."
+	case ContinueAsNewInitiatedByDeciderInCronWorkflow:
+		return "The workflow continued-as-new from workflow code while running under a cron schedule, which can interfere with server-managed cron scheduling."
+	}
+	return fmt.Sprintf("IssueType(%d)", int32(i))
 }
 
 const (

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -41,6 +41,7 @@ const (
 	issueTypeFailures     = "Failure"
 	issueTypeRetry        = "Retry"
 	issueTypeTimeoutRisks = "TimeoutRisk"
+	issueTypeAntipatterns = "Antipatterns"
 )
 
 type DiagnosticsStarterWorkflowInput struct {
@@ -129,6 +130,9 @@ func getIssueType(result DiagnosticsWorkflowResult) string {
 	}
 	if result.TimeoutRisks != nil {
 		issueType = fmt.Sprintf("%s-%s", issueType, issueTypeTimeoutRisks)
+	}
+	if result.Antipatterns != nil {
+		issueType = fmt.Sprintf("%s-%s", issueType, issueTypeAntipatterns)
 	}
 	return issueType
 }

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/antipatterns"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
@@ -57,6 +58,7 @@ type DiagnosticsWorkflowResult struct {
 	Failures     *failureDiagnostics
 	Retries      *retryDiagnostics
 	TimeoutRisks *timeoutRiskDiagnostics
+	Antipatterns *antipatternsDiagnostics
 }
 
 type timeoutDiagnostics struct {
@@ -121,6 +123,18 @@ type timeoutRiskIssuesResult struct {
 	Metadata      *timeoutrisk.TimeoutRiskIssuesMetadata
 }
 
+type antipatternsDiagnostics struct {
+	Issues  []*antipatternsIssuesResult
+	Runbook string
+}
+
+type antipatternsIssuesResult struct {
+	IssueID       int
+	InvariantType string
+	Reason        string
+	Metadata      *antipatterns.AntipatternIssuesMetadata
+}
+
 func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (*DiagnosticsWorkflowResult, error) {
 	scope := w.metricsClient.Scope(metrics.DiagnosticsWorkflowScope, metrics.DomainTag(params.Domain))
 	scope.IncCounter(metrics.DiagnosticsWorkflowStartedCount)
@@ -135,6 +149,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	var failureResult *failureDiagnostics
 	var retryResult *retryDiagnostics
 	var timeoutRiskResult *timeoutRiskDiagnostics
+	var antipatternsResult *antipatternsDiagnostics
 	var checkResult []invariant.InvariantCheckResult
 	var rootCauseResult []invariant.InvariantRootCauseResult
 
@@ -222,12 +237,25 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		}
 	}
 
+	antipatternsIssues, err := retrieveAntipatternsIssues(checkResult)
+	if err != nil {
+		return nil, fmt.Errorf("RetrieveAntipatternsIssues: %w", err)
+	}
+
+	if len(antipatternsIssues) > 0 {
+		antipatternsResult = &antipatternsDiagnostics{
+			Issues:  antipatternsIssues,
+			Runbook: linkToAntipatternsRunbook,
+		}
+	}
+
 	scope.IncCounter(metrics.DiagnosticsWorkflowSuccess)
 	return &DiagnosticsWorkflowResult{
 		Timeouts:     timeoutsResult,
 		Failures:     failureResult,
 		Retries:      retryResult,
 		TimeoutRisks: timeoutRiskResult,
+		Antipatterns: antipatternsResult,
 	}, nil
 }
 
@@ -429,6 +457,37 @@ func retrieveTimeoutRiskIssues(issues []invariant.InvariantCheckResult) ([]*time
 				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
 					ActivityMissingHeartbeatTimeout: &metadata,
 				},
+			})
+		}
+	}
+	return result, nil
+}
+
+func retrieveAntipatternsIssues(issues []invariant.InvariantCheckResult) ([]*antipatternsIssuesResult, error) {
+	result := make([]*antipatternsIssuesResult, 0)
+	for _, issue := range issues {
+		switch issue.InvariantType {
+		case antipatterns.ActivityScheduleBurst.String():
+			var metadata antipatterns.ActivityScheduleBurstMetadata
+			if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
+				return nil, err
+			}
+			result = append(result, &antipatternsIssuesResult{
+				IssueID:       issue.IssueID,
+				InvariantType: issue.InvariantType,
+				Reason:        issue.Reason,
+				Metadata:      &antipatterns.AntipatternIssuesMetadata{ActivityScheduleBurst: &metadata},
+			})
+		case antipatterns.ContinueAsNewInCronWorkflow.String():
+			var metadata antipatterns.ContinueAsNewInCronWorkflowMetadata
+			if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
+				return nil, err
+			}
+			result = append(result, &antipatternsIssuesResult{
+				IssueID:       issue.IssueID,
+				InvariantType: issue.InvariantType,
+				Reason:        issue.Reason,
+				Metadata:      &antipatterns.AntipatternIssuesMetadata{ContinueAsNewInCronWorkflow: &metadata},
 			})
 		}
 	}

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant"
+	"github.com/uber/cadence/service/worker/diagnostics/invariant/antipatterns"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/failure"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/retry"
 	"github.com/uber/cadence/service/worker/diagnostics/invariant/timeout"
@@ -68,7 +69,7 @@ func (s *diagnosticsWorkflowTestSuite) SetupTest() {
 		svcClient:     publicClient,
 		clientBean:    mockResource.ClientBean,
 		metricsClient: mockResource.GetMetricsClient(),
-		invariants:    []invariant.Invariant{timeout.NewInvariant(timeout.Params{Client: publicClient}), failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant()},
+		invariants:    []invariant.Invariant{timeout.NewInvariant(timeout.Params{Client: publicClient}), failure.NewInvariant(), retry.NewInvariant(), timeoutrisk.NewInvariant(), antipatterns.NewInvariant()},
 	}
 
 	s.T().Cleanup(func() {
@@ -538,4 +539,56 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 	result, err := retrieveTimeoutRiskIssues(issues)
 	s.NoError(err)
 	s.ElementsMatch(timeoutRiskIssues, result)
+}
+
+func (s *diagnosticsWorkflowTestSuite) Test__retrieveAntipatternsIssues() {
+	burstMetadata := antipatterns.ActivityScheduleBurstMetadata{
+		FirstEventID:    2,
+		LastEventID:     51,
+		EventCount:      50,
+		WindowStart:     time.Unix(0, 1700000000000000000).UTC(),
+		WindowEnd:       time.Unix(0, 1700000004900000000).UTC(),
+		WindowInSeconds: 10,
+		Threshold:       50,
+	}
+	burstMetadataInBytes, err := json.Marshal(burstMetadata)
+	s.NoError(err)
+	canMetadata := antipatterns.ContinueAsNewInCronWorkflowMetadata{
+		StartedEventID:        1,
+		CronSchedule:          "*/5 * * * *",
+		ContinuedAsNewEventID: 60,
+	}
+	canMetadataInBytes, err := json.Marshal(canMetadata)
+	s.NoError(err)
+	issues := []invariant.InvariantCheckResult{
+		{
+			IssueID:       0,
+			InvariantType: antipatterns.ActivityScheduleBurst.String(),
+			Reason:        antipatterns.ActivityScheduleBurstDetected.String(),
+			Metadata:      burstMetadataInBytes,
+		},
+		{
+			IssueID:       1,
+			InvariantType: antipatterns.ContinueAsNewInCronWorkflow.String(),
+			Reason:        antipatterns.ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
+			Metadata:      canMetadataInBytes,
+		},
+	}
+	antipatternsIssues := []*antipatternsIssuesResult{
+		{
+			IssueID:       0,
+			InvariantType: antipatterns.ActivityScheduleBurst.String(),
+			Reason:        antipatterns.ActivityScheduleBurstDetected.String(),
+			Metadata:      &antipatterns.AntipatternIssuesMetadata{ActivityScheduleBurst: &burstMetadata},
+		},
+		{
+			IssueID:       1,
+			InvariantType: antipatterns.ContinueAsNewInCronWorkflow.String(),
+			Reason:        antipatterns.ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
+			Metadata:      &antipatterns.AntipatternIssuesMetadata{ContinueAsNewInCronWorkflow: &canMetadata},
+		},
+	}
+	result, err := retrieveAntipatternsIssues(issues)
+	s.NoError(err)
+	s.ElementsMatch(antipatternsIssues, result)
 }


### PR DESCRIPTION
## What changed?
Adds an `antipatterns` invariant to workflow diagnostics, with two checks:

- **Activity schedule burst**: 50+ `ActivityTaskScheduled` events within a 10-second sliding window — a very common cause for hot shard problems.
- **Continue-As-New in a cron workflow**: decider-initiated Continue-As-New in a workflow started with a cron schedule, which interferes with server-managed cron scheduling.

## Why?
The existing invariants detect failures or invalid configs after the fact; nothing flags implementation patterns that cause operational trouble before they do damage.

## How did you test it?
```
make pr GEN_DIR=service/worker/diagnostics
make build
make test
go test -race -count=1 ./service/worker/diagnostics/...
```
New table-driven tests cover threshold/window boundaries, initiator variants, and degenerate histories.

### Screenshots from the Cadence UI
<img width="1632" height="407" alt="Screenshot 2026-08-26 at 13 56 21" src="https://github.com/user-attachments/assets/cf3572e0-1fbe-4162-975a-491bfa5dba52" />
<img width="1619" height="351" alt="Screenshot 2026-08-26 at 15 17 15" src="https://github.com/user-attachments/assets/516dcfeb-4cd0-410b-9f1c-0f27eb6a9806" />


## Potential risks
None — isolated, additive change with no API/schema/flag impact.

## Release notes
Workflow diagnostics now flags activity schedule bursts and Continue-As-New usage in cron workflows.

## Documentation Changes
https://github.com/cadence-workflow/Cadence-Docs/pull/404