### PR TITLE
feat: batch map deletion read filter

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -34,6 +34,12 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+// Sentinel values written as tombstone-free placeholders when map entries are deleted.
+const (
+	activitySentinelScheduleID int64 = -1
+	timerSentinelTimerID             = ""
+)
+
 var _ nosqlplugin.WorkflowCRUD = (*CDB)(nil)
 
 // keep batch under Cassandra's default 50KB fail threshold.
@@ -225,6 +231,9 @@ func (db *CDB) SelectWorkflowExecution(ctx context.Context, shardID int, domainI
 	aMap := result["activity_map"].(map[int64]map[string]interface{})
 	for key, value := range aMap {
 		info := parseActivityInfo(domainID, value)
+		if info.ScheduleID == activitySentinelScheduleID {
+			continue
+		}
 		activityInfos[key] = info
 	}
 	state.ActivityInfos = activityInfos
@@ -233,6 +242,9 @@ func (db *CDB) SelectWorkflowExecution(ctx context.Context, shardID int, domainI
 	tMap := result["timer_map"].(map[string]map[string]interface{})
 	for key, value := range tMap {
 		info := parseTimerInfo(value)
+		if info.TimerID == timerSentinelTimerID {
+			continue
+		}
 		timerInfos[key] = info
 	}
 	state.TimerInfos = timerInfos

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
@@ -552,7 +552,7 @@ func TestSelectWorkflowExecution(t *testing.T) {
 						1: {"schedule_id": int64(1)},
 					}
 					m["timer_map"] = map[string]map[string]interface{}{
-						"t1": {"started_id": int64(5)},
+						"t1": {"timer_id": "t1", "started_id": int64(5)},
 					}
 					m["child_executions_map"] = map[int64]map[string]interface{}{
 						3: {"initiated_id": int64(2)},
@@ -579,7 +579,7 @@ func TestSelectWorkflowExecution(t *testing.T) {
 					1: {ScheduleID: 1, DomainID: "test-domain-id"},
 				},
 				TimerInfos: map[string]*persistence.TimerInfo{
-					"t1": {StartedID: 5},
+					"t1": {TimerID: "t1", StartedID: 5},
 				},
 				ChildExecutionInfos: map[int64]*persistence.InternalChildExecutionInfo{
 					3: {InitiatedID: 2},
@@ -596,6 +596,54 @@ func TestSelectWorkflowExecution(t *testing.T) {
 				BufferedEvents: []*persistence.DataBlob{
 					{Encoding: constants.EncodingTypeThriftRW, Data: []byte("test-buffered-events-1")},
 				},
+			},
+		},
+		{
+			name:       "sentinel activity and timer entries are filtered on read",
+			shardID:    1,
+			domainID:   "test-domain-id",
+			workflowID: "test-workflow-id",
+			runID:      "test-run-id",
+			queryMockFn: func(query *gocql.MockQuery) {
+				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
+				query.EXPECT().MapScan(gomock.Any()).DoAndReturn(func(m map[string]interface{}) error {
+					m["execution"] = map[string]interface{}{}
+					m["version_histories"] = []byte{}
+					m["version_histories_encoding"] = "thriftrw"
+					m["replication_state"] = map[string]interface{}{}
+					m["activity_map"] = map[int64]map[string]interface{}{
+						1:  {"schedule_id": int64(1)},
+						10: {"schedule_id": activitySentinelScheduleID},
+						20: {"schedule_id": activitySentinelScheduleID},
+					}
+					m["timer_map"] = map[string]map[string]interface{}{
+						"t1": {"timer_id": "t1", "started_id": int64(5)},
+						"0":  {"timer_id": ""},
+						"1":  {"timer_id": ""},
+						"2":  {"timer_id": ""},
+					}
+					m["child_executions_map"] = map[int64]map[string]interface{}{}
+					m["request_cancel_map"] = map[int64]map[string]interface{}{}
+					m["signal_map"] = map[int64]map[string]interface{}{}
+					m["signal_requested"] = []interface{}{}
+					m["buffered_events_list"] = []map[string]interface{}{}
+					m["checksum"] = map[string]interface{}{}
+					return nil
+				}).Times(1)
+			},
+			wantResp: &nosqlplugin.WorkflowExecution{
+				ExecutionInfo: &persistence.InternalWorkflowExecutionInfo{},
+				ActivityInfos: map[int64]*persistence.InternalActivityInfo{
+					1: {ScheduleID: 1, DomainID: "test-domain-id"},
+				},
+				TimerInfos: map[string]*persistence.TimerInfo{
+					"t1": {TimerID: "t1", StartedID: 5},
+				},
+				ChildExecutionInfos: map[int64]*persistence.InternalChildExecutionInfo{},
+				RequestCancelInfos:  map[int64]*persistence.RequestCancelInfo{},
+				SignalInfos:         map[int64]*persistence.SignalInfo{},
+				SignalRequestedIDs:  map[string]struct{}{},
+				BufferedEvents:      []*persistence.DataBlob{},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added activitySentinelScheduleID and timerSentinelTimerID filters when reading pending activity and timer maps from Cassandra.

This change is the first step needed to implement batch pending activity and batch pending timer deletes, using sentinel values and map upsert.

https://github.com/cadence-workflow/cadence/issues/8318

**Why?**
Cassandra creates a tombstone for every key-value pair deletion on a Cassandra map fields. Cadence use these maps to track pending activities and timers. That means that for every activity completed or timer fired, we delete the entry by creating a tombstone.

This change adds a filter for sentinel values that will be introduced later to be used instead of the deletion path.

**How did you test it?**
go test -race -run "TestSelectWorkflowExecution" ./common/persistence/nosql/nosqlplugin/cassandra/

**Potential risks**
No risk on this change. Cadence already iterates over the maps loaded from the database and it's a simple equality check on the id.

This commit should not be rolled back after batch map deletion write is deployed and enabled through the dynamic config thresholds.

**Release notes**
This commit has to be successfully deployed before the commit with the [batch map deletion write](https://github.com/cadence-workflow/cadence/pull/8522) to ensure backwards compatibility.

This commit should not be rolled back after batch map deletion write is deployed and enabled through the dynamic config thresholds.

**Documentation Changes**
N/A
