### PR TITLE
feat(persistence): bound the per-bucket token budget

### DIFF
--- a/common/persistence/semaphore_metadata_manager.go
+++ b/common/persistence/semaphore_metadata_manager.go
@@ -32,6 +32,17 @@ import (
 // CreateSemaphoreRequest leaves BucketSize unset. N = ceil(size / bucket_size).
 const DefaultSemaphoreBucketSize = 100
 
+// MaxSemaphoreBucketSize caps the per-bucket token budget. SeedSemaphoreTokens writes a
+// whole bucket as one conditional batch of BucketSize statements against one partition,
+// so this bounds the size of a single Paxos round: contention and latency climb with the
+// statement count, and past a few hundred the batch trips the datastore's own size limit
+// and the seed fails outright. Rejecting here gives a caller a clear error instead.
+//
+// Capping rather than chunking is deliberate. The seed is all-or-nothing so that
+// re-seeding a different id set is refused whole rather than half-applied, which is what
+// makes growing a bucket unsupported rather than dangerous.
+const MaxSemaphoreBucketSize = 250
+
 type semaphoreMetadataManagerImpl struct {
 	persistence SemaphoreMetadataStore
 	logger      log.Logger
@@ -71,6 +82,9 @@ func (m *semaphoreMetadataManagerImpl) CreateSemaphore(
 
 	if request.BucketSize < 0 {
 		return nil, fmt.Errorf("BucketSize must not be negative, got %d", request.BucketSize)
+	}
+	if request.BucketSize > MaxSemaphoreBucketSize {
+		return nil, fmt.Errorf("BucketSize must not exceed %d, got %d", MaxSemaphoreBucketSize, request.BucketSize)
 	}
 	// BucketSize is optional: an unset (zero) value falls back to the default.
 	bucketSize := request.BucketSize

--- a/common/persistence/semaphore_metadata_manager.go
+++ b/common/persistence/semaphore_metadata_manager.go
@@ -32,15 +32,13 @@ import (
 // CreateSemaphoreRequest leaves BucketSize unset. N = ceil(size / bucket_size).
 const DefaultSemaphoreBucketSize = 100
 
-// MaxSemaphoreBucketSize caps the per-bucket token budget. SeedSemaphoreTokens writes a
-// whole bucket as one conditional batch of BucketSize statements against one partition,
-// so this bounds the size of a single Paxos round: contention and latency climb with the
-// statement count, and past a few hundred the batch trips the datastore's own size limit
-// and the seed fails outright. Rejecting here gives a caller a clear error instead.
+// MaxSemaphoreBucketSize caps the per-bucket token budget. Buckets exist to spread a
+// semaphore's writes across partitions, so a bigger bucket means fewer partitions and works
+// against that.
 //
-// Capping rather than chunking is deliberate. The seed is all-or-nothing so that
-// re-seeding a different id set is refused whole rather than half-applied, which is what
-// makes growing a bucket unsupported rather than dangerous.
+// Each hold costs two conditional writes, one to take the slot and one to return it, so a
+// busy bucket whose holds last D seconds drives 2*bucket_size/D writes at one partition,
+// whatever the semaphore's total size — 500 a second at this cap with one-second holds.
 const MaxSemaphoreBucketSize = 250
 
 type semaphoreMetadataManagerImpl struct {

--- a/common/persistence/semaphore_metadata_manager_test.go
+++ b/common/persistence/semaphore_metadata_manager_test.go
@@ -140,6 +140,42 @@ func TestSemaphoreManagerCreateSemaphore(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name: "bucket size at the maximum is allowed",
+			request: &CreateSemaphoreRequest{
+				DomainID:      "domain-1",
+				SemaphoreName: "sem-1",
+				Size:          1000,
+				BucketSize:    MaxSemaphoreBucketSize,
+			},
+			setupMock: func(store *MockSemaphoreMetadataStore) {
+				store.EXPECT().CreateSemaphore(gomock.Any(), &SemaphoreMetadata{
+					DomainID:      "domain-1",
+					SemaphoreName: "sem-1",
+					Size:          1000,
+					BucketSize:    MaxSemaphoreBucketSize,
+					CreatedTime:   fixedTime,
+				}).Return(nil).Times(1)
+			},
+			wantResult: &SemaphoreMetadata{
+				DomainID:      "domain-1",
+				SemaphoreName: "sem-1",
+				Size:          1000,
+				BucketSize:    MaxSemaphoreBucketSize,
+				CreatedTime:   fixedTime,
+			},
+		},
+		{
+			name: "bucket size above the maximum",
+			request: &CreateSemaphoreRequest{
+				DomainID:      "domain-1",
+				SemaphoreName: "sem-1",
+				Size:          1000,
+				BucketSize:    MaxSemaphoreBucketSize + 1,
+			},
+			setupMock: func(store *MockSemaphoreMetadataStore) {},
+			wantErr:   true,
+		},
+		{
 			name: "store error is propagated",
 			request: &CreateSemaphoreRequest{
 				DomainID:      "domain-1",

--- a/common/persistence/semaphore_token_manager.go
+++ b/common/persistence/semaphore_token_manager.go
@@ -61,10 +61,9 @@ func (m *semaphoreTokenManagerImpl) SeedSemaphoreTokens(
 	if len(request.TokenIDs) == 0 {
 		return fmt.Errorf("TokenIDs is required")
 	}
-	// One seed is one conditional batch with a statement per token, so the length of this
-	// slice is the bucket's size and carries the same bound CreateSemaphore applies. Checked
-	// again here because the datastore's own limit on batch size rejects an oversized seed
-	// with an error that never mentions buckets.
+	// This slice is the bucket's token set, so it carries the same bound CreateSemaphore
+	// applies. Checked again here because a caller can reach a seed without having gone
+	// through CreateSemaphore.
 	if len(request.TokenIDs) > MaxSemaphoreBucketSize {
 		return fmt.Errorf("a bucket holds at most %d tokens, got %d", MaxSemaphoreBucketSize, len(request.TokenIDs))
 	}

--- a/common/persistence/semaphore_token_manager.go
+++ b/common/persistence/semaphore_token_manager.go
@@ -61,6 +61,13 @@ func (m *semaphoreTokenManagerImpl) SeedSemaphoreTokens(
 	if len(request.TokenIDs) == 0 {
 		return fmt.Errorf("TokenIDs is required")
 	}
+	// One seed is one conditional batch with a statement per token, so the length of this
+	// slice is the bucket's size and carries the same bound CreateSemaphore applies. Checked
+	// again here because the datastore's own limit on batch size rejects an oversized seed
+	// with an error that never mentions buckets.
+	if len(request.TokenIDs) > MaxSemaphoreBucketSize {
+		return fmt.Errorf("a bucket holds at most %d tokens, got %d", MaxSemaphoreBucketSize, len(request.TokenIDs))
+	}
 	for _, id := range request.TokenIDs {
 		if id < 1 {
 			return fmt.Errorf("TokenID must be positive, got %d", id)

--- a/common/persistence/semaphore_token_manager_test.go
+++ b/common/persistence/semaphore_token_manager_test.go
@@ -41,6 +41,16 @@ func newTestSemaphoreTokenManager(store SemaphoreTokenStore, timeSrc clock.TimeS
 	}
 }
 
+// seedTokenIDs builds n sequential token ids, all valid, so a case can vary the count
+// without the per-id checks getting in the way.
+func seedTokenIDs(n int) []int {
+	ids := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		ids = append(ids, i)
+	}
+	return ids
+}
+
 func TestSemaphoreTokenManagerSeedSemaphoreTokens(t *testing.T) {
 	fixedTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
 
@@ -107,6 +117,29 @@ func TestSemaphoreTokenManagerSeedSemaphoreTokens(t *testing.T) {
 				DomainID:      "domain-1",
 				SemaphoreName: "sem-1",
 				TokenIDs:      []int{1, 0},
+			},
+			setupMock: func(store *MockSemaphoreTokenStore) {},
+			wantErr:   true,
+		},
+		{
+			name: "token ids at the maximum are allowed",
+			request: &SeedSemaphoreTokensRequest{
+				DomainID:      "domain-1",
+				SemaphoreName: "sem-1",
+				TokenIDs:      seedTokenIDs(MaxSemaphoreBucketSize),
+			},
+			setupMock: func(store *MockSemaphoreTokenStore) {
+				store.EXPECT().SeedSemaphoreTokens(gomock.Any(), gomock.Any(), fixedTime).Return(nil).Times(1)
+			},
+		},
+		{
+			// The seed is one conditional batch, so an oversized bucket has to be refused
+			// here rather than half-written.
+			name: "more token ids than a bucket may hold",
+			request: &SeedSemaphoreTokensRequest{
+				DomainID:      "domain-1",
+				SemaphoreName: "sem-1",
+				TokenIDs:      seedTokenIDs(MaxSemaphoreBucketSize + 1),
 			},
 			setupMock: func(store *MockSemaphoreTokenStore) {},
 			wantErr:   true,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Adds `MaxSemaphoreBucketSize = 250` and rejects anything above it in two places:

1. `CreateSemaphore` checks `BucketSize`
2. `SeedSemaphoreTokens` checks `len(TokenIDs)`.

**Why?**
- Buckets exist to spread a semaphore's writes across partitions. Every acquire and every release is a conditional write on one bucket's partition, and the datastore serializes those per partition. A bigger bucket means fewer partitions for the same semaphore, which works against the split.
- The traffic one partition sees follows from the bucket's size and how long holds last, not from the semaphore's total size. Each hold costs two conditional writes, so a busy bucket whose holds last D seconds drives `2*bucket_size/D` writes at a single partition — 500 a second at this cap with one-second holds.
- Both call sites are checked because either can be reached first: `CreateSemaphore` records the intended size, `SeedSemaphoreTokens` writes the tokens.

**How did you test it?**
unit test

**Potential risks**
None

**Release notes**
`CreateSemaphore` and `SeedSemaphoreTokens` now reject a bucket larger than 250 tokens.

**Documentation Changes**

None