### PR TITLE
test(queuev2): add immediate task cache simulation scenarios

### DIFF
--- a/.github/workflows/history-simulation.yml
+++ b/.github/workflows/history-simulation.yml
@@ -15,6 +15,7 @@ jobs:
         scenario:
           - default
           - queuev2
+          - queuev2_immediate_cache_enabled
           - queuev2_scheduled_cache_enabled
           - queuev2_split
     continue-on-error: ${{ matrix.experimental == true }}

--- a/simulation/history/dynamicconfig/queuev2_immediate_cache_enabled.yaml
+++ b/simulation/history/dynamicconfig/queuev2_immediate_cache_enabled.yaml
@@ -1,0 +1,41 @@
+system.workflowDeletionJitterRange:
+- value: 0
+  constraints: {}
+history.enableTimerQueueV2:
+- value: true
+  constraints: {}
+history.enableTransferQueueV2:
+- value: true
+  constraints: {}
+history.queueMaxPendingTaskCount:
+- value: 10000
+  constraints: {}
+history.timerTaskBatchSize:
+- value: 100
+  constraints: {}
+history.timerProcessorUpdateAckInterval:
+- value: 30s
+  constraints: {}
+history.timerProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.timerProcessorMaxPollRPS:
+- value: 20
+  constraints: {}
+history.transferTaskBatchSize:
+- value: 100
+  constraints: {}
+history.transferProcessorUpdateAckInterval:
+- value: 30s
+  constraints: {}
+history.transferProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.transferProcessorMaxPollRPS:
+- value: 20
+  constraints: {}
+
+# Cached immediate queue settings
+history.transferProcessorCachedQueueReaderMode:
+- value: "enabled"
+  constraints: {}

--- a/simulation/history/dynamicconfig/queuev2_immediate_cache_shadow.yaml
+++ b/simulation/history/dynamicconfig/queuev2_immediate_cache_shadow.yaml
@@ -1,0 +1,41 @@
+system.workflowDeletionJitterRange:
+- value: 0
+  constraints: {}
+history.enableTimerQueueV2:
+- value: true
+  constraints: {}
+history.enableTransferQueueV2:
+- value: true
+  constraints: {}
+history.queueMaxPendingTaskCount:
+- value: 10000
+  constraints: {}
+history.timerTaskBatchSize:
+- value: 100
+  constraints: {}
+history.timerProcessorUpdateAckInterval:
+- value: 30s
+  constraints: {}
+history.timerProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.timerProcessorMaxPollRPS:
+- value: 20
+  constraints: {}
+history.transferTaskBatchSize:
+- value: 100
+  constraints: {}
+history.transferProcessorUpdateAckInterval:
+- value: 30s
+  constraints: {}
+history.transferProcessorUpdateAckIntervalJitterCoefficient:
+- value: 0
+  constraints: {}
+history.transferProcessorMaxPollRPS:
+- value: 20
+  constraints: {}
+
+# Cached immediate queue settings
+history.transferProcessorCachedQueueReaderMode:
+- value: "shadow"
+  constraints: {}

--- a/simulation/history/testdata/history_simulation_queuev2_immediate_cache_enabled.yaml
+++ b/simulation/history/testdata/history_simulation_queuev2_immediate_cache_enabled.yaml
@@ -1,0 +1,21 @@
+enablearchival: false
+clusterno: 0
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+  simulationconfig:
+    numworkflows: 1000
+    sleepbetweenworkflowstarts: 100ms
+    numworkflowsleeps: 10
+matchingconfig:
+  nummatchinghosts: 1
+workerconfig:
+  enableasyncwfconsumer: false
+  enablearchiver: false
+  enablereplicator: false
+  enableindexer: false
+dynamicclientconfig:
+  filepath: "dynamicconfig/queuev2_immediate_cache_enabled.yaml"
+  pollInterval: "10s"

--- a/simulation/history/testdata/history_simulation_queuev2_immediate_cache_shadow.yaml
+++ b/simulation/history/testdata/history_simulation_queuev2_immediate_cache_shadow.yaml
@@ -1,0 +1,21 @@
+enablearchival: false
+clusterno: 0
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+  simulationconfig:
+    numworkflows: 1000
+    sleepbetweenworkflowstarts: 100ms
+    numworkflowsleeps: 10
+matchingconfig:
+  nummatchinghosts: 1
+workerconfig:
+  enableasyncwfconsumer: false
+  enablearchiver: false
+  enablereplicator: false
+  enableindexer: false
+dynamicclientconfig:
+  filepath: "dynamicconfig/queuev2_immediate_cache_shadow.yaml"
+  pollInterval: "10s"


### PR DESCRIPTION
**What changed?**
Added new history simulation scenarios for the immediate (transfer) task cache:
- `queuev2_immediate_cache_enabled`: exercises the cache in enabled mode
- `queuev2_immediate_cache_shadow`: exercises the cache in shadow mode

Added `queuev2_immediate_cache_enabled` to the CI matrix alongside the existing `queuev2_scheduled_cache_enabled` scenario.

**Why?**
The immediate task cache is a new in-memory cache for transfer tasks, similar to the existing scheduled (timer) task cache. It needs end-to-end simulation coverage in both enabled and shadow modes to verify that enabling the cache does not drop or hide transfer tasks that must be executed. The shadow scenario is available for local testing but not in CI to keep the matrix lean.

Related to #8432 .


**How did you test it?**
Each of the four cache scenarios run 10 times locally with zero failures: 
```
./simulation/history/run.sh --scenario queuev2_immediate_cache_enabled
./simulation/history/run.sh --scenario queuev2_immediate_cache_shadow 
```

**Potential risks**
None. Config-only changes adding new CI simulation scenarios. No production code modified.

**Release notes**
N/A

**Documentation Changes**
N/A
