### PR TITLE
feat(schema): Add range_id fence to tokens table.

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -634,29 +634,26 @@ CREATE TABLE semaphore_metadata (
 
 -- Distributed semaphore: per-token ownership with an inline reverse index.
 --
--- Each bucket (domain_id, semaphore_name, bucket) is one Cassandra partition, written by its single
--- owning Matching host. `type` splits the partition into two row kinds that reuse the same four
--- columns (token_id / owner_id / holder / held_token) for opposite roles:
+-- Each bucket (domain_id, semaphore_name, bucket) is one Cassandra partition with a single
+-- writer, its owning Matching host. `type` splits the partition into three row kinds that share
+-- one set of columns; the column comments below say which kind uses which.
 --
---   token row (type = token): forward index keyed by token_id — "who holds this slot?"
---       token_id = slot id in [1, size] (the key); holder = holder's owner_id, or FREE (LWT-guarded).
---       owner_id, held_token = unused sentinels (OWNER_NONE, TOKEN_NONE).
+--   token row (type = 0): token_id -> holder      — who holds this slot?
+--   owner row (type = 1): owner_id -> held_token  — which slot does this hold own?
+--   lease row (type = 2): the range_id fence      — which host owns this bucket?
 --
---   owner row (type = owner): reverse index keyed by owner_id — "which slot does this hold own?"
---       owner_id = hold identity, length-prefixed workflow_id:run_id:hold_id (the key); held_token = its token_id.
---       token_id, holder = unused sentinels (TOKEN_NONE, OWNER_NONE).
---
--- Grant and release write the paired token row and owner row in ONE atomic batch on the partition,
--- so the forward and reverse views can never diverge.
+-- Grant and release write a token row and its owner row in ONE atomic batch, so the forward and
+-- reverse views can never diverge.
 CREATE TABLE semaphore_tokens (
     domain_id       uuid,
     semaphore_name  text,
     bucket          int,        -- static bucket = f(owner_id)
-    type            int,        -- rowKind {token, owner}: forward row vs reverse-index row
-    token_id        int,        -- token row: slot id [1,size]; owner row: TOKEN_NONE sentinel
-    owner_id        text,       -- owner row: the holder's identity; token row: OWNER_NONE sentinel
-    holder          text,       -- token row: current holder or FREE (LWT-guarded); owner row: OWNER_NONE sentinel
-    held_token      int,        -- owner row: the token this owner holds; token row: TOKEN_NONE sentinel
+    type            int,        -- rowKind {token, owner, lease}: forward row, reverse-index row, or fence row
+    token_id        int,        -- token row: slot id [1,size]; owner and lease rows: TOKEN_NONE sentinel
+    owner_id        text,       -- owner row: the holder's identity; token and lease rows: OWNER_NONE sentinel
+    holder          text,       -- token row: current holder or FREE (LWT-guarded); owner and lease rows: OWNER_NONE sentinel
+    held_token      int,        -- owner row: the token this owner holds; token and lease rows: TOKEN_NONE sentinel
+    range_id        bigint,     -- lease row: the owning host's fence
     updated_time    timestamp,
     PRIMARY KEY ((domain_id, semaphore_name, bucket), type, token_id, owner_id)
 ) WITH compaction = {

--- a/schema/cassandra/cadence/versioned/v0.53/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.53/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.53",
+  "MinCompatibleVersion": "0.53",
+  "Description": "Add range_id ownership fence to semaphore_tokens",
+  "SchemaUpdateCqlFiles": [
+    "semaphore_tokens_range_id.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.53/semaphore_tokens_range_id.cql
+++ b/schema/cassandra/cadence/versioned/v0.53/semaphore_tokens_range_id.cql
@@ -1,0 +1,5 @@
+-- Add the single-writer fence to semaphore_tokens.
+--
+-- range_id is carried on a per-bucket lease row (type = 2), alongside the existing token
+-- (type = 0) and owner (type = 1) rows, and is null on both of those. 
+ALTER TABLE semaphore_tokens ADD range_id bigint;

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -25,7 +25,7 @@ import "github.com/uber/cadence/schema/common"
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.52"
+const Version = "0.53"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.10"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49", "v0.50", "v0.51", "v0.52"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46", "v0.47", "v0.48", "v0.49", "v0.50", "v0.51", "v0.52", "v0.53"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**Detailed Description**
- **New field:** `range_id bigint`, nullable. Carried on one row per partition, distinguished by the existing `type` clustering column. 
- **No field removed, no type changed, no primary key change.** `ALTER TABLE ... ADD` is a metadata-only operation; existing rows read the new column as null.
- **No code path reads or writes the column in this PR.** The persistence layer that uses it lands separately.
- Update some comments in schema

**Why?**
- Without it, two Matching host will think they own a bucket.
- Safety holds. The token never over-admits, whatever the ownership picture. What degrades is the owner's in-mem free-set, and only downward.

**Impact Analysis**
- **Backward Compatibility**: Safe. The column is additive and nullable, and no existing binary selects or binds it. 
- **Forward Compatibility**: Safe for this PR 

**Testing Plan**
- **Unit Tests**: Yes. `go test ./schema/...` covers the version bump, manifest parsing, sequential version numbering, and that the `Version` constant matches the last versioned directory.
- **Persistence Tests**: Not applicable here — this PR adds no data path. 
- **Integration Tests**: Covered indirectly. CI runs `make install-schema` before the Cassandra integration suite, so the migration is applied and exercised on every run.
- **Compatibility Tests**: The change is an additive.

**Rollout Plan**
- **Rollout**: Apply the migration, then deploy as normal. Schema-only
- **Order of deployment**: Does not matter for this PR. It matters for the follow-up — the migration must be applied before the binary that references the column, or its writes fail with an undefined column error.
- **Rollback**: Safe.
- **Kill switch**: Not needed. Nothing reads the column. (In the follow-up, passing `RangeID = 0` omits the guard entirely and restores current behaviour without a schema change.)
