### PR TITLE
docs: update link to Timeout Risks runbooks

### DIFF
--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -38,7 +38,7 @@ const (
 	linkToTimeoutsRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
 	linkToFailuresRunbook     = "https://cadenceworkflow.io/docs/workflow-troubleshooting/activity-failures/"
 	linkToRetriesRunbook      = "https://cadenceworkflow.io/docs/workflow-troubleshooting/retries"
-	linkToTimeoutRisksRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
+	linkToTimeoutRisksRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeout-risks/"
 	linkToAntipatternsRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/antipatterns/"
 	WfDiagnosticsAppName      = "workflow-diagnostics"
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Updated the link for the Timeout Risks invariant runbook from the existing Timeouts page to a dedicated Timeout Risks page.

**Why?**
The new page is a runbook for the exact issues flagged by the invariant.

**How did you test it?**
New link: https://cadenceworkflow.io/docs/workflow-troubleshooting/timeout-risks

**Potential risks**
None

**Release notes**
None

**Documentation Changes**
https://github.com/cadence-workflow/Cadence-Docs/pull/415
