### PR TITLE
feat(queuev2): add immediate cached reader scaffolding

### DIFF
--- a/service/history/queuev2/queue_reader_cached_immediate.go
+++ b/service/history/queuev2/queue_reader_cached_immediate.go
@@ -1,0 +1,79 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queuev2
+
+import (
+	"sync/atomic"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/service/history/shard"
+)
+
+// cachedImmediateQueueReader is the immediate (transfer) cached queue reader. It embeds the shared
+// cachedQueueReaderBase and populates the cache purely from injection; there is no prefetch cycle.
+// Unlike the timer reader, its cap guard drops the OLDEST tasks (LTrimBySize).
+type cachedImmediateQueueReader struct {
+	*cachedQueueReaderBase
+}
+
+func newCachedImmediateQueueReaderWithOptions(
+	base QueueReader,
+	queue InMemQueue,
+	shard shard.Context,
+	clockSource clock.TimeSource,
+	logger log.Logger,
+	metricsScope metrics.Scope,
+	options *cachedQueueReaderOptions,
+) *cachedImmediateQueueReader {
+	return &cachedImmediateQueueReader{
+		cachedQueueReaderBase: newCachedQueueReaderBase(
+			base,
+			queue,
+			shard,
+			clockSource,
+			logger,
+			metricsScope,
+			options,
+		),
+	}
+}
+
+// Start marks the reader started. The log line is kept to simplify debugging if needed.
+func (q *cachedImmediateQueueReader) Start() {
+	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+	q.logger.Info("Immediate Cached Queue Reader state changed", tag.LifeCycleStarted)
+}
+
+// Stop marks the reader stopped. The log line is kept to simplify debugging if needed.
+func (q *cachedImmediateQueueReader) Stop() {
+	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+	q.logger.Info("Immediate Cached Queue Reader state changed", tag.LifeCycleStopped)
+}

--- a/service/history/queuev2/queue_reader_cached_immediate_test.go
+++ b/service/history/queuev2/queue_reader_cached_immediate_test.go
@@ -1,0 +1,99 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queuev2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/service/history/config"
+	"github.com/uber/cadence/service/history/shard"
+)
+
+func testImmediateOptions(overrides ...func(*cachedQueueReaderOptions)) *cachedQueueReaderOptions {
+	opts := &cachedQueueReaderOptions{
+		Mode:                 dynamicproperties.GetStringPropertyFnFilteredByShardID("enabled"),
+		MaxSize:              dynamicproperties.GetIntPropertyFn(100),
+		ShadowSampleInterval: dynamicproperties.GetDurationPropertyFn(0),
+	}
+	for _, o := range overrides {
+		if o == nil {
+			continue
+		}
+		o(opts)
+	}
+	return opts
+}
+
+// setupImmediateCachedReader builds a transfer cached reader backed by a real in-memory queue
+// and a mocked base reader.
+func setupImmediateCachedReader(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	overrides ...func(*cachedQueueReaderOptions),
+) (*cachedImmediateQueueReader, *MockQueueReader) {
+	t.Helper()
+	mockShard := shard.NewMockContext(ctrl)
+	mockShard.EXPECT().GetRangeID().Return(int64(0)).AnyTimes()
+	mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
+	mockShard.EXPECT().GetShardID().Return(0).AnyTimes()
+
+	mockBase := NewMockQueueReader(ctrl)
+	r := newCachedImmediateQueueReaderWithOptions(
+		mockBase,
+		newInMemQueue(),
+		mockShard,
+		clock.NewMockedTimeSource(),
+		testlogger.New(t),
+		metrics.NoopScope,
+		testImmediateOptions(overrides...),
+	)
+	return r, mockBase
+}
+
+// TestCachedImmediateQueueReader_StartStop verifies the lifecycle only flips state: there is no
+// background goroutine (unlike the scheduled reader), so goleak must see nothing leak, and both
+// Start and Stop are idempotent.
+func TestCachedImmediateQueueReader_StartStop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctrl := gomock.NewController(t)
+	r, _ := setupImmediateCachedReader(t, ctrl)
+
+	require.Equal(t, common.DaemonStatusInitialized, r.status)
+
+	r.Start()
+	r.Start() // idempotent
+	require.Equal(t, common.DaemonStatusStarted, r.status)
+
+	r.Stop()
+	r.Stop() // idempotent
+	require.Equal(t, common.DaemonStatusStopped, r.status)
+}


### PR DESCRIPTION
**What changed?**
Add the `cachedImmediateQueueReader` type for transfer (immediate) tasks. It embeds the shared cached queue reader base and is built through an options-based constructor that reads no dynamic config. `Start` and `Stop` only flip the base's atomic lifecycle status and emit status log.

**Why?**
The transfer task cache needs an immediate reader alongside the existing scheduled (timer) reader (#8432). Landing the type and lifecycle skeleton on its own keeps the delta small and lets the core injection logic be reviewed separately in a focused follow-up. The next change implements the core `Inject` method: cache population, window bound tracking, and the size cap.

**How did you test it?**
- `go test -race ./service/history/queuev2/...`

**Potential risks**
None. The reader is not yet wired into any factory or queue, so it is unreachable at runtime and core task processing is unaffected.

**Release notes**
N/A

**Documentation Changes**
N/A
