### PR TITLE
ci(ci-checks): build the test image once and restore its layers from the Actions cache

### DIFF
--- a/.github/actions/build-test-image/action.yml
+++ b/.github/actions/build-test-image/action.yml
@@ -1,0 +1,47 @@
+name: Build CI test image
+description: >-
+  Build the image that every docker compose CI service runs, restoring its layers from the
+  GitHub Actions cache. The image is tagged so `docker compose run` reuses it instead of
+  rebuilding the apt, pip and `go mod download` layers in each of the 16 CI jobs that use
+  compose.
+
+runs:
+  using: composite
+  steps:
+    # The compose services interpolate DOCKERFILE_SUFFIX into both the dockerfile path and
+    # the image tag, but this action builds the default Dockerfile under the unsuffixed
+    # tag. With a suffix set, compose would ignore what we built and build its own, so the
+    # prebuild would be wasted work whose layers still land in the shared cache scope.
+    # Resolved in a shell step because a composite action does not reliably see the
+    # caller's `env` context, and this must fail closed.
+    - name: Check whether the default Dockerfile is in use
+      id: check
+      shell: bash
+      run: |
+        if [ -z "${DOCKERFILE_SUFFIX:-}" ]; then
+          echo "default=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "default=false" >> "$GITHUB_OUTPUT"
+          echo "DOCKERFILE_SUFFIX=${DOCKERFILE_SUFFIX} is set, skipping the prebuild." >&2
+        fi
+
+    - name: Set up Docker Buildx
+      if: steps.check.outputs.default == 'true'
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build test image
+      if: steps.check.outputs.default == 'true'
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/github_actions/Dockerfile
+        tags: cadence-ci-test:local
+        # Load into the local daemon so `docker compose run` finds the tag and skips its
+        # own build. Without this the image only exists inside the buildx builder.
+        load: true
+        cache-from: type=gha,scope=ci-test-image
+        # Export only from the default branch. A pull_request run from a fork gets a
+        # read-only GITHUB_TOKEN, so the export would 403 there, and having all 16 jobs
+        # export the full mode=max layer set on every run would churn the 10GB per-repo
+        # cache budget. PR runs read the cache that master populated.
+        cache-to: ${{ github.ref == 'refs/heads/master' && 'type=gha,mode=max,scope=ci-test-image,ignore-error=true' || '' }}

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
       
       - name: Run unit test
         uses: nick-fields/retry@v3
@@ -68,6 +71,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run golint
         run: docker compose -f docker/github_actions/docker-compose.yml run coverage-report bash -c "./scripts/github_actions/golint.sh"
 
@@ -87,6 +93,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for cassandra
         uses: nick-fields/retry@v3
@@ -117,6 +126,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for cassandra running history queue v2
         uses: nick-fields/retry@v3
@@ -149,6 +161,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for cassandra running history queue v2 with alert
         uses: nick-fields/retry@v3
         with:
@@ -179,6 +194,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for cassandra running history queue v2 with cached reader
         uses: nick-fields/retry@v3
@@ -212,6 +230,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for cassandra and elasticsearch v7
         uses: nick-fields/retry@v3
         with:
@@ -243,6 +264,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration test with cassandra and pinot
         uses: nick-fields/retry@v3
@@ -276,6 +300,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for cassandra and opensearch v2
         uses: nick-fields/retry@v3
         with:
@@ -307,6 +334,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run ndc profile for cassandra
         uses: nick-fields/retry@v3
@@ -340,6 +370,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for mysql
         uses: nick-fields/retry@v3
         with:
@@ -371,6 +404,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run ndc profile for mysql
         uses: nick-fields/retry@v3
@@ -404,6 +440,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for postgres
         uses: nick-fields/retry@v3
         with:
@@ -434,6 +473,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for sqlite
         uses: nick-fields/retry@v3
@@ -466,6 +508,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run ndc profile for postgres
         uses: nick-fields/retry@v3
         with:
@@ -496,6 +541,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run async wf integration test with kafka
         uses: nick-fields/retry@v3

--- a/docker/github_actions/docker-compose-es7.yml
+++ b/docker/github_actions/docker-compose-es7.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -48,9 +58,7 @@ services:
       - discovery.type=single-node
 
   integration-test-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"

--- a/docker/github_actions/docker-compose-opensearch2.yml
+++ b/docker/github_actions/docker-compose-opensearch2.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -57,9 +67,7 @@ services:
       - 9600:9600 # Performance Analyzer
 
   integration-test-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"

--- a/docker/github_actions/docker-compose-pinot.yml
+++ b/docker/github_actions/docker-compose-pinot.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -141,9 +151,7 @@ services:
           - pinot-server
 
   integration-test-cassandra-pinot:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"

--- a/docker/github_actions/docker-compose.yml
+++ b/docker/github_actions/docker-compose.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -89,9 +99,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: cadence
 
   unit-test:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     volumes:
       - ../../:/cadence
     networks:
