### PR TITLE
refactor(queuev2): generalize cached queue wrapper to any queue kind

### DIFF
--- a/service/history/queuev2/queue_cached.go
+++ b/service/history/queuev2/queue_cached.go
@@ -29,46 +29,47 @@ import (
 	hcommon "github.com/uber/cadence/service/history/common"
 )
 
-type cachedScheduledQueue struct {
-	*scheduledQueue
+type cachedQueue struct {
+	Queue
 	reader CachedQueueReader
 }
 
-func newCachedScheduledQueue(inner *scheduledQueue, reader CachedQueueReader) Queue {
+// newCachedQueue wraps passed queue with reader.
+// queueBase must be queue's underlying *queueBase.
+func newCachedQueue(queue Queue, queueBase *queueBase, reader CachedQueueReader) Queue {
 	// Wrap the queue state update to propagate min read level across all virtual queues
 	// to CachedQueueReader each time the ack level is updated
-	originalUpdateFn := inner.base.updateQueueStateFn
-	inner.base.updateQueueStateFn = func(ctx context.Context) {
+	originalUpdateFn := queueBase.updateQueueStateFn
+	queueBase.updateQueueStateFn = func(ctx context.Context) {
 		originalUpdateFn(ctx)
 		// MaximumHistoryTaskKey means no slices — fall back to ack level.
-		readLevel := inner.base.virtualQueueManager.GetMinReadLevel()
+		readLevel := queueBase.virtualQueueManager.GetMinReadLevel()
 		if readLevel.Equal(persistence.MaximumHistoryTaskKey) {
-			readLevel = inner.base.exclusiveAckLevel
+			readLevel = queueBase.exclusiveAckLevel
 		}
 		reader.UpdateReadLevel(readLevel)
 	}
-
-	return &cachedScheduledQueue{
-		scheduledQueue: inner,
-		reader:         reader,
+	return &cachedQueue{
+		Queue:  queue,
+		reader: reader,
 	}
 }
 
-func (q *cachedScheduledQueue) NotifyNewTask(clusterName string, info *hcommon.NotifyTaskInfo) {
+func (q *cachedQueue) NotifyNewTask(clusterName string, info *hcommon.NotifyTaskInfo) {
 	if info.PersistenceError {
 		q.reader.Clear()
 	} else {
 		q.reader.Inject(info.Tasks)
 	}
-	q.scheduledQueue.NotifyNewTask(clusterName, info)
+	q.Queue.NotifyNewTask(clusterName, info)
 }
 
-func (q *cachedScheduledQueue) Start() {
+func (q *cachedQueue) Start() {
 	q.reader.Start()
-	q.scheduledQueue.Start()
+	q.Queue.Start()
 }
 
-func (q *cachedScheduledQueue) Stop() {
-	q.scheduledQueue.Stop()
+func (q *cachedQueue) Stop() {
+	q.Queue.Stop()
 	q.reader.Stop()
 }

--- a/service/history/queuev2/queue_cached_test.go
+++ b/service/history/queuev2/queue_cached_test.go
@@ -50,18 +50,18 @@ func TestCachedScheduledQueue_Construction(t *testing.T) {
 		config.NewForTest(),
 	)
 
-	options := testScheduledQueueOptions()
+	options := testQueueOptions()
 	mockReader := NewMockCachedQueueReader(ctrl)
 
 	inner := NewScheduledQueue(mockShard, persistence.HistoryTaskCategoryTimer,
 		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
 		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options).(*scheduledQueue)
 
-	q := newCachedScheduledQueue(inner, mockReader)
+	q := newCachedQueue(inner, inner.base, mockReader)
 
 	require.NotNil(t, q)
-	_, ok := q.(*cachedScheduledQueue)
-	require.True(t, ok, "expected *cachedScheduledQueue")
+	_, ok := q.(*cachedQueue)
+	require.True(t, ok, "expected *cachedQueue")
 }
 
 func TestCachedScheduledQueue_NotifyNewTask(t *testing.T) {
@@ -110,8 +110,8 @@ func TestCachedScheduledQueue_NotifyNewTask(t *testing.T) {
 			mockReader := NewMockCachedQueueReader(ctrl)
 			tt.setupMockReader(mockReader)
 
-			csq := &cachedScheduledQueue{
-				scheduledQueue: &scheduledQueue{
+			csq := &cachedQueue{
+				Queue: &scheduledQueue{
 					base: &queueBase{
 						metricsScope: metrics.NoopScope,
 					},
@@ -135,7 +135,7 @@ func TestCachedScheduledQueue_StartStop(t *testing.T) {
 		config.NewForTest(),
 	)
 
-	options := testScheduledQueueOptions()
+	options := testQueueOptions()
 	mockReader := NewMockCachedQueueReader(ctrl)
 
 	// processEventLoop calls LookAHead after the timer gate fires, and GetTask
@@ -158,7 +158,7 @@ func TestCachedScheduledQueue_StartStop(t *testing.T) {
 		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
 		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options).(*scheduledQueue)
 
-	q := newCachedScheduledQueue(inner, mockReader)
+	q := newCachedQueue(inner, inner.base, mockReader)
 
 	q.Start()
 	q.Stop()
@@ -174,7 +174,7 @@ func TestCachedScheduledQueue_EvictionHookWired(t *testing.T) {
 		config.NewForTest(),
 	)
 
-	options := testScheduledQueueOptions()
+	options := testQueueOptions()
 	mockReader := NewMockCachedQueueReader(ctrl)
 
 	inner := NewScheduledQueue(mockShard, persistence.HistoryTaskCategoryTimer,
@@ -185,12 +185,11 @@ func TestCachedScheduledQueue_EvictionHookWired(t *testing.T) {
 	// can be called without triggering real shard persistence.
 	inner.base.updateQueueStateFn = func(ctx context.Context) {}
 
-	q := newCachedScheduledQueue(inner, mockReader)
-	csq := q.(*cachedScheduledQueue)
+	newCachedQueue(inner, inner.base, mockReader)
 
 	// Calling the hooked function exercises the closure (covers the inner body).
 	mockReader.EXPECT().UpdateReadLevel(gomock.Any()).Times(1)
-	csq.scheduledQueue.base.updateQueueStateFn(context.Background())
+	inner.base.updateQueueStateFn(context.Background())
 }
 
 func TestCachedScheduledQueue_UpdateQueueStateFn_PropagatesReadLevel(t *testing.T) {
@@ -234,13 +233,13 @@ func TestCachedScheduledQueue_UpdateQueueStateFn_PropagatesReadLevel(t *testing.
 			mockVQM.EXPECT().GetMinReadLevel().Return(tt.minReadLevel)
 			mockReader.EXPECT().UpdateReadLevel(tt.expectedLevel)
 
-			q := newCachedScheduledQueue(inner, mockReader)
-			q.(*cachedScheduledQueue).scheduledQueue.base.updateQueueStateFn(context.Background())
+			newCachedQueue(inner, inner.base, mockReader)
+			inner.base.updateQueueStateFn(context.Background())
 		})
 	}
 }
 
-func testScheduledQueueOptions() *Options {
+func testQueueOptions() *Options {
 	return &Options{
 		DeleteBatchSize:                      dynamicproperties.GetIntPropertyFn(100),
 		RedispatchInterval:                   dynamicproperties.GetDurationPropertyFn(10 * time.Second),

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -164,7 +164,7 @@ func (f *timerQueueFactory) createQueuev2(
 		reader = cachedReader
 	}
 
-	base := newScheduledQueue(
+	queue := newScheduledQueue(
 		shard,
 		persistence.HistoryTaskCategoryTimer,
 		f.taskProcessor,
@@ -177,8 +177,8 @@ func (f *timerQueueFactory) createQueuev2(
 	)
 
 	if cachedReader != nil {
-		return newCachedScheduledQueue(base, cachedReader)
+		return newCachedQueue(queue, queue.base, cachedReader)
 	}
 
-	return base
+	return queue
 }

--- a/service/history/queuev2/timer_queue_factory_test.go
+++ b/service/history/queuev2/timer_queue_factory_test.go
@@ -53,7 +53,7 @@ func TestTimerQueueFactory_CreateQueuev2(t *testing.T) {
 			processor := factory.createQueuev2(mockShard, execution.NewMockCache(ctrl), invariant.NewMockInvariant(ctrl))
 
 			assert.NotNil(t, processor)
-			_, isCached := processor.(*cachedScheduledQueue)
+			_, isCached := processor.(*cachedQueue)
 			assert.Equal(t, tc.wantCached, isCached, "mode=%q", tc.mode)
 		})
 	}


### PR DESCRIPTION
**What changed?**
Replaced `cachedScheduledQueue` (which embedded the concrete `*scheduledQueue`) with a generic `cachedQueue` that embeds the `Queue` interface and overrides only the lifecycle and notify methods. 

**Why?**
Part of the transfer task cache work (#8432).

The previous wrapper was tied to `*scheduledQueue`, so reusing it for another queue kind (i.e. for transfer tasks) would have meant copying the whole file and keeping two identical copies of the caching logic. 

Up next: make the immediate (transfer) queue cacheable by reusing `cachedQueue`

**How did you test it?**
Behavior-preserving refactor covered by the existing (retargeted) tests:
- `go test -race ./service/history/queuev2/...`

**Potential risks**
Low: refactoring with preserving the existing tests.

**Release notes**
N/A.

**Documentation Changes**
N/A.