### PR TITLE
ci(ci-checks): give the compose containers a persistent Go build cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ cadence-bench
 cadence-sql-tool
 cadence-cassandra-tool
 vendor/
+.gocache/

--- a/.github/actions/build-test-image/action.yml
+++ b/.github/actions/build-test-image/action.yml
@@ -1,0 +1,47 @@
+name: Build CI test image
+description: >-
+  Build the image that every docker compose CI service runs, restoring its layers from the
+  GitHub Actions cache. The image is tagged so `docker compose run` reuses it instead of
+  rebuilding the apt, pip and `go mod download` layers in each of the 16 CI jobs that use
+  compose.
+
+runs:
+  using: composite
+  steps:
+    # The compose services interpolate DOCKERFILE_SUFFIX into both the dockerfile path and
+    # the image tag, but this action builds the default Dockerfile under the unsuffixed
+    # tag. With a suffix set, compose would ignore what we built and build its own, so the
+    # prebuild would be wasted work whose layers still land in the shared cache scope.
+    # Resolved in a shell step because a composite action does not reliably see the
+    # caller's `env` context, and this must fail closed.
+    - name: Check whether the default Dockerfile is in use
+      id: check
+      shell: bash
+      run: |
+        if [ -z "${DOCKERFILE_SUFFIX:-}" ]; then
+          echo "default=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "default=false" >> "$GITHUB_OUTPUT"
+          echo "DOCKERFILE_SUFFIX=${DOCKERFILE_SUFFIX} is set, skipping the prebuild." >&2
+        fi
+
+    - name: Set up Docker Buildx
+      if: steps.check.outputs.default == 'true'
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build test image
+      if: steps.check.outputs.default == 'true'
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/github_actions/Dockerfile
+        tags: cadence-ci-test:local
+        # Load into the local daemon so `docker compose run` finds the tag and skips its
+        # own build. Without this the image only exists inside the buildx builder.
+        load: true
+        cache-from: type=gha,scope=ci-test-image
+        # Export only from the default branch. A pull_request run from a fork gets a
+        # read-only GITHUB_TOKEN, so the export would 403 there, and having all 16 jobs
+        # export the full mode=max layer set on every run would churn the 10GB per-repo
+        # cache budget. PR runs read the cache that master populated.
+        cache-to: ${{ github.ref == 'refs/heads/master' && 'type=gha,mode=max,scope=ci-test-image,ignore-error=true' || '' }}

