### PR TITLE
refactor(persistence): Move schema Update/Verify out of cmd

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -29,14 +29,15 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/urfave/cli/v2"
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
 
 	"github.com/uber/cadence/common/client"
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence/schema"
 	"github.com/uber/cadence/common/service"
 
 	_ "go.uber.org/automaxprocs" // defines automaxpocs for dockerized usage.
@@ -165,11 +166,15 @@ func BuildCLI(releaseVersion string, gitRevision string) *cli.App {
 					return fmt.Errorf("validate config: %w", err)
 				}
 
-				logger := newUpdateSchemaLogger()
-				factory := newPersistenceFactory(cfg, logger)
-				defer factory.Close()
-
-				return runUpdateSchema(c.Context, factory, logger, clock.NewRealTimeSource())
+				err := schema.Update(c.Context, schema.Options{
+					ClusterName:    cfg.ClusterGroupMetadata.CurrentClusterName,
+					Config:         &cfg.Persistence,
+					ConnectTimeout: 30 * time.Second,
+				})
+				if err != nil {
+					return fmt.Errorf("update schema: %w", err)
+				}
+				return nil
 			},
 		},
 	}

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -46,6 +46,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/metricsfx"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"github.com/uber/cadence/common/persistence/schema"
 	"github.com/uber/cadence/common/rpc"
 	"github.com/uber/cadence/common/rpc/rpcfx"
 	"github.com/uber/cadence/common/service"
