### PR TITLE
fix(queuev2): attribute dropped-task logging per cache's shadow mode

### DIFF
--- a/service/history/shard/notify_task.go
+++ b/service/history/shard/notify_task.go
@@ -23,8 +23,6 @@
 package shard
 
 import (
-	"slices"
-
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	hcommon "github.com/uber/cadence/service/history/common"
@@ -67,7 +65,7 @@ func (s *contextImpl) notifyTasksFromCreateWorkflowExecution(
 		s.notifyTasksFromSnapshot(&request.NewWorkflowSnapshot, persistenceError)
 		return
 	}
-	s.logNotifyTaskDroppedOnPersistenceError(err, taskIDsFromSnapshot(&request.NewWorkflowSnapshot))
+	s.logNotifyTaskDroppedOnPersistenceError(err, snapshotTasks(&request.NewWorkflowSnapshot))
 }
 
 // notifyTasksFromUpdateWorkflowExecution sends task notifications for an UpdateWorkflowExecution operation.
@@ -81,10 +79,10 @@ func (s *contextImpl) notifyTasksFromUpdateWorkflowExecution(
 		s.notifyTasksFromSnapshot(request.NewWorkflowSnapshot, persistenceError)
 		return
 	}
-	s.logNotifyTaskDroppedOnPersistenceError(err, slices.Concat(
-		taskIDsFromMutation(&request.UpdateWorkflowMutation),
-		taskIDsFromSnapshot(request.NewWorkflowSnapshot),
-	))
+	s.logNotifyTaskDroppedOnPersistenceError(err,
+		mutationTasks(&request.UpdateWorkflowMutation),
+		snapshotTasks(request.NewWorkflowSnapshot),
+	)
 }
 
 // notifyTasksFromConflictResolveWorkflowExecution sends task notifications for a ConflictResolveWorkflowExecution operation.
@@ -99,11 +97,11 @@ func (s *contextImpl) notifyTasksFromConflictResolveWorkflowExecution(
 		s.notifyTasksFromMutation(request.CurrentWorkflowMutation, persistenceError)
 		return
 	}
-	s.logNotifyTaskDroppedOnPersistenceError(err, slices.Concat(
-		taskIDsFromSnapshot(&request.ResetWorkflowSnapshot),
-		taskIDsFromSnapshot(request.NewWorkflowSnapshot),
-		taskIDsFromMutation(request.CurrentWorkflowMutation),
-	))
+	s.logNotifyTaskDroppedOnPersistenceError(err,
+		snapshotTasks(&request.ResetWorkflowSnapshot),
+		snapshotTasks(request.NewWorkflowSnapshot),
+		mutationTasks(request.CurrentWorkflowMutation),
+	)
 }
 
 // notifyTasksFromReinjectHistoryTasks sends task notifications for a ReinjectHistoryTasks operation.
@@ -119,19 +117,41 @@ func (s *contextImpl) notifyTasksFromReinjectHistoryTasks(
 		s.notifyTasks(nil, tasksByCategory, persistenceError)
 		return
 	}
-	s.logNotifyTaskDroppedOnPersistenceError(err, taskIDsFromCategories(tasksByCategory))
+	s.logNotifyTaskDroppedOnPersistenceError(err, tasksByCategory)
 }
 
