### PR TITLE
feat(history): smooth history task DLQ processor load on failover and deploys

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1643,6 +1643,13 @@ const (
 	// Allowed filters: N/A
 	QueueMaxVirtualQueueCount
 
+	// HistoryTaskDLQProcessorHostConcurrency is the maximum number of shards that may process the History Task DLQ concurrently on one history host.
+	// KeyName: history.historyTaskDLQProcessorHostConcurrency
+	// Value type: Int
+	// Default value: 10
+	// Allowed filters: N/A
+	HistoryTaskDLQProcessorHostConcurrency
+
 	// HistoryTaskListNiceValue is the nice value for task processing priority per domain and task list.
 	// KeyName: history.taskListNiceValue
 	// Value type: Int
@@ -4619,6 +4626,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		KeyName:      "history.queueMaxVirtualQueueCount",
 		Description:  "QueueMaxVirtualQueueCount is the max number of virtual queues",
 		DefaultValue: 2,
+	},
+	HistoryTaskDLQProcessorHostConcurrency: {
+		KeyName:      "history.historyTaskDLQProcessorHostConcurrency",
+		Description:  "HistoryTaskDLQProcessorHostConcurrency is the maximum number of shards that may process the History Task DLQ concurrently on one history host",
+		DefaultValue: 10,
 	},
 	HistoryTaskListNiceValue: {
 		KeyName:      "history.taskListNiceValue",

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -3374,6 +3374,12 @@ const (
 	// Allowed filters: ShardID
 	HistoryTaskDLQProcessorInterval
 
+	// HistoryTaskDLQProcessorFailoverJitterMaxDelay is the maximum jitter delay before processing failover-triggered History Task DLQ partitions
+	// KeyName: history.historyTaskDLQProcessorFailoverJitterMaxDelay
+	// Value type: Duration
+	// Default value: 1m (1 * time.Minute)
+	HistoryTaskDLQProcessorFailoverJitterMaxDelay
+
 	// OperationalConfigStorePollInterval controls how often the operational
 	// dynamic config store re-reads its snapshot from the primary database.
 	// KeyName: system.operationalConfigStorePollInterval
@@ -6115,6 +6121,11 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		Filters:      []Filter{ShardID},
 		Description:  "HistoryTaskDLQProcessorInterval is the interval for background processing of the History Task DLQ",
 		DefaultValue: time.Minute * 30,
+	},
+	HistoryTaskDLQProcessorFailoverJitterMaxDelay: {
+		KeyName:      "history.historyTaskDLQProcessorFailoverJitterMaxDelay",
+		Description:  "HistoryTaskDLQProcessorFailoverJitterMaxDelay is the maximum jitter delay before processing failover-triggered History Task DLQ partitions",
+		DefaultValue: time.Minute,
 	},
 	OperationalConfigStorePollInterval: {
 		KeyName:      "system.operationalConfigStorePollInterval",

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -362,6 +362,7 @@ type Config struct {
 	HistoryTaskDLQProcessorInterval               dynamicproperties.DurationPropertyFnWithShardIDFilter
 	HistoryTaskDLQProcessorFailoverJitterMaxDelay dynamicproperties.DurationPropertyFn
 	HistoryTaskDLQProcessorEnabled                dynamicproperties.BoolPropertyFn
+	HistoryTaskDLQProcessorHostConcurrency        dynamicproperties.IntPropertyFn
 
 	// HostName for machine running the service
 	HostName string
@@ -646,6 +647,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		HistoryTaskDLQProcessorInterval:               dc.GetDurationPropertyFilteredByShardID(dynamicproperties.HistoryTaskDLQProcessorInterval),
 		HistoryTaskDLQProcessorFailoverJitterMaxDelay: dc.GetDurationProperty(dynamicproperties.HistoryTaskDLQProcessorFailoverJitterMaxDelay),
 		HistoryTaskDLQProcessorEnabled:                dc.GetBoolProperty(dynamicproperties.HistoryTaskDLQProcessorEnabled),
+		HistoryTaskDLQProcessorHostConcurrency:        dc.GetIntProperty(dynamicproperties.HistoryTaskDLQProcessorHostConcurrency),
 
 		HostName: hostname,
 	}

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -358,9 +358,10 @@ type Config struct {
 	GlobalRatelimiterGCAfter        dynamicproperties.DurationPropertyFn
 
 	// History Task DLQ Configuration
-	HistoryTaskDLQMode              dynamicproperties.StringPropertyFnWithDomainFilter
-	HistoryTaskDLQProcessorInterval dynamicproperties.DurationPropertyFnWithShardIDFilter
-	HistoryTaskDLQProcessorEnabled  dynamicproperties.BoolPropertyFn
+	HistoryTaskDLQMode                            dynamicproperties.StringPropertyFnWithDomainFilter
+	HistoryTaskDLQProcessorInterval               dynamicproperties.DurationPropertyFnWithShardIDFilter
+	HistoryTaskDLQProcessorFailoverJitterMaxDelay dynamicproperties.DurationPropertyFn
+	HistoryTaskDLQProcessorEnabled                dynamicproperties.BoolPropertyFn
 
 	// HostName for machine running the service
 	HostName string
@@ -641,9 +642,10 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		GlobalRatelimiterDecayAfter:     dc.GetDurationProperty(dynamicproperties.HistoryGlobalRatelimiterDecayAfter),
 		GlobalRatelimiterGCAfter:        dc.GetDurationProperty(dynamicproperties.HistoryGlobalRatelimiterGCAfter),
 
-		HistoryTaskDLQMode:              dc.GetStringPropertyFilteredByDomain(dynamicproperties.HistoryTaskDLQMode),
-		HistoryTaskDLQProcessorInterval: dc.GetDurationPropertyFilteredByShardID(dynamicproperties.HistoryTaskDLQProcessorInterval),
-		HistoryTaskDLQProcessorEnabled:  dc.GetBoolProperty(dynamicproperties.HistoryTaskDLQProcessorEnabled),
+		HistoryTaskDLQMode:                            dc.GetStringPropertyFilteredByDomain(dynamicproperties.HistoryTaskDLQMode),
+		HistoryTaskDLQProcessorInterval:               dc.GetDurationPropertyFilteredByShardID(dynamicproperties.HistoryTaskDLQProcessorInterval),
+		HistoryTaskDLQProcessorFailoverJitterMaxDelay: dc.GetDurationProperty(dynamicproperties.HistoryTaskDLQProcessorFailoverJitterMaxDelay),
+		HistoryTaskDLQProcessorEnabled:                dc.GetBoolProperty(dynamicproperties.HistoryTaskDLQProcessorEnabled),
 
 		HostName: hostname,
 	}

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -295,6 +295,8 @@ func TestNewConfig(t *testing.T) {
 		"RequireChecksumMatchAfterRebuildRepair":                 {dynamicproperties.RequireChecksumMatchAfterRebuildRepair, true},
 		"HistoryTaskDLQMode":                                     {dynamicproperties.HistoryTaskDLQMode, "enabled"},
 		"HistoryTaskDLQProcessorInterval":                        {dynamicproperties.HistoryTaskDLQProcessorInterval, time.Second},
+		"HistoryTaskDLQProcessorFailoverJitterMaxDelay":          {dynamicproperties.HistoryTaskDLQProcessorFailoverJitterMaxDelay, time.Second},
+		"HistoryTaskDLQProcessorHostConcurrency":                 {dynamicproperties.HistoryTaskDLQProcessorHostConcurrency, 10},
 		"HistoryTaskDLQProcessorEnabled":                         {dynamicproperties.HistoryTaskDLQProcessorEnabled, true},
 	}
 	client := dynamicconfig.NewInMemoryClient()

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -145,6 +145,7 @@ func NewEngineWithShardContext(
 	rawMatchingClient matching.Client,
 	failoverCoordinator failover.Coordinator,
 	queueFactories []queue.Factory,
+	dlqHostLimiter *taskdlq.HostLimiter,
 ) engine.Engine {
 	currentClusterName := shard.GetService().GetClusterMetadata().GetCurrentClusterName()
 
@@ -302,6 +303,7 @@ func NewEngineWithShardContext(
 		config.HistoryTaskDLQProcessorFailoverJitterMaxDelay,
 		config.HistoryTaskDLQMode,
 		config.HistoryTaskDLQProcessorEnabled,
+		dlqHostLimiter,
 	)
 
 	shard.SetEngine(historyEngImpl)

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -299,6 +299,7 @@ func NewEngineWithShardContext(
 		shard,
 		100,
 		config.HistoryTaskDLQProcessorInterval,
+		config.HistoryTaskDLQProcessorFailoverJitterMaxDelay,
 		config.HistoryTaskDLQMode,
 		config.HistoryTaskDLQProcessorEnabled,
 	)

--- a/service/history/engine/testdata/engine_for_tests.go
+++ b/service/history/engine/testdata/engine_for_tests.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/service/history/queue"
 	"github.com/uber/cadence/service/history/replication"
 	"github.com/uber/cadence/service/history/shard"
+	"github.com/uber/cadence/service/history/taskdlq"
 )
 
 type EngineForTest struct {
@@ -58,6 +59,7 @@ type NewEngineFn func(
 	rawMatchingClient matching.Client,
 	failoverCoordinator failover.Coordinator,
 	queueFactories []queue.Factory,
+	dlqHostLimiter *taskdlq.HostLimiter,
 ) engine.Engine
 
 func NewEngineForTest(t *testing.T, newEngineFn NewEngineFn) *EngineForTest {
@@ -147,6 +149,7 @@ func NewEngineForTest(t *testing.T, newEngineFn NewEngineFn) *EngineForTest {
 		shardCtx.Resource.MatchingClient,
 		failoverCoordinator,
 		queueFactories,
+		nil,
 	)
 
 	shardCtx.SetEngine(engine)

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -61,6 +61,7 @@ import (
 	"github.com/uber/cadence/service/history/resource"
 	"github.com/uber/cadence/service/history/shard"
 	"github.com/uber/cadence/service/history/task"
+	"github.com/uber/cadence/service/history/taskdlq"
 	"github.com/uber/cadence/service/history/workflowcache"
 )
 
@@ -87,6 +88,7 @@ type (
 		ratelimitAggregator      algorithm.RequestWeighted
 		queueFactories           []queue.Factory
 		replicationBudgetManager cache.Manager
+		dlqHostLimiter           *taskdlq.HostLimiter
 	}
 )
 
@@ -106,6 +108,8 @@ func NewHandler(
 		rateLimiter:         quotas.NewDynamicRateLimiter(config.RPS.AsFloat64()),
 		workflowIDCache:     wfCache,
 		ratelimitAggregator: resource.GetRatelimiterAlgorithm(),
+		// Evaluated once at host startup; changing the concurrency requires a restart.
+		dlqHostLimiter: taskdlq.NewHostLimiter(config.HistoryTaskDLQProcessorHostConcurrency()),
 	}
 
 	// prevent us from trying to serve requests before shard controller is started and ready
@@ -258,6 +262,7 @@ func (h *handlerImpl) CreateEngine(
 		h.GetMatchingRawClient(),
 		h.failoverCoordinator,
 		h.queueFactories,
+		h.dlqHostLimiter,
 	)
 }
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -163,8 +163,9 @@ type (
 		CreateHistoryDLQAckLevelIfNotExists(ctx context.Context, request persistence.CreateHistoryDLQAckLevelRequest) error
 	}
 
-	// TaskDLQPartitionWriteTracker reports whether this shard has written history task DLQ
-	// rows for a partition during the current shard ownership.
+	// TaskDLQPartitionWriteTracker reports whether this shard has started writing history task DLQ
+	// rows for a partition during the current shard ownership. Partitions are marked before the
+	// persistence write is issued and remain marked if the write fails.
 	TaskDLQPartitionWriteTracker interface {
 		HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName string) bool
 	}
@@ -2016,8 +2017,9 @@ type dlqPartitionKey struct {
 type shardedHistoryTaskDLQWriter struct {
 	writer TaskDLQWriter
 
-	mu                   sync.Mutex
-	dlqAckLevelsCreated  map[dlqAckLevelKey]struct{}
+	mu                  sync.Mutex
+	dlqAckLevelsCreated map[dlqAckLevelKey]struct{}
+	// dlqPartitionsWritten is marked before a partition write is issued and remains marked if it fails.
 	dlqPartitionsWritten map[dlqPartitionKey]struct{}
 }
 
@@ -2025,17 +2027,15 @@ var _ TaskDLQWriter = &shardedHistoryTaskDLQWriter{}
 var _ TaskDLQPartitionWriteTracker = &shardedHistoryTaskDLQWriter{}
 
 func (w *shardedHistoryTaskDLQWriter) CreateHistoryDLQTask(ctx context.Context, request persistence.CreateHistoryDLQTaskRequest) error {
-	if err := w.writer.CreateHistoryDLQTask(ctx, request); err != nil {
-		return err
-	}
-	w.mu.Lock()
-	w.dlqPartitionsWritten[dlqPartitionKey{
+	partitionKey := dlqPartitionKey{
 		domainID:              request.DomainID,
 		clusterAttributeScope: request.ClusterAttributeScope,
 		clusterAttributeName:  request.ClusterAttributeName,
-	}] = struct{}{}
+	}
+	w.mu.Lock()
+	w.dlqPartitionsWritten[partitionKey] = struct{}{}
 	w.mu.Unlock()
-	return nil
+	return w.writer.CreateHistoryDLQTask(ctx, request)
 }
 
 func (w *shardedHistoryTaskDLQWriter) CreateHistoryDLQAckLevelIfNotExists(ctx context.Context, request persistence.CreateHistoryDLQAckLevelRequest) error {
@@ -2051,9 +2051,9 @@ func (w *shardedHistoryTaskDLQWriter) CreateHistoryDLQAckLevelIfNotExists(ctx co
 		taskCategoryID:        request.TaskCategory.ID(),
 	}
 	w.mu.Lock()
+	w.dlqPartitionsWritten[partitionKey] = struct{}{}
 	_, cached := w.dlqAckLevelsCreated[ackLevelKey]
 	if cached {
-		w.dlqPartitionsWritten[partitionKey] = struct{}{}
 		w.mu.Unlock()
 		return nil
 	}
@@ -2063,11 +2063,12 @@ func (w *shardedHistoryTaskDLQWriter) CreateHistoryDLQAckLevelIfNotExists(ctx co
 	}
 	w.mu.Lock()
 	w.dlqAckLevelsCreated[ackLevelKey] = struct{}{}
-	w.dlqPartitionsWritten[partitionKey] = struct{}{}
 	w.mu.Unlock()
 	return nil
 }
 
+// HasWrittenDLQPartition reports whether either write method has started a write for the partition.
+// The partition is reported as written before persistence is called, even if that call later fails.
 func (w *shardedHistoryTaskDLQWriter) HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName string) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -73,6 +73,7 @@ type (
 		PreviousShardOwnerWasDifferent() bool
 		GetReplicationBudgetManager() cache.Manager
 		GetHistoryTaskDLQWriter() TaskDLQWriter
+		GetHistoryTaskDLQPartitionWriteTracker() TaskDLQPartitionWriteTracker
 
 		GetEngine() engine.Engine
 		SetEngine(engine.Engine)
@@ -147,7 +148,7 @@ type (
 
 		// historyTaskDLQWriter wraps the host-wide DLQ manager with a shard-scoped ack-level dedup
 		// cache. The cache dies with the shard.
-		historyTaskDLQWriter TaskDLQWriter
+		historyTaskDLQWriter *shardedHistoryTaskDLQWriter
 
 		// exist only in memory
 		remoteClusterCurrentTime map[string]time.Time
@@ -160,6 +161,12 @@ type (
 	TaskDLQWriter interface {
 		CreateHistoryDLQTask(ctx context.Context, request persistence.CreateHistoryDLQTaskRequest) error
 		CreateHistoryDLQAckLevelIfNotExists(ctx context.Context, request persistence.CreateHistoryDLQAckLevelRequest) error
+	}
+
+	// TaskDLQPartitionWriteTracker reports whether this shard has written history task DLQ
+	// rows for a partition during the current shard ownership.
+	TaskDLQPartitionWriteTracker interface {
+		HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName string) bool
 	}
 )
 
@@ -1854,8 +1861,9 @@ func acquireShard(
 		scheduledTaskMaxReadLevelMap: scheduledTaskMaxReadLevelMap, // use ack to init read level
 		failoverLevels:               make(map[persistence.HistoryTaskCategory]map[string]persistence.FailoverLevel),
 		historyTaskDLQWriter: &shardedHistoryTaskDLQWriter{
-			writer:              shardItem.GetHistoryTaskDLQManager(),
-			dlqAckLevelsCreated: make(map[dlqAckLevelKey]struct{}),
+			writer:               shardItem.GetHistoryTaskDLQManager(),
+			dlqAckLevelsCreated:  make(map[dlqAckLevelKey]struct{}),
+			dlqPartitionsWritten: make(map[dlqPartitionKey]struct{}),
 		},
 		logger:                         shardItem.logger,
 		throttledLogger:                shardItem.throttledLogger,
@@ -1984,6 +1992,10 @@ func (s *contextImpl) GetHistoryTaskDLQWriter() TaskDLQWriter {
 	return s.historyTaskDLQWriter
 }
 
+func (s *contextImpl) GetHistoryTaskDLQPartitionWriteTracker() TaskDLQPartitionWriteTracker {
+	return s.historyTaskDLQWriter
+}
+
 // dlqAckLevelKey identifies a single DLQ partition + task category within a shard.
 type dlqAckLevelKey struct {
 	domainID              string
@@ -1992,40 +2004,77 @@ type dlqAckLevelKey struct {
 	taskCategoryID        int
 }
 
+type dlqPartitionKey struct {
+	domainID              string
+	clusterAttributeScope string
+	clusterAttributeName  string
+}
+
 // shardedHistoryTaskDLQWriter wraps the host-wide DLQ manager with a shard-scoped dedup cache so the
 // idempotent ack-level write is issued at most once per partition/task-category for the life of the
 // shard. It holds no shard reference: shardID is stamped onto each request by the caller.
 type shardedHistoryTaskDLQWriter struct {
 	writer TaskDLQWriter
 
-	mu                  sync.Mutex
-	dlqAckLevelsCreated map[dlqAckLevelKey]struct{}
+	mu                   sync.Mutex
+	dlqAckLevelsCreated  map[dlqAckLevelKey]struct{}
+	dlqPartitionsWritten map[dlqPartitionKey]struct{}
 }
 
 var _ TaskDLQWriter = &shardedHistoryTaskDLQWriter{}
+var _ TaskDLQPartitionWriteTracker = &shardedHistoryTaskDLQWriter{}
 
 func (w *shardedHistoryTaskDLQWriter) CreateHistoryDLQTask(ctx context.Context, request persistence.CreateHistoryDLQTaskRequest) error {
-	return w.writer.CreateHistoryDLQTask(ctx, request)
+	if err := w.writer.CreateHistoryDLQTask(ctx, request); err != nil {
+		return err
+	}
+	w.mu.Lock()
+	w.dlqPartitionsWritten[dlqPartitionKey{
+		domainID:              request.DomainID,
+		clusterAttributeScope: request.ClusterAttributeScope,
+		clusterAttributeName:  request.ClusterAttributeName,
+	}] = struct{}{}
+	w.mu.Unlock()
+	return nil
 }
 
 func (w *shardedHistoryTaskDLQWriter) CreateHistoryDLQAckLevelIfNotExists(ctx context.Context, request persistence.CreateHistoryDLQAckLevelRequest) error {
-	key := dlqAckLevelKey{
+	partitionKey := dlqPartitionKey{
+		domainID:              request.DomainID,
+		clusterAttributeScope: request.ClusterAttributeScope,
+		clusterAttributeName:  request.ClusterAttributeName,
+	}
+	ackLevelKey := dlqAckLevelKey{
 		domainID:              request.DomainID,
 		clusterAttributeScope: request.ClusterAttributeScope,
 		clusterAttributeName:  request.ClusterAttributeName,
 		taskCategoryID:        request.TaskCategory.ID(),
 	}
 	w.mu.Lock()
-	_, cached := w.dlqAckLevelsCreated[key]
-	w.mu.Unlock()
+	_, cached := w.dlqAckLevelsCreated[ackLevelKey]
 	if cached {
+		w.dlqPartitionsWritten[partitionKey] = struct{}{}
+		w.mu.Unlock()
 		return nil
 	}
+	w.mu.Unlock()
 	if err := w.writer.CreateHistoryDLQAckLevelIfNotExists(ctx, request); err != nil {
 		return err
 	}
 	w.mu.Lock()
-	w.dlqAckLevelsCreated[key] = struct{}{}
+	w.dlqAckLevelsCreated[ackLevelKey] = struct{}{}
+	w.dlqPartitionsWritten[partitionKey] = struct{}{}
 	w.mu.Unlock()
 	return nil
+}
+
+func (w *shardedHistoryTaskDLQWriter) HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, written := w.dlqPartitionsWritten[dlqPartitionKey{
+		domainID:              domainID,
+		clusterAttributeScope: clusterAttributeScope,
+		clusterAttributeName:  clusterAttributeName,
+	}]
+	return written
 }

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -311,6 +311,20 @@ func (mr *MockContextMockRecorder) GetHistoryManager() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryManager", reflect.TypeOf((*MockContext)(nil).GetHistoryManager))
 }
 
+// GetHistoryTaskDLQPartitionWriteTracker mocks base method.
+func (m *MockContext) GetHistoryTaskDLQPartitionWriteTracker() TaskDLQPartitionWriteTracker {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHistoryTaskDLQPartitionWriteTracker")
+	ret0, _ := ret[0].(TaskDLQPartitionWriteTracker)
+	return ret0
+}
+
+// GetHistoryTaskDLQPartitionWriteTracker indicates an expected call of GetHistoryTaskDLQPartitionWriteTracker.
+func (mr *MockContextMockRecorder) GetHistoryTaskDLQPartitionWriteTracker() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTaskDLQPartitionWriteTracker", reflect.TypeOf((*MockContext)(nil).GetHistoryTaskDLQPartitionWriteTracker))
+}
+
 // GetHistoryTaskDLQWriter mocks base method.
 func (m *MockContext) GetHistoryTaskDLQWriter() TaskDLQWriter {
 	m.ctrl.T.Helper()
@@ -795,4 +809,42 @@ func (m *MockTaskDLQWriter) CreateHistoryDLQTask(ctx context.Context, request pe
 func (mr *MockTaskDLQWriterMockRecorder) CreateHistoryDLQTask(ctx, request any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHistoryDLQTask", reflect.TypeOf((*MockTaskDLQWriter)(nil).CreateHistoryDLQTask), ctx, request)
+}
+
+// MockTaskDLQPartitionWriteTracker is a mock of TaskDLQPartitionWriteTracker interface.
+type MockTaskDLQPartitionWriteTracker struct {
+	ctrl     *gomock.Controller
+	recorder *MockTaskDLQPartitionWriteTrackerMockRecorder
+	isgomock struct{}
+}
+
+// MockTaskDLQPartitionWriteTrackerMockRecorder is the mock recorder for MockTaskDLQPartitionWriteTracker.
+type MockTaskDLQPartitionWriteTrackerMockRecorder struct {
+	mock *MockTaskDLQPartitionWriteTracker
+}
+
+// NewMockTaskDLQPartitionWriteTracker creates a new mock instance.
+func NewMockTaskDLQPartitionWriteTracker(ctrl *gomock.Controller) *MockTaskDLQPartitionWriteTracker {
+	mock := &MockTaskDLQPartitionWriteTracker{ctrl: ctrl}
+	mock.recorder = &MockTaskDLQPartitionWriteTrackerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTaskDLQPartitionWriteTracker) EXPECT() *MockTaskDLQPartitionWriteTrackerMockRecorder {
+	return m.recorder
+}
+
+// HasWrittenDLQPartition mocks base method.
+func (m *MockTaskDLQPartitionWriteTracker) HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasWrittenDLQPartition", domainID, clusterAttributeScope, clusterAttributeName)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasWrittenDLQPartition indicates an expected call of HasWrittenDLQPartition.
+func (mr *MockTaskDLQPartitionWriteTrackerMockRecorder) HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasWrittenDLQPartition", reflect.TypeOf((*MockTaskDLQPartitionWriteTracker)(nil).HasWrittenDLQPartition), domainID, clusterAttributeScope, clusterAttributeName)
 }

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -2318,6 +2318,57 @@ func TestShardedHistoryTaskDLQWriterAckLevel(t *testing.T) {
 	}
 }
 
+func TestShardedHistoryTaskDLQWriter_MarksPartitionBeforePersistenceWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// The inner writer observes the tracker state at the moment the persistence
+	// write is issued: the partition must already be reported as written, so a
+	// concurrent reader can never see a committed write with an unmarked partition.
+	inner := NewMockTaskDLQWriter(ctrl)
+	w := &shardedHistoryTaskDLQWriter{
+		writer:               inner,
+		dlqAckLevelsCreated:  make(map[dlqAckLevelKey]struct{}),
+		dlqPartitionsWritten: make(map[dlqPartitionKey]struct{}),
+	}
+
+	taskReq := persistence.CreateHistoryDLQTaskRequest{
+		ShardID:               1,
+		DomainID:              "d1",
+		ClusterAttributeScope: "s",
+		ClusterAttributeName:  "n",
+	}
+	inner.EXPECT().CreateHistoryDLQTask(gomock.Any(), taskReq).DoAndReturn(
+		func(ctx context.Context, req persistence.CreateHistoryDLQTaskRequest) error {
+			require.True(t, w.HasWrittenDLQPartition("d1", "s", "n"),
+				"partition must be marked written before the persistence write is issued")
+			return errors.New("persistence write failed")
+		})
+	require.Error(t, w.CreateHistoryDLQTask(context.Background(), taskReq))
+	// Pre-marking is conservative: the mark survives a failed write.
+	require.True(t, w.HasWrittenDLQPartition("d1", "s", "n"))
+
+	ackReq := persistence.CreateHistoryDLQAckLevelRequest{
+		ShardID:               1,
+		DomainID:              "d2",
+		ClusterAttributeScope: "s",
+		ClusterAttributeName:  "n",
+		TaskCategory:          persistence.HistoryTaskCategoryTransfer,
+	}
+	inner.EXPECT().CreateHistoryDLQAckLevelIfNotExists(gomock.Any(), ackReq).DoAndReturn(
+		func(ctx context.Context, req persistence.CreateHistoryDLQAckLevelRequest) error {
+			require.True(t, w.HasWrittenDLQPartition("d2", "s", "n"),
+				"partition must be marked written before the ack-level create is issued")
+			return errors.New("persistence write failed")
+		})
+	require.Error(t, w.CreateHistoryDLQAckLevelIfNotExists(context.Background(), ackReq))
+	require.True(t, w.HasWrittenDLQPartition("d2", "s", "n"))
+	// The ack-level dedup cache must NOT cache the failure: a retry must call
+	// the inner writer again.
+	inner.EXPECT().CreateHistoryDLQAckLevelIfNotExists(gomock.Any(), ackReq).Return(nil)
+	require.NoError(t, w.CreateHistoryDLQAckLevelIfNotExists(context.Background(), ackReq))
+}
+
 func TestShardedHistoryTaskDLQWriterPartitionWriteTracking(t *testing.T) {
 	const (
 		domainID = "dom"
@@ -2366,7 +2417,7 @@ func TestShardedHistoryTaskDLQWriterPartitionWriteTracking(t *testing.T) {
 		require.True(t, w.HasWrittenDLQPartition(domainID, scope, name))
 	})
 
-	t.Run("failed writes do not mark partition", func(t *testing.T) {
+	t.Run("failed writes mark partition", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		dlqMgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
 		w := newWriter(dlqMgr)
@@ -2385,10 +2436,10 @@ func TestShardedHistoryTaskDLQWriterPartitionWriteTracking(t *testing.T) {
 
 		dlqMgr.EXPECT().CreateHistoryDLQTask(gomock.Any(), taskReq).Return(writeErr)
 		require.ErrorIs(t, w.CreateHistoryDLQTask(context.Background(), taskReq), writeErr)
-		require.False(t, w.HasWrittenDLQPartition(domainID, scope, name))
+		require.True(t, w.HasWrittenDLQPartition(domainID, scope, name))
 
 		dlqMgr.EXPECT().CreateHistoryDLQAckLevelIfNotExists(gomock.Any(), ackReq).Return(writeErr)
 		require.ErrorIs(t, w.CreateHistoryDLQAckLevelIfNotExists(context.Background(), ackReq), writeErr)
-		require.False(t, w.HasWrittenDLQPartition(domainID, scope, name))
+		require.True(t, w.HasWrittenDLQPartition(domainID, scope, name))
 	})
 }

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -2300,7 +2300,11 @@ func TestShardedHistoryTaskDLQWriterAckLevel(t *testing.T) {
 				}).
 				Times(tc.wantManagerCalls)
 
-			w := &shardedHistoryTaskDLQWriter{writer: dlqMgr, dlqAckLevelsCreated: make(map[dlqAckLevelKey]struct{})}
+			w := &shardedHistoryTaskDLQWriter{
+				writer:               dlqMgr,
+				dlqAckLevelsCreated:  make(map[dlqAckLevelKey]struct{}),
+				dlqPartitionsWritten: make(map[dlqPartitionKey]struct{}),
+			}
 			for i, want := range tc.wantErrs {
 				err := w.CreateHistoryDLQAckLevelIfNotExists(context.Background(), req)
 				if want == "" {
@@ -2312,4 +2316,79 @@ func TestShardedHistoryTaskDLQWriterAckLevel(t *testing.T) {
 			assert.Equal(t, tc.wantManagerCalls, managerCalls)
 		})
 	}
+}
+
+func TestShardedHistoryTaskDLQWriterPartitionWriteTracking(t *testing.T) {
+	const (
+		domainID = "dom"
+		scope    = "scope"
+		name     = "cluster-a"
+	)
+
+	newWriter := func(dlqMgr TaskDLQWriter) *shardedHistoryTaskDLQWriter {
+		return &shardedHistoryTaskDLQWriter{
+			writer:               dlqMgr,
+			dlqAckLevelsCreated:  make(map[dlqAckLevelKey]struct{}),
+			dlqPartitionsWritten: make(map[dlqPartitionKey]struct{}),
+		}
+	}
+
+	t.Run("successful task write marks partition", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dlqMgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+		w := newWriter(dlqMgr)
+		req := persistence.CreateHistoryDLQTaskRequest{
+			DomainID:              domainID,
+			ClusterAttributeScope: scope,
+			ClusterAttributeName:  name,
+		}
+
+		require.False(t, w.HasWrittenDLQPartition(domainID, scope, name))
+		dlqMgr.EXPECT().CreateHistoryDLQTask(gomock.Any(), req).Return(nil)
+		require.NoError(t, w.CreateHistoryDLQTask(context.Background(), req))
+		require.True(t, w.HasWrittenDLQPartition(domainID, scope, name))
+	})
+
+	t.Run("successful ack-level write marks partition", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dlqMgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+		w := newWriter(dlqMgr)
+		req := persistence.CreateHistoryDLQAckLevelRequest{
+			DomainID:              domainID,
+			ClusterAttributeScope: scope,
+			ClusterAttributeName:  name,
+			TaskCategory:          persistence.HistoryTaskCategoryTransfer,
+		}
+
+		require.False(t, w.HasWrittenDLQPartition(domainID, scope, name))
+		dlqMgr.EXPECT().CreateHistoryDLQAckLevelIfNotExists(gomock.Any(), req).Return(nil)
+		require.NoError(t, w.CreateHistoryDLQAckLevelIfNotExists(context.Background(), req))
+		require.True(t, w.HasWrittenDLQPartition(domainID, scope, name))
+	})
+
+	t.Run("failed writes do not mark partition", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dlqMgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+		w := newWriter(dlqMgr)
+		taskReq := persistence.CreateHistoryDLQTaskRequest{
+			DomainID:              domainID,
+			ClusterAttributeScope: scope,
+			ClusterAttributeName:  name,
+		}
+		ackReq := persistence.CreateHistoryDLQAckLevelRequest{
+			DomainID:              domainID,
+			ClusterAttributeScope: scope,
+			ClusterAttributeName:  name,
+			TaskCategory:          persistence.HistoryTaskCategoryTransfer,
+		}
+		writeErr := errors.New("write failed")
+
+		dlqMgr.EXPECT().CreateHistoryDLQTask(gomock.Any(), taskReq).Return(writeErr)
+		require.ErrorIs(t, w.CreateHistoryDLQTask(context.Background(), taskReq), writeErr)
+		require.False(t, w.HasWrittenDLQPartition(domainID, scope, name))
+
+		dlqMgr.EXPECT().CreateHistoryDLQAckLevelIfNotExists(gomock.Any(), ackReq).Return(writeErr)
+		require.ErrorIs(t, w.CreateHistoryDLQAckLevelIfNotExists(context.Background(), ackReq), writeErr)
+		require.False(t, w.HasWrittenDLQPartition(domainID, scope, name))
+	})
 }

