### PR TITLE
feat(queuev2): add cached immediate queue wrapper

### DIFF
--- a/service/history/queuev2/queue_immediate.go
+++ b/service/history/queuev2/queue_immediate.go
@@ -55,7 +55,7 @@ type (
 	}
 )
 
-func NewImmediateQueue(
+func newImmediateQueue(
 	shard shard.Context,
 	category persistence.HistoryTaskCategory,
 	taskProcessor task.Processor,
@@ -65,7 +65,7 @@ func NewImmediateQueue(
 	metricsScope metrics.Scope,
 	queueReader QueueReader,
 	options *Options,
-) Queue {
+) *immediateQueue {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &immediateQueue{
 		base: newQueueBase(
@@ -83,6 +83,21 @@ func NewImmediateQueue(
 		ctx:      ctx,
 		cancel:   cancel,
 	}
+}
+
+func NewImmediateQueue(
+	shard shard.Context,
+	category persistence.HistoryTaskCategory,
+	taskProcessor task.Processor,
+	taskExecutor task.Executor,
+	logger log.Logger,
+	metricsClient metrics.Client,
+	metricsScope metrics.Scope,
+	queueReader QueueReader,
+	options *Options,
+) Queue {
+	return newImmediateQueue(shard, category, taskProcessor, taskExecutor,
+		logger, metricsClient, metricsScope, queueReader, options)
 }
 
 func (q *immediateQueue) Start() {
@@ -187,7 +202,7 @@ func (q *immediateQueue) processEventLoop() {
 		case <-q.pollTimer.Chan():
 			q.processPollTimer()
 		case <-q.base.updateQueueStateTimer.Chan():
-			q.base.updateQueueState(q.ctx)
+			q.base.updateQueueStateFn(q.ctx)
 		case alert := <-q.base.alertCh:
 			q.base.handleAlert(q.ctx, alert)
 		case <-q.ctx.Done():

--- a/service/history/queuev2/queue_immediate_cached.go
+++ b/service/history/queuev2/queue_immediate_cached.go
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queuev2
+
+import (
+	"context"
+
+	"github.com/uber/cadence/common/persistence"
+	hcommon "github.com/uber/cadence/service/history/common"
+)
+
+type cachedImmediateQueue struct {
+	*immediateQueue
+	reader CachedQueueReader
+}
+
+func newCachedImmediateQueue(inner *immediateQueue, reader CachedQueueReader) Queue {
+	// Wrap the queue state update to propagate min read level across all virtual queues
+	// to CachedQueueReader each time the ack level is updated
+	originalUpdateFn := inner.base.updateQueueStateFn
+	inner.base.updateQueueStateFn = func(ctx context.Context) {
+		originalUpdateFn(ctx)
+		// MaximumHistoryTaskKey means no slices — fall back to ack level.
+		readLevel := inner.base.virtualQueueManager.GetMinReadLevel()
+		if readLevel.Equal(persistence.MaximumHistoryTaskKey) {
+			readLevel = inner.base.exclusiveAckLevel
+		}
+		reader.UpdateReadLevel(readLevel)
+	}
+
+	return &cachedImmediateQueue{
+		immediateQueue: inner,
+		reader:         reader,
+	}
+}
+
+func (q *cachedImmediateQueue) NotifyNewTask(clusterName string, info *hcommon.NotifyTaskInfo) {
+	if info.PersistenceError {
+		q.reader.Clear()
+	} else {
+		q.reader.Inject(info.Tasks)
+	}
+	q.immediateQueue.NotifyNewTask(clusterName, info)
+}
+
+func (q *cachedImmediateQueue) Start() {
+	q.reader.Start()
+	q.immediateQueue.Start()
+}
+
+func (q *cachedImmediateQueue) Stop() {
+	q.immediateQueue.Stop()
+	q.reader.Stop()
+}

--- a/service/history/queuev2/queue_immediate_cached_test.go
+++ b/service/history/queuev2/queue_immediate_cached_test.go
@@ -1,0 +1,225 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queuev2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	hcommon "github.com/uber/cadence/service/history/common"
+	"github.com/uber/cadence/service/history/config"
+	"github.com/uber/cadence/service/history/shard"
+	"github.com/uber/cadence/service/history/task"
+)
+
+func testImmediateQueueOptions() *Options {
+	return &Options{
+		DeleteBatchSize:                      dynamicproperties.GetIntPropertyFn(100),
+		RedispatchInterval:                   dynamicproperties.GetDurationPropertyFn(10 * time.Second),
+		PageSize:                             dynamicproperties.GetIntPropertyFn(100),
+		PollBackoffInterval:                  dynamicproperties.GetDurationPropertyFn(10 * time.Second),
+		MaxPollInterval:                      dynamicproperties.GetDurationPropertyFn(10 * time.Second),
+		MaxPollIntervalJitterCoefficient:     dynamicproperties.GetFloatPropertyFn(0.1),
+		UpdateAckInterval:                    dynamicproperties.GetDurationPropertyFn(10 * time.Second),
+		UpdateAckIntervalJitterCoefficient:   dynamicproperties.GetFloatPropertyFn(0.1),
+		MaxPollRPS:                           dynamicproperties.GetIntPropertyFn(100),
+		MaxPendingTasksCount:                 dynamicproperties.GetIntPropertyFn(100),
+		PollBackoffIntervalJitterCoefficient: dynamicproperties.GetFloatPropertyFn(0.0),
+		VirtualSliceForceAppendInterval:      dynamicproperties.GetDurationPropertyFn(10 * time.Second),
+		CriticalPendingTaskCount:             dynamicproperties.GetIntPropertyFn(90),
+		EnablePendingTaskCountAlert:          func() bool { return true },
+		MaxVirtualQueueCount:                 dynamicproperties.GetIntPropertyFn(2),
+	}
+}
+
+func TestCachedImmediateQueue_Construction(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctrl := gomock.NewController(t)
+
+	mockShard := shard.NewTestContext(
+		t, ctrl,
+		&persistence.ShardInfo{ShardID: 10, RangeID: 1, TransferAckLevel: 0},
+		config.NewForTest(),
+	)
+
+	options := testImmediateQueueOptions()
+	mockReader := NewMockCachedQueueReader(ctrl)
+
+	inner := newImmediateQueue(mockShard, persistence.HistoryTaskCategoryTransfer,
+		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
+		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options)
+
+	q := newCachedImmediateQueue(inner, mockReader)
+
+	require.NotNil(t, q)
+	_, ok := q.(*cachedImmediateQueue)
+	require.True(t, ok, "expected *cachedImmediateQueue")
+}
+
+func TestCachedImmediateQueue_NotifyNewTask(t *testing.T) {
+	tasks := []persistence.Task{
+		&persistence.ActivityTask{TaskData: persistence.TaskData{TaskID: 1}},
+	}
+
+	tests := []struct {
+		name            string
+		info            *hcommon.NotifyTaskInfo
+		setupMockReader func(*MockCachedQueueReader)
+	}{
+		{
+			name: "nil tasks",
+			info: &hcommon.NotifyTaskInfo{Tasks: nil},
+			setupMockReader: func(r *MockCachedQueueReader) {
+				r.EXPECT().Inject([]persistence.Task(nil)).Times(1)
+			},
+		},
+		{
+			name: "with tasks",
+			info: &hcommon.NotifyTaskInfo{Tasks: tasks},
+			setupMockReader: func(r *MockCachedQueueReader) {
+				r.EXPECT().Inject(tasks).Times(1)
+			},
+		},
+		{
+			name: "persistence error",
+			info: &hcommon.NotifyTaskInfo{
+				Tasks:            []persistence.Task{&persistence.ActivityTask{}},
+				PersistenceError: true,
+			},
+			setupMockReader: func(r *MockCachedQueueReader) {
+				r.EXPECT().Clear().Times(1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockReader := NewMockCachedQueueReader(ctrl)
+			tt.setupMockReader(mockReader)
+
+			ciq := &cachedImmediateQueue{
+				immediateQueue: &immediateQueue{
+					base: &queueBase{
+						metricsScope: metrics.NoopScope,
+					},
+					notifyCh: make(chan struct{}, 1),
+				},
+				reader: mockReader,
+			}
+
+			ciq.NotifyNewTask("test-cluster", tt.info)
+		})
+	}
+}
+
+func TestCachedImmediateQueue_StartStop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctrl := gomock.NewController(t)
+
+	mockShard := shard.NewTestContext(
+		t, ctrl,
+		&persistence.ShardInfo{ShardID: 10, RangeID: 1, TransferAckLevel: 0},
+		config.NewForTest(),
+	)
+
+	options := testImmediateQueueOptions()
+	mockReader := NewMockCachedQueueReader(ctrl)
+
+	// processEventLoop calls GetTask when processing new tasks; it can fire multiple times.
+	mockReader.EXPECT().GetTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *GetTaskRequest) (*GetTaskResponse, error) {
+			return &GetTaskResponse{
+				Progress: &GetTaskProgress{
+					Range:       req.Progress.Range,
+					NextTaskKey: req.Progress.ExclusiveMaxTaskKey,
+				},
+			}, nil
+		},
+	).AnyTimes()
+	mockReader.EXPECT().Start().Times(1)
+	mockReader.EXPECT().Stop().Times(1)
+
+	inner := newImmediateQueue(mockShard, persistence.HistoryTaskCategoryTransfer,
+		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
+		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options)
+
+	q := newCachedImmediateQueue(inner, mockReader)
+
+	q.Start()
+	q.Stop()
+}
+
+func TestCachedImmediateQueue_UpdateQueueStateFn_PropagatesReadLevel(t *testing.T) {
+	sliceReadLevel := persistence.NewImmediateTaskKey(100)
+	ackLevel := persistence.NewImmediateTaskKey(50)
+
+	tests := []struct {
+		name          string
+		minReadLevel  persistence.HistoryTaskKey
+		expectedLevel persistence.HistoryTaskKey
+	}{
+		{
+			name:          "slices exist - use min read level",
+			minReadLevel:  sliceReadLevel,
+			expectedLevel: sliceReadLevel,
+		},
+		{
+			name:          "no slices - fall back to ack level",
+			minReadLevel:  persistence.MaximumHistoryTaskKey,
+			expectedLevel: ackLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockReader := NewMockCachedQueueReader(ctrl)
+			mockVQM := NewMockVirtualQueueManager(ctrl)
+
+			inner := &immediateQueue{
+				base: &queueBase{
+					metricsScope:        metrics.NoopScope,
+					virtualQueueManager: mockVQM,
+					exclusiveAckLevel:   ackLevel,
+				},
+				notifyCh: make(chan struct{}, 1),
+			}
+			inner.base.updateQueueStateFn = func(ctx context.Context) {}
+
+			mockVQM.EXPECT().GetMinReadLevel().Return(tt.minReadLevel)
+			mockReader.EXPECT().UpdateReadLevel(tt.expectedLevel)
+
+			q := newCachedImmediateQueue(inner, mockReader)
+			q.(*cachedImmediateQueue).immediateQueue.base.updateQueueStateFn(context.Background())
+		})
+	}
+}


### PR DESCRIPTION
**What changed?**
Add a cached wrapper around the immediate (transfer) queue, mirroring the cached scheduled (timer) queue.

**Why?**
This is one of the steps toward adding the transfer task cache (#8432). Up next: wire the wrapper into the transfer queue factory and expose the transfer cache dynamic-config keys.

**How did you test it?**
- `go test -race ./service/history/queuev2/...`

**Potential risks**
None. The wrapper is not wired into any factory yet

**Release notes**
N/A

**Documentation Changes**
N/A