-// logNotifyTaskDroppedOnPersistenceError logs dropped task IDs when the cached queue reader
-// is in shadow mode. In shadow mode the cache is validated against the DB, so dropped tasks
-// produce observable mismatches that are worth tracking. In other modes the log is noise.
-func (s *contextImpl) logNotifyTaskDroppedOnPersistenceError(err error, droppedTaskIDs []int64) {
-	if s.config.TimerProcessorCachedQueueReaderMode(s.GetShardID()) != "shadow" {
+// logNotifyTaskDroppedOnPersistenceError logs dropped task IDs per category, but only for a category
+// whose cached queue reader is in shadow mode, where the cache is validated against the DB and a
+// dropped task surfaces as an observable mismatch. For other modes (and categories with no cached
+// reader, e.g. replication) the log is just noise, so when no cache is shadowing it returns before
+// touching the sources, keeping the steady-state path free of per-task work.
+func (s *contextImpl) logNotifyTaskDroppedOnPersistenceError(
+	err error,
+	sources ...map[persistence.HistoryTaskCategory][]persistence.Task,
+) {
+	shardID := s.GetShardID()
+	timerCacheShadow := s.config.TimerProcessorCachedQueueReaderMode(shardID) == "shadow"
+	transferCacheShadow := s.config.TransferProcessorCachedQueueReaderMode(shardID) == "shadow"
+	if !timerCacheShadow && !transferCacheShadow {
+		return
+	}
+
+	var droppedTimerTaskIDs, droppedTransferTaskIDs []int64
+	for _, src := range sources {
+		if timerCacheShadow {
+			droppedTimerTaskIDs = appendTaskIDs(droppedTimerTaskIDs, src[persistence.HistoryTaskCategoryTimer])
+		}
+		if transferCacheShadow {
+			droppedTransferTaskIDs = appendTaskIDs(droppedTransferTaskIDs, src[persistence.HistoryTaskCategoryTransfer])
+		}
+	}
+	if len(droppedTimerTaskIDs) == 0 && len(droppedTransferTaskIDs) == 0 {
 		return
 	}
 	s.logger.Info("notify tasks dropped due to persistence error",
 		tag.Error(err),
-		tag.Dynamic("droppedTaskIDs", droppedTaskIDs),
+		tag.Dynamic("droppedTimerTaskIDs", droppedTimerTaskIDs),
+		tag.Dynamic("droppedTransferTaskIDs", droppedTransferTaskIDs),
 	)
 }
 
@@ -179,26 +199,23 @@ func (s *contextImpl) notifyTasksFromMutation(mutation *persistence.WorkflowMuta
 	s.notifyTasks(mutation.ExecutionInfo, mutation.TasksByCategory, persistenceError)
 }
 
-func taskIDsFromSnapshot(snapshot *persistence.WorkflowSnapshot) []int64 {
+func snapshotTasks(snapshot *persistence.WorkflowSnapshot) map[persistence.HistoryTaskCategory][]persistence.Task {
 	if snapshot == nil {
 		return nil
 	}
-	return taskIDsFromCategories(snapshot.TasksByCategory)
+	return snapshot.TasksByCategory
 }
 
-func taskIDsFromMutation(mutation *persistence.WorkflowMutation) []int64 {
+func mutationTasks(mutation *persistence.WorkflowMutation) map[persistence.HistoryTaskCategory][]persistence.Task {
 	if mutation == nil {
 		return nil
 	}
-	return taskIDsFromCategories(mutation.TasksByCategory)
+	return mutation.TasksByCategory
 }
 
-func taskIDsFromCategories(tasksByCategory map[persistence.HistoryTaskCategory][]persistence.Task) []int64 {
-	var ids []int64
-	for _, tasks := range tasksByCategory {
-		for _, t := range tasks {
-			ids = append(ids, t.GetTaskID())
-		}
+func appendTaskIDs(ids []int64, tasks []persistence.Task) []int64 {
+	for _, t := range tasks {
+		ids = append(ids, t.GetTaskID())
 	}
 	return ids
 }

--- a/service/history/shard/notify_task_test.go
+++ b/service/history/shard/notify_task_test.go
@@ -28,8 +28,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/config"
 )
 
 func TestIsOperationPossiblySuccessfulError(t *testing.T) {
@@ -56,6 +58,133 @@ func TestIsOperationPossiblySuccessfulError(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, isOperationPossiblySuccessfulError(tc.err))
+		})
+	}
+}
+
+// toInt64s normalizes a task-ID slice recovered from an observed log entry, whose ContextMap
+// reconstructs the logged []int64 as []interface{}. Returns nil for absent/empty values so the
+// "no IDs of this category" case compares equal to a nil expectation.
+func toInt64s(v interface{}) []int64 {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []int64
+	for _, e := range arr {
+		out = append(out, e.(int64))
+	}
+	return out
+}
+
+func transferTask(id int64) persistence.Task {
+	return &persistence.ActivityTask{TaskData: persistence.TaskData{TaskID: id}}
+}
+
+func timerTask(id int64) persistence.Task {
+	return &persistence.UserTimerTask{TaskData: persistence.TaskData{TaskID: id}}
+}
+
+func replicationTask(id int64) persistence.Task {
+	return &persistence.HistoryReplicationTask{TaskData: persistence.TaskData{TaskID: id}}
+}
+
+func TestLogNotifyTaskDroppedOnPersistenceError(t *testing.T) {
+	tests := []struct {
+		name            string
+		timerMode       string
+		transferMode    string
+		sources         []map[persistence.HistoryTaskCategory][]persistence.Task
+		wantLogged      bool
+		wantTimerIDs    []int64
+		wantTransferIDs []int64
+	}{
+		{
+			name:         "neither cache in shadow: nothing logged",
+			timerMode:    "enabled",
+			transferMode: "enabled",
+			sources: []map[persistence.HistoryTaskCategory][]persistence.Task{{
+				persistence.HistoryTaskCategoryTimer:    {timerTask(1)},
+				persistence.HistoryTaskCategoryTransfer: {transferTask(2)},
+			}},
+			wantLogged: false,
+		},
+		{
+			name:         "timer shadow only: only timer IDs logged",
+			timerMode:    "shadow",
+			transferMode: "enabled",
+			sources: []map[persistence.HistoryTaskCategory][]persistence.Task{{
+				persistence.HistoryTaskCategoryTimer:    {timerTask(1), timerTask(2)},
+				persistence.HistoryTaskCategoryTransfer: {transferTask(3)},
+			}},
+			wantLogged:      true,
+			wantTimerIDs:    []int64{1, 2},
+			wantTransferIDs: nil,
+		},
+		{
+			name:         "transfer shadow only: only transfer IDs logged",
+			timerMode:    "disabled",
+			transferMode: "shadow",
+			sources: []map[persistence.HistoryTaskCategory][]persistence.Task{{
+				persistence.HistoryTaskCategoryTimer:    {timerTask(1)},
+				persistence.HistoryTaskCategoryTransfer: {transferTask(3), transferTask(4)},
+			}},
+			wantLogged:      true,
+			wantTimerIDs:    nil,
+			wantTransferIDs: []int64{3, 4},
+		},
+		{
+			name:         "both shadow: both categories logged across multiple sources",
+			timerMode:    "shadow",
+			transferMode: "shadow",
+			sources: []map[persistence.HistoryTaskCategory][]persistence.Task{
+				{
+					persistence.HistoryTaskCategoryTimer:    {timerTask(1)},
+					persistence.HistoryTaskCategoryTransfer: {transferTask(3)},
+				},
+				{
+					persistence.HistoryTaskCategoryTimer:    {timerTask(2)},
+					persistence.HistoryTaskCategoryTransfer: {transferTask(4)},
+				},
+			},
+			wantLogged:      true,
+			wantTimerIDs:    []int64{1, 2},
+			wantTransferIDs: []int64{3, 4},
+		},
+		{
+			name:         "both shadow but batch has only replication tasks: nothing logged",
+			timerMode:    "shadow",
+			transferMode: "shadow",
+			sources: []map[persistence.HistoryTaskCategory][]persistence.Task{{
+				persistence.HistoryTaskCategoryReplication: {replicationTask(5)},
+			}},
+			wantLogged: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, obs := testlogger.NewObserved(t)
+			s := &contextImpl{
+				shardID: 1,
+				logger:  logger,
+				config: &config.Config{
+					TimerProcessorCachedQueueReaderMode:    func(int) string { return tc.timerMode },
+					TransferProcessorCachedQueueReaderMode: func(int) string { return tc.transferMode },
+				},
+			}
+
+			s.logNotifyTaskDroppedOnPersistenceError(assert.AnError, tc.sources...)
+
+			entries := obs.FilterMessage("notify tasks dropped due to persistence error").All()
+			if !tc.wantLogged {
+				assert.Empty(t, entries)
+				return
+			}
+			assert.Len(t, entries, 1)
+			ctxMap := entries[0].ContextMap()
+			assert.Equal(t, tc.wantTimerIDs, toInt64s(ctxMap["droppedTimerTaskIDs"]))
+			assert.Equal(t, tc.wantTransferIDs, toInt64s(ctxMap["droppedTransferTaskIDs"]))
 		})
 	}
 }


### PR DESCRIPTION
**What changed?**

`logNotifyTaskDroppedOnPersistenceError` now reports dropped task IDs per category and gates each category on its own cached queue reader's shadow mode, instead of consulting only the timer cache and logging a single flattened list.

**Why?**

Now that the transfer queue is cacheable, the shard's persistence-error drop logging has to cover the transfer cache too. Previously the function checked only the timer cache's mode and emitted one flat list of dropped task IDs, so it could neither report transfer drops nor tell which category a given ID belonged to.

A workflow write persists all task categories atomically, so a single ambiguous persistence error drops timer, transfer, and replication tasks together. A dropped task is only worth logging when its own category's cache is in shadow mode, where the cache is validated against the DB and the drop shows up as an observable mismatch; for other modes, and for categories with no cached reader (replication), the log is just noise. 

Part of #8432.

**How did you test it?**

`go test -race ./service/history/shard/`

The table test covers timer-only shadow, transfer-only shadow, both shadow, neither shadow, and a batch containing replication tasks (which must never be logged).

**Potential risks**

N/A. Log-only change on the persistence-error path; no API, IDL, or schema changes. The steady state (no cache shadowing) returns before touching the task sources, so there is no added per-task cost when the feature is off.

**Release notes**

N/A. Internal observability change with no user-facing behavior.

**Documentation Changes**

N/A.