### PR TITLE
chore: Recommend not adding license files

### DIFF
--- a/.gitar/rules/no-license-headers.md
+++ b/.gitar/rules/no-license-headers.md
@@ -1,0 +1,62 @@
+---
+title: No License Headers in Source Files
+description: Prevents MIT or other per-file license headers from being added to Go files
+when: PR adds or modifies Go files
+actions: Detect license headers in new or modified Go files; recommend removal
+---
+
+# No License Headers in Source Files
+
+The project uses a single top-level `LICENSE` file (Apache 2.0). Per-file license headers are not used and should not be added. Existing MIT license headers are being removed as part of the license migration (see GitHub issue #8483).
+
+## Overview
+
+When evaluating a pull request:
+
+1. **Check for license headers in new Go files** — new files must not include any license header
+2. **Check for license headers reintroduced in modified files** — edits must not add a license block
+3. **Recommend removal** when violations are found
+
+## Detection Logic
+
+### Step 1: Identify Go files with license headers
+
+Scan the PR diff for **added lines** in `**/*.go` files that contain any of these markers:
+
+- `Permission is hereby granted` (MIT license)
+- `Licensed under the Apache License` (Apache boilerplate — the top-level LICENSE file is sufficient)
+- `SPDX-License-Identifier` (SPDX header)
+- `THE SOFTWARE IS PROVIDED "AS IS"` (MIT warranty disclaimer)
+
+Only flag lines that appear in the **added** side of the diff (lines starting with `+`), not removed lines.
+
+### Step 2: Distinguish headers from legitimate references
+
+Do **not** flag:
+- Files under `.gen/` — these are generated from IDL and may carry upstream headers
+- Test files that reference license text as test data
+- Comments that discuss licensing (e.g., `// This package is licensed under...` in documentation)
+
+Flag only structured license blocks: multi-line comment blocks at the top of a file that contain a full or partial license grant.
+
+## Report Format
+
+When violations are detected, provide:
+
+> **No per-file license headers**
+>
+> This project does not use per-file license headers. The top-level `LICENSE` file covers all source files.
+>
+> The following files contain license headers that should be removed:
+>
+> - `path/to/file.go` — MIT license header detected
+>
+> **Fix:** Remove the license header block. Do not replace it with an SPDX identifier or Apache boilerplate.
+
+## Skip Conditions
+
+Skip this rule when **ANY** of these is true:
+
+1. No Go files were added or modified
+2. All flagged files are under `.gen/` (generated code)
+3. The PR is specifically updating the LICENSE file itself

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,12 @@ go test -race -run TestFoo ./path/to/pkg/...  # run a specific test
   - **What to do instead:** Move the blank import to `cmd/server/main.go` or the appropriate entry point.
   - **Example:** `common/persistence/sql/sqlplugin/sqlite/db.go` should NOT import drivers. Instead, `cmd/server/main.go` imports both the plugin package AND the driver.
 
+- **License Headers**:
+  - Do **not** add per-file license headers (MIT, Apache, or SPDX) to any source file.
+  - The top-level `LICENSE` file (Apache 2.0) covers the entire repository.
+  - When creating new `.go` files, start with the `package` declaration — no copyright or license block.
+  - Files under `.gen/` are generated from IDL and may carry upstream headers — do not modify those manually.
+
 ## Architecture Guidelines
 
 **Core Principle**: Cadence must support both the standard open-source build and custom builds from a single codebase. Different builds may use different libraries (e.g., open-source Kafka client vs. company-internal Kafka library). This requires strict separation between core logic and proprietary implementations.


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Add rules to gitar and our AGENTS.md to recommend that we don't create license files. 

**Why?**

We have switched from MIT to Apache, and no longer need per-file license headers. 

Fixes: https://github.com/cadence-workflow/cadence/issues/8483

**How did you test it?**

N/A - Pure documentation change. 

**Potential risks**

None

**Release notes**

No release notes necessary. 

**Documentation Changes**

None. 