--- a/service/history/shard/context_test_utils.go
+++ b/service/history/shard/context_test_utils.go
@@ -74,8 +74,9 @@ func NewTestContext(
 		scheduledTaskMaxReadLevelMap: make(map[string]time.Time),
 		failoverLevels:               make(map[persistence.HistoryTaskCategory]map[string]persistence.FailoverLevel),
 		historyTaskDLQWriter: &shardedHistoryTaskDLQWriter{
-			writer:              resource.GetHistoryTaskDLQManager(),
-			dlqAckLevelsCreated: make(map[dlqAckLevelKey]struct{}),
+			writer:               resource.GetHistoryTaskDLQManager(),
+			dlqAckLevelsCreated:  make(map[dlqAckLevelKey]struct{}),
+			dlqPartitionsWritten: make(map[dlqPartitionKey]struct{}),
 		},
 		remoteClusterCurrentTime: make(map[string]time.Time),
 		eventsCache:              eventsCache,

--- a/service/history/taskdlq/host_limiter.go
+++ b/service/history/taskdlq/host_limiter.go
@@ -1,0 +1,62 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2026 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package taskdlq
+
+import (
+	"context"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// HostLimiter bounds how many shards' DLQ processing may run concurrently on a
+// single history host. A nil *HostLimiter, or one built with a non-positive
+// limit, imposes no bound.
+type HostLimiter struct {
+	sem *semaphore.Weighted
+}
+
+// NewHostLimiter returns a limiter allowing up to limit concurrent holders.
+// A non-positive limit returns an unbounded limiter.
+func NewHostLimiter(limit int) *HostLimiter {
+	limiter := &HostLimiter{}
+	if limit > 0 {
+		limiter.sem = semaphore.NewWeighted(int64(limit))
+	}
+	return limiter
+}
+
+// Acquire blocks until a slot is free or ctx is done.
+func (l *HostLimiter) Acquire(ctx context.Context) error {
+	if l == nil || l.sem == nil {
+		return ctx.Err()
+	}
+	return l.sem.Acquire(ctx, 1)
+}
+
+// Release frees a slot previously acquired with Acquire.
+func (l *HostLimiter) Release() {
+	if l == nil || l.sem == nil {
+		return
+	}
+	l.sem.Release(1)
+}

--- a/service/history/taskdlq/host_limiter_test.go
+++ b/service/history/taskdlq/host_limiter_test.go
@@ -1,0 +1,103 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2026 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package taskdlq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostLimiter_NilReceiver(t *testing.T) {
+	var limiter *HostLimiter
+	require.NoError(t, limiter.Acquire(context.Background()))
+	limiter.Release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, limiter.Acquire(ctx), context.Canceled)
+}
+
+func TestHostLimiter_NonPositiveLimitIsUnbounded(t *testing.T) {
+	limiter := NewHostLimiter(0)
+	require.NoError(t, limiter.Acquire(context.Background()))
+	limiter.Release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, limiter.Acquire(ctx), context.Canceled)
+}
+
+func TestHostLimiter_BlocksUntilRelease(t *testing.T) {
+	limiter := NewHostLimiter(1)
+	require.NoError(t, limiter.Acquire(context.Background()))
+
+	acquired := make(chan error, 1)
+	go func() {
+		acquired <- limiter.Acquire(context.Background())
+	}()
+
+	select {
+	case err := <-acquired:
+		require.NoError(t, err)
+		t.Fatal("second acquire succeeded before release")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	limiter.Release()
+	select {
+	case err := <-acquired:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second acquire did not succeed after release")
+	}
+	limiter.Release()
+}
+
+func TestHostLimiter_AcquireReturnsContextErrorWhileWaiting(t *testing.T) {
+	limiter := NewHostLimiter(1)
+	require.NoError(t, limiter.Acquire(context.Background()))
+	defer limiter.Release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- limiter.Acquire(ctx)
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("acquire returned before cancellation: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("acquire did not return after cancellation")
+	}
+}

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -98,6 +98,7 @@ type (
 		failoverJitterMaxDelay dynamicproperties.DurationPropertyFn
 		domainMode             dynamicproperties.StringPropertyFnWithDomainFilter
 		enabled                dynamicproperties.BoolPropertyFn
+		hostLimiter            *HostLimiter
 		timeSource             clock.TimeSource
 		metricsClient          metrics.Client
 		logger                 log.Logger
@@ -134,6 +135,7 @@ type (
 		FailoverJitterMaxDelay dynamicproperties.DurationPropertyFn
 		DomainMode             dynamicproperties.StringPropertyFnWithDomainFilter
 		Enabled                dynamicproperties.BoolPropertyFn
+		HostLimiter            *HostLimiter
 		TimeSource             clock.TimeSource
 		MetricsClient          metrics.Client
 		Logger                 log.Logger
@@ -164,6 +166,7 @@ func NewProcessor(params ProcessorParams) *ProcessorImpl {
 		failoverJitterMaxDelay: params.FailoverJitterMaxDelay,
 		domainMode:             params.DomainMode,
 		enabled:                params.Enabled,
+		hostLimiter:            params.HostLimiter,
 		timeSource:             params.TimeSource,
 		metricsClient:          params.MetricsClient,
 		logger:                 params.Logger,
@@ -199,6 +202,7 @@ func NewProcessorFromShard(
 	failoverJitterMaxDelay dynamicproperties.DurationPropertyFn,
 	domainMode dynamicproperties.StringPropertyFnWithDomainFilter,
 	enabled dynamicproperties.BoolPropertyFn,
+	hostLimiter *HostLimiter,
 ) *ProcessorImpl {
 	return NewProcessor(ProcessorParams{
 		ShardID:                shard.GetShardID(),
@@ -210,6 +214,7 @@ func NewProcessorFromShard(
 		FailoverJitterMaxDelay: failoverJitterMaxDelay,
 		DomainMode:             domainMode,
 		Enabled:                enabled,
+		HostLimiter:            hostLimiter,
 		TimeSource:             shard.GetTimeSource(),
 		MetricsClient:          shard.GetMetricsClient(),
 		Logger:                 shard.GetLogger(),
@@ -351,6 +356,10 @@ func (p *ProcessorImpl) processPendingFailovers() {
 func (p *ProcessorImpl) ProcessShard(ctx context.Context) error {
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
+	if err := p.hostLimiter.Acquire(ctx); err != nil {
+		return err
+	}
+	defer p.hostLimiter.Release()
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -372,6 +381,10 @@ func (p *ProcessorImpl) ProcessPartition(ctx context.Context, domainID, clusterA
 
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
+	if err := p.hostLimiter.Acquire(ctx); err != nil {
+		return err
+	}
+	defer p.hostLimiter.Release()
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -27,10 +27,12 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.uber.org/multierr"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
@@ -40,6 +42,10 @@ import (
 	"github.com/uber/cadence/service/history/constants"
 	"github.com/uber/cadence/service/history/shard"
 )
+
+// sweepIntervalJitterCoefficient spreads periodic sweeps across shards; see
+// emitDLQSizeMetricsLoop in service/history/replication/dlq_handler.go for precedent.
+const sweepIntervalJitterCoefficient = 0.15
 
 type (
 	// Processor reads tasks from the history task DLQ and executes them synchronously.
@@ -238,7 +244,7 @@ func (p *ProcessorImpl) processLoop() {
 	defer p.wg.Done()
 	defer func() { log.CapturePanic(recover(), p.logger, nil) }()
 
-	timer := p.timeSource.NewTimer(p.interval(p.shardID))
+	timer := p.timeSource.NewTimer(p.sweepInterval())
 	defer timer.Stop()
 
 	for {
@@ -252,9 +258,15 @@ func (p *ProcessorImpl) processLoop() {
 			p.runSweep()
 			// A failover may have preempted the sweep; drain it before the next tick.
 			p.processPendingFailovers()
-			timer.Reset(p.interval(p.shardID))
+			timer.Reset(p.sweepInterval())
 		}
 	}
+}
+
+// sweepInterval returns the configured sweep interval with jitter applied so
+// shards' periodic sweeps don't run in synchronized cluster-wide waves.
+func (p *ProcessorImpl) sweepInterval() time.Duration {
+	return backoff.JitDuration(p.interval(p.shardID), sweepIntervalJitterCoefficient)
 }
 
 // runSweep runs one periodic ProcessShard synchronously under a cancelable context.

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -88,6 +88,13 @@ type (
 	// of the given category in the current processing round.
 	MaxReadLevelFn func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey
 
+	// PartitionWriteTracker reports whether the shard has written DLQ rows for a
+	// partition during the current shard ownership. See
+	// shard.TaskDLQPartitionWriteTracker for the production implementation.
+	PartitionWriteTracker interface {
+		HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName string) bool
+	}
+
 	ProcessorImpl struct {
 		shardID                int
 		mgr                    persistence.HistoryTaskDLQManager
@@ -99,6 +106,7 @@ type (
 		domainMode             dynamicproperties.StringPropertyFnWithDomainFilter
 		enabled                dynamicproperties.BoolPropertyFn
 		hostLimiter            *HostLimiter
+		writeTracker           PartitionWriteTracker
 		timeSource             clock.TimeSource
 		metricsClient          metrics.Client
 		logger                 log.Logger
@@ -108,6 +116,13 @@ type (
 		cancel    context.CancelFunc
 		wg        sync.WaitGroup
 		processMu sync.Mutex // serializes ProcessShard and ProcessPartition
+
+		// verifiedEmptyMu guards verifiedEmpty.
+		verifiedEmptyMu sync.Mutex
+		// verifiedEmpty holds Partition.key()s whose GetHistoryDLQAckLevels returned no rows.
+		// A key is only trusted while writeTracker reports the partition unwritten, and is
+		// cleared whenever a shard sweep sees the partition.
+		verifiedEmpty map[string]struct{}
 
 		// failoverMu guards the failover coordination state below.
 		failoverMu sync.Mutex
@@ -136,6 +151,7 @@ type (
 		DomainMode             dynamicproperties.StringPropertyFnWithDomainFilter
 		Enabled                dynamicproperties.BoolPropertyFn
 		HostLimiter            *HostLimiter
+		WriteTracker           PartitionWriteTracker
 		TimeSource             clock.TimeSource
 		MetricsClient          metrics.Client
 		Logger                 log.Logger
@@ -167,11 +183,13 @@ func NewProcessor(params ProcessorParams) *ProcessorImpl {
 		domainMode:             params.DomainMode,
 		enabled:                params.Enabled,
 		hostLimiter:            params.HostLimiter,
+		writeTracker:           params.WriteTracker,
 		timeSource:             params.TimeSource,
 		metricsClient:          params.MetricsClient,
 		logger:                 params.Logger,
 		status:                 common.DaemonStatusInitialized,
 		cancel:                 func() {}, // no-op until Start() sets the real cancel
+		verifiedEmpty:          make(map[string]struct{}),
 		pendingFailover:        make(map[string]Partition),
 		failoverSignal:         make(chan struct{}, 1),
 	}
@@ -215,6 +233,7 @@ func NewProcessorFromShard(
 		DomainMode:             domainMode,
 		Enabled:                enabled,
 		HostLimiter:            hostLimiter,
+		WriteTracker:           shard.GetHistoryTaskDLQPartitionWriteTracker(),
 		TimeSource:             shard.GetTimeSource(),
 		MetricsClient:          shard.GetMetricsClient(),
 		Logger:                 shard.GetLogger(),
@@ -378,6 +397,26 @@ func (p *ProcessorImpl) ProcessPartition(ctx context.Context, domainID, clusterA
 		p.logger.Debug("DLQ not enabled for domain, skipping partition processing", tag.ShardID(p.shardID), tag.WorkflowDomainID(domainID))
 		return nil
 	}
+	partition := Partition{
+		DomainID:              domainID,
+		ClusterAttributeScope: clusterAttributeScope,
+		ClusterAttributeName:  clusterAttributeName,
+	}
+	partitionKey := partition.key()
+	if p.writeTracker != nil {
+		p.verifiedEmptyMu.Lock()
+		_, verifiedEmpty := p.verifiedEmpty[partitionKey]
+		p.verifiedEmptyMu.Unlock()
+		if verifiedEmpty && !p.writeTracker.HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName) {
+			p.logger.Debug("DLQ partition previously verified empty, skipping partition processing",
+				tag.ShardID(p.shardID),
+				tag.WorkflowDomainID(domainID),
+				tag.Dynamic("cluster-attribute-scope", clusterAttributeScope),
+				tag.Dynamic("cluster-attribute-name", clusterAttributeName),
+			)
+			return nil
+		}
+	}
 
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
@@ -397,6 +436,11 @@ func (p *ProcessorImpl) ProcessPartition(ctx context.Context, domainID, clusterA
 	if err != nil {
 		return fmt.Errorf("get DLQ ack levels for partition (shard=%d domain=%s scope=%s name=%s): %w",
 			p.shardID, domainID, clusterAttributeScope, clusterAttributeName, err)
+	}
+	if len(ackLevels) == 0 && p.writeTracker != nil {
+		p.verifiedEmptyMu.Lock()
+		p.verifiedEmpty[partitionKey] = struct{}{}
+		p.verifiedEmptyMu.Unlock()
 	}
 	return p.processAckLevels(ctx, ackLevels)
 }
@@ -431,6 +475,16 @@ func (p *ProcessorImpl) FailoverPartitions(partitions []Partition) {
 // It manages context cancellation to allow the processor to preempt and ongoing operation.
 // Returns an error when any of the ack levels cannot be processed
 func (p *ProcessorImpl) processAckLevels(ctx context.Context, ackLevels []persistence.HistoryDLQAckLevel) error {
+	p.verifiedEmptyMu.Lock()
+	for _, al := range ackLevels {
+		delete(p.verifiedEmpty, (&Partition{
+			DomainID:              al.DomainID,
+			ClusterAttributeScope: al.ClusterAttributeScope,
+			ClusterAttributeName:  al.ClusterAttributeName,
+		}).key())
+	}
+	p.verifiedEmptyMu.Unlock()
+
 	var errs error
 	for _, al := range ackLevels {
 		// Preempt promptly when the sweep's context is canceled (e.g. a failover wants to run

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -25,6 +25,7 @@ package taskdlq
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -88,17 +89,18 @@ type (
 	MaxReadLevelFn func(category persistence.HistoryTaskCategory) persistence.HistoryTaskKey
 
 	ProcessorImpl struct {
-		shardID       int
-		mgr           persistence.HistoryTaskDLQManager
-		reinjector    TaskReinjector
-		maxReadLevel  MaxReadLevelFn
-		pageSize      int
-		interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
-		domainMode    dynamicproperties.StringPropertyFnWithDomainFilter
-		enabled       dynamicproperties.BoolPropertyFn
-		timeSource    clock.TimeSource
-		metricsClient metrics.Client
-		logger        log.Logger
+		shardID                int
+		mgr                    persistence.HistoryTaskDLQManager
+		reinjector             TaskReinjector
+		maxReadLevel           MaxReadLevelFn
+		pageSize               int
+		interval               dynamicproperties.DurationPropertyFnWithShardIDFilter
+		failoverJitterMaxDelay dynamicproperties.DurationPropertyFn
+		domainMode             dynamicproperties.StringPropertyFnWithDomainFilter
+		enabled                dynamicproperties.BoolPropertyFn
+		timeSource             clock.TimeSource
+		metricsClient          metrics.Client
+		logger                 log.Logger
 
 		status    int32
 		ctx       context.Context
@@ -126,14 +128,15 @@ type (
 		Reinjector TaskReinjector
 		// MaxReadLevel provides the exclusive upper bound for each processing round.
 		// Optional: defaults to an unbounded read (MaximumHistoryTaskKey) when nil.
-		MaxReadLevel  MaxReadLevelFn
-		PageSize      int
-		Interval      dynamicproperties.DurationPropertyFnWithShardIDFilter
-		DomainMode    dynamicproperties.StringPropertyFnWithDomainFilter
-		Enabled       dynamicproperties.BoolPropertyFn
-		TimeSource    clock.TimeSource
-		MetricsClient metrics.Client
-		Logger        log.Logger
+		MaxReadLevel           MaxReadLevelFn
+		PageSize               int
+		Interval               dynamicproperties.DurationPropertyFnWithShardIDFilter
+		FailoverJitterMaxDelay dynamicproperties.DurationPropertyFn
+		DomainMode             dynamicproperties.StringPropertyFnWithDomainFilter
+		Enabled                dynamicproperties.BoolPropertyFn
+		TimeSource             clock.TimeSource
+		MetricsClient          metrics.Client
+		Logger                 log.Logger
 	}
 )
 
@@ -152,21 +155,22 @@ func NewProcessor(params ProcessorParams) *ProcessorImpl {
 		}
 	}
 	return &ProcessorImpl{
-		shardID:         params.ShardID,
-		mgr:             params.Manager,
-		reinjector:      params.Reinjector,
-		maxReadLevel:    maxReadLevel,
-		pageSize:        params.PageSize,
-		interval:        params.Interval,
-		domainMode:      params.DomainMode,
-		enabled:         params.Enabled,
-		timeSource:      params.TimeSource,
-		metricsClient:   params.MetricsClient,
-		logger:          params.Logger,
-		status:          common.DaemonStatusInitialized,
-		cancel:          func() {}, // no-op until Start() sets the real cancel
-		pendingFailover: make(map[string]Partition),
-		failoverSignal:  make(chan struct{}, 1),
+		shardID:                params.ShardID,
+		mgr:                    params.Manager,
+		reinjector:             params.Reinjector,
+		maxReadLevel:           maxReadLevel,
+		pageSize:               params.PageSize,
+		interval:               params.Interval,
+		failoverJitterMaxDelay: params.FailoverJitterMaxDelay,
+		domainMode:             params.DomainMode,
+		enabled:                params.Enabled,
+		timeSource:             params.TimeSource,
+		metricsClient:          params.MetricsClient,
+		logger:                 params.Logger,
+		status:                 common.DaemonStatusInitialized,
+		cancel:                 func() {}, // no-op until Start() sets the real cancel
+		pendingFailover:        make(map[string]Partition),
+		failoverSignal:         make(chan struct{}, 1),
 	}
 }
 
@@ -192,21 +196,23 @@ func NewProcessorFromShard(
 	// TODO(c-warren): Convert pageSize to a dynamic property.
 	pageSize int,
 	interval dynamicproperties.DurationPropertyFnWithShardIDFilter,
+	failoverJitterMaxDelay dynamicproperties.DurationPropertyFn,
 	domainMode dynamicproperties.StringPropertyFnWithDomainFilter,
 	enabled dynamicproperties.BoolPropertyFn,
 ) *ProcessorImpl {
 	return NewProcessor(ProcessorParams{
-		ShardID:       shard.GetShardID(),
-		Manager:       shard.GetService().GetHistoryTaskDLQManager(),
-		Reinjector:    shard,
-		MaxReadLevel:  NewShardMaxReadLevelFn(shard),
-		PageSize:      pageSize,
-		Interval:      interval,
-		DomainMode:    domainMode,
-		Enabled:       enabled,
-		TimeSource:    shard.GetTimeSource(),
-		MetricsClient: shard.GetMetricsClient(),
-		Logger:        shard.GetLogger(),
+		ShardID:                shard.GetShardID(),
+		Manager:                shard.GetService().GetHistoryTaskDLQManager(),
+		Reinjector:             shard,
+		MaxReadLevel:           NewShardMaxReadLevelFn(shard),
+		PageSize:               pageSize,
+		Interval:               interval,
+		FailoverJitterMaxDelay: failoverJitterMaxDelay,
+		DomainMode:             domainMode,
+		Enabled:                enabled,
+		TimeSource:             shard.GetTimeSource(),
+		MetricsClient:          shard.GetMetricsClient(),
+		Logger:                 shard.GetLogger(),
 	})
 }
 
@@ -297,6 +303,24 @@ func (p *ProcessorImpl) runSweep() {
 
 // processPendingFailovers drains the pending failover set and processes each partition.
 func (p *ProcessorImpl) processPendingFailovers() {
+	p.failoverMu.Lock()
+	if len(p.pendingFailover) == 0 {
+		p.failoverMu.Unlock()
+		return
+	}
+	p.failoverMu.Unlock()
+
+	if window := p.failoverJitterMaxDelay(); window > 0 {
+		delay := time.Duration(rand.Int63n(int64(window)) + 1)
+		timer := p.timeSource.NewTimer(delay)
+		select {
+		case <-timer.Chan():
+		case <-p.ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
+
 	p.failoverMu.Lock()
 	parts := make([]Partition, 0, len(p.pendingFailover))
 	for _, part := range p.pendingFailover {

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -78,17 +78,18 @@ func newProcessor(
 ) *ProcessorImpl {
 	t.Helper()
 	return NewProcessor(ProcessorParams{
-		ShardID:       1,
-		Manager:       params.Manager,
-		Reinjector:    params.Reinjector,
-		PageSize:      10,
-		Interval:      dynamicproperties.GetDurationPropertyFnFilteredByShardID(defaultTestProcessingInterval),
-		DomainMode:    dynamicproperties.GetStringPropertyFnFilteredByDomain(params.DomainMode),
-		Enabled:       dynamicproperties.GetBoolPropertyFn(params.ProcessingEnabled),
-		TimeSource:    params.TimeSource,
-		MetricsClient: metrics.NewNoopMetricsClient(),
-		Logger:        testlogger.New(t),
-		MaxReadLevel:  params.MaxReadLevel,
+		ShardID:                1,
+		Manager:                params.Manager,
+		Reinjector:             params.Reinjector,
+		PageSize:               10,
+		Interval:               dynamicproperties.GetDurationPropertyFnFilteredByShardID(defaultTestProcessingInterval),
+		FailoverJitterMaxDelay: dynamicproperties.GetDurationPropertyFn(0),
+		DomainMode:             dynamicproperties.GetStringPropertyFnFilteredByDomain(params.DomainMode),
+		Enabled:                dynamicproperties.GetBoolPropertyFn(params.ProcessingEnabled),
+		TimeSource:             params.TimeSource,
+		MetricsClient:          metrics.NewNoopMetricsClient(),
+		Logger:                 testlogger.New(t),
+		MaxReadLevel:           params.MaxReadLevel,
 	})
 }
 
@@ -1154,5 +1155,98 @@ func TestFailoverPartitions_WhenNotEnabled_DoesNotProcess(t *testing.T) {
 	case <-called:
 		t.Fatal("ProcessPartition ran while the processor was disabled")
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestFailoverPartitions_JitterDelaysProcessing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	ts := clock.NewMockedTimeSource()
+	proc := NewProcessor(ProcessorParams{
+		ShardID:                1,
+		Manager:                mgr,
+		Reinjector:             reinjector,
+		PageSize:               10,
+		Interval:               dynamicproperties.GetDurationPropertyFnFilteredByShardID(time.Hour),
+		FailoverJitterMaxDelay: dynamicproperties.GetDurationPropertyFn(10 * time.Second),
+		DomainMode:             dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		Enabled:                dynamicproperties.GetBoolPropertyFn(true),
+		TimeSource:             ts,
+		MetricsClient:          metrics.NewNoopMetricsClient(),
+		Logger:                 testlogger.New(t),
+	})
+
+	processed := make(chan struct{}, 1)
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{
+		ShardID:  1,
+		DomainID: "test-domain",
+	}).DoAndReturn(func(ctx context.Context, req persistence.HistoryDLQGetAckLevelsRequest) ([]persistence.HistoryDLQAckLevel, error) {
+		processed <- struct{}{}
+		return nil, nil
+	})
+
+	proc.Start()
+	defer proc.Stop()
+	ts.BlockUntil(1) // the periodic sweep timer is armed
+
+	proc.FailoverPartitions([]Partition{{DomainID: "test-domain"}})
+
+	// The drain must arm a jitter timer before doing any DB work.
+	ts.BlockUntil(2)
+	select {
+	case <-processed:
+		t.Fatal("failover partition processed before the jitter delay elapsed")
+	default:
+	}
+
+	// Advancing past the maximum jitter window fires the jitter timer.
+	ts.Advance(10 * time.Second)
+	select {
+	case <-processed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("failover partition not processed after the jitter window elapsed")
+	}
+}
+
+func TestFailoverPartitions_ZeroJitterProcessesImmediately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+	proc := NewProcessor(ProcessorParams{
+		ShardID:                1,
+		Manager:                mgr,
+		Reinjector:             reinjector,
+		PageSize:               10,
+		Interval:               dynamicproperties.GetDurationPropertyFnFilteredByShardID(time.Hour),
+		FailoverJitterMaxDelay: dynamicproperties.GetDurationPropertyFn(0),
+		DomainMode:             dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		Enabled:                dynamicproperties.GetBoolPropertyFn(true),
+		TimeSource:             clock.NewMockedTimeSource(),
+		MetricsClient:          metrics.NewNoopMetricsClient(),
+		Logger:                 testlogger.New(t),
+	})
+
+	processed := make(chan struct{}, 1)
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{
+		ShardID:  1,
+		DomainID: "test-domain",
+	}).DoAndReturn(func(ctx context.Context, req persistence.HistoryDLQGetAckLevelsRequest) ([]persistence.HistoryDLQAckLevel, error) {
+		processed <- struct{}{}
+		return nil, nil
+	})
+
+	proc.Start()
+	defer proc.Stop()
+
+	proc.FailoverPartitions([]Partition{{DomainID: "test-domain"}})
+	select {
+	case <-processed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("failover partition not processed with zero jitter window")
 	}
 }

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -25,6 +25,7 @@ package taskdlq
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -179,6 +180,44 @@ func setupProcessor(t *testing.T, ctrl *gomock.Controller) (*ProcessorImpl, *per
 		TimeSource:        clock.NewMockedTimeSource(),
 	})
 	return proc, mgr, reinjector
+}
+
+// fakeWriteTracker implements PartitionWriteTracker with a settable answer.
+type fakeWriteTracker struct {
+	mu      sync.Mutex
+	written bool
+}
+
+func (f *fakeWriteTracker) HasWrittenDLQPartition(domainID, clusterAttributeScope, clusterAttributeName string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.written
+}
+
+func (f *fakeWriteTracker) setWritten(w bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.written = w
+}
+
+func newCacheTestProcessor(t *testing.T, ctrl *gomock.Controller, tracker PartitionWriteTracker) (*ProcessorImpl, *persistence.MockHistoryTaskDLQManager) {
+	t.Helper()
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	proc := NewProcessor(ProcessorParams{
+		ShardID:                1,
+		Manager:                mgr,
+		Reinjector:             NewMockTaskReinjector(ctrl),
+		PageSize:               10,
+		Interval:               dynamicproperties.GetDurationPropertyFnFilteredByShardID(time.Hour),
+		FailoverJitterMaxDelay: dynamicproperties.GetDurationPropertyFn(0),
+		DomainMode:             dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		Enabled:                dynamicproperties.GetBoolPropertyFn(true),
+		WriteTracker:           tracker,
+		TimeSource:             clock.NewMockedTimeSource(),
+		MetricsClient:          metrics.NewNoopMetricsClient(),
+		Logger:                 testlogger.New(t),
+	})
+	return proc, mgr
 }
 
 func TestSweepIntervalIsJittered(t *testing.T) {
@@ -689,6 +728,107 @@ func TestProcessPartition_WhenGetAckLevelsFails_ReturnsError(t *testing.T) {
 	err := proc.ProcessPartition(context.Background(), "d", "s", "n")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "partition error")
+}
+
+func TestProcessPartition_VerifiedEmptySkipsRepeatQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tracker := &fakeWriteTracker{}
+	proc, mgr := newCacheTestProcessor(t, ctrl, tracker)
+	ctx := context.Background()
+
+	req := persistence.HistoryDLQGetAckLevelsRequest{
+		ShardID:               1,
+		DomainID:              "d1",
+		ClusterAttributeScope: "s",
+		ClusterAttributeName:  "n",
+	}
+
+	// First call queries and finds the partition empty.
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), req).Return(nil, nil).Times(1)
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
+
+	// Second call must be served from the verified-empty cache: no further DB call
+	// (the Times(1) above makes an extra call fail the test).
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
+
+	// Once the shard has written the partition, the cache no longer applies.
+	tracker.setWritten(true)
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), req).Return(nil, nil).Times(1)
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
+}
+
+func TestProcessPartition_NonEmptyPartitionIsNotCached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tracker := &fakeWriteTracker{}
+	proc, mgr := newCacheTestProcessor(t, ctrl, tracker)
+	ctx := context.Background()
+
+	al := persistence.HistoryDLQAckLevel{
+		ShardID:               1,
+		DomainID:              "d1",
+		ClusterAttributeScope: "s",
+		ClusterAttributeName:  "n",
+		TaskCategory:          persistence.HistoryTaskCategoryTransfer,
+		AckLevelVisibilityTS:  time.Unix(0, 0).UTC(),
+		AckLevelTaskID:        -1,
+	}
+	req := persistence.HistoryDLQGetAckLevelsRequest{
+		ShardID:               1,
+		DomainID:              "d1",
+		ClusterAttributeScope: "s",
+		ClusterAttributeName:  "n",
+	}
+	// Both calls must query: a partition with rows is never cached as empty.
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), req).Return([]persistence.HistoryDLQAckLevel{al}, nil).Times(2)
+	mgr.EXPECT().GetHistoryDLQTasks(gomock.Any(), gomock.Any()).Return(persistence.HistoryDLQGetTasksResponse{}, nil).Times(2)
+
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
+}
+
+func TestProcessShard_ClearsVerifiedEmptyForSeenPartitions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tracker := &fakeWriteTracker{}
+	proc, mgr := newCacheTestProcessor(t, ctrl, tracker)
+	ctx := context.Background()
+
+	partReq := persistence.HistoryDLQGetAckLevelsRequest{
+		ShardID:               1,
+		DomainID:              "d1",
+		ClusterAttributeScope: "s",
+		ClusterAttributeName:  "n",
+	}
+	// Mark the partition verified-empty via the failover path.
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), partReq).Return(nil, nil).Times(1)
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
+	// Cache hit: no query.
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
+
+	// A shard sweep sees rows for the partition (e.g. a zombie previous owner wrote
+	// them after our verification) — the sweep must clear the verified-empty entry.
+	al := persistence.HistoryDLQAckLevel{
+		ShardID:               1,
+		DomainID:              "d1",
+		ClusterAttributeScope: "s",
+		ClusterAttributeName:  "n",
+		TaskCategory:          persistence.HistoryTaskCategoryTransfer,
+		AckLevelVisibilityTS:  time.Unix(0, 0).UTC(),
+		AckLevelTaskID:        -1,
+	}
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{ShardID: 1}).
+		Return([]persistence.HistoryDLQAckLevel{al}, nil).Times(1)
+	mgr.EXPECT().GetHistoryDLQTasks(gomock.Any(), gomock.Any()).Return(persistence.HistoryDLQGetTasksResponse{}, nil).AnyTimes()
+	require.NoError(t, proc.ProcessShard(ctx))
+
+	// The partition must be queried again now.
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), partReq).Return([]persistence.HistoryDLQAckLevel{al}, nil).Times(1)
+	require.NoError(t, proc.ProcessPartition(ctx, "d1", "s", "n"))
 }
 
 func TestProcessPartition_WhenMultipleTaskTypes_ProcessesAll(t *testing.T) {

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -25,6 +25,7 @@ package taskdlq
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,6 +42,79 @@ import (
 	"github.com/uber/cadence/service/history/constants"
 	"github.com/uber/cadence/service/history/shard"
 )
+
+func TestHostLimiter_BoundsConcurrentProcessingAcrossShards(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	limiter := NewHostLimiter(1)
+	mgr := persistence.NewMockHistoryTaskDLQManager(ctrl)
+	reinjector := NewMockTaskReinjector(ctrl)
+
+	newProc := func(shardID int) *ProcessorImpl {
+		return NewProcessor(ProcessorParams{
+			ShardID:                shardID,
+			Manager:                mgr,
+			Reinjector:             reinjector,
+			PageSize:               10,
+			Interval:               dynamicproperties.GetDurationPropertyFnFilteredByShardID(time.Hour),
+			FailoverJitterMaxDelay: dynamicproperties.GetDurationPropertyFn(0),
+			DomainMode:             dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+			Enabled:                dynamicproperties.GetBoolPropertyFn(true),
+			HostLimiter:            limiter,
+			TimeSource:             clock.NewMockedTimeSource(),
+			MetricsClient:          metrics.NewNoopMetricsClient(),
+			Logger:                 testlogger.New(t),
+		})
+	}
+	proc1 := newProc(1)
+	proc2 := newProc(2)
+
+	entered1 := make(chan struct{})
+	release1 := make(chan struct{})
+	var secondStarted atomic.Bool
+	done2 := make(chan struct{})
+
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{
+		ShardID:  1,
+		DomainID: "test-domain",
+	}).DoAndReturn(func(ctx context.Context, req persistence.HistoryDLQGetAckLevelsRequest) ([]persistence.HistoryDLQAckLevel, error) {
+		close(entered1)
+		<-release1
+		return nil, nil
+	})
+	mgr.EXPECT().GetHistoryDLQAckLevels(gomock.Any(), persistence.HistoryDLQGetAckLevelsRequest{
+		ShardID:  2,
+		DomainID: "test-domain",
+	}).DoAndReturn(func(ctx context.Context, req persistence.HistoryDLQGetAckLevelsRequest) ([]persistence.HistoryDLQAckLevel, error) {
+		secondStarted.Store(true)
+		close(done2)
+		return nil, nil
+	})
+
+	proc1.Start()
+	defer proc1.Stop()
+	proc2.Start()
+	defer proc2.Stop()
+
+	proc1.FailoverPartitions([]Partition{{DomainID: "test-domain"}})
+	select {
+	case <-entered1: // proc1 now holds the single host slot inside its DB call
+	case <-time.After(5 * time.Second):
+		t.Fatal("first shard's DLQ processing never started")
+	}
+
+	proc2.FailoverPartitions([]Partition{{DomainID: "test-domain"}})
+	time.Sleep(100 * time.Millisecond)
+	require.False(t, secondStarted.Load(), "second shard's DLQ query ran while the host slot was held")
+
+	close(release1)
+	select {
+	case <-done2:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second shard's DLQ processing never ran after the slot freed")
+	}
+}
 
 const (
 	defaultTestProcessingInterval = 15 * time.Second

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -106,6 +106,25 @@ func setupProcessor(t *testing.T, ctrl *gomock.Controller) (*ProcessorImpl, *per
 	return proc, mgr, reinjector
 }
 
+func TestSweepIntervalIsJittered(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc, _, _ := setupProcessor(t, ctrl)
+
+	base := defaultTestProcessingInterval
+	lo := time.Duration(float64(base) * (1 - sweepIntervalJitterCoefficient))
+	hi := time.Duration(float64(base) * (1 + sweepIntervalJitterCoefficient))
+	distinct := make(map[time.Duration]struct{})
+	for i := 0; i < 200; i++ {
+		d := proc.sweepInterval()
+		require.GreaterOrEqual(t, d, lo)
+		require.LessOrEqual(t, d, hi)
+		distinct[d] = struct{}{}
+	}
+	require.Greater(t, len(distinct), 1, "sweep interval should be jittered, got 200 identical values")
+}
+
 func baseAckLevel(shardID int) persistence.HistoryDLQAckLevel {
 	return persistence.HistoryDLQAckLevel{
 		ShardID:               shardID,
@@ -785,7 +804,7 @@ func TestStop_WhenStoreRespectsContextCancellation_ReturnsPromptly(t *testing.T)
 	proc.Start()
 
 	ts.BlockUntil(1)
-	ts.Advance(defaultTestProcessingInterval)
+	ts.Advance(time.Duration(float64(defaultTestProcessingInterval) * (1 + sweepIntervalJitterCoefficient)))
 
 	select {
 	case <-inGetAckLevels:
@@ -889,7 +908,7 @@ func TestStart_ShouldCallProcessShardOnInterval(t *testing.T) {
 	defer proc.Stop()
 
 	ts.BlockUntil(1)
-	ts.Advance(defaultTestProcessingInterval)
+	ts.Advance(time.Duration(float64(defaultTestProcessingInterval) * (1 + sweepIntervalJitterCoefficient)))
 
 	select {
 	case <-processed:
@@ -919,7 +938,7 @@ func TestStart_WhenNotEnabled_SkipsProcessingButContinuesLoop(t *testing.T) {
 	// The loop always starts; wait for the first timer to be registered.
 	ts.BlockUntil(1)
 	// Advance past the interval — enabled() returns false, so GetAckLevels must not be called.
-	ts.Advance(defaultTestProcessingInterval)
+	ts.Advance(time.Duration(float64(defaultTestProcessingInterval) * (1 + sweepIntervalJitterCoefficient)))
 	// Wait for the timer to be reset, confirming the loop ran and continued.
 	ts.BlockUntil(1)
 	// ctrl.Finish() verifies GetAckLevels was called 0 times.
@@ -1083,7 +1102,7 @@ func TestFailoverPartitions_PreemptsInProgressSweep(t *testing.T) {
 
 	// Kick off a periodic sweep and wait for it to block inside the shard-level query.
 	ts.BlockUntil(1)
-	ts.Advance(defaultTestProcessingInterval)
+	ts.Advance(time.Duration(float64(defaultTestProcessingInterval) * (1 + sweepIntervalJitterCoefficient)))
 	select {
 	case <-sweepStarted:
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
**What changed?**

Smooths history task DLQ processor load per #8451, in four parts, all in the DLQ processor path:

- Jittered the periodic sweep timer in `service/history/taskdlq/processor.go` with `backoff.JitDuration` (coefficient 0.15).
- Added per-shard jitter on failover-triggered DLQ reprocessing, controlled by new dynamic config `history.historyTaskDLQProcessorFailoverJitterMaxDelay` (default 1m).
- Added a host-wide concurrency cap (`taskdlq.HostLimiter`, a semaphore created in the history handler and shared by all shards' processors), sized by new dynamic config `history.historyTaskDLQProcessorHostConcurrency` (default 10).
- Added a verified-empty partition cache: failover-path `ProcessPartition` skips the repeat `GetHistoryDLQAckLevels` for partitions already verified empty, guarded by partition write tracking on `shardedHistoryTaskDLQWriter` (partitions are marked written *before* the persistence write is issued).

Fixes #8451.

**Why?**

On domain failover, `domainChangeCB` runs on every shard as the domain cache refreshes, so every shard's DLQ `processLoop` woke at once and issued `GetHistoryDLQAckLevels` + `GetHistoryDLQTasks` — a cluster-wide synchronized query burst (tens of thousands of queries within seconds at production shard counts) with no jitter and no concurrency cap, landing on top of the failover's own load. Separately, the periodic sweep reset with no jitter, so after a deploy all shards' 30-minute sweeps ran in synchronized waves.

The jitter spreads the failover burst and the sweep waves; the host cap is a hard backstop under the jitter; the verified-empty cache removes the (dominant) wasted reads for partitions with no DLQ rows at all. This is complementary to the persistence rate limiter on the DLQ manager (#8449, #8459): the rate limiter protects the database when a burst happens, this PR reduces the burst itself.

One deliberate divergence from the issue text: part 3 proposed caching partitions *known to have* DLQ rows, but a positive cache saves no reads (the ack-level query is itself the first step of processing). Implemented instead as a verified-**empty** cache that a skip may only trust while the shard's own writer has never written the partition during the current ownership; the periodic sweep never consults the cache and clears entries for any partition it sees, bounding staleness from a zombie previous owner's late write to one sweep interval.

**How did you test it?**

Unit tests (all new behavior is covered by targeted tests; TDD red→green per change):

```
go test -race -run 'TestSweepIntervalIsJittered|TestFailoverPartitions_JitterDelaysProcessing|TestFailoverPartitions_ZeroJitterProcessesImmediately|TestHostLimiter' ./service/history/taskdlq/...
go test -race -run 'TestProcessPartition_VerifiedEmptySkipsRepeatQuery|TestProcessPartition_NonEmptyPartitionIsNotCached|TestProcessShard_ClearsVerifiedEmptyForSeenPartitions' ./service/history/taskdlq/...
go test -race -run TestShardedHistoryTaskDLQWriter_MarksPartitionBeforePersistenceWrite ./service/history/shard/...
go test -race ./service/history/...   # full history service suite, green
```

`make pr GEN_DIR=service/history` runs clean (tidy → go-generate → fmt → lint; shard `Context` mock regenerated, no drift).

**Potential risks**

- No API/IDL or schema changes; server-only (history DLQ processor path). The DLQ processor is behind `history.historyTaskDLQProcessorEnabled` (default off).
- `history.historyTaskDLQProcessorHostConcurrency` is evaluated once at host startup (fixed-size semaphore); changing it requires a restart, unlike the other DLQ dynamic properties. Called out in code.
- The host cap does not prioritize failover-triggered reprocessing over periodic sweeps when saturated; sweeps are rare (30m, jittered) so contention is unlikely, but a priority scheme is possible future work.
- Verified-empty cache staleness from a zombie previous shard owner writing after verification is bounded to one sweep interval (sweep always queries and clears seen partitions).

**Release notes**

Reduces synchronized DLQ query bursts on domain failover and after deploys: failover fan-out jitter (`history.historyTaskDLQProcessorFailoverJitterMaxDelay`, default 1m), host-level DLQ processing concurrency cap (`history.historyTaskDLQProcessorHostConcurrency`, default 10), sweep interval jitter, and a verified-empty partition cache that skips redundant failover DLQ reads. See #8451.

**Documentation Changes**

N/A — dynamic config keys are self-documented in `common/dynamicconfig/dynamicproperties/constants.go`.