--- a/.github/actions/go-build-cache-release/action.yml
+++ b/.github/actions/go-build-cache-release/action.yml
@@ -1,0 +1,30 @@
+name: Save the Go build cache
+description: >-
+  Hand the bind-mounted Go build cache back to the runner user and save it. Runs only on
+  the default branch, and only when the step that compiles actually succeeded.
+
+inputs:
+  compiled:
+    description: >-
+      The outcome of the step that compiles. The cache is saved only when this is
+      'success', so a job that dies early cannot write a near-empty entry that later
+      prefix restores would pick up in place of a warm one.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # The containers run as root, so the cache action cannot read what they wrote.
+    - name: Hand the cache back to the runner user
+      if: github.ref == 'refs/heads/master' && inputs.compiled == 'success'
+      shell: bash
+      run: sudo chown -R "$(id -u):$(id -g)" .gocache
+
+    - name: Save the Go build cache
+      if: github.ref == 'refs/heads/master' && inputs.compiled == 'success'
+      uses: actions/cache/save@v4
+      with:
+        path: .gocache/go-build
+        # run_attempt too, so re-running a failed master job refreshes the entry instead
+        # of hitting the key the failed attempt already reserved.
+        key: cadence-gocache-${{ runner.os }}-${{ hashFiles('**/go.sum', '!.gocache/**') }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/actions/go-build-cache/action.yml
+++ b/.github/actions/go-build-cache/action.yml
@@ -1,0 +1,26 @@
+name: Restore the Go build cache
+description: >-
+  Restore the Go build cache that the unit test and lint compose services bind-mount.
+  `actions/setup-go` caches GOCACHE on the runner host, but compilation happens inside
+  `docker compose run` containers that never see the host Go directories, so that cache
+  does not apply to the work that takes the time.
+
+runs:
+  using: composite
+  steps:
+    # Must exist before compose starts, or the bind mount creates it root-owned and the
+    # restore cannot write into it.
+    - name: Create the cache directory
+      shell: bash
+      run: mkdir -p .gocache/go-build
+
+    - name: Restore the Go build cache
+      uses: actions/cache/restore@v4
+      with:
+        path: .gocache/go-build
+        # `!.gocache/**` keeps hashFiles from walking the cache it is keying.
+        key: cadence-gocache-${{ runner.os }}-${{ hashFiles('**/go.sum', '!.gocache/**') }}
+        # Saves append a run id, so the exact key never matches and this always resolves
+        # through the prefix to the newest entry, which is what is wanted.
+        restore-keys: |
+          cadence-gocache-${{ runner.os }}-

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
       
       - name: Run unit test
         uses: nick-fields/retry@v3
@@ -68,6 +71,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run golint
         run: docker compose -f docker/github_actions/docker-compose.yml run coverage-report bash -c "./scripts/github_actions/golint.sh"
 
@@ -87,6 +93,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for cassandra
         uses: nick-fields/retry@v3
@@ -117,6 +126,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for cassandra running history queue v2
         uses: nick-fields/retry@v3
@@ -149,6 +161,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for cassandra running history queue v2 with alert
         uses: nick-fields/retry@v3
         with:
@@ -179,6 +194,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for cassandra running history queue v2 with cached reader
         uses: nick-fields/retry@v3
@@ -212,6 +230,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for cassandra and elasticsearch v7
         uses: nick-fields/retry@v3
         with:
@@ -243,6 +264,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration test with cassandra and pinot
         uses: nick-fields/retry@v3
@@ -276,6 +300,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for cassandra and opensearch v2
         uses: nick-fields/retry@v3
         with:
@@ -307,6 +334,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run ndc profile for cassandra
         uses: nick-fields/retry@v3
@@ -340,6 +370,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for mysql
         uses: nick-fields/retry@v3
         with:
@@ -371,6 +404,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run ndc profile for mysql
         uses: nick-fields/retry@v3
@@ -404,6 +440,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run integration profile for postgres
         uses: nick-fields/retry@v3
         with:
@@ -434,6 +473,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run integration profile for sqlite
         uses: nick-fields/retry@v3
@@ -466,6 +508,9 @@ jobs:
         with:
           go-version: '1.24.5'
 
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
+
       - name: Run ndc profile for postgres
         uses: nick-fields/retry@v3
         with:
@@ -496,6 +541,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
+
+      - name: Build CI test image
+        uses: ./.github/actions/build-test-image
 
       - name: Run async wf integration test with kafka
         uses: nick-fields/retry@v3

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -36,14 +36,24 @@ jobs:
 
       - name: Build CI test image
         uses: ./.github/actions/build-test-image
-      
+
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+
       - name: Run unit test
+        id: unit-test
         uses: nick-fields/retry@v3
         with:
           max_attempts: 2
           timeout_minutes: 30
           command: |
             docker compose -f docker/github_actions/docker-compose.yml run unit-test bash -c "make .just-build && make cover_profile && ./scripts/github_actions/gen_coverage_metadata.sh .build/coverage/metadata.txt"
+
+      - name: Save the Go build cache
+        if: always()
+        uses: ./.github/actions/go-build-cache-release
+        with:
+          compiled: ${{ steps.unit-test.outcome }}
 
       - name: Upload coverage artifacts
         if: always()
@@ -74,8 +84,18 @@ jobs:
       - name: Build CI test image
         uses: ./.github/actions/build-test-image
 
+      - name: Restore the Go build cache
+        uses: ./.github/actions/go-build-cache
+
       - name: Run golint
+        id: golint
         run: docker compose -f docker/github_actions/docker-compose.yml run coverage-report bash -c "./scripts/github_actions/golint.sh"
+
+      - name: Save the Go build cache
+        if: always()
+        uses: ./.github/actions/go-build-cache-release
+        with:
+          compiled: ${{ steps.golint.outcome }}
 
 
   golang-integration-test-with-cassandra:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cadence_visibility.db*
 settings.local.json
 .mcp.json
 *.bak
+
+# Go build cache, bind-mounted into the unit test and lint CI containers
+.gocache/

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ SUBMODULE_PATHS = $(shell \
 		-name "go.mod" \
 		-not -path "./go.mod" \
 		-not -path "./idls/*" \
+		-not -path "./.gocache/*" \
 		-exec dirname {} \; \
 	| sed 's|^\./||' \
 )
@@ -141,6 +142,7 @@ FRESH_ALL_SRC = $(shell \
 		-o -path './idls/*' \
 		-o -path './.build/*' \
 		-o -path './.bin/*' \
+		-o -path './.gocache/*' \
 		-o -path './.git/*' \
 		-o -path './.worktrees/*' \
 	\) \
@@ -409,7 +411,7 @@ $(BUILD)/code-lint: $(LINT_SRC) $(BIN)/revive $(BIN)/nilaway | $(BUILD)
 	$Q go vet -copylocks ./... ./common/archiver/gcloud/...
 	$Q $(BIN)/revive -config revive.toml -exclude './vendor/...' -exclude './.gen/...' -exclude './.worktrees/...' -formatter stylish ./...
 	$Q # look for go files with "//comments", and ignore "//go:build"-style directives ("grep -n" shows "file:line: //go:build" so the regex is a bit complex)
-	$Q bad="$$(find . -type f -name '*.go' -not -path './idls/*' -not -path './.worktrees/*' | xargs grep -n -E '^\s*//\S' | grep -E -v '^[^:]+:[^:]+:\s*//[a-z]+:[a-z]+' || true)"; \
+	$Q bad="$$(find . -type f -name '*.go' -not -path './idls/*' -not -path './.worktrees/*' -not -path './.gocache/*' | xargs grep -n -E '^\s*//\S' | grep -E -v '^[^:]+:[^:]+:\s*//[a-z]+:[a-z]+' || true)"; \
 		if [ -n "$$bad" ]; then \
 		  echo "$$bad" >&2; \
 		  echo 'non-directive comments must have a space after the "//"' >&2; \

--- a/docker/github_actions/docker-compose-es7.yml
+++ b/docker/github_actions/docker-compose-es7.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -48,9 +58,7 @@ services:
       - discovery.type=single-node
 
   integration-test-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"

--- a/docker/github_actions/docker-compose-opensearch2.yml
+++ b/docker/github_actions/docker-compose-opensearch2.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -57,9 +67,7 @@ services:
       - 9600:9600 # Performance Analyzer
 
   integration-test-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"

--- a/docker/github_actions/docker-compose-pinot.yml
+++ b/docker/github_actions/docker-compose-pinot.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -141,9 +151,7 @@ services:
           - pinot-server
 
   integration-test-cassandra-pinot:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"

--- a/docker/github_actions/docker-compose.yml
+++ b/docker/github_actions/docker-compose.yml
@@ -102,6 +102,11 @@ services:
     <<: *test-image
     volumes:
       - ../../:/cadence
+      # Bind the Go build cache out of the container so `actions/cache` can persist it
+      # between runs. Only this service and coverage-report mount it: they are the two
+      # jobs that compile the whole tree. The module cache is deliberately not mounted,
+      # the image's own `go mod download` layer already supplies /go/pkg/mod.
+      - ../../.gocache/go-build:/root/.cache/go-build
     networks:
       services-network:
         aliases:
@@ -352,6 +357,8 @@ services:
       - GITHUB_PULL_REQUEST_REPO
     volumes:
       - ../../:/cadence
+      # Same build cache as unit-test, see the note there.
+      - ../../.gocache/go-build:/root/.cache/go-build
 
 networks:
   services-network:

--- a/docker/github_actions/docker-compose.yml
+++ b/docker/github_actions/docker-compose.yml
@@ -1,3 +1,13 @@
+# All CI services run the same test image. Defining it once lets a pre-built image be
+# reused instead of rebuilding the apt, pip and `go mod download` layers per service.
+# The build block stays so `docker compose run` still builds the image on demand when it
+# is not already present, which is what happens outside CI.
+x-test-image: &test-image
+  image: cadence-ci-test:local${DOCKERFILE_SUFFIX}
+  build:
+    context: ../../
+    dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+
 services:
   cassandra:
     image: cassandra:4.1.1
@@ -89,9 +99,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: cadence
 
   unit-test:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     volumes:
       - ../../:/cadence
     networks:
@@ -100,9 +108,7 @@ services:
           - unit-test
 
   integration-test-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -124,9 +130,7 @@ services:
           - integration-test
 
   integration-test-cassandra-queue-v2:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -149,9 +153,7 @@ services:
           - integration-test
 
   integration-test-cassandra-queue-v2-alert:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -175,9 +177,7 @@ services:
           - integration-test
 
   integration-test-cassandra-queue-v2-cached-reader:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -201,9 +201,7 @@ services:
           - integration-test
 
   integration-test-mysql:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
@@ -224,9 +222,7 @@ services:
           - integration-test
 
   integration-test-postgres:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "POSTGRES=1"
       - "POSTGRES_SEEDS=postgres"
@@ -247,9 +243,7 @@ services:
           - integration-test
 
   integration-test-sqlite:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "PERSISTENCE_PLUGIN=sqlite"
       - "PERSISTENCE_TYPE=sql"
@@ -261,9 +255,7 @@ services:
           - integration-test
 
   integration-test-ndc-cassandra:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
@@ -285,9 +277,7 @@ services:
           - integration-test-ndc
 
   integration-test-ndc-mysql:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
@@ -308,9 +298,7 @@ services:
           - integration-test-ndc
 
   integration-test-ndc-postgres:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "POSTGRES=1"
       - "POSTGRES_SEEDS=postgres"
@@ -331,9 +319,7 @@ services:
           - integration-test-ndc
 
   integration-test-async-wf:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - "ASYNC_WF_KAFKA_QUEUE_TOPIC=async-wf-topic1"
       - "CASSANDRA=1"
@@ -354,9 +340,7 @@ services:
           - integration-test-async-wf
 
   coverage-report:
-    build:
-      context: ../../
-      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    <<: *test-image
     environment:
       - CI
       - GITHUB_BRANCH

--- a/scripts/check-go-toolchain.sh
+++ b/scripts/check-go-toolchain.sh
@@ -29,7 +29,7 @@ while read file; do
   if [[ "$version" != "$target" ]]; then
     bad "Wrong Go version in file $file:\n\t$line"
   fi
-done < <( find "$root" -name Dockerfile -not -path '*/.worktrees/*' )
+done < <( find "$root" -name Dockerfile -not -path '*/.worktrees/*' -not -path '*/.gocache/*' )
 
 declare -a codecov_files=( "$root/.github/workflows/codecov-on-pr.yml" "$root/.github/workflows/codecov-on-master.yml" );
 


### PR DESCRIPTION
<!-- Second of the two PRs @c-warren asked for on #8408. -->

> Stacked on #8484, so the diff here also contains that PR's commit. Review the second commit (`ci(ci-checks): give the compose containers a persistent Go build cache`) on its own, or merge #8484 first and this will shrink to it. Both touch the same compose files, which is why they are stacked rather than parallel.

**What changed?**

`actions/setup-go@v5` caches `GOMODCACHE` and `GOCACHE`, but it caches them **on the host**, while compilation happens inside the `docker compose run` containers, whose Go directories are never mounted. So the cache step never applies to the work that actually takes the time, and every job recompiles the entire dependency graph from scratch.

- Bind-mount the container's `/root/.cache/go-build` and `/go/pkg/mod` out to `.gocache/` on the host, through the existing volume list.
- Restore and save `.gocache/` with `actions/cache`, keyed on `**/go.sum` with a prefix `restore-keys` fallback, via a new `.github/actions/go-build-cache` composite action.
- Hand `.gocache/` back to the runner user at the end of each job.

Two details worth calling out:

- `.gocache/` rather than `.build/`, because `make clean` does `rm -Rf $(BUILD)` and would take the cache with it.
- The module cache is at `/go/pkg/mod`, not `/root/go/pkg/mod` as #8408 says. The `golang:1.24.5-bullseye` base image sets `GOPATH=/go`.

**Why?**

Piece 2 of the two you asked for on #8408, kept separate from the image build so each can be reviewed and reverted on its own.

The chown step exists because the containers run as root, so the files they leave in the bind mount are not readable by the cache action's post step, which runs as the runner user. It is `if: always()` so a failing test still saves the cache it warmed.

**How did you test it?**

I cannot measure the real saving from outside, that needs your runners. Verified locally:

- All four changed compose files parse (`docker compose config -q`).
- Diffing the fully resolved `docker compose config` before and after, the only change is the two bind mounts appearing on each of the 13 services in `docker-compose.yml`, and the equivalent in the other three files. Nothing else moves.
- `ci-checks.yml` and the new `action.yml` parse as YAML, and the restore step plus the closing chown step land in all 16 compose jobs.
- Confirmed `.gocache/` is outside `$(BUILD)`, so `make clean` leaves it alone, and added it to `.gitignore`.

Happy to mark this draft so the timings come from a real run before you review.

**Potential risks**

- The chown needs passwordless `sudo`, which GitHub-hosted `ubuntu-latest` runners have. It would need revisiting on self-hosted runners.
- The Go build cache grows over time. `actions/cache` entries are evicted at 7 days idle and against the repo's 10 GB budget, which is shared with #8484's image layer cache. If the two together push you over the limit, this one is the cheaper of the two to scope down, for example by caching only `go-mod`.
- First run after a `go.sum` change still recompiles; `restore-keys` means it starts from the previous cache rather than from nothing.
- If a stale cache is ever suspected of causing a weird failure, bumping the `cadence-gocache-` key prefix invalidates everything.

**Release notes**

None. CI configuration only.

**Documentation Changes**

None.
