### PR TITLE
feat(diagnostics): diagnose large workflow histories

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -103,8 +103,8 @@ const (
 	FailureReasonHeartbeatExceedsLimit = "HEARTBEAT_EXCEEDS_LIMIT"
 	// FailureReasonDecisionBlobSizeExceedsLimit is the failureReason for decision blob exceeds size limit
 	FailureReasonDecisionBlobSizeExceedsLimit = "DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
-	// FailureReasonSizeExceedsLimit is reason to fail workflow when history size or count exceed limit
-	FailureReasonSizeExceedsLimit = "HISTORY_EXCEEDS_LIMIT"
+	// FailureReasonHistorySizeExceedsLimit is reason to fail workflow when history size or count exceed limit
+	FailureReasonHistorySizeExceedsLimit = "HISTORY_EXCEEDS_LIMIT"
 	// FailureReasonTransactionSizeExceedsLimit is the failureReason for when transaction cannot be committed because it exceeds size limit
 	FailureReasonTransactionSizeExceedsLimit = "TRANSACTION_SIZE_EXCEEDS_LIMIT"
 	// FailureReasonDecisionAttemptsExceedsLimit is reason to fail workflow when decision attempts fail too many times

--- a/host/size_limit_test.go
+++ b/host/size_limit_test.go
@@ -180,7 +180,7 @@ func (s *SizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 	lastEvent := history.Events[len(history.Events)-1]
 	s.Equal(types.EventTypeWorkflowExecutionFailed, lastEvent.GetEventType())
 	failedEventAttributes := lastEvent.WorkflowExecutionFailedEventAttributes
-	s.Equal(common.FailureReasonSizeExceedsLimit, failedEventAttributes.GetReason())
+	s.Equal(common.FailureReasonHistorySizeExceedsLimit, failedEventAttributes.GetReason())
 
 	// verify visibility is correctly processed from open to close
 	isCloseCorrect := false

--- a/service/history/decision/checker.go
+++ b/service/history/decision/checker.go
@@ -181,7 +181,7 @@ func (c *workflowSizeChecker) failWorkflowSizeExceedsLimit() (bool, error) {
 		)
 
 		attributes := &types.FailWorkflowExecutionDecisionAttributes{
-			Reason:  common.StringPtr(common.FailureReasonSizeExceedsLimit),
+			Reason:  common.StringPtr(common.FailureReasonHistorySizeExceedsLimit),
 			Details: []byte("Workflow history size / count exceeds limit."),
 		}
 

--- a/service/history/decision/checker_test.go
+++ b/service/history/decision/checker_test.go
@@ -995,7 +995,7 @@ func TestWorkflowSizeChecker_failWorkflowSizeExceedsLimit(t *testing.T) {
 			}
 			if tc.expectFail {
 				mutableState.EXPECT().AddFailWorkflowEvent(testEventID, &types.FailWorkflowExecutionDecisionAttributes{
-					Reason:  common.StringPtr(common.FailureReasonSizeExceedsLimit),
+					Reason:  common.StringPtr(common.FailureReasonHistorySizeExceedsLimit),
 					Details: []byte("Workflow history size / count exceeds limit."),
 				}).Return(nil, nil).Times(1)
 			}

--- a/service/history/decision/task_handler_test.go
+++ b/service/history/decision/task_handler_test.go
@@ -1606,7 +1606,7 @@ func TestHandleDecisions(t *testing.T) {
 		taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetNextEventID().Return(int64(12)) // nextEventID - 1 > historyCountLimit of 10
 		taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{})
 		taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddFailWorkflowEvent(taskHandler.sizeLimitChecker.completedID, &types.FailWorkflowExecutionDecisionAttributes{
-			Reason:  common.StringPtr(common.FailureReasonSizeExceedsLimit),
+			Reason:  common.StringPtr(common.FailureReasonHistorySizeExceedsLimit),
 			Details: []byte("Workflow history size / count exceeds limit."),
 		}).Return(nil, errors.New("some error adding fail workflow event"))
 		res, err := taskHandler.handleDecisions(context.Background(), []byte{}, []*types.Decision{})

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	linkToTimeoutsRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
-	linkToFailuresRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/failures"
+	linkToFailuresRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/activity-failures/"
 	linkToRetriesRunbook      = "https://cadenceworkflow.io/docs/workflow-troubleshooting/retries"
 	linkToTimeoutRisksRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
 	WfDiagnosticsAppName      = "workflow-diagnostics"

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	linkToTimeoutsRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
-	linkToFailuresRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/activity-failures/"
+	linkToFailuresRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/failures"
 	linkToRetriesRunbook      = "https://cadenceworkflow.io/docs/workflow-troubleshooting/retries"
 	linkToTimeoutRisksRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
 	WfDiagnosticsAppName      = "workflow-diagnostics"

--- a/service/worker/diagnostics/invariant/failure/failure.go
+++ b/service/worker/diagnostics/invariant/failure/failure.go
@@ -57,14 +57,14 @@ func (f *failure) Check(ctx context.Context, params invariant.InvariantCheckInpu
 					Metadata:      invariant.MarshalData(FailureIssuesMetadata{Identity: identity}),
 				})
 				issueID++
-			} else if *reason == common.FailureReasonSizeExceedsLimit {
+			} else if *reason == common.FailureReasonHistorySizeExceedsLimit {
 				result = append(result, invariant.InvariantCheckResult{
 					IssueID:       issueID,
 					InvariantType: WorkflowFailed.String(),
-					Reason:        WorkflowSizeExceedsLimit.String(),
+					Reason:        HistorySizeExceedsLimit.String(),
 					Metadata: invariant.MarshalData(FailureIssuesMetadata{
-						Identity:          identity,
-						HistoryEventCount: event.ID,
+						Identity:      identity,
+						FailedEventID: event.ID,
 					}),
 				})
 				issueID++
@@ -182,7 +182,7 @@ func (f *failure) RootCause(ctx context.Context, params invariant.InvariantRootC
 				RootCause: invariant.RootCauseTypeServiceSideCustomError,
 				Metadata:  issue.Metadata,
 			})
