### PR TITLE
refactor(queuev2): make the immediate queue structurally cache-ready

### DIFF
--- a/service/history/queuev2/queue_cached_test.go
+++ b/service/history/queuev2/queue_cached_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/uber/cadence/service/history/task"
 )
 
-func TestCachedScheduledQueue_Construction(t *testing.T) {
+func TestCachedQueue_Construction_Scheduled(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 
@@ -64,68 +64,81 @@ func TestCachedScheduledQueue_Construction(t *testing.T) {
 	require.True(t, ok, "expected *cachedQueue")
 }
 
-func TestCachedScheduledQueue_NotifyNewTask(t *testing.T) {
-	tasks := []persistence.Task{
-		&persistence.DecisionTimeoutTask{
-			TaskData: persistence.TaskData{
-				VisibilityTimestamp: time.Now(),
-			},
-		},
-	}
+func TestCachedQueue_Construction_Immediate(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctrl := gomock.NewController(t)
 
-	tests := []struct {
-		name            string
-		info            *hcommon.NotifyTaskInfo
-		setupMockReader func(*MockCachedQueueReader)
-	}{
-		{
-			name: "nil tasks",
-			info: &hcommon.NotifyTaskInfo{Tasks: nil},
-			setupMockReader: func(r *MockCachedQueueReader) {
-				r.EXPECT().Inject([]persistence.Task(nil)).Times(1)
-			},
-		},
-		{
-			name: "with tasks",
-			info: &hcommon.NotifyTaskInfo{Tasks: tasks},
-			setupMockReader: func(r *MockCachedQueueReader) {
-				r.EXPECT().Inject(tasks).Times(1)
-			},
-		},
-		{
-			name: "persistence error",
-			info: &hcommon.NotifyTaskInfo{
-				Tasks:            []persistence.Task{&persistence.DecisionTimeoutTask{}},
-				PersistenceError: true,
-			},
-			setupMockReader: func(r *MockCachedQueueReader) {
-				r.EXPECT().Clear().Times(1)
-			},
-		},
-	}
+	mockShard := shard.NewTestContext(
+		t, ctrl,
+		&persistence.ShardInfo{ShardID: 10, RangeID: 1, TransferAckLevel: 0},
+		config.NewForTest(),
+	)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockReader := NewMockCachedQueueReader(ctrl)
-			tt.setupMockReader(mockReader)
+	options := testQueueOptions()
+	mockReader := NewMockCachedQueueReader(ctrl)
 
-			csq := &cachedQueue{
-				Queue: &scheduledQueue{
-					base: &queueBase{
-						metricsScope: metrics.NoopScope,
+	inner := newImmediateQueue(mockShard, persistence.HistoryTaskCategoryTransfer,
+		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
+		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options)
+
+	q := newCachedQueue(inner, inner.base, mockReader)
+
+	require.NotNil(t, q)
+	_, ok := q.(*cachedQueue)
+	require.True(t, ok, "expected *cachedQueue")
+}
+
+func TestCachedQueue_NotifyNewTask(t *testing.T) {
+	for _, k := range cachedQueueKinds() {
+		t.Run(k.name, func(t *testing.T) {
+			tests := []struct {
+				name            string
+				info            *hcommon.NotifyTaskInfo
+				setupMockReader func(*MockCachedQueueReader)
+			}{
+				{
+					name: "nil tasks",
+					info: &hcommon.NotifyTaskInfo{Tasks: nil},
+					setupMockReader: func(r *MockCachedQueueReader) {
+						r.EXPECT().Inject([]persistence.Task(nil)).Times(1)
 					},
-					newTimerCh: make(chan struct{}, 1),
 				},
-				reader: mockReader,
+				{
+					name: "with tasks",
+					info: &hcommon.NotifyTaskInfo{Tasks: k.tasks},
+					setupMockReader: func(r *MockCachedQueueReader) {
+						r.EXPECT().Inject(k.tasks).Times(1)
+					},
+				},
+				{
+					name: "persistence error",
+					info: &hcommon.NotifyTaskInfo{
+						Tasks:            k.tasks,
+						PersistenceError: true,
+					},
+					setupMockReader: func(r *MockCachedQueueReader) {
+						r.EXPECT().Clear().Times(1)
+					},
+				},
 			}
 
-			csq.NotifyNewTask("test-cluster", tt.info)
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					ctrl := gomock.NewController(t)
+					mockReader := NewMockCachedQueueReader(ctrl)
+					tt.setupMockReader(mockReader)
+
+					inner := newMinimalInnerQueue(k.category, &queueBase{metricsScope: metrics.NoopScope})
+					cq := &cachedQueue{Queue: inner, reader: mockReader}
+
+					cq.NotifyNewTask("test-cluster", tt.info)
+				})
+			}
 		})
 	}
 }
 
-func TestCachedScheduledQueue_StartStop(t *testing.T) {
+func TestCachedQueue_StartStop_Scheduled(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 
@@ -164,7 +177,7 @@ func TestCachedScheduledQueue_StartStop(t *testing.T) {
 	q.Stop()
 }
 
-func TestCachedScheduledQueue_EvictionHookWired(t *testing.T) {
+func TestCachedQueue_StartStop_Immediate(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctrl := gomock.NewController(t)
 
@@ -177,64 +190,72 @@ func TestCachedScheduledQueue_EvictionHookWired(t *testing.T) {
 	options := testQueueOptions()
 	mockReader := NewMockCachedQueueReader(ctrl)
 
-	inner := NewScheduledQueue(mockShard, persistence.HistoryTaskCategoryTimer,
+	// processEventLoop calls GetTask when processing new tasks; it can fire multiple times.
+	mockReader.EXPECT().GetTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *GetTaskRequest) (*GetTaskResponse, error) {
+			return &GetTaskResponse{
+				Progress: &GetTaskProgress{
+					Range:       req.Progress.Range,
+					NextTaskKey: req.Progress.ExclusiveMaxTaskKey,
+				},
+			}, nil
+		},
+	).AnyTimes()
+	mockReader.EXPECT().Start().Times(1)
+	mockReader.EXPECT().Stop().Times(1)
+
+	inner := newImmediateQueue(mockShard, persistence.HistoryTaskCategoryTransfer,
 		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
-		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options).(*scheduledQueue)
+		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options)
 
-	// Replace the original updateQueueStateFn with a no-op so the hook closure
-	// can be called without triggering real shard persistence.
-	inner.base.updateQueueStateFn = func(ctx context.Context) {}
+	q := newCachedQueue(inner, inner.base, mockReader)
 
-	newCachedQueue(inner, inner.base, mockReader)
-
-	// Calling the hooked function exercises the closure (covers the inner body).
-	mockReader.EXPECT().UpdateReadLevel(gomock.Any()).Times(1)
-	inner.base.updateQueueStateFn(context.Background())
+	q.Start()
+	q.Stop()
 }
 
-func TestCachedScheduledQueue_UpdateQueueStateFn_PropagatesReadLevel(t *testing.T) {
-	now := time.Now()
-	sliceReadLevel := persistence.NewHistoryTaskKey(now, 100)
-	ackLevel := persistence.NewHistoryTaskKey(now.Add(-time.Minute), 50)
-
-	tests := []struct {
-		name          string
-		minReadLevel  persistence.HistoryTaskKey
-		expectedLevel persistence.HistoryTaskKey
-	}{
-		{
-			name:          "slices exist - use min read level",
-			minReadLevel:  sliceReadLevel,
-			expectedLevel: sliceReadLevel,
-		},
-		{
-			name:          "no slices - fall back to ack level",
-			minReadLevel:  persistence.MaximumHistoryTaskKey,
-			expectedLevel: ackLevel,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockReader := NewMockCachedQueueReader(ctrl)
-			mockVQM := NewMockVirtualQueueManager(ctrl)
-
-			inner := &scheduledQueue{
-				base: &queueBase{
-					metricsScope:        metrics.NoopScope,
-					virtualQueueManager: mockVQM,
-					exclusiveAckLevel:   ackLevel,
+func TestCachedQueue_UpdateQueueStateFn_PropagatesReadLevel(t *testing.T) {
+	for _, k := range cachedQueueKinds() {
+		t.Run(k.name, func(t *testing.T) {
+			tests := []struct {
+				name          string
+				minReadLevel  persistence.HistoryTaskKey
+				expectedLevel persistence.HistoryTaskKey
+			}{
+				{
+					name:          "slices exist - use min read level",
+					minReadLevel:  k.sliceReadLevel,
+					expectedLevel: k.sliceReadLevel,
 				},
-				newTimerCh: make(chan struct{}, 1),
+				{
+					name:          "no slices - fall back to ack level",
+					minReadLevel:  persistence.MaximumHistoryTaskKey,
+					expectedLevel: k.ackLevel,
+				},
 			}
-			inner.base.updateQueueStateFn = func(ctx context.Context) {}
 
-			mockVQM.EXPECT().GetMinReadLevel().Return(tt.minReadLevel)
-			mockReader.EXPECT().UpdateReadLevel(tt.expectedLevel)
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					ctrl := gomock.NewController(t)
+					mockReader := NewMockCachedQueueReader(ctrl)
+					mockVQM := NewMockVirtualQueueManager(ctrl)
 
-			newCachedQueue(inner, inner.base, mockReader)
-			inner.base.updateQueueStateFn(context.Background())
+					base := &queueBase{
+						metricsScope:        metrics.NoopScope,
+						virtualQueueManager: mockVQM,
+						exclusiveAckLevel:   k.ackLevel,
+					}
+					base.updateQueueStateFn = func(ctx context.Context) {}
+					inner := newMinimalInnerQueue(k.category, base)
+
+					mockVQM.EXPECT().GetMinReadLevel().Return(tt.minReadLevel)
+					mockReader.EXPECT().UpdateReadLevel(tt.expectedLevel)
+
+					// newCachedQueue wraps base.updateQueueStateFn in place; invoke it directly.
+					newCachedQueue(inner, base, mockReader)
+					base.updateQueueStateFn(context.Background())
+				})
+			}
 		})
 	}
 }
@@ -256,5 +277,50 @@ func testQueueOptions() *Options {
 		CriticalPendingTaskCount:             dynamicproperties.GetIntPropertyFn(90),
 		EnablePendingTaskCountAlert:          func() bool { return true },
 		MaxVirtualQueueCount:                 dynamicproperties.GetIntPropertyFn(2),
+	}
+}
+
+// newMinimalInnerQueue builds a bare inner Queue of the requested kind for behaviour tests that only
+// exercise the cachedQueue wrapper. base is supplied by the caller so it can invoke the wrapped
+// updateQueueStateFn directly.
+func newMinimalInnerQueue(kind persistence.HistoryTaskCategory, base *queueBase) Queue {
+	if kind.Type() == persistence.HistoryTaskCategoryTypeScheduled {
+		return &scheduledQueue{base: base, newTimerCh: make(chan struct{}, 1)}
+	}
+	return &immediateQueue{base: base, notifyCh: make(chan struct{}, 1)}
+}
+
+// cachedQueueKind describes one concrete queue kind the generic cachedQueue wrapper supports.
+type cachedQueueKind struct {
+	name           string
+	category       persistence.HistoryTaskCategory
+	tasks          []persistence.Task
+	sliceReadLevel persistence.HistoryTaskKey
+	ackLevel       persistence.HistoryTaskKey
+}
+
+func cachedQueueKinds() []cachedQueueKind {
+	now := time.Now()
+	return []cachedQueueKind{
+		{
+			name:     "scheduled",
+			category: persistence.HistoryTaskCategoryTimer,
+			tasks: []persistence.Task{
+				&persistence.DecisionTimeoutTask{
+					TaskData: persistence.TaskData{VisibilityTimestamp: now},
+				},
+			},
+			sliceReadLevel: persistence.NewHistoryTaskKey(now, 100),
+			ackLevel:       persistence.NewHistoryTaskKey(now.Add(-time.Minute), 50),
+		},
+		{
+			name:     "immediate",
+			category: persistence.HistoryTaskCategoryTransfer,
+			tasks: []persistence.Task{
+				&persistence.ActivityTask{TaskData: persistence.TaskData{TaskID: 1}},
+			},
+			sliceReadLevel: persistence.NewImmediateTaskKey(100),
+			ackLevel:       persistence.NewImmediateTaskKey(50),
+		},
 	}
 }

--- a/service/history/queuev2/queue_immediate.go
+++ b/service/history/queuev2/queue_immediate.go
@@ -55,7 +55,7 @@ type (
 	}
 )
 
-func NewImmediateQueue(
+func newImmediateQueue(
 	shard shard.Context,
 	category persistence.HistoryTaskCategory,
 	taskProcessor task.Processor,
@@ -65,7 +65,7 @@ func NewImmediateQueue(
 	metricsScope metrics.Scope,
 	queueReader QueueReader,
 	options *Options,
-) Queue {
+) *immediateQueue {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &immediateQueue{
 		base: newQueueBase(
@@ -83,6 +83,21 @@ func NewImmediateQueue(
 		ctx:      ctx,
 		cancel:   cancel,
 	}
+}
+
+func NewImmediateQueue(
+	shard shard.Context,
+	category persistence.HistoryTaskCategory,
+	taskProcessor task.Processor,
+	taskExecutor task.Executor,
+	logger log.Logger,
+	metricsClient metrics.Client,
+	metricsScope metrics.Scope,
+	queueReader QueueReader,
+	options *Options,
+) Queue {
+	return newImmediateQueue(shard, category, taskProcessor, taskExecutor,
+		logger, metricsClient, metricsScope, queueReader, options)
 }
 
 func (q *immediateQueue) Start() {
@@ -187,7 +202,7 @@ func (q *immediateQueue) processEventLoop() {
 		case <-q.pollTimer.Chan():
 			q.processPollTimer()
 		case <-q.base.updateQueueStateTimer.Chan():
-			q.base.updateQueueState(q.ctx)
+			q.base.updateQueueStateFn(q.ctx)
 		case alert := <-q.base.alertCh:
 			q.base.handleAlert(q.ctx, alert)
 		case <-q.ctx.Done():


### PR DESCRIPTION
**What changed?**
- Split the immediate queue constructor: an unexported `newImmediateQueue` now returns the concrete `*immediateQueue`, and the exported `NewImmediateQueue` delegates to it, mirroring the scheduled queue convention.
- Routed the immediate event-loop ack-update through the injectable `updateQueueStateFn` hook instead of calling `updateQueueState` directly.
- Generalized the cached-queue wrapper tests to cover the immediate kind alongside the scheduled kind.

**Why?**
The cached-queue wrapper needs the inner queue's concrete `*immediateQueue` to reach its `queueBase`, and it propagates read levels by wrapping `updateQueueStateFn`. Previously the exported constructor returned only the `Queue` interface and the event loop called `updateQueueState` directly, so neither hook point was reachable for a wrapper. This change opens both up while leaving the immediate queue's external contract unchanged, so a later commit can wrap the transfer queue with the cached reader without touching this path. 

Related to #8432 .

**How did you test it?**
- `go test -race ./service/history/queuev2/...`

**Potential risks**
Low. No behavior change: `NewImmediateQueue` keeps the same signature and return type for callers, and `updateQueueStateFn` defaults to `updateQueueState`, so the event loop does exactly what it did before.

**Release notes**
N/A - internal refactor with no user-facing or operator-facing change.

**Documentation Changes**
N/A - no user-facing behavior change.
