### PR TITLE
fix(persistence): return the row type from token-ownership reads

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -168,10 +168,8 @@ const (
 	SemaphoreGrantSlotTaken
 )
 
-// SemaphoreRowType is the `type` clustering column of semaphore_tokens: whether a row is the
-// forward token row or the reverse owner row. Numbering starts at 1 so the Go zero value
-// matches neither. The values are persisted and must never be renumbered; reads are not
-// validated, so handle an unrecognized one with a default branch.
+// SemaphoreRowType is the `type` clustering column of semaphore_tokens: a forward token row
+// or a reverse owner row.
 type SemaphoreRowType int
 
 // Semaphore Row Type

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -168,6 +168,20 @@ const (
 	SemaphoreGrantSlotTaken
 )
 
+// SemaphoreRowType is the `type` clustering column of semaphore_tokens: whether a row is the
+// forward token row or the reverse owner row. Numbering starts at 1 so the Go zero value
+// matches neither. The values are persisted and must never be renumbered; reads are not
+// validated, so handle an unrecognized one with a default branch.
+type SemaphoreRowType int
+
+// Semaphore Row Type
+const (
+	// SemaphoreRowTypeToken the forward row for a slot: TokenID -> Holder, Holder empty when free
+	SemaphoreRowTypeToken SemaphoreRowType = iota + 1
+	// SemaphoreRowTypeOwner the reverse row for a hold: OwnerID -> HeldToken
+	SemaphoreRowTypeOwner
+)
+
 // Workflow execution states
 const (
 	WorkflowStateCreated = iota
@@ -1473,6 +1487,10 @@ type (
 	// (TokenID -> Holder, empty when the slot is free) or a reverse "owner" row
 	// per hold (OwnerID -> HeldToken).
 	SemaphoreOwnership struct {
+		// RowType says which of the two row shapes this is. Set on every read; a scan of a
+		// bucket returns both shapes interleaved and only RowType tells them apart without
+		// relying on which fields happen to be zero.
+		RowType       SemaphoreRowType
 		DomainID      string
 		SemaphoreName string
 		Bucket        int

--- a/common/persistence/nosql/nosql_semaphore_token_store.go
+++ b/common/persistence/nosql/nosql_semaphore_token_store.go
@@ -162,7 +162,7 @@ func (m *nosqlSemaphoreTokenStore) GetSemaphoreOwnershipByOwner(
 	return toSemaphoreOwnership(row), nil
 }
 
-// ScanSemaphoreBucket scans a bucket partition (both row kinds), paginated.
+// ScanSemaphoreBucket scans a bucket partition (both row types), paginated.
 func (m *nosqlSemaphoreTokenStore) ScanSemaphoreBucket(
 	ctx context.Context,
 	request *persistence.ScanSemaphoreBucketRequest,
@@ -193,6 +193,7 @@ func (m *nosqlSemaphoreTokenStore) ScanSemaphoreBucket(
 
 func toSemaphoreOwnership(row *nosqlplugin.SemaphoreOwnershipRow) *persistence.SemaphoreOwnership {
 	return &persistence.SemaphoreOwnership{
+		RowType:       row.RowType,
 		DomainID:      row.DomainID,
 		SemaphoreName: row.SemaphoreName,
 		Bucket:        row.Bucket,

--- a/common/persistence/nosql/nosql_semaphore_token_store_test.go
+++ b/common/persistence/nosql/nosql_semaphore_token_store_test.go
@@ -233,12 +233,12 @@ func TestNoSQLGetSemaphoreOwnershipByToken(t *testing.T) {
 		"success maps row to token": {
 			setupMock: func(dbMock *nosqlplugin.MockDB) {
 				row := &nosqlplugin.SemaphoreOwnershipRow{
-					DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, TokenID: 5, Holder: "owner-abc",
+					RowType: persistence.SemaphoreRowTypeToken, DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, TokenID: 5, Holder: "owner-abc",
 				}
 				dbMock.EXPECT().SelectSemaphoreOwnershipByToken(ctx, "domain-1", "sem-1", 0, 5).Return(row, nil).Times(1)
 			},
 			expected: &persistence.SemaphoreOwnership{
-				DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, TokenID: 5, Holder: "owner-abc",
+				RowType: persistence.SemaphoreRowTypeToken, DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, TokenID: 5, Holder: "owner-abc",
 			},
 		},
 		"error propagates": {
@@ -281,12 +281,12 @@ func TestNoSQLGetSemaphoreOwnershipByOwner(t *testing.T) {
 		"success maps row to token": {
 			setupMock: func(dbMock *nosqlplugin.MockDB) {
 				row := &nosqlplugin.SemaphoreOwnershipRow{
-					DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, OwnerID: "owner-abc", HeldToken: 5,
+					RowType: persistence.SemaphoreRowTypeOwner, DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, OwnerID: "owner-abc", HeldToken: 5,
 				}
 				dbMock.EXPECT().SelectSemaphoreOwnershipByOwner(ctx, "domain-1", "sem-1", 0, "owner-abc").Return(row, nil).Times(1)
 			},
 			expected: &persistence.SemaphoreOwnership{
-				DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, OwnerID: "owner-abc", HeldToken: 5,
+				RowType: persistence.SemaphoreRowTypeOwner, DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, OwnerID: "owner-abc", HeldToken: 5,
 			},
 		},
 		"error propagates": {
@@ -330,8 +330,8 @@ func TestNoSQLScanSemaphoreBucket(t *testing.T) {
 		"success maps rows and token": {
 			setupMock: func(dbMock *nosqlplugin.MockDB) {
 				rows := []*nosqlplugin.SemaphoreOwnershipRow{
-					{DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, TokenID: 5, Holder: "owner-abc"},
-					{DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, OwnerID: "owner-abc", HeldToken: 5},
+					{RowType: persistence.SemaphoreRowTypeToken, DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, TokenID: 5, Holder: "owner-abc"},
+					{RowType: persistence.SemaphoreRowTypeOwner, DomainID: "domain-1", SemaphoreName: "sem-1", Bucket: 0, OwnerID: "owner-abc", HeldToken: 5},
 				}
 				expectedFilter := &nosqlplugin.SemaphoreOwnershipFilter{
 					DomainID:      "domain-1",
@@ -345,7 +345,9 @@ func TestNoSQLScanSemaphoreBucket(t *testing.T) {
 			},
 			expectedCount: 2,
 			validate: func(t *testing.T, resp *persistence.ScanSemaphoreBucketResponse) {
+				assert.Equal(t, persistence.SemaphoreRowTypeToken, resp.Ownerships[0].RowType)
 				assert.Equal(t, 5, resp.Ownerships[0].TokenID)
+				assert.Equal(t, persistence.SemaphoreRowTypeOwner, resp.Ownerships[1].RowType)
 				assert.Equal(t, "owner-abc", resp.Ownerships[1].OwnerID)
 				assert.Equal(t, []byte("next"), resp.NextPageToken)
 			},

--- a/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens.go
@@ -31,13 +31,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-// Row kinds for the `type` clustering column of semaphore_tokens.
-const (
-	rowTypeSemaphoreToken = iota // forward index row, keyed by token_id (token_id -> holder)
-	rowTypeSemaphoreOwner        // reverse index row, keyed by owner_id (owner_id -> held_token)
-)
-
-// Placeholders for key columns that do not apply to a given row kind. Non-key columns
+// Placeholders for key columns that do not apply to a given row type. Non-key columns
 // that do not apply are bound to gogocql.UnsetValue instead.
 //
 // The text values are PROVISIONAL: only freeSentinel is LWT-compared, so only its literal
@@ -72,7 +66,7 @@ func (db *CDB) InsertSemaphoreTokens(ctx context.Context, rows []*nosqlplugin.Se
 			row.DomainID,
 			row.SemaphoreName,
 			row.Bucket,
-			rowTypeSemaphoreToken, // type = 0 (forward "token" row)
+			persistence.SemaphoreRowTypeToken, // forward "token" row
 			row.TokenID,
 			ownerNoneSentinel,  // owner_id key = __NONE__
 			freeSentinel,       // holder = __FREE__, the slot is unheld
@@ -104,7 +98,7 @@ func (db *CDB) GrantSemaphoreToken(ctx context.Context, row *nosqlplugin.Semapho
 		row.DomainID,
 		row.SemaphoreName,
 		row.Bucket,
-		rowTypeSemaphoreToken,
+		persistence.SemaphoreRowTypeToken,
 		row.TokenID,
 		ownerNoneSentinel, // token row's owner_id key
 		freeSentinel,      // IF holder = FREE
@@ -113,7 +107,7 @@ func (db *CDB) GrantSemaphoreToken(ctx context.Context, row *nosqlplugin.Semapho
 		row.DomainID,
 		row.SemaphoreName,
 		row.Bucket,
-		rowTypeSemaphoreOwner,
+		persistence.SemaphoreRowTypeOwner,
 		emptyTokenID,
 		row.OwnerID,
 		gogocql.UnsetValue, // holder does not apply to an owner row
@@ -171,15 +165,18 @@ func parseAlreadyHeldTokenFromCAS(previous map[string]interface{}, iter gocql.It
 	return 0
 }
 
-// parseHeldTokenIfOwnerRow is a helper for parseAlreadyHeldTokenFromCAS: it
-// returns the held_token of the given CAS row when it is an owner (reverse-index)
-// row, or 0 when absent; ok is false for any other row kind.
+// parseHeldTokenIfOwnerRow returns the held_token of an owner (reverse-index) CAS row.
+// ok is false for any other row type, and for an owner row whose held_token is absent or
+// not positive: that owner holds no valid token.
 func parseHeldTokenIfOwnerRow(row map[string]interface{}) (int, bool) {
 	rowType, ok := row["type"].(int)
-	if !ok || rowType != rowTypeSemaphoreOwner {
+	if !ok || rowType != int(persistence.SemaphoreRowTypeOwner) {
 		return 0, false
 	}
-	heldToken, _ := row["held_token"].(int)
+	heldToken, ok := row["held_token"].(int)
+	if !ok || heldToken <= 0 {
+		return 0, false
+	}
 	return heldToken, true
 }
 
@@ -195,7 +192,7 @@ func (db *CDB) ReleaseSemaphoreToken(ctx context.Context, row *nosqlplugin.Semap
 		row.DomainID,
 		row.SemaphoreName,
 		row.Bucket,
-		rowTypeSemaphoreToken,
+		persistence.SemaphoreRowTypeToken,
 		row.TokenID,
 		ownerNoneSentinel,
 		row.OwnerID, // IF holder = owner_id
@@ -204,7 +201,7 @@ func (db *CDB) ReleaseSemaphoreToken(ctx context.Context, row *nosqlplugin.Semap
 		row.DomainID,
 		row.SemaphoreName,
 		row.Bucket,
-		rowTypeSemaphoreOwner,
+		persistence.SemaphoreRowTypeOwner,
 		emptyTokenID,
 		row.OwnerID,
 	)
@@ -222,7 +219,7 @@ func (db *CDB) ReleaseSemaphoreToken(ctx context.Context, row *nosqlplugin.Semap
 func (db *CDB) SelectSemaphoreOwnershipByToken(ctx context.Context, domainID, semaphoreName string, bucket, tokenID int) (*nosqlplugin.SemaphoreOwnershipRow, error) {
 	row := &nosqlplugin.SemaphoreOwnershipRow{}
 	query := db.session.Query(templateSelectSemaphoreOwnershipByTokenQuery,
-		domainID, semaphoreName, bucket, rowTypeSemaphoreToken, tokenID,
+		domainID, semaphoreName, bucket, persistence.SemaphoreRowTypeToken, tokenID,
 	).WithContext(ctx)
 	if err := scanSemaphoreOwnershipRow(query, row); err != nil {
 		return nil, err
@@ -234,7 +231,7 @@ func (db *CDB) SelectSemaphoreOwnershipByToken(ctx context.Context, domainID, se
 func (db *CDB) SelectSemaphoreOwnershipByOwner(ctx context.Context, domainID, semaphoreName string, bucket int, ownerID string) (*nosqlplugin.SemaphoreOwnershipRow, error) {
 	row := &nosqlplugin.SemaphoreOwnershipRow{}
 	query := db.session.Query(templateSelectSemaphoreOwnershipByOwnerQuery,
-		domainID, semaphoreName, bucket, rowTypeSemaphoreOwner, emptyTokenID, ownerID,
+		domainID, semaphoreName, bucket, persistence.SemaphoreRowTypeOwner, emptyTokenID, ownerID,
 	).WithContext(ctx)
 	if err := scanSemaphoreOwnershipRow(query, row); err != nil {
 		return nil, err
@@ -242,7 +239,7 @@ func (db *CDB) SelectSemaphoreOwnershipByOwner(ctx context.Context, domainID, se
 	return row, nil
 }
 
-// SelectSemaphoreOwnershipsByBucket scans a bucket partition (both row kinds), paginated.
+// SelectSemaphoreOwnershipsByBucket scans a bucket partition (both row types), paginated.
 func (db *CDB) SelectSemaphoreOwnershipsByBucket(ctx context.Context, filter *nosqlplugin.SemaphoreOwnershipFilter) ([]*nosqlplugin.SemaphoreOwnershipRow, []byte, error) {
 	query := db.session.Query(templateSelectSemaphoreOwnershipsByBucketQuery,
 		filter.DomainID, filter.SemaphoreName, filter.Bucket,
@@ -263,13 +260,12 @@ func (db *CDB) SelectSemaphoreOwnershipsByBucket(ctx context.Context, filter *no
 	}
 
 	var rows []*nosqlplugin.SemaphoreOwnershipRow
-	var rowType int
 	row := &nosqlplugin.SemaphoreOwnershipRow{}
 	for iter.Scan(
 		&row.DomainID,
 		&row.SemaphoreName,
 		&row.Bucket,
-		&rowType,
+		&row.RowType,
 		&row.TokenID,
 		&row.OwnerID,
 		&row.Holder,
@@ -300,6 +296,7 @@ func scanSemaphoreOwnershipRow(query gocql.Query, row *nosqlplugin.SemaphoreOwne
 		&row.DomainID,
 		&row.SemaphoreName,
 		&row.Bucket,
+		&row.RowType,
 		&row.TokenID,
 		&row.OwnerID,
 		&row.Holder,

--- a/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens_cql.go
@@ -51,20 +51,25 @@ const (
 	templateReleaseSemaphoreOwnerDeleteQuery = `DELETE FROM semaphore_tokens ` +
 		`WHERE domain_id = ? AND semaphore_name = ? AND bucket = ? AND type = ? AND token_id = ? AND owner_id = ?`
 
-	// Forward read: owner_id is the trailing clustering column, so it is omitted.
+	// The three reads below share one column list, in this order, so a single scan helper
+	// can serve all of them.
+	//
+	// Forward read: owner_id is the trailing clustering column, so it is omitted. Exactly
+	// one token row exists per (type, token_id) — every write binds ownerNoneSentinel — so
+	// this returns a single row without depending on that sentinel's literal value.
 	templateSelectSemaphoreOwnershipByTokenQuery = `SELECT ` +
-		`domain_id, semaphore_name, bucket, token_id, owner_id, holder, held_token, updated_time ` +
+		`domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time ` +
 		`FROM semaphore_tokens ` +
 		`WHERE domain_id = ? AND semaphore_name = ? AND bucket = ? AND type = ? AND token_id = ?`
 
-	// Reverse read: token_id (a middle clustering column) must be pinned to reach owner_id.
+	// Reverse read
 	templateSelectSemaphoreOwnershipByOwnerQuery = `SELECT ` +
-		`domain_id, semaphore_name, bucket, token_id, owner_id, holder, held_token, updated_time ` +
+		`domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time ` +
 		`FROM semaphore_tokens ` +
 		`WHERE domain_id = ? AND semaphore_name = ? AND bucket = ? AND type = ? AND token_id = ? AND owner_id = ?`
 
 	// Full-partition read: no type predicate, so this deliberately returns BOTH row
-	// kinds - token rows first, then owner rows, per the type clustering order.
+	// types - token rows first, then owner rows, per the type clustering order.
 	// It rebuilds a bucket's forward and reverse indexes in one pass, for cache
 	// warm-up on host start and on ownership transfer
 	templateSelectSemaphoreOwnershipsByBucketQuery = `SELECT ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens_cql.go
@@ -51,12 +51,8 @@ const (
 	templateReleaseSemaphoreOwnerDeleteQuery = `DELETE FROM semaphore_tokens ` +
 		`WHERE domain_id = ? AND semaphore_name = ? AND bucket = ? AND type = ? AND token_id = ? AND owner_id = ?`
 
-	// The three reads below share one column list, in this order, so a single scan helper
-	// can serve all of them.
-	//
-	// Forward read: owner_id is the trailing clustering column, so it is omitted. Exactly
-	// one token row exists per (type, token_id) — every write binds ownerNoneSentinel — so
-	// this returns a single row without depending on that sentinel's literal value.
+	// Forward read: owner_id, the trailing clustering column, is omitted. Every write binds
+	// ownerNoneSentinel, so exactly one token row exists per (type, token_id).
 	templateSelectSemaphoreOwnershipByTokenQuery = `SELECT ` +
 		`domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time ` +
 		`FROM semaphore_tokens ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens_test.go
@@ -72,9 +72,9 @@ func TestInsertSemaphoreTokens(t *testing.T) {
 		assert.Len(t, session.batches, 1)
 		assert.Equal(t, []string{
 			`INSERT INTO semaphore_tokens (domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time) ` +
-				`VALUES(10000000-1000-f000-f000-000000000000, sem-1, 0, 0, 1, __NONE__, __FREE__, {}, ` + now.UTC().Format(time.RFC3339) + `) IF NOT EXISTS`,
+				`VALUES(10000000-1000-f000-f000-000000000000, sem-1, 0, 1, 1, __NONE__, __FREE__, {}, ` + now.UTC().Format(time.RFC3339) + `) IF NOT EXISTS`,
 			`INSERT INTO semaphore_tokens (domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time) ` +
-				`VALUES(10000000-1000-f000-f000-000000000000, sem-1, 0, 0, 2, __NONE__, __FREE__, {}, ` + now.UTC().Format(time.RFC3339) + `) IF NOT EXISTS`,
+				`VALUES(10000000-1000-f000-f000-000000000000, sem-1, 0, 1, 2, __NONE__, __FREE__, {}, ` + now.UTC().Format(time.RFC3339) + `) IF NOT EXISTS`,
 		}, session.batches[0].queries)
 		assert.True(t, session.iter.closed)
 	})
@@ -85,7 +85,7 @@ func TestInsertSemaphoreTokens(t *testing.T) {
 		session := &fakeSession{
 			mapExecuteBatchCASApplied: false,
 			mapExecuteBatchCASPrev: map[string]any{
-				"type":     rowTypeSemaphoreToken,
+				"type":     int(persistence.SemaphoreRowTypeToken),
 				"token_id": 1,
 				"holder":   "owner-abc",
 			},
@@ -129,9 +129,9 @@ func TestGrantSemaphoreToken(t *testing.T) {
 		assert.Equal(t, []string{
 			`UPDATE semaphore_tokens SET holder = owner-abc, updated_time = ` + now.UTC().Format(time.RFC3339) + ` ` +
 				`WHERE domain_id = 10000000-1000-f000-f000-000000000000 AND semaphore_name = sem-1 AND bucket = 0 ` +
-				`AND type = 0 AND token_id = 5 AND owner_id = __NONE__ IF holder = __FREE__`,
+				`AND type = 1 AND token_id = 5 AND owner_id = __NONE__ IF holder = __FREE__`,
 			`INSERT INTO semaphore_tokens (domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time) ` +
-				`VALUES(10000000-1000-f000-f000-000000000000, sem-1, 0, 1, -1, owner-abc, {}, 5, ` + now.UTC().Format(time.RFC3339) + `) IF NOT EXISTS`,
+				`VALUES(10000000-1000-f000-f000-000000000000, sem-1, 0, 2, -1, owner-abc, {}, 5, ` + now.UTC().Format(time.RFC3339) + `) IF NOT EXISTS`,
 		}, session.batches[0].queries)
 		assert.True(t, session.iter.closed)
 	})
@@ -142,7 +142,7 @@ func TestGrantSemaphoreToken(t *testing.T) {
 		session := &fakeSession{
 			mapExecuteBatchCASApplied: false,
 			mapExecuteBatchCASPrev: map[string]any{
-				"type":   rowTypeSemaphoreToken,
+				"type":   int(persistence.SemaphoreRowTypeToken),
 				"holder": "owner-xyz",
 			},
 			iter: &fakeIter{},
@@ -160,7 +160,7 @@ func TestGrantSemaphoreToken(t *testing.T) {
 		session := &fakeSession{
 			mapExecuteBatchCASApplied: false,
 			mapExecuteBatchCASPrev: map[string]any{
-				"type":       rowTypeSemaphoreOwner,
+				"type":       int(persistence.SemaphoreRowTypeOwner),
 				"held_token": 7,
 			},
 			iter: &fakeIter{},
@@ -179,12 +179,12 @@ func TestGrantSemaphoreToken(t *testing.T) {
 		session := &fakeSession{
 			mapExecuteBatchCASApplied: false,
 			mapExecuteBatchCASPrev: map[string]any{
-				"type":   rowTypeSemaphoreToken,
+				"type":   int(persistence.SemaphoreRowTypeToken),
 				"holder": "owner-abc",
 			},
 			iter: &fakeIter{
 				mapScanInputs: []map[string]interface{}{
-					{"type": rowTypeSemaphoreOwner, "held_token": 9},
+					{"type": int(persistence.SemaphoreRowTypeOwner), "held_token": 9},
 				},
 			},
 		}
@@ -193,6 +193,46 @@ func TestGrantSemaphoreToken(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, persistence.SemaphoreGrantAlreadyHeld, result.Outcome)
 		assert.Equal(t, 9, result.HeldToken)
+		assert.True(t, session.iter.closed)
+	})
+
+	t.Run("not applied - owner row with an unusable held_token is skipped", func(t *testing.T) {
+		// A malformed owner row must neither be reported as a hold nor stop the search:
+		// the well-formed owner row behind it is the one that carries the answer.
+		session := &fakeSession{
+			mapExecuteBatchCASApplied: false,
+			mapExecuteBatchCASPrev: map[string]any{
+				"type": int(persistence.SemaphoreRowTypeOwner), // held_token missing entirely
+			},
+			iter: &fakeIter{
+				mapScanInputs: []map[string]interface{}{
+					{"type": int(persistence.SemaphoreRowTypeOwner), "held_token": 0}, // present but not a slot id
+					{"type": int(persistence.SemaphoreRowTypeOwner), "held_token": 9},
+				},
+			},
+		}
+		db := newTestSemaphoreTokenDB(t, session)
+		result, err := db.GrantSemaphoreToken(context.Background(), row)
+		assert.NoError(t, err)
+		assert.Equal(t, persistence.SemaphoreGrantAlreadyHeld, result.Outcome)
+		assert.Equal(t, 9, result.HeldToken)
+		assert.True(t, session.iter.closed)
+	})
+
+	t.Run("not applied - only malformed owner rows falls back to slot taken", func(t *testing.T) {
+		session := &fakeSession{
+			mapExecuteBatchCASApplied: false,
+			mapExecuteBatchCASPrev: map[string]any{
+				"type":       int(persistence.SemaphoreRowTypeOwner),
+				"held_token": -1,
+			},
+			iter: &fakeIter{},
+		}
+		db := newTestSemaphoreTokenDB(t, session)
+		result, err := db.GrantSemaphoreToken(context.Background(), row)
+		assert.NoError(t, err)
+		assert.Equal(t, persistence.SemaphoreGrantSlotTaken, result.Outcome)
+		assert.Zero(t, result.HeldToken)
 		assert.True(t, session.iter.closed)
 	})
 
@@ -226,10 +266,10 @@ func TestReleaseSemaphoreToken(t *testing.T) {
 		assert.Equal(t, []string{
 			`UPDATE semaphore_tokens SET holder = __FREE__, updated_time = ` + now.UTC().Format(time.RFC3339) + ` ` +
 				`WHERE domain_id = 10000000-1000-f000-f000-000000000000 AND semaphore_name = sem-1 AND bucket = 0 ` +
-				`AND type = 0 AND token_id = 5 AND owner_id = __NONE__ IF holder = owner-abc`,
+				`AND type = 1 AND token_id = 5 AND owner_id = __NONE__ IF holder = owner-abc`,
 			`DELETE FROM semaphore_tokens ` +
 				`WHERE domain_id = 10000000-1000-f000-f000-000000000000 AND semaphore_name = sem-1 AND bucket = 0 ` +
-				`AND type = 1 AND token_id = -1 AND owner_id = owner-abc`,
+				`AND type = 2 AND token_id = -1 AND owner_id = owner-abc`,
 		}, session.batches[0].queries)
 		assert.True(t, session.iter.closed)
 	})
@@ -264,20 +304,22 @@ func TestSelectSemaphoreOwnershipByToken(t *testing.T) {
 			name: "held slot normalizes sentinels",
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
-				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(args ...interface{}) error {
 						*args[0].(*string) = testSemaphoreDomainID
 						*args[1].(*string) = testSemaphoreName
 						*args[2].(*int) = 0
-						*args[3].(*int) = 5
-						*args[4].(*string) = ownerNoneSentinel // token row owner_id key
-						*args[5].(*string) = "owner-abc"       // holder
-						*args[6].(*int) = 0                    // held_token unset on token rows -> reads as 0
-						*args[7].(*time.Time) = now
+						*args[3].(*persistence.SemaphoreRowType) = persistence.SemaphoreRowTypeToken
+						*args[4].(*int) = 5
+						*args[5].(*string) = ownerNoneSentinel // token row owner_id key
+						*args[6].(*string) = "owner-abc"       // holder
+						*args[7].(*int) = 0                    // held_token unset on token rows -> reads as 0
+						*args[8].(*time.Time) = now
 						return nil
 					}).Times(1)
 			},
 			wantRow: &nosqlplugin.SemaphoreOwnershipRow{
+				RowType:       persistence.SemaphoreRowTypeToken,
 				DomainID:      testSemaphoreDomainID,
 				SemaphoreName: testSemaphoreName,
 				Bucket:        0,
@@ -292,20 +334,22 @@ func TestSelectSemaphoreOwnershipByToken(t *testing.T) {
 			name: "free slot normalizes holder",
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
-				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(args ...interface{}) error {
 						*args[0].(*string) = testSemaphoreDomainID
 						*args[1].(*string) = testSemaphoreName
 						*args[2].(*int) = 0
-						*args[3].(*int) = 5
-						*args[4].(*string) = ownerNoneSentinel
-						*args[5].(*string) = freeSentinel
-						*args[6].(*int) = 0
-						*args[7].(*time.Time) = now
+						*args[3].(*persistence.SemaphoreRowType) = persistence.SemaphoreRowTypeToken
+						*args[4].(*int) = 5
+						*args[5].(*string) = ownerNoneSentinel
+						*args[6].(*string) = freeSentinel
+						*args[7].(*int) = 0
+						*args[8].(*time.Time) = now
 						return nil
 					}).Times(1)
 			},
 			wantRow: &nosqlplugin.SemaphoreOwnershipRow{
+				RowType:       persistence.SemaphoreRowTypeToken,
 				DomainID:      testSemaphoreDomainID,
 				SemaphoreName: testSemaphoreName,
 				Bucket:        0,
@@ -320,7 +364,7 @@ func TestSelectSemaphoreOwnershipByToken(t *testing.T) {
 			name: "not found",
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
-				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("not found")).Times(1)
 			},
 			wantErr: true,
@@ -336,6 +380,14 @@ func TestSelectSemaphoreOwnershipByToken(t *testing.T) {
 			db := newTestSemaphoreTokenDB(t, session)
 
 			row, err := db.SelectSemaphoreOwnershipByToken(context.Background(), testSemaphoreDomainID, testSemaphoreName, 0, 5)
+			// The selected columns must match scanSemaphoreOwnershipRow one for one,
+			// `type` included: gocql rejects a count mismatch and matches the rest by
+			// position.
+			assert.Equal(t, []string{
+				`SELECT domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time ` +
+					`FROM semaphore_tokens WHERE domain_id = 10000000-1000-f000-f000-000000000000 ` +
+					`AND semaphore_name = sem-1 AND bucket = 0 AND type = 1 AND token_id = 5`,
+			}, session.queries)
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
@@ -359,20 +411,22 @@ func TestSelectSemaphoreOwnershipByOwner(t *testing.T) {
 			name: "found normalizes sentinels",
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
-				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(args ...interface{}) error {
 						*args[0].(*string) = testSemaphoreDomainID
 						*args[1].(*string) = testSemaphoreName
 						*args[2].(*int) = 0
-						*args[3].(*int) = emptyTokenID   // token_id N/A on owner row
-						*args[4].(*string) = "owner-abc" // owner_id
-						*args[5].(*string) = ""          // holder unset on owner rows -> reads as ""
-						*args[6].(*int) = 5              // held_token
-						*args[7].(*time.Time) = now
+						*args[3].(*persistence.SemaphoreRowType) = persistence.SemaphoreRowTypeOwner
+						*args[4].(*int) = emptyTokenID   // token_id N/A on owner row
+						*args[5].(*string) = "owner-abc" // owner_id
+						*args[6].(*string) = ""          // holder unset on owner rows -> reads as ""
+						*args[7].(*int) = 5              // held_token
+						*args[8].(*time.Time) = now
 						return nil
 					}).Times(1)
 			},
 			wantRow: &nosqlplugin.SemaphoreOwnershipRow{
+				RowType:       persistence.SemaphoreRowTypeOwner,
 				DomainID:      testSemaphoreDomainID,
 				SemaphoreName: testSemaphoreName,
 				Bucket:        0,
@@ -387,7 +441,7 @@ func TestSelectSemaphoreOwnershipByOwner(t *testing.T) {
 			name: "not found",
 			queryMockFn: func(query *gocql.MockQuery) {
 				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
-				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				query.EXPECT().Scan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("not found")).Times(1)
 			},
 			wantErr: true,
@@ -403,6 +457,11 @@ func TestSelectSemaphoreOwnershipByOwner(t *testing.T) {
 			db := newTestSemaphoreTokenDB(t, session)
 
 			row, err := db.SelectSemaphoreOwnershipByOwner(context.Background(), testSemaphoreDomainID, testSemaphoreName, 0, "owner-abc")
+			assert.Equal(t, []string{
+				`SELECT domain_id, semaphore_name, bucket, type, token_id, owner_id, holder, held_token, updated_time ` +
+					`FROM semaphore_tokens WHERE domain_id = 10000000-1000-f000-f000-000000000000 ` +
+					`AND semaphore_name = sem-1 AND bucket = 0 AND type = 2 AND token_id = -1 AND owner_id = owner-abc`,
+			}, session.queries)
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
@@ -439,7 +498,7 @@ func TestSelectSemaphoreOwnershipsByBucket(t *testing.T) {
 						*args[0].(*string) = testSemaphoreDomainID
 						*args[1].(*string) = testSemaphoreName
 						*args[2].(*int) = 0
-						*args[3].(*int) = rowTypeSemaphoreToken
+						*args[3].(*persistence.SemaphoreRowType) = persistence.SemaphoreRowTypeToken
 						*args[4].(*int) = 5
 						*args[5].(*string) = ownerNoneSentinel
 						*args[6].(*string) = "owner-abc"
@@ -453,7 +512,7 @@ func TestSelectSemaphoreOwnershipsByBucket(t *testing.T) {
 						*args[0].(*string) = testSemaphoreDomainID
 						*args[1].(*string) = testSemaphoreName
 						*args[2].(*int) = 0
-						*args[3].(*int) = rowTypeSemaphoreOwner
+						*args[3].(*persistence.SemaphoreRowType) = persistence.SemaphoreRowTypeOwner
 						*args[4].(*int) = emptyTokenID
 						*args[5].(*string) = "owner-abc"
 						*args[6].(*string) = ""
@@ -467,8 +526,8 @@ func TestSelectSemaphoreOwnershipsByBucket(t *testing.T) {
 				iter.EXPECT().Close().Return(nil).Times(1)
 			},
 			wantRows: []*nosqlplugin.SemaphoreOwnershipRow{
-				{DomainID: testSemaphoreDomainID, SemaphoreName: testSemaphoreName, Bucket: 0, TokenID: 5, OwnerID: "", Holder: "owner-abc", HeldToken: 0, UpdatedTime: now},
-				{DomainID: testSemaphoreDomainID, SemaphoreName: testSemaphoreName, Bucket: 0, TokenID: 0, OwnerID: "owner-abc", Holder: "", HeldToken: 5, UpdatedTime: now},
+				{RowType: persistence.SemaphoreRowTypeToken, DomainID: testSemaphoreDomainID, SemaphoreName: testSemaphoreName, Bucket: 0, TokenID: 5, OwnerID: "", Holder: "owner-abc", HeldToken: 0, UpdatedTime: now},
+				{RowType: persistence.SemaphoreRowTypeOwner, DomainID: testSemaphoreDomainID, SemaphoreName: testSemaphoreName, Bucket: 0, TokenID: 0, OwnerID: "owner-abc", Holder: "", HeldToken: 5, UpdatedTime: now},
 			},
 			wantToken: nil,
 		},
@@ -485,7 +544,7 @@ func TestSelectSemaphoreOwnershipsByBucket(t *testing.T) {
 						*args[0].(*string) = testSemaphoreDomainID
 						*args[1].(*string) = testSemaphoreName
 						*args[2].(*int) = 0
-						*args[3].(*int) = rowTypeSemaphoreToken
+						*args[3].(*persistence.SemaphoreRowType) = persistence.SemaphoreRowTypeToken
 						*args[4].(*int) = 5
 						*args[5].(*string) = ownerNoneSentinel
 						*args[6].(*string) = freeSentinel
@@ -497,7 +556,7 @@ func TestSelectSemaphoreOwnershipsByBucket(t *testing.T) {
 				iter.EXPECT().Close().Return(nil).Times(1)
 			},
 			wantRows: []*nosqlplugin.SemaphoreOwnershipRow{
-				{DomainID: testSemaphoreDomainID, SemaphoreName: testSemaphoreName, Bucket: 0, TokenID: 5, OwnerID: "", Holder: "", HeldToken: 0, UpdatedTime: now},
+				{RowType: persistence.SemaphoreRowTypeToken, DomainID: testSemaphoreDomainID, SemaphoreName: testSemaphoreName, Bucket: 0, TokenID: 5, OwnerID: "", Holder: "", HeldToken: 0, UpdatedTime: now},
 			},
 			wantToken: []byte("next"),
 		},

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -298,16 +298,19 @@ type (
 	}
 
 	// SemaphoreOwnershipRow defines a row of the semaphore_tokens table, in either
-	// of its two kinds: a forward "token" row or a reverse "owner" row.
+	// of its two types: a forward "token" row or a reverse "owner" row.
 	SemaphoreOwnershipRow struct {
 		DomainID      string
 		SemaphoreName string
 		Bucket        int
-		TokenID       int
-		OwnerID       string
-		Holder        string
-		HeldToken     int
-		UpdatedTime   time.Time
+		// RowType is the row's `type` column. Reads set it; writes ignore it, since each
+		// write path already knows which shape of row it is producing.
+		RowType     persistence.SemaphoreRowType
+		TokenID     int
+		OwnerID     string
+		Holder      string
+		HeldToken   int
+		UpdatedTime time.Time
 	}
 
 	// SemaphoreGrantResult reports the outcome of a conditional grant batch.
@@ -318,7 +321,7 @@ type (
 	}
 
 	// SemaphoreOwnershipFilter contains the filter criteria for scanning a bucket
-	// partition (both row kinds), paginated.
+	// partition (both row types), paginated.
 	SemaphoreOwnershipFilter struct {
 		DomainID      string
 		SemaphoreName string

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -303,8 +303,14 @@ type (
 		DomainID      string
 		SemaphoreName string
 		Bucket        int
-		// RowType is the row's `type` column. Reads set it; writes ignore it, since each
-		// write path already knows which shape of row it is producing.
+		// RowType is an output: reads fill it in from the stored `type` column, and
+		// writes ignore whatever it holds.
+		//
+		// Writes cannot honor it. Grant and release each write two rows in one batch,
+		// a token row and an owner row, so no single value on this struct could
+		// describe them. Seeding does write one row per struct, but honoring it there
+		// alone would leave a field that two of the three write paths still ignore.
+		// All three hardcode the `type` for each row they store.
 		RowType     persistence.SemaphoreRowType
 		TokenID     int
 		OwnerID     string

--- a/common/persistence/persistence-tests/semaphoreTokenPersistenceTest.go
+++ b/common/persistence/persistence-tests/semaphoreTokenPersistenceTest.go
@@ -228,7 +228,7 @@ func (s *SemaphoreTokenPersistenceSuite) TestSeedIsIdempotent() {
 	s.Equal(owner, byToken.Ownership.Holder)
 }
 
-// TestScanSemaphoreBucket verifies a bucket scan returns both row kinds,
+// TestScanSemaphoreBucket verifies a bucket scan returns both row types,
 // paginated.
 func (s *SemaphoreTokenPersistenceSuite) TestScanSemaphoreBucket() {
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
@@ -264,6 +264,7 @@ func (s *SemaphoreTokenPersistenceSuite) TestScanSemaphoreBucket() {
 	// scan the whole partition: numTokens token rows + numGranted owner rows
 	pageSize := 3
 	total := 0
+	byRowType := map[persistence.SemaphoreRowType]int{}
 	var nextPageToken []byte
 	for {
 		scanResp, err := manager.ScanSemaphoreBucket(ctx, &persistence.ScanSemaphoreBucketRequest{
@@ -276,10 +277,17 @@ func (s *SemaphoreTokenPersistenceSuite) TestScanSemaphoreBucket() {
 		s.NoError(err)
 		s.NotNil(scanResp)
 		total += len(scanResp.Ownerships)
+		for _, ownership := range scanResp.Ownerships {
+			byRowType[ownership.RowType]++
+		}
 		if len(scanResp.NextPageToken) == 0 {
 			break
 		}
 		nextPageToken = scanResp.NextPageToken
 	}
 	s.Equal(numTokens+numGranted, total)
+	// A scan is the only read that returns both types interleaved, so it is the only place
+	// the stored type column is what tells them apart.
+	s.Equal(numTokens, byRowType[persistence.SemaphoreRowTypeToken])
+	s.Equal(numGranted, byRowType[persistence.SemaphoreRowTypeOwner])
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Reads of the token-ownership table now return the row's `type` column.

- Adds `SemaphoreRowType` to `SemaphoreOwnership` and `SemaphoreOwnershipRow`. The column was scanned off the wire and discarded, so a bucket scan returned forward and reverse rows interleaved with nothing to tell them apart.
- All three reads now select `type` and share one column list, so a single scan helper serves both point reads and the paginated scan.
- Fixes the CAS-result parser: an owner row with a missing or non-positive `held_token` was accepted as a valid answer, so a conditional grant that hit one reported "slot aken" instead of "already held" and stopped before the remaining conflict rows.

**Why?**

- The Matching-side bucket owner rebuilds its free set and its owner→token index from one partition scan, and cannot classify a row without the discriminator. 

**How did you test it?**
- unit test

**Potential risks**
- The enum's values go into the column as-is — 1 for a token row, 2 for an owner row. The
table has no writers and no rows today, so there is no migration


**Release notes**
None

**Documentation Changes**
None
