### PR TITLE
test(matching): stop asserting an exact poller wait time flake tests

### DIFF
--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -365,13 +365,15 @@ func (s *matchingEngineSuite) PollForDecisionTasksResultTest() {
 			Name: tl,
 			Kind: &tlKind,
 		},
-		AutoConfigHint: &types.AutoConfigHint{
-			EnableAutoConfig:   false,
-			PollerWaitTimeInMs: 0,
-		},
 	}
 
 	s.Nil(err)
+	// PollerWaitTimeInMs is time.Since(startT), so it is 0 on a fast machine and 1 or more
+	// on a loaded one. Check the deterministic half of the hint, then drop it before the
+	// deep comparison, as the other polls in this file do.
+	s.NotNil(resp.AutoConfigHint)
+	s.False(resp.AutoConfigHint.EnableAutoConfig)
+	resp.AutoConfigHint = nil
 	s.Equal(expectedResp, resp)
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- `TestPollForDecisionTasks` compared the whole poll response, which pulled `AutoConfigHint.PollerWaitTimeInMs` into the comparison. The hint is now dropped before the deep comparison, with an explicit check on `EnableAutoConfig` so the deterministic half stays covered. Test-only; no production code touched.

**Why?**
- `PollerWaitTimeInMs` is `time.Since(startT)` in milliseconds, so it reads 0 on a fast machine and 1 or more on a loaded CI runner. The test failed intermittently on that difference, which reflects the runner's speed rather than any behaviour. The other polls in this file already nil the hint out; this brings the one outlier in line.

**How did you test it?**
- unit test

**Potential risks**
Low

**Release notes**
None

**Documentation Changes**
None