@@ -100,9 +108,7 @@ services:
           - unit-test
 
   integration-test-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -124,9 +130,7 @@ services:
           - integration-test
 
   integration-test-cassandra-queue-v2:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -149,9 +153,7 @@ services:
           - integration-test
 
   integration-test-cassandra-queue-v2-alert:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -175,9 +177,7 @@ services:
           - integration-test
 
   integration-test-cassandra-queue-v2-cached-reader:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -201,9 +201,7 @@ services:
           - integration-test
 
   integration-test-mysql:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
@@ -224,9 +222,7 @@ services:
           - integration-test
 
   integration-test-postgres:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "POSTGRES=1"
       - "POSTGRES_SEEDS=postgres"
@@ -247,9 +243,7 @@ services:
           - integration-test
 
   integration-test-sqlite:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "PERSISTENCE_PLUGIN=sqlite"
       - "PERSISTENCE_TYPE=sql"
@@ -261,9 +255,7 @@ services:
           - integration-test
 
   integration-test-ndc-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -285,9 +277,7 @@ services:
           - integration-test-ndc
 
   integration-test-ndc-mysql:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
@@ -308,9 +298,7 @@ services:
           - integration-test-ndc
 
   integration-test-ndc-postgres:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "POSTGRES=1"
       - "POSTGRES_SEEDS=postgres"
@@ -331,9 +319,7 @@ services:
           - integration-test-ndc
 
   integration-test-async-wf:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "ASYNC_WF_KAFKA_QUEUE_TOPIC=async-wf-topic1"
       - "CASSANDRA=1"
@@ -354,9 +340,7 @@ services:
           - integration-test-async-wf
 
   coverage-report:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - CI
       - GITHUB_BRANCH


### PR DESCRIPTION
<!-- First of the two PRs @c-warren asked for on #8408. This one is the image build; the Go build cache follows separately. -->

**What changed?**

All 18 CI Checks jobs run on their own runner and each rebuilds the same test image from scratch. The compose `build:` blocks carry no `cache_from`/`cache_to`, so these layers are rebuilt once per job on every run:

- `apt-get update && apt-get install` for 8 packages
- `pip3 install cqlsh`
- `go mod download`, which the Dockerfile's own comment notes downloads every module rather than just the top one because of `go.work`

Two pieces:

1. A composite action, `.github/actions/build-test-image`, that builds `docker/github_actions/Dockerfile` with buildx, restores and saves layers through the GitHub Actions cache backend (`type=gha`, `scope=ci-test-image`), and `load`s the result into the local daemon as `cadence-ci-test:local`. It runs before the compose step in each of the 16 jobs that use compose.
2. The compose services now carry that tag as their `image`. Compose builds only when the tag is missing, so CI reuses the pre-built image while a local `docker compose run` still builds on demand exactly as before.

The `build:` block itself is unchanged. It is now written once as a YAML anchor rather than repeated 16 times across the four CI compose files.

**Why?**

Per your note on #8408, this is piece 1 of 2, kept separate from the Go build cache so each can be reviewed and reverted on its own.

I went with the GHA cache backend rather than a registry cache because `docker compose run` is what the jobs actually invoke, so the image has to end up in the local daemon; `load: true` plus a fixed tag is the most predictable way to get there without giving fork PRs registry credentials.

**How did you test it?**

I cannot measure the real saving from outside, since that needs your runners. What I did verify locally:

- All four changed compose files parse: `docker compose -f <file> config -q`.
- The refactor is behaviour preserving. Diffing the fully resolved `docker compose config` output before and after, the only difference is the added `image: cadence-ci-test:local` line on each service. The build context and dockerfile path resolve byte-identically.
- `ci-checks.yml` and the new `action.yml` both parse as YAML, and the new step lands after `Setup Go environment` and before the compose step in all 16 compose jobs.
- Confirmed no workflow or script passes `--build` or `docker compose build`, so nothing forces a rebuild over the pre-built tag.
- Confirmed the four files I touched are used only by `ci-checks.yml`. `scripts/run_cass_and_test.sh` uses `docker/docker-compose.yml`, which is a different file, and the simulation workflows use the `docker-compose-local-*` files.

Happy to put this up as a draft first if you would rather see the timings from a real run before reviewing.

**Potential risks**

- Adds two Docker-maintained actions, `docker/setup-buildx-action` and `docker/build-push-action`. If you have an allowlist for third-party actions these need to be on it.
- On a cold cache all jobs build in parallel and all write to the cache, so the first run after a Dockerfile or `go.sum` change is no faster than today. The saving shows up from the next run onward.
- `#8408` notes the GHA cache limit is 10 GB. `mode=max` stores intermediate layers, so if the image turns out to be too large for the budget the fix is to drop to `mode=min` or scope the cache more narrowly. I left it at `max` because the expensive layers here are intermediate ones.
- `DOCKERFILE_SUFFIX` is interpolated into the tag, so a non-default suffix still gets its own image rather than silently reusing the default one.

**Release notes**

None. CI configuration only.

**Documentation Changes**

None.
