### PR TITLE
fix(matching): stop leaked goroutines in tasklist manager tests

### DIFF
--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -495,12 +495,12 @@ func TestQueriesPerSecond(t *testing.T) {
 }
 
 func TestCheckIdleTaskList(t *testing.T) {
-	defer goleak.VerifyNone(t)
 	idleInterval := 100 * time.Millisecond
 	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
 	cfg.IdleTasklistCheckInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(idleInterval)
 
 	t.Run("Idle task-list", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
 		ctrl := gomock.NewController(t)
 		mockClock := clock.NewMockedTimeSource()
 		tlm := createTestTaskListManagerWithConfig(t, testlogger.New(t), ctrl, cfg, mockClock)
@@ -516,6 +516,7 @@ func TestCheckIdleTaskList(t *testing.T) {
 	})
 
 	t.Run("Active poll-er", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
 		ctrl := gomock.NewController(t)
 		mockClock := clock.NewMockedTimeSource()
 		tlm := createTestTaskListManagerWithConfig(t, testlogger.New(t), ctrl, cfg, mockClock)
@@ -543,6 +544,7 @@ func TestCheckIdleTaskList(t *testing.T) {
 	})
 
 	t.Run("Active adding task", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
 		ctrl := gomock.NewController(t)
 		mockClock := clock.NewMockedTimeSource()
 		tlm := createTestTaskListManagerWithConfig(t, testlogger.New(t), ctrl, cfg, mockClock)
@@ -1363,6 +1365,7 @@ func TestTaskListManagerImpl_HasPollerAfter(t *testing.T) {
 			tlm := createTestTaskListManager(t, logger, controller)
 			err := tlm.Start(context.Background())
 			assert.NoError(t, err)
+			defer tlm.Stop()
 
 			if tc.prepareManager != nil {
 				tc.prepareManager(tlm)
@@ -1769,7 +1772,9 @@ func TestManagerStart_RootPartition(t *testing.T) {
 			WritePartitions: partitions(2),
 		},
 	}).Return(&types.MatchingRefreshTaskListPartitionConfigResponse{}, nil)
+	deps.mockTaskManager.EXPECT().UpdateTaskList(gomock.Any(), gomock.Any()).Return(&persistence.UpdateTaskListResponse{}, nil).AnyTimes()
 	assert.NoError(t, tlm.Start(context.Background()))
+	defer tlm.Stop()
 	assert.Equal(t, &types.TaskListPartitionConfig{Version: 1, ReadPartitions: partitions(2), WritePartitions: partitions(2)}, tlm.TaskListPartitionConfig())
 	tlm.stopWG.Wait()
 }
@@ -1811,7 +1816,9 @@ func TestManagerStart_NonRootPartition(t *testing.T) {
 			RangeID:  0,
 		},
 	}, nil)
+	deps.mockTaskManager.EXPECT().UpdateTaskList(gomock.Any(), gomock.Any()).Return(&persistence.UpdateTaskListResponse{}, nil).AnyTimes()
 	assert.NoError(t, tlm.Start(context.Background()))
+	defer tlm.Stop()
 	assert.Equal(t, &types.TaskListPartitionConfig{
 		Version:         1,
 		ReadPartitions:  partitions(3),


### PR DESCRIPTION
**What changed?**

Fixed three tests in `service/matching/tasklist/task_list_manager_test.go` that start a real `taskListManagerImpl` (spawning background goroutines: taskReader, taskWriter, liveness, adaptiveScaler, qpsTracker) via `tlm.Start(...)` but never call `tlm.Stop()`: `TestManagerStart_RootPartition`, `TestManagerStart_NonRootPartition`, and `TestTaskListManagerImpl_HasPollerAfter`. Also moved `TestCheckIdleTaskList`'s `goleak.VerifyNone(t)` check from the outer test function into each of its three subtests individually.

**Why?**

Report: https://github.com/cadence-workflow/cadence/issues/7863

The issue reports a flaky race-detector failure in this package observed once in CI. Reproducing with `go test -race -count=3 ./service/matching/tasklist/...` reliably fails, but not with an actual `WARNING: DATA RACE` (verified zero occurrences via grep) — instead with `goleak.VerifyNone` catching leaked background goroutines in unrelated, later tests.

The root cause for three of these leaks is straightforward: `TestManagerStart_RootPartition`, `TestManagerStart_NonRootPartition`, and `TestTaskListManagerImpl_HasPollerAfter` call `tlm.Start(context.Background())` but never `tlm.Stop()`, so their background goroutines run forever and get caught by whichever later test's `goleak.VerifyNone(t)` happens to run next. This is 100% reproducible (not probabilistic) once triggered by test ordering/count.

Separately, `TestCheckIdleTaskList` starts three managers that self-stop asynchronously (via the idle-liveness callback invoking `tlm.Stop()` in a background goroutine) and only checked for goroutine leaks once, after all three subtests completed. That stacks three pending async shutdowns into a single goleak retry window instead of giving each shutdown its own; moving the check into each subtest isolates them.

**How did you test it?**

```
go test -race -count=1 ./service/matching/tasklist/...
```
Passes cleanly (verified 3 consecutive runs before and after this change — this matches what standard CI runs).

```
go test -race -count=1 -v -run 'TestManagerStart_RootPartition|TestManagerStart_NonRootPartition|TestTaskListManagerImpl_HasPollerAfter|TestCheckIdleTaskList' ./service/matching/tasklist/...
```
All four tests pass individually with no panics or unmet-mock errors.

Also ran `golangci-lint run ./service/matching/tasklist/...` before and after the change: identical 14 pre-existing findings in both cases, none on lines touched by this diff.

Disclosure: `go test -race -count=3 ./service/matching/tasklist/...` (an artificial stress repro, not what CI runs) still shows occasional residual "found unexpected goroutines" failures after this fix, traced to at least one more test (`TestGetTasksPumpConditionFailedUnloadsTaskList` in task_reader_test.go, not modified here) that self-stops asynchronously and only polls `tlm.stopped == 1` — a flag set at the very top of `Stop()`, before the internal wait for child goroutines to actually exit. That test already carries a `goleak.IgnoreCurrent()` workaround with a comment acknowledging "other tests in this package start task lists without stopping them." Fixing it properly would need a reliable "fully stopped" signal that doesn't currently exist, which is a larger change than fits here. This PR fixes the three confirmed, 100%-reproducible leak sources; it does not claim to make the package immune to all goroutine-leak flakiness under artificial stress.

**Potential risks**

Test-only change; no production code paths are modified. `taskListManagerImpl.Stop()` is idempotent (guarded by `atomic.CompareAndSwapInt32`), so the added `defer tlm.Stop()` calls are safe even if a manager was already stopped by other test logic.

**Release notes**

N/A — test-only fix, no user-facing behavior change.

**Documentation Changes**

N/A

Fixes #7863