### PR TITLE
fix(onebox): configure shard distributor gRPC outbound

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -1300,6 +1300,7 @@ func (c *cadenceImpl) newRPCFactory(serviceName string, host membership.HostInfo
 		OutboundsBuilder: rpc.CombineOutbounds(
 			rpc.NewSingleGRPCOutboundBuilder(testOutboundName(serviceName), serviceName, grpcAddress),
 			rpc.NewSingleGRPCOutboundBuilder(rpc.OutboundPublicClient, service.Frontend, frontendGrpcAddress),
+			rpc.NewSingleGRPCOutboundBuilder(service.ShardDistributor, service.ShardDistributor, grpcAddress),
 			rpc.NewCrossDCOutbounds(c.clusterMetadata.GetAllClusterInfo(), rpc.NewDNSPeerChooserFactory(0, c.logger)),
 			rpc.NewDirectOutboundBuilder(service.History, true, nil, directOutboundPCF, directConnRetainFn),
 			rpc.NewDirectOutboundBuilder(service.Matching, true, nil, directOutboundPCF, directConnRetainFn),


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Added a gRPC outbound named `shard-distributor` to the onebox RPC factory. Production RPC configuration is unchanged.

**Why?**

Shard Manager [now](https://github.com/cadence-workflow/shard-manager/pull/100/changes) rejects executor construction when its shard-distributor client is nil. Onebox configures matching's shard-distributor executor but did not provide the corresponding YARPC outbound, causing matching startup to fail in the embedded Cadence tests.

Onebox uses 0% shard-distributor onboarding, so the client sends no executor heartbeats. But the outbound is still required.

**How did you test it?**

- Ran `.build/bin/goimports -w host/onebox.go`.
- Ran `go test ./host`.

**Potential risks**

Low. The new outbound affects only onebox.

**Release notes**


**Documentation Changes**
