### PR TITLE
chore: add vladimir-gavrilenko to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-* @adhityamamallan @macrotim @Assem-Uber @abhishekj720 @fimanishi @bowenxia @timl3136 @eleonoradgr @gazi-yestemirova @arzonus @c-warren @natemort @Shaddoll @neil-xie @davidporter-id-au @shijiesheng @jakobht @sankari165 @dkrotx @demirkayaender
+* @adhityamamallan @macrotim @Assem-Uber @abhishekj720 @fimanishi @bowenxia @timl3136 @eleonoradgr @gazi-yestemirova @arzonus @vladimir-gavrilenko @c-warren @natemort @Shaddoll @neil-xie @davidporter-id-au @shijiesheng @jakobht @sankari165 @dkrotx @demirkayaender


### PR DESCRIPTION
**What changed?**
Added @vladimir-gavrilenko to the global CODEOWNERS rule in `.github/CODEOWNERS`.

**Why?**
To receive review requests and be able to make changes to `.github/workflows/` w/o a warning like [this](https://github.com/cadence-workflow/cadence/pull/8514#issuecomment-5523105301).

**How did you test it?**
Verified the CODEOWNERS file syntax is correct — single `*` pattern with the new handle appended.

**Potential risks**
N/A — additive change only; does not remove any existing owners.

**Release notes**
N/A

**Documentation Changes**
N/A