### PR TITLE
fix(persistence): truncate startTime to millisecond precision in TestVisibilityPagination

### DIFF
--- a/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
@@ -295,7 +295,10 @@ func (s *DBVisibilityPersistenceSuite) TestVisibilityPagination() {
 	testDomainUUID := uuid.New()
 
 	// Create 2 executions
-	startTime1 := time.Now()
+	// Truncate to millisecond precision: MySQL DATETIME(6) columns round
+	// sub-microsecond nanoseconds, which can push the stored value across a
+	// millisecond boundary and make the ms-truncated comparisons below flaky.
+	startTime1 := time.Now().Truncate(time.Millisecond)
 	workflowExecution1 := types.WorkflowExecution{
 		WorkflowID: "visibility-pagination-test1",
 		RunID:      "fb15e4b5-356f-466d-8c6d-a29223e5c536",


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Truncated `startTime1` to millisecond precision in `TestVisibilityPagination` (`common/persistence/persistence-tests/dbVisibilityPersistenceTest.go`), instead of capturing it with full nanosecond precision via `time.Now()`.

**Why?**

The test intermittently fails against MySQL with a 1ms mismatch between the written and read-back start time. The MySQL `executions_visibility.start_time` column is `DATETIME(6)` (microsecond precision), and MySQL rounds (rather than truncates) fractional seconds when given a value with finer resolution than the column supports. The `go-sql-driver/mysql` client sends the full nanosecond-precision value as text (it does not itself truncate to microseconds), so whenever `time.Now()`'s sub-microsecond nanoseconds were >=500ns while its microseconds sat at 999999us within the millisecond, MySQL's rounding pushed the stored value into the next millisecond — causing the test's millisecond-truncated comparison (`nanosToMillis(req.StartTimestamp)` vs `nanosToMillis(resp.GetStartTime())`) to fail. Truncating the captured time to millisecond precision eliminates the sub-millisecond component before it ever reaches MySQL, so rounding can no longer cross a millisecond boundary.

**How did you test it?**

- `go build ./common/persistence/persistence-tests/...` passes.
- `go test ./common/persistence/sql/sqlplugin/sqlite/... -run TestSQLiteVisibilityPersistenceSuite/TestVisibilityPagination -count 20 -v` passes — confirms the fix doesn't break the test's logic against a real (non-MySQL) backend.
- Confirmed the MySQL schema column is `DATETIME(6)` (`schema/mysql/v8/visibility/schema.sql`) and traced `go-sql-driver/mysql` v1.9.3's `appendDateTime`, which sends the full nanosecond-precision value to the server without client-side truncation — confirming the server-side rounding-on-storage described above is the actual mechanism.
- `golangci-lint run` and `go vet` on the changed package show only pre-existing issues in unrelated files, nothing new introduced by this change.
- Could **not** run the actual `TestMySQLVisibilityPersistenceSuite` locally: it's gated behind `testflags.RequireMySQL` (`MYSQL=1` env var + a live MySQL instance), and this environment has neither Docker nor MySQL installed. The root cause was instead verified by tracing the schema and driver code as described above, which fully explains the reported failure and shows the fix removes the only variable input (sub-millisecond nanoseconds) that can trigger it.

**Potential risks**

Very low. This is a one-line change confined to a single test function; it only affects the precision of a locally-generated test timestamp and does not touch any production code path.

**Release notes**

None — test-only change fixing a flaky/intermittent test failure.

**Documentation Changes**

None.

Fixes #8038