@@ -164,7 +165,7 @@ func (a *App) Stop(ctx context.Context) error {
 }
 
 func (a *App) verifySchema(ctx context.Context) error {
-	if err := VerifySchema(ctx, a.cfg); err != nil {
+	if err := schema.Verify(ctx, schema.OptionsFromConfig(a.cfg)); err != nil {
 		if a.dynamicCollection.GetBoolProperty(dynamicproperties.EnforceSchemaVerificationV2)() {
 			return fmt.Errorf("schema verification failed: %w", err)
 		}

--- a/common/elasticsearch/client/v6/client.go
+++ b/common/elasticsearch/client/v6/client.go
@@ -49,6 +49,10 @@ type (
 
 var _ elastic.Logger = (convertlogger)(nil)
 
+// docTypeName is the mapping type used by the v6 visibility index template. Mapping types were
+// removed in ES 7, but v6 still requires one when reading and writing mappings.
+const docTypeName = "_doc"
+
 func (c convertlogger) Printf(format string, v ...interface{}) {
 	c(fmt.Sprintf(format, v...))
 }
@@ -239,11 +243,25 @@ func (c *ElasticV6) GetMappings(ctx context.Context, indexName string) (map[stri
 	if err != nil {
 		return nil, err
 	}
-	return res, nil
+	// The ES v6 API structure:
+	//   {"<index>": {"mappings": {"_doc": {"dynamic": ..., "properties": {...}}}}}
+	index, ok := res[indexName].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	mappings, ok := index["mappings"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	docType, ok := mappings[docTypeName].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	return docType, nil
 }
 
 func (c *ElasticV6) PutMappings(ctx context.Context, indexName string, mappings map[string]any) error {
-	resp, err := c.client.PutMapping().Index(indexName).Type("_doc").BodyJson(mappings).Do(ctx)
+	resp, err := c.client.PutMapping().Index(indexName).Type(docTypeName).BodyJson(mappings).Do(ctx)
 	if err != nil {
 		return err
 	}
@@ -262,7 +280,11 @@ func (c *ElasticV6) MappingsFromTemplate(template []byte) (map[string]any, error
 	if !ok {
 		return nil, fmt.Errorf("mappings not found in template")
 	}
-	return m["_doc"].(map[string]interface{}), nil
+	docType, ok := m[docTypeName].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("mapping type %q not found in template", docTypeName)
+	}
+	return docType, nil
 }
 
 func (c *ElasticV6) LatestTemplate() []byte {

--- a/common/elasticsearch/client/v6/client_test.go
+++ b/common/elasticsearch/client/v6/client_test.go
@@ -273,21 +273,55 @@ func TestDeleteIndex(t *testing.T) {
 }
 
 func TestGetMappings(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" || !strings.HasPrefix(r.URL.Path, "/testIndex/_mapping") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"testIndex":{"mappings":{"_doc":{"properties":{"title":{"type":"text"}}}}}}`))
-	})
+	tests := []struct {
+		name     string
+		body     string
+		expected map[string]any
+	}{
+		{
+			name: "unwraps the index, mappings and doc type levels",
+			body: `{"testIndex":{"mappings":{"_doc":{"dynamic":"false","properties":{"title":{"type":"text"}}}}}}`,
+			expected: map[string]any{
+				"dynamic":    "false",
+				"properties": map[string]any{"title": map[string]any{"type": "text"}},
+			},
+		},
+		{
+			name:     "returns nil when the mapping type is not _doc",
+			body:     `{"testIndex":{"mappings":{"cadence-visibility":{"properties":{"title":{"type":"text"}}}}}}`,
+			expected: nil,
+		},
+		{
+			name:     "returns nil when the mappings are missing",
+			body:     `{"testIndex":{}}`,
+			expected: nil,
+		},
+		{
+			name:     "returns nil when the index is absent",
+			body:     `{"other-index":{"mappings":{"_doc":{"properties":{"title":{"type":"text"}}}}}}`,
+			expected: nil,
+		},
+	}
 
-	elasticV6, testServer := getMockClient(t, handler)
-	defer testServer.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" || !strings.HasPrefix(r.URL.Path, "/testIndex/_mapping") {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			})
 
-	mappings, err := elasticV6.GetMappings(context.Background(), "testIndex")
-	assert.NoError(t, err)
-	assert.Contains(t, mappings, "testIndex")
+			elasticV6, testServer := getMockClient(t, handler)
+			defer testServer.Close()
+
+			mappings, err := elasticV6.GetMappings(context.Background(), "testIndex")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, mappings)
+		})
+	}
 }
 
 func TestMappingsFromTemplate(t *testing.T) {

--- a/common/elasticsearch/client/v7/client.go
+++ b/common/elasticsearch/client/v7/client.go
@@ -217,7 +217,17 @@ func (c *ElasticV7) GetMappings(ctx context.Context, indexName string) (map[stri
 	if err != nil {
 		return nil, err
 	}
-	return res, nil
+	// The ES v7 API structure:
+	//   {"<index>": {"mappings": {"dynamic": ..., "properties": {...}}}}
+	index, ok := res[indexName].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	mappings, ok := index["mappings"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	return mappings, nil
 }
 
 func (c *ElasticV7) PutMappings(ctx context.Context, indexName string, mappings map[string]any) error {
@@ -236,7 +246,11 @@ func (c *ElasticV7) MappingsFromTemplate(template []byte) (map[string]any, error
 	if err := json.Unmarshal(template, &schemaJSON); err != nil {
 		return nil, err
 	}
-	return schemaJSON["mappings"].(map[string]any), nil
+	mappings, ok := schemaJSON["mappings"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("mappings not found in template")
+	}
+	return mappings, nil
 }
 
 func (c *ElasticV7) LatestTemplate() []byte {

--- a/common/elasticsearch/client/v7/client_test.go
+++ b/common/elasticsearch/client/v7/client_test.go
@@ -273,21 +273,50 @@ func TestDeleteIndex(t *testing.T) {
 }
 
 func TestGetMappings(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" || !strings.HasPrefix(r.URL.Path, "/testIndex/_mapping") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"testIndex":{"mappings":{"properties":{"title":{"type":"text"}}}}}`))
-	})
+	tests := []struct {
+		name     string
+		body     string
+		expected map[string]any
+	}{
+		{
+			name: "unwraps the index and mappings levels",
+			body: `{"testIndex":{"mappings":{"dynamic":"false","properties":{"title":{"type":"text"}}}}}`,
+			expected: map[string]any{
+				"dynamic":    "false",
+				"properties": map[string]any{"title": map[string]any{"type": "text"}},
+			},
+		},
+		{
+			name:     "returns nil when the mappings are missing",
+			body:     `{"testIndex":{}}`,
+			expected: nil,
+		},
+		{
+			name:     "returns nil when the index is absent",
+			body:     `{"other-index":{"mappings":{"properties":{"title":{"type":"text"}}}}}`,
+			expected: nil,
+		},
+	}
 
-	elasticV7, testServer := getMockClient(t, handler)
-	defer testServer.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" || !strings.HasPrefix(r.URL.Path, "/testIndex/_mapping") {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			})
 
-	mappings, err := elasticV7.GetMappings(context.Background(), "testIndex")
-	assert.NoError(t, err)
-	assert.Contains(t, mappings, "testIndex")
+			elasticV7, testServer := getMockClient(t, handler)
+			defer testServer.Close()
+
+			mappings, err := elasticV7.GetMappings(context.Background(), "testIndex")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, mappings)
+		})
+	}
 }
 
 func TestMappingsFromTemplate(t *testing.T) {

--- a/common/persistence/elasticsearch/admin.go
+++ b/common/persistence/elasticsearch/admin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/uber/cadence/common/elasticsearch"
 	"github.com/uber/cadence/common/elasticsearch/client"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -21,6 +22,7 @@ const (
 
 type admin struct {
 	client client.Client
+	logger log.Logger
 	cfg    *config.ElasticSearchConfig
 }
 
@@ -29,7 +31,7 @@ func NewAdminDB(config *config.ElasticSearchConfig, logger log.Logger) (persiste
 	if err != nil {
 		return nil, err
 	}
-	return &admin{client: client.Client, cfg: config}, nil
+	return &admin{client: client.Client, logger: logger, cfg: config}, nil
 }
 
 func (a *admin) PluginName() string {
@@ -60,6 +62,7 @@ func (a *admin) CreateSetupDB() (persistence.SetupDB, error) {
 
 	return &setupDB{
 		client:       a.client,
+		logger:       a.logger,
 		indexName:    indexName,
 		templateName: visibilityTemplateName,
 	}, nil
@@ -75,6 +78,7 @@ func (a *admin) CreateSchemaDB() (persistence.SchemaDB, error) {
 
 type setupDB struct {
 	client       client.Client
+	logger       log.Logger
 	indexName    string
 	templateName string
 }
@@ -96,9 +100,17 @@ func (s *setupDB) IsSetup(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("getting template mappings: %w", err)
 	}
 
-	missing, err := IsMissingMappings(currentMappings, latestMappings)
-
-	return !missing, err
+	missing, err := GetMissingMappings(currentMappings, latestMappings)
+	if err != nil {
+		return false, fmt.Errorf("comparing mappings: %w", err)
+	}
+	if len(missing) > 0 {
+		s.logger.Warn("Visibility index is missing mappings",
+			tag.Dynamic("index", s.indexName),
+			tag.Dynamic("missing-mappings", strings.Join(missing, ", ")))
+		return false, nil
+	}
+	return true, nil
 }
 
 func (s *setupDB) Setup(ctx context.Context, _ map[string]string) error {

--- a/common/persistence/elasticsearch/admin_test.go
+++ b/common/persistence/elasticsearch/admin_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/elasticsearch/client"
+	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -76,8 +77,9 @@ func TestAdminDB_CreateSetupDB(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockClient := client.NewMockClient(ctrl)
 			cfg := testESConfig(t, v6, tt.indexName)
+			logger := testlogger.New(t)
 
-			a := &admin{client: mockClient, cfg: cfg}
+			a := &admin{client: mockClient, logger: logger, cfg: cfg}
 			if tt.wantErrContains == "invalid visibility index" {
 				// no calls expected
 			} else {
@@ -99,6 +101,7 @@ func TestAdminDB_CreateSetupDB(t *testing.T) {
 				assert.Equal(t, cfg.GetVisibilityIndex(), s.indexName)
 				assert.Equal(t, visibilityTemplateName, s.templateName)
 				assert.Same(t, mockClient, s.client)
+				assert.Same(t, logger, s.logger)
 			}
 		})
 	}
@@ -179,7 +182,7 @@ func TestSetupDB_IsSetup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockClient := client.NewMockClient(ctrl)
-			s := &setupDB{client: mockClient, indexName: "cadence-visibility-test", templateName: visibilityTemplateName}
+			s := &setupDB{client: mockClient, logger: testlogger.New(t), indexName: "cadence-visibility-test", templateName: visibilityTemplateName}
 			tt.allowances(s, mockClient)
 
 			got, err := s.IsSetup(t.Context())

--- a/common/persistence/elasticsearch/mapping_diff.go
+++ b/common/persistence/elasticsearch/mapping_diff.go
@@ -2,8 +2,7 @@ package elasticsearch
 
 import (
 	"encoding/json"
-
-	"golang.org/x/exp/maps"
+	"sort"
 )
 
 type (
@@ -18,17 +17,21 @@ type (
 	}
 )
 
-func IsMissingMappings(current, expected map[string]any) (bool, error) {
+// GetMissingMappings returns the sorted dot notation paths of every property that is present in
+// expected but missing from current, e.g. ["Attr.CustomBoolField", "CloseTime"].
+// Properties that only exist in current are considered superfluous and are ignored.
+func GetMissingMappings(current, expected map[string]any) ([]string, error) {
 	c, err := convertMappings(current)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	e, err := convertMappings(expected)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	diff := mappingsDifferences(c.Properties, e.Properties)
-	return len(diff) > 0, nil
+	missing := missingMappingPaths("", c.Properties, e.Properties)
+	sort.Strings(missing)
+	return missing, nil
 }
 
 func convertMappings(m map[string]interface{}) (*mappings, error) {
@@ -43,39 +46,25 @@ func convertMappings(m map[string]interface{}) (*mappings, error) {
 	return &result, nil
 }
 
-func mappingsDifferences(current map[string]property, expected map[string]property) map[string]property {
-	missing := make(map[string]property)
-	keys := append(maps.Keys(current), maps.Keys(expected)...)
-	visited := make(map[string]bool)
+// missingMappingPaths walks the expected properties and collects the dot notation path of every
+// property that isn't present in current. Properties present in both are recursed into so that
+// only the missing leaves of a shared subtree are reported.
+func missingMappingPaths(prefix string, current, expected map[string]property) []string {
+	var missing []string
+	for key, expectedProperty := range expected {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
 
-	// go through and find which are missing, which are
-	// additional and superfluous
-	for _, key := range keys {
-
-		// the list of keys will contain duplicates because it's summing up the maps keys directly above, so don't
-		// bother visiting more than once.
-		if visited[key] {
+		currentProperty, presentInCurrent := current[key]
+		if !presentInCurrent {
+			// missing key identified, no need to descend into it
+			missing = append(missing, path)
 			continue
 		}
 
-		existingProperty, presentInCurrent := current[key]
-		expectedProperty, presentInExpected := expected[key]
-
-		if presentInCurrent && presentInExpected {
-			missingSubtree := mappingsDifferences(existingProperty.Properties, expectedProperty.Properties)
-			if len(missingSubtree) > 0 {
-				missing[key] = property{
-					Properties: missingSubtree,
-				}
-			}
-		} else if presentInCurrent && !presentInExpected {
-			// ignore, superfluous mapping
-		} else if presentInExpected && !presentInCurrent {
-			// missing key identified
-			missing[key] = expectedProperty
-		}
-
-		visited[key] = true
+		missing = append(missing, missingMappingPaths(path, currentProperty.Properties, expectedProperty.Properties)...)
 	}
 
 	return missing

--- a/common/persistence/elasticsearch/mapping_diff_test.go
+++ b/common/persistence/elasticsearch/mapping_diff_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsMissingMappings(t *testing.T) {
+func TestGetMissingMappings(t *testing.T) {
 	tests := []struct {
 		name        string
 		current     map[string]any
 		expected    map[string]any
-		wantMissing bool
+		wantMissing []string
 	}{
 		{
 			name: "current is empty",
@@ -24,7 +24,7 @@ func TestIsMissingMappings(t *testing.T) {
 					"WorkflowID": map[string]any{"type": "keyword"},
 				},
 			},
-			wantMissing: true,
+			wantMissing: []string{"WorkflowID"},
 		},
 		{
 			name: "current is allowed to have values not present in expected",
@@ -39,7 +39,7 @@ func TestIsMissingMappings(t *testing.T) {
 					"WorkflowID": map[string]any{"type": "keyword"},
 				},
 			},
-			wantMissing: false,
+			wantMissing: nil,
 		},
 		{
 			name: "expected is not allowed to have values not present in current",
@@ -54,7 +54,7 @@ func TestIsMissingMappings(t *testing.T) {
 					"CloseTime":  map[string]any{"type": "long"},
 				},
 			},
-			wantMissing: true,
+			wantMissing: []string{"CloseTime"},
 		},
 		{
 			name: "current and expected are equal",
@@ -72,7 +72,7 @@ func TestIsMissingMappings(t *testing.T) {
 					"CloseTime":  map[string]any{"type": "long"},
 				},
 			},
-			wantMissing: false,
+			wantMissing: nil,
 		},
 		{
 			name: "there are differences in nested properties",
@@ -95,13 +95,59 @@ func TestIsMissingMappings(t *testing.T) {
 					},
 				},
 			},
-			wantMissing: true,
+			wantMissing: []string{"Attr.CustomBoolField"},
+		},
+		{
+			name: "missing parent is reported without descending into it",
+			current: map[string]any{
+				"properties": map[string]any{},
+			},
+			expected: map[string]any{
+				"properties": map[string]any{
+					"Attr": map[string]any{
+						"properties": map[string]any{
+							"CustomKeywordField": map[string]any{"type": "keyword"},
+						},
+					},
+				},
+			},
+			wantMissing: []string{"Attr"},
+		},
+		{
+			name: "results are sorted and deeply nested",
+			current: map[string]any{
+				"properties": map[string]any{
+					"Attr": map[string]any{
+						"properties": map[string]any{
+							"Nested": map[string]any{
+								"properties": map[string]any{},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]any{
+				"properties": map[string]any{
+					"WorkflowID": map[string]any{"type": "keyword"},
+					"Attr": map[string]any{
+						"properties": map[string]any{
+							"CustomBoolField": map[string]any{"type": "boolean"},
+							"Nested": map[string]any{
+								"properties": map[string]any{
+									"Deep": map[string]any{"type": "long"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantMissing: []string{"Attr.CustomBoolField", "Attr.Nested.Deep", "WorkflowID"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			missing, err := IsMissingMappings(tt.current, tt.expected)
+			missing, err := GetMissingMappings(tt.current, tt.expected)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantMissing, missing)
 		})

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -48,6 +48,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/client"
+	"github.com/uber/cadence/common/persistence/schema"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 )
@@ -238,41 +239,17 @@ func (s *TestBase) Setup() {
 }
 
 func (s *TestBase) SetupPersistence() {
-	for _, adminDB := range s.AdminDBs {
-		s.SetupDB(adminDB)
+	options := schema.Options{
+		ClusterName:  s.ClusterMetadata.GetCurrentClusterName(),
+		Config:       &s.PersistenceConfig,
+		SetupOptions: DBSetupOptions,
+		Logger:       s.Logger,
 	}
-}
-
-func (s *TestBase) SetupDB(adminDB persistence.AdminDB) {
-	setup, err := adminDB.CreateSetupDB()
-	if err != nil {
-		s.fatalOnError("Failed to connect to DB", err)
-		return
-	}
-	defer setup.Close()
-	alreadySetup, err := setup.IsSetup(s.T().Context())
-	if err != nil {
-		s.fatalOnError(fmt.Sprintf("Failed to check for DB for: %s/%s", adminDB.PluginName(), adminDB.Identifier()), err)
-	}
-	// We might have multiple AdminDBs pointing to the same physical DB, that's probably not okay but not fatal yet
-	if !alreadySetup {
-		err = setup.Setup(s.T().Context(), DBSetupOptions)
-		s.fatalOnError("Failed to setup DB", err)
-	}
-	// If the AdminDB supports schema management we need to install it
-	// This is likely to fail if multiple AdminDBs point as the same DB, as the versions are global in the keyspace/DB.
-	if adminDB.SupportsSchema() {
-		schemaDB, err := adminDB.CreateSchemaDB()
-		s.fatalOnError("Failed to get schemaDB", err)
-		defer schemaDB.Close()
-
-		err = schemaDB.SetupVersioning(s.T().Context())
-		s.fatalOnError("Failed to setup schema versioning", err)
-		latest, err := schemaDB.LatestSchema().SkipToLatest()
-		s.fatalOnError("Failed to get latest schema", err)
-		err = schemaDB.UpdateSchema(s.T().Context(), latest)
-		s.fatalOnError("Failed to force apply schema", err)
-	}
+	err := schema.Update(s.T().Context(), options)
+	s.fatalOnError("Schema update failed", err)
+	// Not necessary but can't hurt and it's good to exercise this
+	err = schema.Verify(s.T().Context(), options)
+	s.fatalOnError("Schema verify failed", err)
 }
 
 func (s *TestBase) fatalOnError(msg string, err error) {

--- a/common/persistence/schema/common.go
+++ b/common/persistence/schema/common.go
@@ -1,0 +1,86 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/persistence"
+	persistenceClient "github.com/uber/cadence/common/persistence/client"
+)
+
+// defaultConnectTimeout is the default amount of time allowed to connect to all DBs.
+const defaultConnectTimeout = 10 * time.Second
+
+type Options struct {
+	// Required
+	// ClusterName is the name of the current cluster
+	ClusterName string
+	// Config is the persistence config to use for connecting to the DBs. It must be non-nil.
+	Config *config.Persistence
+	// Optional
+	// SetupOptions are parameters passed to SetupDB.Setup. Defaults to empty
+	SetupOptions map[string]string
+	// Logger is the logger. Defaults to zap production defaults
+	Logger log.Logger
+	// ConnectTimeout is the amount of time allowed to spend connecting to all DB instances. Defaults to 10s.
+	// During this time period, any errors are retried with a short backoff. This is to tolerate the DBs not yet
+	// being available.
+	ConnectTimeout time.Duration
+	// Time is the time source. Defaults to real time.
+	Time clock.TimeSource
+}
+
+func OptionsFromConfig(cfg config.Config) Options {
+	return Options{
+		ClusterName: cfg.ClusterGroupMetadata.CurrentClusterName,
+		Config:      &cfg.Persistence,
+	}
+}
+
+// withDefaults validates the required fields of opts and fills in the documented defaults
+// for any optional field that wasn't provided.
+func withDefaults(opts Options) (Options, error) {
+	if opts.ClusterName == "" {
+		return opts, errors.New("ClusterName is required")
+	}
+	if opts.Config == nil {
+		return opts, errors.New("Config is required")
+	}
+	if opts.SetupOptions == nil {
+		opts.SetupOptions = map[string]string{}
+	}
+	if opts.Logger == nil {
+		zapLogger, err := zap.NewProduction()
+		if err != nil {
+			return opts, fmt.Errorf("create logger: %w", err)
+		}
+		opts.Logger = log.NewLogger(zapLogger)
+	}
+	if opts.ConnectTimeout <= 0 {
+		opts.ConnectTimeout = defaultConnectTimeout
+	}
+	if opts.Time == nil {
+		opts.Time = clock.NewRealTimeSource()
+	}
+	return opts, nil
+}
+
+// newPersistenceFactory constructs a persistence factory from the provided config. It doesn't support dynamic config
+// or the more complex features of a full server.
+func newPersistenceFactory(clusterName string, cfg *config.Persistence, logger log.Logger) persistenceClient.Factory {
+	return persistenceClient.NewFactory(
+		cfg,
+		func() float64 { return 0 },
+		clusterName,
+		nil, // no metrics client needed for schema updates
+		logger,
+		persistence.NewDynamicConfiguration(dynamicconfig.NewNopCollection()),
+	)
+}

--- a/common/persistence/schema/common_test.go
+++ b/common/persistence/schema/common_test.go
@@ -1,0 +1,82 @@
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/config"
+)
+
+func TestWithDefaults(t *testing.T) {
+	persistenceConfig := &config.Persistence{DefaultStore: "default"}
+
+	tests := []struct {
+		name    string
+		opts    Options
+		wantErr string
+		verify  func(t *testing.T, opts Options)
+	}{
+		{
+			name:    "missing cluster name",
+			opts:    Options{Config: persistenceConfig},
+			wantErr: "ClusterName is required",
+		},
+		{
+			name:    "missing config",
+			opts:    Options{ClusterName: "cluster"},
+			wantErr: "Config is required",
+		},
+		{
+			name: "fills in all defaults",
+			opts: Options{ClusterName: "cluster", Config: persistenceConfig},
+			verify: func(t *testing.T, opts Options) {
+				assert.Equal(t, "cluster", opts.ClusterName)
+				assert.Same(t, persistenceConfig, opts.Config)
+				assert.Empty(t, opts.SetupOptions)
+				assert.NotNil(t, opts.SetupOptions)
+				assert.NotNil(t, opts.Logger)
+				assert.Equal(t, defaultConnectTimeout, opts.ConnectTimeout)
+				assert.NotNil(t, opts.Time)
+			},
+		},
+		{
+			name: "keeps provided values",
+			opts: Options{
+				ClusterName:    "cluster",
+				Config:         persistenceConfig,
+				SetupOptions:   map[string]string{"key": "value"},
+				ConnectTimeout: 30 * time.Second,
+			},
+			verify: func(t *testing.T, opts Options) {
+				assert.Equal(t, map[string]string{"key": "value"}, opts.SetupOptions)
+				assert.Equal(t, 30*time.Second, opts.ConnectTimeout)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := withDefaults(tt.opts)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			tt.verify(t, got)
+		})
+	}
+}
+
+func TestOptionsFromConfig(t *testing.T) {
+	cfg := config.Config{
+		Persistence: config.Persistence{DefaultStore: "default"},
+	}
+	cfg.ClusterGroupMetadata = &config.ClusterGroupMetadata{CurrentClusterName: "primary"}
+
+	opts := OptionsFromConfig(cfg)
+	assert.Equal(t, "primary", opts.ClusterName)
+	assert.Equal(t, "default", opts.Config.DefaultStore)
+}

--- a/common/persistence/schema/update.go
+++ b/common/persistence/schema/update.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package cadence
+package schema
 
 import (
 	"cmp"
@@ -27,22 +27,15 @@ import (
 	"slices"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/uber/cadence/common/clock"
-	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	persistenceClient "github.com/uber/cadence/common/persistence/client"
 )
 
-// Amount of time allowed to connect to all DBs
-const setupTimeout = 2 * time.Minute
-
 // Backoff whenever we fail to connect to a DB
-const setupRetryInterval = 3 * time.Second
+const setupRetryInterval = 1 * time.Second
 
 type setupTask struct {
 	adminDB persistence.AdminDB
@@ -56,52 +49,45 @@ type schemaUpdateTask struct {
 	update   *persistence.SchemaUpdate
 }
 
-// newPersistenceFactory constructs a persistence factory from the provided config. It doesn't support dynamic config
-// or the more complex features of a full server.
-func newPersistenceFactory(cfg config.Config, logger log.Logger) persistenceClient.Factory {
-	dc := dynamicconfig.NewNopCollection()
-	clusterName := ""
-	if cfg.ClusterGroupMetadata != nil {
-		clusterName = cfg.ClusterGroupMetadata.CurrentClusterName
+// Update updates the schema for all DBs referenced in the specified config
+func Update(ctx context.Context, options Options) error {
+	options, err := withDefaults(options)
+	if err != nil {
+		return err
 	}
-	return persistenceClient.NewFactory(
-		&cfg.Persistence,
-		func() float64 { return 0 },
-		clusterName,
-		nil, // no metrics client needed for schema updates
-		logger,
-		persistence.NewDynamicConfiguration(dc),
-	)
-}
+	factory := newPersistenceFactory(options.ClusterName, options.Config, options.Logger)
+	defer factory.Close()
 
-// newUpdateSchemaLogger builds a simple zap-based logger suitable for the CLI update-schema command.
-func newUpdateSchemaLogger() log.Logger {
-	return log.NewLogger(zap.Must(zap.NewProduction()))
+	err = runUpdateSchema(ctx, factory, options)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // runUpdateSchema applies all pending schema updates for every AdminDB instance returned
 // by factory. It follows the steps below:
 //
-//  1. Within a 2-minute retry window, construct a SetupDB for every AdminDB. Any errors
+//  1. Within the configured connect timeout, construct a SetupDB for every AdminDB. Any errors
 //     are retried until the deadline.
 //  2. For each SetupDB, call IsSetup; if the result is false, call Setup.
 //  3. For each AdminDB that reports SupportsSchema() == true, create a SchemaDB, check
 //     the current schema version against the latest, and collect any updates that need
 //     to be applied.
 //  4. Sort the collected updates by (PluginName/DBType, Version) and apply them in that order.
-func runUpdateSchema(ctx context.Context, factory persistenceClient.Factory, logger log.Logger, timeSource clock.TimeSource) error {
+func runUpdateSchema(ctx context.Context, factory persistenceClient.Factory, opts Options) error {
 	adminDBs, err := factory.NewAdminDBs()
 	if err != nil {
 		return fmt.Errorf("get admin DBs: %w", err)
 	}
 
-	setupTasks, setupDBs, err := connectToDBs(ctx, logger, timeSource, adminDBs)
+	setupTasks, setupDBs, err := connectToDBs(ctx, opts, adminDBs)
 	defer closeSetupDBs(setupDBs)
 	if err != nil {
 		return err
 	}
 
-	if err = ensureSetup(ctx, logger, setupTasks); err != nil {
+	if err = ensureSetup(ctx, opts.Logger, setupTasks, opts.SetupOptions); err != nil {
 		return err
 	}
 
@@ -111,18 +97,18 @@ func runUpdateSchema(ctx context.Context, factory persistenceClient.Factory, log
 		return err
 	}
 
-	return applyUpdates(ctx, logger, updates)
+	return applyUpdates(ctx, opts.Logger, updates)
 }
 
-// connectToDBs tries to create a SetupDB for every AdminDB within a 2-minute
-// window, retrying on any error until the deadline is exceeded.
-func connectToDBs(ctx context.Context, logger log.Logger, timeSource clock.TimeSource, adminDBs []persistence.AdminDB) ([]setupTask, []persistence.SetupDB, error) {
+// connectToDBs tries to create a SetupDB for every AdminDB within the configured
+// connect timeout, retrying on any error until the deadline is exceeded.
+func connectToDBs(ctx context.Context, opts Options, adminDBs []persistence.AdminDB) ([]setupTask, []persistence.SetupDB, error) {
 	tasks := make([]setupTask, 0, len(adminDBs))
 	setupDBs := make([]persistence.SetupDB, 0, len(adminDBs))
-	ctx, cancel := timeSource.ContextWithTimeout(ctx, setupTimeout)
+	ctx, cancel := opts.Time.ContextWithTimeout(ctx, opts.ConnectTimeout)
 	defer cancel()
 	for _, adminDB := range adminDBs {
-		setupDB, err := retryUntilConnected(ctx, logger, adminDB, timeSource)
+		setupDB, err := retryUntilConnected(ctx, opts.Logger, adminDB, opts.Time)
 		if err != nil {
 			return tasks, setupDBs, err
 		}
@@ -156,7 +142,7 @@ func retryUntilConnected(ctx context.Context, logger log.Logger, adminDB persist
 }
 
 // ensureSetup calls Setup on any SetupDB that reports IsSetup() == false.
-func ensureSetup(ctx context.Context, logger log.Logger, tasks []setupTask) error {
+func ensureSetup(ctx context.Context, logger log.Logger, tasks []setupTask, setupOptions map[string]string) error {
 	for _, t := range tasks {
 		dbLogger := logger.WithTags(dbTags(t.adminDB)...)
 		isSetup, err := t.setupDB.IsSetup(ctx)
@@ -168,7 +154,7 @@ func ensureSetup(ctx context.Context, logger log.Logger, tasks []setupTask) erro
 			continue
 		}
 		dbLogger.Info("Setting up database...")
-		if err = t.setupDB.Setup(ctx, nil); err != nil {
+		if err = t.setupDB.Setup(ctx, setupOptions); err != nil {
 			return fmt.Errorf("setting up %s: %w", describeDB(t.adminDB), err)
 		}
 		dbLogger.Info("Database set up successfully")

--- a/common/persistence/schema/update_test.go
+++ b/common/persistence/schema/update_test.go
@@ -1,4 +1,4 @@
-package cadence
+package schema
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	persistenceclient "github.com/uber/cadence/common/persistence/client"
@@ -30,7 +31,6 @@ func TestConnectToDBs(t *testing.T) {
 		{
 			name: "success without retries",
 			run: func(t *testing.T, ctrl *gomock.Controller) {
-				logger := testlogger.New(t)
 				timeSource := clock.NewMockedTimeSourceAt(time.Unix(0, 0))
 				adminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
 				setupDB := persistence.NewMockSetupDB(ctrl)
@@ -38,7 +38,7 @@ func TestConnectToDBs(t *testing.T) {
 				adminDB.EXPECT().CreateSetupDB().Return(setupDB, nil)
 				setupDB.EXPECT().Close()
 
-				tasks, setupDBs, err := connectToDBs(context.Background(), logger, timeSource, []persistence.AdminDB{adminDB})
+				tasks, setupDBs, err := connectToDBs(context.Background(), testOptions(t, timeSource), []persistence.AdminDB{adminDB})
 				require.NoError(t, err)
 				require.Len(t, tasks, 1)
 				require.Len(t, setupDBs, 1)
@@ -52,7 +52,6 @@ func TestConnectToDBs(t *testing.T) {
 		{
 			name: "retries until success",
 			run: func(t *testing.T, ctrl *gomock.Controller) {
-				logger := testlogger.New(t)
 				timeSource := clock.NewMockedTimeSourceAt(time.Unix(0, 0))
 				adminDB := newMockAdminDB(ctrl, "cassandra", persistence.DBTypeVisibility, "shard-a")
 				setupDB := persistence.NewMockSetupDB(ctrl)
@@ -64,9 +63,10 @@ func TestConnectToDBs(t *testing.T) {
 				)
 				setupDB.EXPECT().Close()
 
+				opts := testOptions(t, timeSource)
 				resultCh := make(chan connectResult, 1)
 				go func() {
-					tasks, setupDBs, err := connectToDBs(context.Background(), logger, timeSource, []persistence.AdminDB{adminDB})
+					tasks, setupDBs, err := connectToDBs(context.Background(), opts, []persistence.AdminDB{adminDB})
 					resultCh <- connectResult{tasks: tasks, setupDBs: setupDBs, err: err}
 				}()
 
@@ -84,19 +84,19 @@ func TestConnectToDBs(t *testing.T) {
 		{
 			name: "returns context deadline exceeded when retries exhaust timeout",
 			run: func(t *testing.T, ctrl *gomock.Controller) {
-				logger := testlogger.New(t)
 				timeSource := clock.NewMockedTimeSourceAt(time.Unix(0, 0))
 				adminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-timeout")
 				adminDB.EXPECT().CreateSetupDB().Return(nil, errors.New("still down")).AnyTimes()
 
+				opts := testOptions(t, timeSource)
 				resultCh := make(chan connectResult, 1)
 				go func() {
-					tasks, setupDBs, err := connectToDBs(context.Background(), logger, timeSource, []persistence.AdminDB{adminDB})
+					tasks, setupDBs, err := connectToDBs(context.Background(), opts, []persistence.AdminDB{adminDB})
 					resultCh <- connectResult{tasks: tasks, setupDBs: setupDBs, err: err}
 				}()
 
 				timeSource.BlockUntil(2)
-				timeSource.Advance(setupTimeout + setupRetryInterval)
+				timeSource.Advance(opts.ConnectTimeout + setupRetryInterval)
 
 				res := waitForConnectResult(t, resultCh)
 				require.ErrorIs(t, res.err, context.DeadlineExceeded)
@@ -163,7 +163,7 @@ func TestEnsureSetup(t *testing.T) {
 				setupDB: setupDB,
 			}}
 
-			err := ensureSetup(context.Background(), logger, tasks)
+			err := ensureSetup(context.Background(), logger, tasks, nil)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
@@ -470,7 +470,6 @@ func TestApplyUpdates(t *testing.T) {
 
 func TestRunUpdateSchema(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	logger := testlogger.New(t)
 	timeSource := clock.NewMockedTimeSourceAt(time.Unix(0, 0))
 	factory := persistenceclient.NewMockFactory(ctrl)
 	adminDB := newMockAdminDB(ctrl, "mysql", persistence.DBTypeDefault, "db-1")
@@ -479,13 +478,16 @@ func TestRunUpdateSchema(t *testing.T) {
 	schema := persistence.NewMockSchema(ctrl)
 	update := &persistence.SchemaUpdate{Version: persistence.Version{Major: 2, Minor: 0}}
 
+	opts := testOptions(t, timeSource)
+	opts.SetupOptions = map[string]string{"key": "value"}
+
 	// Happy path e2e
 
 	factory.EXPECT().NewAdminDBs().Return([]persistence.AdminDB{adminDB}, nil)
 	// Setup
 	adminDB.EXPECT().CreateSetupDB().Return(setupDB, nil)
 	setupDB.EXPECT().IsSetup(gomock.Any()).Return(false, nil)
-	setupDB.EXPECT().Setup(gomock.Any(), nil).Return(nil)
+	setupDB.EXPECT().Setup(gomock.Any(), opts.SetupOptions).Return(nil)
 	// Schema planning
 	adminDB.EXPECT().SupportsSchema().Return(true)
 	adminDB.EXPECT().CreateSchemaDB().Return(schemaDB, nil)
@@ -499,8 +501,21 @@ func TestRunUpdateSchema(t *testing.T) {
 	setupDB.EXPECT().Close()
 	schemaDB.EXPECT().Close()
 
-	err := runUpdateSchema(context.Background(), factory, logger, timeSource)
+	err := runUpdateSchema(context.Background(), factory, opts)
 	require.NoError(t, err)
+}
+
+// testOptions returns a fully defaulted Options suitable for unit tests.
+func testOptions(t *testing.T, timeSource clock.TimeSource) Options {
+	t.Helper()
+	opts, err := withDefaults(Options{
+		ClusterName: "test-cluster",
+		Config:      &config.Persistence{},
+		Logger:      testlogger.New(t),
+		Time:        timeSource,
+	})
+	require.NoError(t, err)
+	return opts
 }
 
 func newMockAdminDB(ctrl *gomock.Controller, pluginName string, dbType persistence.DBType, identifier string) *persistence.MockAdminDB {

--- a/common/persistence/schema/verify.go
+++ b/common/persistence/schema/verify.go
@@ -1,4 +1,4 @@
-package cadence
+package schema
 
 import (
 	"cmp"
@@ -7,14 +7,16 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/persistence"
 	persistenceClient "github.com/uber/cadence/common/persistence/client"
 )
 
-func VerifySchema(ctx context.Context, cfg config.Config) error {
-	logger := newUpdateSchemaLogger()
-	factory := newPersistenceFactory(cfg, logger)
+func Verify(ctx context.Context, opts Options) error {
+	opts, err := withDefaults(opts)
+	if err != nil {
+		return err
+	}
+	factory := newPersistenceFactory(opts.ClusterName, opts.Config, opts.Logger)
 	defer factory.Close()
 
 	return checkSchemas(ctx, factory)

--- a/common/persistence/schema/verify_test.go
+++ b/common/persistence/schema/verify_test.go
@@ -1,4 +1,4 @@
-package cadence
+package schema
 
 import (
 	"context"

--- a/common/persistence/sql/sqlplugin/cloudsql-mysql/go.mod
+++ b/common/persistence/sql/sqlplugin/cloudsql-mysql/go.mod
@@ -107,7 +107,6 @@ require (
 	go.uber.org/yarpc v1.88.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.30.0 // indirect


### PR DESCRIPTION
Move Update/Verify to their own package in persistence. Reuse them in persistence tests.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Move Schema Update/Verify logic out of the cmd directory.

**Why?**
- Reuse it in persistence tests now that they've been standardized.

**How did you test it?**
- Unit tests and the persistence tests.

**Potential risks**


**Release notes**


**Documentation Changes**

