### PR TITLE
docs: fix typo propogate -> propagate

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -415,12 +415,12 @@ func getFlagsForStart() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name: FlagHeaderValue,
-			Usage: "Optional info to propogate via workflow context, in JSON format. If there are multiple JSON, concatenate them and separate by space. " +
+			Usage: "Optional info to propagate via workflow context, in JSON format. If there are multiple JSON, concatenate them and separate by space. " +
 				"The order must be same as " + FlagHeaderKey,
 		},
 		&cli.StringFlag{
 			Name: FlagHeaderFile,
-			Usage: "Optional info to propogate via workflow context, from JSON format file. If there are multiple JSON, concatenate them and separate by space or newline. " +
+			Usage: "Optional info to propagate via workflow context, from JSON format file. If there are multiple JSON, concatenate them and separate by space or newline. " +
 				"The order must be same as " + FlagHeaderKey,
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
Corrects the misspelling `propogate` -> `propagate` in `tools/cli/flags.go`.

Documentation only, no behaviour change.