-		case WorkflowSizeExceedsLimit.String():
+		case HistorySizeExceedsLimit.String():
 			result = append(result, invariant.InvariantRootCauseResult{
 				IssueID:   issue.IssueID,
 				RootCause: invariant.RootCauseTypeHistorySizeExceedsLimit,

--- a/service/worker/diagnostics/invariant/failure/failure.go
+++ b/service/worker/diagnostics/invariant/failure/failure.go
@@ -57,6 +57,17 @@ func (f *failure) Check(ctx context.Context, params invariant.InvariantCheckInpu
 					Metadata:      invariant.MarshalData(FailureIssuesMetadata{Identity: identity}),
 				})
 				issueID++
+			} else if *reason == common.FailureReasonSizeExceedsLimit {
+				result = append(result, invariant.InvariantCheckResult{
+					IssueID:       issueID,
+					InvariantType: WorkflowFailed.String(),
+					Reason:        WorkflowSizeExceedsLimit.String(),
+					Metadata: invariant.MarshalData(FailureIssuesMetadata{
+						Identity:          identity,
+						HistoryEventCount: event.ID,
+					}),
+				})
+				issueID++
 			} else {
 				result = append(result, invariant.InvariantCheckResult{
 					IssueID:       issueID,
@@ -169,6 +180,12 @@ func (f *failure) RootCause(ctx context.Context, params invariant.InvariantRootC
 			result = append(result, invariant.InvariantRootCauseResult{
 				IssueID:   issue.IssueID,
 				RootCause: invariant.RootCauseTypeServiceSideCustomError,
+				Metadata:  issue.Metadata,
+			})
+		case WorkflowSizeExceedsLimit.String():
+			result = append(result, invariant.InvariantRootCauseResult{
+				IssueID:   issue.IssueID,
+				RootCause: invariant.RootCauseTypeWorkflowSizeExceedsLimit,
 				Metadata:  issue.Metadata,
 			})
 		}

--- a/service/worker/diagnostics/invariant/failure/failure.go
+++ b/service/worker/diagnostics/invariant/failure/failure.go
@@ -185,7 +185,7 @@ func (f *failure) RootCause(ctx context.Context, params invariant.InvariantRootC
 		case WorkflowSizeExceedsLimit.String():
 			result = append(result, invariant.InvariantRootCauseResult{
 				IssueID:   issue.IssueID,
-				RootCause: invariant.RootCauseTypeWorkflowSizeExceedsLimit,
+				RootCause: invariant.RootCauseTypeHistorySizeExceedsLimit,
 				Metadata:  issue.Metadata,
 			})
 		}

--- a/service/worker/diagnostics/invariant/failure/failure_test.go
+++ b/service/worker/diagnostics/invariant/failure/failure_test.go
@@ -348,7 +348,7 @@ func Test__RootCause(t *testing.T) {
 				}},
 			expectedResult: []invariant.InvariantRootCauseResult{{
 				IssueID:   0,
-				RootCause: invariant.RootCauseTypeWorkflowSizeExceedsLimit,
+				RootCause: invariant.RootCauseTypeHistorySizeExceedsLimit,
 				Metadata:  largeHistoryMetadataInBytes,
 			}},
 			err: nil,

--- a/service/worker/diagnostics/invariant/failure/failure_test.go
+++ b/service/worker/diagnostics/invariant/failure/failure_test.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	testDomain             = "test-domain"
-	largeHistoryEventCount = int64(200001)
+	testDomain                = "test-domain"
+	largeHistoryFailedEventID = int64(200001)
 )
 
 func Test__Check(t *testing.T) {
@@ -46,8 +46,8 @@ func Test__Check(t *testing.T) {
 	metadataInBytes, err := json.Marshal(metadata)
 	require.NoError(t, err)
 	largeHistoryMetadata := FailureIssuesMetadata{
-		Identity:          "localhost",
-		HistoryEventCount: largeHistoryEventCount,
+		Identity:      "localhost",
+		FailedEventID: largeHistoryFailedEventID,
 	}
 	largeHistoryMetadataInBytes, err := json.Marshal(largeHistoryMetadata)
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func Test__Check(t *testing.T) {
 				{
 					IssueID:       0,
 					InvariantType: WorkflowFailed.String(),
-					Reason:        WorkflowSizeExceedsLimit.String(),
+					Reason:        HistorySizeExceedsLimit.String(),
 					Metadata:      largeHistoryMetadataInBytes,
 				},
 			},
@@ -152,9 +152,9 @@ func historySizeLimitExceededHistory() *types.GetWorkflowExecutionHistoryRespons
 					},
 				},
 				{
-					ID: largeHistoryEventCount,
+					ID: largeHistoryFailedEventID,
 					WorkflowExecutionFailedEventAttributes: &types.WorkflowExecutionFailedEventAttributes{
-						Reason:                       common.StringPtr(common.FailureReasonSizeExceedsLimit),
+						Reason:                       common.StringPtr(common.FailureReasonHistorySizeExceedsLimit),
 						Details:                      []byte("Workflow history size / count exceeds limit."),
 						DecisionTaskCompletedEventID: 10,
 					},
@@ -279,8 +279,8 @@ func Test__RootCause(t *testing.T) {
 	metadataInBytes, err := json.Marshal(metadata)
 	require.NoError(t, err)
 	largeHistoryMetadataInBytes, err := json.Marshal(FailureIssuesMetadata{
-		Identity:          "localhost",
-		HistoryEventCount: largeHistoryEventCount,
+		Identity:      "localhost",
+		FailedEventID: largeHistoryFailedEventID,
 	})
 	require.NoError(t, err)
 	testCases := []struct {
@@ -343,7 +343,7 @@ func Test__RootCause(t *testing.T) {
 				{
 					IssueID:       0,
 					InvariantType: WorkflowFailed.String(),
-					Reason:        WorkflowSizeExceedsLimit.String(),
+					Reason:        HistorySizeExceedsLimit.String(),
 					Metadata:      largeHistoryMetadataInBytes,
 				}},
 			expectedResult: []invariant.InvariantRootCauseResult{{

--- a/service/worker/diagnostics/invariant/failure/failure_test.go
+++ b/service/worker/diagnostics/invariant/failure/failure_test.go
@@ -35,7 +35,8 @@ import (
 )
 
 const (
-	testDomain = "test-domain"
+	testDomain             = "test-domain"
+	largeHistoryEventCount = int64(200001)
 )
 
 func Test__Check(t *testing.T) {
@@ -43,6 +44,12 @@ func Test__Check(t *testing.T) {
 		Identity: "localhost",
 	}
 	metadataInBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	largeHistoryMetadata := FailureIssuesMetadata{
+		Identity:          "localhost",
+		HistoryEventCount: largeHistoryEventCount,
+	}
+	largeHistoryMetadataInBytes, err := json.Marshal(largeHistoryMetadata)
 	require.NoError(t, err)
 	actMetadata := FailureIssuesMetadata{
 		Identity:            "localhost",
@@ -108,6 +115,19 @@ func Test__Check(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name:     "workflow history size limit exceeded",
+			testData: historySizeLimitExceededHistory(),
+			expectedResult: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: WorkflowFailed.String(),
+					Reason:        WorkflowSizeExceedsLimit.String(),
+					Metadata:      largeHistoryMetadataInBytes,
+				},
+			},
+			err: nil,
+		},
 	}
 	for _, tc := range testCases {
 		inv := NewInvariant()
@@ -118,6 +138,29 @@ func Test__Check(t *testing.T) {
 		require.Equal(t, tc.err, err)
 		require.Equal(t, len(tc.expectedResult), len(result))
 		require.ElementsMatch(t, tc.expectedResult, result)
+	}
+}
+
+func historySizeLimitExceededHistory() *types.GetWorkflowExecutionHistoryResponse {
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History: &types.History{
+			Events: []*types.HistoryEvent{
+				{
+					ID: 10,
+					DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+						Identity: "localhost",
+					},
+				},
+				{
+					ID: largeHistoryEventCount,
+					WorkflowExecutionFailedEventAttributes: &types.WorkflowExecutionFailedEventAttributes{
+						Reason:                       common.StringPtr(common.FailureReasonSizeExceedsLimit),
+						Details:                      []byte("Workflow history size / count exceeds limit."),
+						DecisionTaskCompletedEventID: 10,
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -235,6 +278,11 @@ func Test__RootCause(t *testing.T) {
 	}
 	metadataInBytes, err := json.Marshal(metadata)
 	require.NoError(t, err)
+	largeHistoryMetadataInBytes, err := json.Marshal(FailureIssuesMetadata{
+		Identity:          "localhost",
+		HistoryEventCount: largeHistoryEventCount,
+	})
+	require.NoError(t, err)
 	testCases := []struct {
 		name           string
 		input          []invariant.InvariantCheckResult
@@ -286,6 +334,22 @@ func Test__RootCause(t *testing.T) {
 				IssueID:   0,
 				RootCause: invariant.RootCauseTypeServiceSidePanic,
 				Metadata:  metadataInBytes,
+			}},
+			err: nil,
+		},
+		{
+			name: "workflow history size limit exceeded",
+			input: []invariant.InvariantCheckResult{
+				{
+					IssueID:       0,
+					InvariantType: WorkflowFailed.String(),
+					Reason:        WorkflowSizeExceedsLimit.String(),
+					Metadata:      largeHistoryMetadataInBytes,
+				}},
+			expectedResult: []invariant.InvariantRootCauseResult{{
+				IssueID:   0,
+				RootCause: invariant.RootCauseTypeWorkflowSizeExceedsLimit,
+				Metadata:  largeHistoryMetadataInBytes,
 			}},
 			err: nil,
 		},

--- a/service/worker/diagnostics/invariant/failure/types.go
+++ b/service/worker/diagnostics/invariant/failure/types.go
@@ -32,7 +32,7 @@ const (
 	HeartBeatBlobSizeLimit      ErrorType = "Heartbeat details has exceeded the blob size limit"
 	ActivityOutputBlobSizeLimit ErrorType = "Activity output has exceeded the blob size limit"
 	DecisionBlobSizeLimit       ErrorType = "Decision result caused to exceed blob size limit"
-	WorkflowSizeExceedsLimit    ErrorType = "The workflow history size or event count exceeded the configured limit"
+	HistorySizeExceedsLimit     ErrorType = "The workflow history size or event count exceeded the configured limit"
 )
 
 func (e ErrorType) String() string {
@@ -56,7 +56,7 @@ type FailureIssuesMetadata struct {
 	ActivityType        string
 	ActivityScheduledID int64
 	ActivityStartedID   int64
-	HistoryEventCount   int64
+	FailedEventID       int64 `json:",omitempty"`
 }
 
 // BlobSizeMetadata includes the details of blob size limits

--- a/service/worker/diagnostics/invariant/failure/types.go
+++ b/service/worker/diagnostics/invariant/failure/types.go
@@ -32,6 +32,7 @@ const (
 	HeartBeatBlobSizeLimit      ErrorType = "Heartbeat details has exceeded the blob size limit"
 	ActivityOutputBlobSizeLimit ErrorType = "Activity output has exceeded the blob size limit"
 	DecisionBlobSizeLimit       ErrorType = "Decision result caused to exceed blob size limit"
+	WorkflowSizeExceedsLimit    ErrorType = "The workflow history size or event count exceeded the configured limit"
 )
 
 func (e ErrorType) String() string {
@@ -55,6 +56,7 @@ type FailureIssuesMetadata struct {
 	ActivityType        string
 	ActivityScheduledID int64
 	ActivityStartedID   int64
+	HistoryEventCount   int64
 }
 
 // BlobSizeMetadata includes the details of blob size limits

--- a/service/worker/diagnostics/invariant/interface.go
+++ b/service/worker/diagnostics/invariant/interface.go
@@ -66,7 +66,7 @@ const (
 	RootCauseTypeServiceSidePanic                      RootCause = "There is a panic in the activity/workflow that is causing a failure"
 	RootCauseTypeServiceSideCustomError                RootCause = "Customised error returned by the activity/workflow"
 	RootCauseTypeBlobSizeLimit                         RootCause = "Workflow has exceeded the blob size limits configured for the domain"
-	RootCauseTypeWorkflowSizeExceedsLimit              RootCause = "The workflow history exceeded its size or event count limit. Use ContinueAsNew to split the workflow into smaller runs. Keep payloads small and avoid unbounded activity, signal, or timer loops in one run"
+	RootCauseTypeHistorySizeExceedsLimit               RootCause = "Workflow history has exceeded the size or event count limit configured for the domain"
 )
 
 func (r RootCause) String() string {

--- a/service/worker/diagnostics/invariant/interface.go
+++ b/service/worker/diagnostics/invariant/interface.go
@@ -66,6 +66,7 @@ const (
 	RootCauseTypeServiceSidePanic                      RootCause = "There is a panic in the activity/workflow that is causing a failure"
 	RootCauseTypeServiceSideCustomError                RootCause = "Customised error returned by the activity/workflow"
 	RootCauseTypeBlobSizeLimit                         RootCause = "Workflow has exceeded the blob size limits configured for the domain"
+	RootCauseTypeWorkflowSizeExceedsLimit              RootCause = "The workflow history exceeded its size or event count limit. Use ContinueAsNew to split the workflow into smaller runs. Keep payloads small and avoid unbounded activity, signal, or timer loops in one run"
 )
 
 func (r RootCause) String() string {

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -354,13 +354,16 @@ func retrieveFailureIssues(issues []invariant.InvariantCheckResult) ([]*failureI
 func retrieveFailureRootCause(rootCause []invariant.InvariantRootCauseResult) ([]*failureRootCauseResult, error) {
 	result := make([]*failureRootCauseResult, 0)
 	for _, rc := range rootCause {
-		if rc.RootCause == invariant.RootCauseTypeServiceSideIssue || rc.RootCause == invariant.RootCauseTypeServiceSidePanic || rc.RootCause == invariant.RootCauseTypeServiceSideCustomError || rc.RootCause == invariant.RootCauseTypeHistorySizeExceedsLimit {
+		switch rc.RootCause {
+		case invariant.RootCauseTypeServiceSideIssue,
+			invariant.RootCauseTypeServiceSidePanic,
+			invariant.RootCauseTypeServiceSideCustomError,
+			invariant.RootCauseTypeHistorySizeExceedsLimit:
 			result = append(result, &failureRootCauseResult{
 				IssueID:       rc.IssueID,
 				RootCauseType: rc.RootCause.String(),
 			})
-		}
-		if rc.RootCause == invariant.RootCauseTypeBlobSizeLimit {
+		case invariant.RootCauseTypeBlobSizeLimit:
 			var metadata failure.FailureRootcauseMetadata
 			err := json.Unmarshal(rc.Metadata, &metadata)
 			if err != nil {

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -354,7 +354,7 @@ func retrieveFailureIssues(issues []invariant.InvariantCheckResult) ([]*failureI
 func retrieveFailureRootCause(rootCause []invariant.InvariantRootCauseResult) ([]*failureRootCauseResult, error) {
 	result := make([]*failureRootCauseResult, 0)
 	for _, rc := range rootCause {
-		if rc.RootCause == invariant.RootCauseTypeServiceSideIssue || rc.RootCause == invariant.RootCauseTypeServiceSidePanic || rc.RootCause == invariant.RootCauseTypeServiceSideCustomError || rc.RootCause == invariant.RootCauseTypeWorkflowSizeExceedsLimit {
+		if rc.RootCause == invariant.RootCauseTypeServiceSideIssue || rc.RootCause == invariant.RootCauseTypeServiceSidePanic || rc.RootCause == invariant.RootCauseTypeServiceSideCustomError || rc.RootCause == invariant.RootCauseTypeHistorySizeExceedsLimit {
 			result = append(result, &failureRootCauseResult{
 				IssueID:       rc.IssueID,
 				RootCauseType: rc.RootCause.String(),

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -354,7 +354,7 @@ func retrieveFailureIssues(issues []invariant.InvariantCheckResult) ([]*failureI
 func retrieveFailureRootCause(rootCause []invariant.InvariantRootCauseResult) ([]*failureRootCauseResult, error) {
 	result := make([]*failureRootCauseResult, 0)
 	for _, rc := range rootCause {
-		if rc.RootCause == invariant.RootCauseTypeServiceSideIssue || rc.RootCause == invariant.RootCauseTypeServiceSidePanic || rc.RootCause == invariant.RootCauseTypeServiceSideCustomError {
+		if rc.RootCause == invariant.RootCauseTypeServiceSideIssue || rc.RootCause == invariant.RootCauseTypeServiceSidePanic || rc.RootCause == invariant.RootCauseTypeServiceSideCustomError || rc.RootCause == invariant.RootCauseTypeWorkflowSizeExceedsLimit {
 			result = append(result, &failureRootCauseResult{
 				IssueID:       rc.IssueID,
 				RootCauseType: rc.RootCause.String(),

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/testsuite"
@@ -440,6 +441,23 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveFailureRootCause() {
 	result, err := retrieveFailureRootCause(rootCause)
 	s.NoError(err)
 	s.ElementsMatch(failureRootCause, result)
+}
+
+func TestRetrieveFailureRootCauseWorkflowSizeExceedsLimit(t *testing.T) {
+	result, err := retrieveFailureRootCause([]invariant.InvariantRootCauseResult{
+		{
+			IssueID:   1,
+			RootCause: invariant.RootCauseTypeWorkflowSizeExceedsLimit,
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []*failureRootCauseResult{
+		{
+			IssueID:       1,
+			RootCauseType: invariant.RootCauseTypeWorkflowSizeExceedsLimit.String(),
+		},
+	}, result)
 }
 
 func (s *diagnosticsWorkflowTestSuite) Test__retrieveRetryIssues() {

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -443,11 +443,11 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveFailureRootCause() {
 	s.ElementsMatch(failureRootCause, result)
 }
 
-func TestRetrieveFailureRootCauseWorkflowSizeExceedsLimit(t *testing.T) {
+func TestRetrieveFailureRootCauseHistorySizeExceedsLimit(t *testing.T) {
 	result, err := retrieveFailureRootCause([]invariant.InvariantRootCauseResult{
 		{
 			IssueID:   1,
-			RootCause: invariant.RootCauseTypeWorkflowSizeExceedsLimit,
+			RootCause: invariant.RootCauseTypeHistorySizeExceedsLimit,
 		},
 	})
 
@@ -455,7 +455,7 @@ func TestRetrieveFailureRootCauseWorkflowSizeExceedsLimit(t *testing.T) {
 	require.Equal(t, []*failureRootCauseResult{
 		{
 			IssueID:       1,
-			RootCauseType: invariant.RootCauseTypeWorkflowSizeExceedsLimit.String(),
+			RootCauseType: invariant.RootCauseTypeHistorySizeExceedsLimit.String(),
 		},
 	}, result)
 }


### PR DESCRIPTION
## What changed?
The diagnostics failure invariant now recognizes workflows that failed with the "history exceeds limit" error and reports a dedicated root cause, including the history event count of the failed workflow.

Misc:
- The variable `FailureReasonSizeExceedsLimit` has been renamed to `FailureReasonHistorySizeExceedsLimit`

## Why?
When a workflow fails because its history grew past the size or event count limit, diagnostics previously bucketed it as a generic custom error ("Customised error returned by the activity/workflow"), which points users in the wrong direction. The new root cause names the actual problem. The runbook update linked below suggests remediation (ContinueAsNew, smaller payloads, avoiding unbounded loops in one run).

## How did you test it?
```
make pr GEN_DIR=service/worker/diagnostics  # clean, no generated diffs
make build
make test                                   # all unit tests pass
go test -race ./service/worker/diagnostics/...
```

## Potential risks
None — isolated change to the diagnostics worker; no API/schema/flag impact.

## Release notes
Workflow diagnostics now identifies failures caused by exceeding history size/count limits and surfaces an actionable root cause.

## Documentation Changes
Failures runbook update: https://github.com/cadence-workflow/Cadence-Docs/pull/406