### PR TITLE
feat: batch map deletion write

### DIFF
--- a/common/dynamicconfig/dynamicproperties/config_mock.go
+++ b/common/dynamicconfig/dynamicproperties/config_mock.go
@@ -125,3 +125,8 @@ func GetStringPropertyFnFilteredByShardID(value string) func(shardID int) string
 func GetMapPropertyFn(value map[string]interface{}) func(opts ...FilterOption) map[string]interface{} {
 	return func(...FilterOption) map[string]interface{} { return value }
 }
+
+// GetListPropertyFn returns value as ListPropertyFn
+func GetListPropertyFn(value []interface{}) func(opts ...FilterOption) []interface{} {
+	return func(...FilterOption) []interface{} { return value }
+}

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1674,6 +1674,13 @@ const (
 	// per transaction (e.g., 100 = rewrite roughly every 100th transaction).
 	// 0 disables the optimization. 1 means rewrite every time.
 	// Only applies to backends listed in MapRewriteOptimizationBackends.
+	//
+	// When enabled, deletes write sentinel entries instead of issuing database
+	// deletes, and full rewrites compact them. A rate too high means sentinels
+	// accumulate, growing the map. Larger maps increase read latency because
+	// sentinels must be filtered on every load — especially costly during shard
+	// movement or cache eviction when the full map is read from the database.
+	//
 	// KeyName: history.activityMapRewriteSampleRate
 	// Value type: Int
 	// Default value: 0
@@ -1684,6 +1691,13 @@ const (
 	// per transaction (e.g., 100 = rewrite roughly every 100th transaction).
 	// 0 disables the optimization. 1 means rewrite every time.
 	// Only applies to backends listed in MapRewriteOptimizationBackends.
+	//
+	// When enabled, deletes write sentinel entries instead of issuing database
+	// deletes, and full rewrites compact them. A rate too high means sentinels
+	// accumulate, growing the map. Larger maps increase read latency because
+	// sentinels must be filtered on every load — especially costly during shard
+	// movement or cache eviction when the full map is read from the database.
+	//
 	// KeyName: history.timerMapRewriteSampleRate
 	// Value type: Int
 	// Default value: 0
@@ -4664,12 +4678,12 @@ var IntKeys = map[IntKey]DynamicInt{
 	},
 	ActivityMapRewriteSampleRate: {
 		KeyName:      "history.activityMapRewriteSampleRate",
-		Description:  "How often a full activity map rewrite is triggered on transactions with deletes. N means 1-in-N chance (e.g. 100 = every ~100th transaction). 0 disables. Only applies to backends in MapRewriteOptimizationBackends.",
+		Description:  "How often a full activity map rewrite is triggered on transactions with deletes. N means 1-in-N chance (e.g. 100 = every ~100th transaction). 0 disables. Only applies to backends in MapRewriteOptimizationBackends. A rate too high causes sentinel accumulation, growing the map and increasing read latency on shard movement or cache eviction.",
 		DefaultValue: 0,
 	},
 	TimerMapRewriteSampleRate: {
 		KeyName:      "history.timerMapRewriteSampleRate",
-		Description:  "How often a full timer map rewrite is triggered on transactions with deletes. N means 1-in-N chance (e.g. 100 = every ~100th transaction). 0 disables. Only applies to backends in MapRewriteOptimizationBackends.",
+		Description:  "How often a full timer map rewrite is triggered on transactions with deletes. N means 1-in-N chance (e.g. 100 = every ~100th transaction). 0 disables. Only applies to backends in MapRewriteOptimizationBackends. A rate too high causes sentinel accumulation, growing the map and increasing read latency on shard movement or cache eviction.",
 		DefaultValue: 0,
 	},
 }

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1669,6 +1669,26 @@ const (
 	// Allowed filters: DomainName
 	SchedulerWorkerRedundancyFactor
 
+	// ActivityMapRewriteSampleRate controls how often a full activity map rewrite
+	// is triggered on transactions with deletes. A value of N means a 1-in-N chance
+	// per transaction (e.g., 100 = rewrite roughly every 100th transaction).
+	// 0 disables the optimization. 1 means rewrite every time.
+	// Only applies to backends listed in MapRewriteOptimizationBackends.
+	// KeyName: history.activityMapRewriteSampleRate
+	// Value type: Int
+	// Default value: 0
+	ActivityMapRewriteSampleRate
+
+	// TimerMapRewriteSampleRate controls how often a full timer map rewrite
+	// is triggered on transactions with deletes. A value of N means a 1-in-N chance
+	// per transaction (e.g., 100 = rewrite roughly every 100th transaction).
+	// 0 disables the optimization. 1 means rewrite every time.
+	// Only applies to backends listed in MapRewriteOptimizationBackends.
+	// KeyName: history.timerMapRewriteSampleRate
+	// Value type: Int
+	// Default value: 0
+	TimerMapRewriteSampleRate
+
 	// LastIntKey must be the last one in this const group
 	LastIntKey
 )
@@ -3507,6 +3527,17 @@ const (
 	// Default value: forward all headers.  (this is a problematic value, and it will be changing as we reduce to a list of known values)
 	HeaderForwardingRules
 
+	// MapRewriteOptimizationBackends is the list of persistence backends that support
+	// the map rewrite optimization (sentinel writes + probabilistic full map rewrite).
+	// Currently only Cassandra is known to need this optimization (to avoid tombstones).
+	// Note: this value is read once at process startup and cached. Changes require a
+	// restart to take effect. Use the sample rate configs as a live kill switch instead.
+	// KeyName: history.mapRewriteOptimizationBackends
+	// Value type: []string
+	// Default value: ["cassandra"]
+	// Allowed filters: N/A
+	MapRewriteOptimizationBackends
+
 	LastListKey
 )
 
@@ -4630,6 +4661,16 @@ var IntKeys = map[IntKey]DynamicInt{
 		Filters:      []Filter{DomainName},
 		Description:  "Number of cadence-worker hosts that concurrently run a scheduler worker for each enabled domain. Re-read live every refresh tick.",
 		DefaultValue: 2,
+	},
+	ActivityMapRewriteSampleRate: {
+		KeyName:      "history.activityMapRewriteSampleRate",
+		Description:  "How often a full activity map rewrite is triggered on transactions with deletes. N means 1-in-N chance (e.g. 100 = every ~100th transaction). 0 disables. Only applies to backends in MapRewriteOptimizationBackends.",
+		DefaultValue: 0,
+	},
+	TimerMapRewriteSampleRate: {
+		KeyName:      "history.timerMapRewriteSampleRate",
+		Description:  "How often a full timer map rewrite is triggered on transactions with deletes. N means 1-in-N chance (e.g. 100 = every ~100th transaction). 0 disables. Only applies to backends in MapRewriteOptimizationBackends.",
+		DefaultValue: 0,
 	},
 }
 
@@ -6197,6 +6238,11 @@ var ListKeys = map[ListKey]DynamicList{
 		KeyName:      "system.rateLimiterBypassCallerTypes",
 		Description:  "List of caller types that bypass rate limiters (both frontend and persistence)",
 		DefaultValue: []interface{}{},
+	},
+	MapRewriteOptimizationBackends: {
+		KeyName:      "history.mapRewriteOptimizationBackends",
+		Description:  "List of persistence backends that support the map rewrite optimization (sentinel writes + probabilistic rewrite). Currently only Cassandra is known to need this (to avoid tombstones). Cached at startup; changes require restart. Use sample rate configs as a live kill switch.",
+		DefaultValue: []interface{}{"cassandra"},
 	},
 	DefaultIsolationGroupConfigStoreManagerGlobalMapping: {
 		KeyName: "system.defaultIsolationGroupConfigStoreManagerGlobalMapping",

--- a/common/persistence/config.go
+++ b/common/persistence/config.go
@@ -42,6 +42,9 @@ type (
 		RateLimiterBypassCallerTypes             dynamicproperties.ListPropertyFn
 		TransactionSizeLimit                     dynamicproperties.IntPropertyFn
 		ErrorInjectionRate                       dynamicproperties.FloatPropertyFn
+		ActivityMapRewriteSampleRate             dynamicproperties.IntPropertyFn
+		TimerMapRewriteSampleRate                dynamicproperties.IntPropertyFn
+		MapRewriteOptimizationBackends           dynamicproperties.ListPropertyFn
 	}
 )
 
@@ -62,6 +65,9 @@ func NewDynamicConfiguration(dc *dynamicconfig.Collection) *DynamicConfiguration
 		RateLimiterBypassCallerTypes:             dc.GetListProperty(dynamicproperties.RateLimiterBypassCallerTypes),
 		TransactionSizeLimit:                     dc.GetIntProperty(dynamicproperties.TransactionSizeLimit),
 		ErrorInjectionRate:                       dc.GetFloat64Property(dynamicproperties.PersistenceErrorInjectionRate),
+		ActivityMapRewriteSampleRate:             dc.GetIntProperty(dynamicproperties.ActivityMapRewriteSampleRate),
+		TimerMapRewriteSampleRate:                dc.GetIntProperty(dynamicproperties.TimerMapRewriteSampleRate),
+		MapRewriteOptimizationBackends:           dc.GetListProperty(dynamicproperties.MapRewriteOptimizationBackends),
 	}
 }
 

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -938,8 +938,10 @@ type (
 
 		UpsertActivityInfos       []*ActivityInfo
 		DeleteActivityInfos       []int64
+		RewriteActivityInfos      []*ActivityInfo
 		UpsertTimerInfos          []*TimerInfo
 		DeleteTimerInfos          []string
+		RewriteTimerInfos         []*TimerInfo
 		UpsertChildExecutionInfos []*ChildExecutionInfo
 		DeleteChildExecutionInfos []int64
 		UpsertRequestCancelInfos  []*RequestCancelInfo

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -605,21 +605,25 @@ type (
 		StartVersion     int64
 		LastWriteVersion int64
 
-		UpsertActivityInfos       []*InternalActivityInfo
-		DeleteActivityInfos       []int64
-		UpsertTimerInfos          []*TimerInfo
-		DeleteTimerInfos          []string
-		WorkflowTimerTasks        []HistoryTaskKey
-		UpsertChildExecutionInfos []*InternalChildExecutionInfo
-		DeleteChildExecutionInfos []int64
-		UpsertRequestCancelInfos  []*RequestCancelInfo
-		DeleteRequestCancelInfos  []int64
-		UpsertSignalInfos         []*SignalInfo
-		DeleteSignalInfos         []int64
-		UpsertSignalRequestedIDs  []string
-		DeleteSignalRequestedIDs  []string
-		NewBufferedEvents         *DataBlob
-		ClearBufferedEvents       bool
+		UpsertActivityInfos          []*InternalActivityInfo
+		DeleteActivityInfos          []int64
+		RewriteActivityInfos         []*InternalActivityInfo
+		ActivitySentinelWriteEnabled bool
+		UpsertTimerInfos             []*TimerInfo
+		DeleteTimerInfos             []string
+		RewriteTimerInfos            []*TimerInfo
+		TimerSentinelWriteEnabled    bool
+		WorkflowTimerTasks           []HistoryTaskKey
+		UpsertChildExecutionInfos    []*InternalChildExecutionInfo
+		DeleteChildExecutionInfos    []int64
+		UpsertRequestCancelInfos     []*RequestCancelInfo
+		DeleteRequestCancelInfos     []int64
+		UpsertSignalInfos            []*SignalInfo
+		DeleteSignalInfos            []int64
+		UpsertSignalRequestedIDs     []string
+		DeleteSignalRequestedIDs     []string
+		NewBufferedEvents            *DataBlob
+		ClearBufferedEvents          bool
 
 		TasksByCategory map[HistoryTaskCategory][]Task
 

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -23,6 +23,7 @@ package persistence
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -36,12 +37,13 @@ import (
 type (
 	// executionManagerImpl implements ExecutionManager based on ExecutionStore, statsComputer and PayloadSerializer
 	executionManagerImpl struct {
-		serializer    PayloadSerializer
-		persistence   ExecutionStore
-		statsComputer statsComputer
-		logger        log.Logger
-		timeSrc       clock.TimeSource
-		dc            *DynamicConfiguration
+		serializer          PayloadSerializer
+		persistence         ExecutionStore
+		statsComputer       statsComputer
+		logger              log.Logger
+		timeSrc             clock.TimeSource
+		dc                  *DynamicConfiguration
+		mapRewriteSupported bool
 	}
 )
 
@@ -55,17 +57,41 @@ func NewExecutionManagerImpl(
 	dc *DynamicConfiguration,
 ) ExecutionManager {
 	return &executionManagerImpl{
-		serializer:    serializer,
-		persistence:   persistence,
-		statsComputer: statsComputer{},
-		logger:        logger,
-		timeSrc:       clock.NewRealTimeSource(),
-		dc:            dc,
+		serializer:          serializer,
+		persistence:         persistence,
+		statsComputer:       statsComputer{},
+		logger:              logger,
+		timeSrc:             clock.NewRealTimeSource(),
+		dc:                  dc,
+		mapRewriteSupported: isMapRewriteSupported(persistence, dc),
 	}
 }
 
 func (m *executionManagerImpl) GetName() string {
 	return m.persistence.GetName()
+}
+
+// isMapRewriteSupported is evaluated once at construction and cached. Runtime changes to
+// MapRewriteOptimizationBackends require a process restart to take effect. The sample rate
+// configs remain dynamic, so setting them to 0 disables the feature without a restart.
+func isMapRewriteSupported(store ExecutionStore, dc *DynamicConfiguration) bool {
+	if store == nil || dc == nil || dc.MapRewriteOptimizationBackends == nil {
+		return false
+	}
+	name := store.GetName()
+	for _, b := range dc.MapRewriteOptimizationBackends() {
+		if s, ok := b.(string); ok && s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldRewrite returns true with a 1-in-rate probability, used to
+// probabilistically trigger a full map rewrite that compacts sentinel
+// entries accumulated from previous deletes.
+func shouldRewrite(rate int) bool {
+	return rand.Intn(rate) == 0
 }
 
 // The below three APIs are related to serialization/deserialization
@@ -710,6 +736,41 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 	if err != nil {
 		return nil, err
 	}
+	var serializedRewriteActivityInfos []*InternalActivityInfo
+	var rewriteTimerInfos []*TimerInfo
+	var activityRate, timerRate int
+	if m.mapRewriteSupported && m.dc != nil {
+		if m.dc.ActivityMapRewriteSampleRate != nil {
+			activityRate = m.dc.ActivityMapRewriteSampleRate()
+		}
+		if m.dc.TimerMapRewriteSampleRate != nil {
+			timerRate = m.dc.TimerMapRewriteSampleRate()
+		}
+	}
+	if input.RewriteActivityInfos != nil && activityRate > 0 && shouldRewrite(activityRate) {
+		serializedRewriteActivityInfos, err = m.SerializeUpsertActivityInfos(input.RewriteActivityInfos, encoding)
+		if err != nil {
+			return nil, err
+		}
+		if serializedRewriteActivityInfos == nil {
+			serializedRewriteActivityInfos = []*InternalActivityInfo{}
+		}
+		m.logger.Info("activity map rewrite triggered",
+			tag.WorkflowDomainID(input.ExecutionInfo.DomainID),
+			tag.WorkflowID(input.ExecutionInfo.WorkflowID),
+			tag.WorkflowRunID(input.ExecutionInfo.RunID),
+			tag.Counter(len(serializedRewriteActivityInfos)),
+		)
+	}
+	if input.RewriteTimerInfos != nil && timerRate > 0 && shouldRewrite(timerRate) {
+		rewriteTimerInfos = input.RewriteTimerInfos
+		m.logger.Info("timer map rewrite triggered",
+			tag.WorkflowDomainID(input.ExecutionInfo.DomainID),
+			tag.WorkflowID(input.ExecutionInfo.WorkflowID),
+			tag.WorkflowRunID(input.ExecutionInfo.RunID),
+			tag.Counter(len(rewriteTimerInfos)),
+		)
+	}
 	serializedUpsertChildExecutionInfos, err := m.SerializeUpsertChildExecutionInfos(input.UpsertChildExecutionInfos, encoding)
 	if err != nil {
 		return nil, err
@@ -741,21 +802,25 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 		StartVersion:     startVersion,
 		LastWriteVersion: lastWriteVersion,
 
-		UpsertActivityInfos:       serializedUpsertActivityInfos,
-		DeleteActivityInfos:       input.DeleteActivityInfos,
-		UpsertTimerInfos:          input.UpsertTimerInfos,
-		DeleteTimerInfos:          input.DeleteTimerInfos,
-		WorkflowTimerTasks:        m.syncTimerTaskTrackingKeys(input.TasksByCategory),
-		UpsertChildExecutionInfos: serializedUpsertChildExecutionInfos,
-		DeleteChildExecutionInfos: input.DeleteChildExecutionInfos,
-		UpsertRequestCancelInfos:  input.UpsertRequestCancelInfos,
-		DeleteRequestCancelInfos:  input.DeleteRequestCancelInfos,
-		UpsertSignalInfos:         input.UpsertSignalInfos,
-		DeleteSignalInfos:         input.DeleteSignalInfos,
-		UpsertSignalRequestedIDs:  input.UpsertSignalRequestedIDs,
-		DeleteSignalRequestedIDs:  input.DeleteSignalRequestedIDs,
-		NewBufferedEvents:         serializedNewBufferedEvents,
-		ClearBufferedEvents:       input.ClearBufferedEvents,
+		UpsertActivityInfos:          serializedUpsertActivityInfos,
+		DeleteActivityInfos:          input.DeleteActivityInfos,
+		RewriteActivityInfos:         serializedRewriteActivityInfos,
+		ActivitySentinelWriteEnabled: activityRate > 0,
+		UpsertTimerInfos:             input.UpsertTimerInfos,
+		DeleteTimerInfos:             input.DeleteTimerInfos,
+		RewriteTimerInfos:            rewriteTimerInfos,
+		TimerSentinelWriteEnabled:    timerRate > 0,
+		WorkflowTimerTasks:           m.syncTimerTaskTrackingKeys(input.TasksByCategory),
+		UpsertChildExecutionInfos:    serializedUpsertChildExecutionInfos,
+		DeleteChildExecutionInfos:    input.DeleteChildExecutionInfos,
+		UpsertRequestCancelInfos:     input.UpsertRequestCancelInfos,
+		DeleteRequestCancelInfos:     input.DeleteRequestCancelInfos,
+		UpsertSignalInfos:            input.UpsertSignalInfos,
+		DeleteSignalInfos:            input.DeleteSignalInfos,
+		UpsertSignalRequestedIDs:     input.UpsertSignalRequestedIDs,
+		DeleteSignalRequestedIDs:     input.DeleteSignalRequestedIDs,
+		NewBufferedEvents:            serializedNewBufferedEvents,
+		ClearBufferedEvents:          input.ClearBufferedEvents,
 
 		TasksByCategory: input.TasksByCategory,
 

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -67,7 +67,7 @@ func TestExecutionManager_ProxyStoreMethods(t *testing.T) {
 		{
 			method: "GetName",
 			prepareMocks: func(mockedStore *MockExecutionStore) {
-				mockedStore.EXPECT().GetName().Return("test").Times(1)
+				mockedStore.EXPECT().GetName().Return("test").AnyTimes()
 			},
 		},
 		{
@@ -141,6 +141,7 @@ func TestExecutionManager_ProxyStoreMethods(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockedStore := NewMockExecutionStore(ctrl)
 			tc.prepareMocks(mockedStore)
+			mockedStore.EXPECT().GetName().Return("").AnyTimes()
 			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, NewDefaultDynamicConfiguration())
 			v := reflect.ValueOf(manager)
 			method := v.MethodByName(tc.method)
@@ -175,6 +176,7 @@ func TestExecutionManager_GetWorkflowExecution(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetWorkflowExecutionRequest{
@@ -265,6 +267,7 @@ func TestExecutionManager_GetWorkflowExecution_NoWorkflow(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetWorkflowExecutionRequest{
@@ -288,6 +291,7 @@ func TestExecutionManager_UpdateWorkflowExecution(t *testing.T) {
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	expectedInfo := sampleInternalWorkflowMutation()
@@ -343,6 +347,187 @@ func TestExecutionManager_UpdateWorkflowExecution(t *testing.T) {
 		TaskCountByCategory: map[HistoryTaskCategory]int{},
 	}
 	assert.Equal(t, stats, res.MutableStateUpdateSessionStats)
+}
+
+func TestSerializeWorkflowMutation_RewriteProbability(t *testing.T) {
+	tests := []struct {
+		name                  string
+		storeName             string
+		activityRate          int
+		timerRate             int
+		rewriteActivityInfos  []*ActivityInfo
+		rewriteTimerInfos     []*TimerInfo
+		deleteActivityInfos   []int64
+		deleteTimerInfos      []string
+		expectRewriteActivity bool
+		expectRewriteTimer    bool
+	}{
+		{
+			name:         "cassandra with rate 1 triggers rewrite and preserves deletes",
+			storeName:    "cassandra",
+			activityRate: 1,
+			timerRate:    1,
+			rewriteActivityInfos: []*ActivityInfo{
+				{Version: 1, ScheduleID: 10, ScheduledEvent: activityScheduledEvent(), StartedEvent: activityStartedEvent()},
+			},
+			rewriteTimerInfos:     []*TimerInfo{{TimerID: "t1"}},
+			deleteActivityInfos:   []int64{5},
+			deleteTimerInfos:      []string{"t2"},
+			expectRewriteActivity: true,
+			expectRewriteTimer:    true,
+		},
+		{
+			name:         "cassandra with rate 0 disables rewrite",
+			storeName:    "cassandra",
+			activityRate: 0,
+			timerRate:    0,
+			rewriteActivityInfos: []*ActivityInfo{
+				{Version: 1, ScheduleID: 10, ScheduledEvent: activityScheduledEvent(), StartedEvent: activityStartedEvent()},
+			},
+			rewriteTimerInfos:     []*TimerInfo{{TimerID: "t1"}},
+			deleteActivityInfos:   []int64{5},
+			deleteTimerInfos:      []string{"t2"},
+			expectRewriteActivity: false,
+			expectRewriteTimer:    false,
+		},
+		{
+			name:                  "cassandra with nil rewrite infos skips rewrite even with rate 1",
+			storeName:             "cassandra",
+			activityRate:          1,
+			timerRate:             1,
+			rewriteActivityInfos:  nil,
+			rewriteTimerInfos:     nil,
+			deleteActivityInfos:   []int64{5},
+			deleteTimerInfos:      []string{"t2"},
+			expectRewriteActivity: false,
+			expectRewriteTimer:    false,
+		},
+		{
+			name:                  "cassandra with all activities deleted triggers rewrite with empty map",
+			storeName:             "cassandra",
+			activityRate:          1,
+			timerRate:             1,
+			rewriteActivityInfos:  []*ActivityInfo{},
+			rewriteTimerInfos:     []*TimerInfo{},
+			deleteActivityInfos:   []int64{5},
+			deleteTimerInfos:      []string{"t2"},
+			expectRewriteActivity: true,
+			expectRewriteTimer:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockedStore := NewMockExecutionStore(ctrl)
+			mockedSerializer := NewMockPayloadSerializer(ctrl)
+
+			mockedStore.EXPECT().GetName().Return(tc.storeName).AnyTimes()
+			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
+				SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+				ActivityMapRewriteSampleRate:   dynamicproperties.GetIntPropertyFn(tc.activityRate),
+				TimerMapRewriteSampleRate:      dynamicproperties.GetIntPropertyFn(tc.timerRate),
+				MapRewriteOptimizationBackends: dynamicproperties.GetListPropertyFn([]interface{}{"cassandra"}),
+			})
+
+			mockedSerializer.EXPECT().SerializeEvent(gomock.Any(), gomock.Any()).Return(sampleEventData(), nil).AnyTimes()
+			mockedSerializer.EXPECT().SerializeResetPoints(gomock.Any(), gomock.Any()).Return(sampleResetPointsData(), nil).AnyTimes()
+			mockedSerializer.EXPECT().SerializeChecksum(gomock.Any(), gomock.Any()).Return(sampleCheckSumData(), nil).AnyTimes()
+			mockedSerializer.EXPECT().SerializeActiveClusterSelectionPolicy(gomock.Any(), gomock.Any()).Return(sampleActiveClusterSelectionPolicyData(), nil).AnyTimes()
+
+			mockedStore.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, req *InternalUpdateWorkflowExecutionRequest) error {
+					mut := req.UpdateWorkflowMutation
+					if tc.expectRewriteActivity {
+						assert.NotNil(t, mut.RewriteActivityInfos, "rewrite activity infos should be set")
+					} else {
+						assert.Nil(t, mut.RewriteActivityInfos, "rewrite activity infos should be nil")
+					}
+					if tc.expectRewriteTimer {
+						assert.NotNil(t, mut.RewriteTimerInfos, "rewrite timer infos should be set")
+					} else {
+						assert.Nil(t, mut.RewriteTimerInfos, "rewrite timer infos should be nil")
+					}
+					assert.Equal(t, tc.deleteActivityInfos, mut.DeleteActivityInfos, "deletes should always be preserved")
+					assert.Equal(t, tc.deleteTimerInfos, mut.DeleteTimerInfos, "deletes should always be preserved")
+					return nil
+				}).Times(1)
+
+			mutation := sampleWorkflowMutation()
+			mutation.RewriteActivityInfos = tc.rewriteActivityInfos
+			mutation.RewriteTimerInfos = tc.rewriteTimerInfos
+			mutation.DeleteActivityInfos = tc.deleteActivityInfos
+			mutation.DeleteTimerInfos = tc.deleteTimerInfos
+
+			_, err := manager.UpdateWorkflowExecution(context.Background(), &UpdateWorkflowExecutionRequest{
+				RangeID:                1,
+				Mode:                   UpdateWorkflowModeBypassCurrent,
+				UpdateWorkflowMutation: *mutation,
+				Encoding:               constants.EncodingTypeThriftRW,
+			})
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func FuzzRewriteSkippedForUnsupportedBackend(f *testing.F) {
+	f.Add("mysql")
+	f.Add("postgres")
+	f.Add("dynamodb")
+	f.Add("mongodb")
+	f.Add("Cassandra")
+	f.Add("CASSANDRA")
+	f.Add("cassandra ")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, storeName string) {
+		if storeName == "cassandra" {
+			t.Skip("cassandra is the supported backend")
+		}
+
+		ctrl := gomock.NewController(t)
+		mockedStore := NewMockExecutionStore(ctrl)
+		mockedSerializer := NewMockPayloadSerializer(ctrl)
+
+		mockedStore.EXPECT().GetName().Return(storeName).AnyTimes()
+		manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
+			SerializationEncoding:          dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+			ActivityMapRewriteSampleRate:   dynamicproperties.GetIntPropertyFn(1),
+			TimerMapRewriteSampleRate:      dynamicproperties.GetIntPropertyFn(1),
+			MapRewriteOptimizationBackends: dynamicproperties.GetListPropertyFn([]interface{}{"cassandra"}),
+		})
+
+		mockedSerializer.EXPECT().SerializeEvent(gomock.Any(), gomock.Any()).Return(sampleEventData(), nil).AnyTimes()
+		mockedSerializer.EXPECT().SerializeResetPoints(gomock.Any(), gomock.Any()).Return(sampleResetPointsData(), nil).AnyTimes()
+		mockedSerializer.EXPECT().SerializeChecksum(gomock.Any(), gomock.Any()).Return(sampleCheckSumData(), nil).AnyTimes()
+		mockedSerializer.EXPECT().SerializeActiveClusterSelectionPolicy(gomock.Any(), gomock.Any()).Return(sampleActiveClusterSelectionPolicyData(), nil).AnyTimes()
+
+		mockedStore.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, req *InternalUpdateWorkflowExecutionRequest) error {
+				mut := req.UpdateWorkflowMutation
+				assert.Nil(t, mut.RewriteActivityInfos, "unsupported backend %q must not trigger activity rewrite", storeName)
+				assert.Nil(t, mut.RewriteTimerInfos, "unsupported backend %q must not trigger timer rewrite", storeName)
+				assert.Equal(t, []int64{5}, mut.DeleteActivityInfos, "deletes must be preserved")
+				assert.Equal(t, []string{"t2"}, mut.DeleteTimerInfos, "deletes must be preserved")
+				return nil
+			}).Times(1)
+
+		mutation := sampleWorkflowMutation()
+		mutation.RewriteActivityInfos = []*ActivityInfo{
+			{Version: 1, ScheduleID: 10, ScheduledEvent: activityScheduledEvent(), StartedEvent: activityStartedEvent()},
+		}
+		mutation.RewriteTimerInfos = []*TimerInfo{{TimerID: "t1"}}
+		mutation.DeleteActivityInfos = []int64{5}
+		mutation.DeleteTimerInfos = []string{"t2"}
+
+		_, err := manager.UpdateWorkflowExecution(context.Background(), &UpdateWorkflowExecutionRequest{
+			RangeID:                1,
+			Mode:                   UpdateWorkflowModeBypassCurrent,
+			UpdateWorkflowMutation: *mutation,
+			Encoding:               constants.EncodingTypeThriftRW,
+		})
+		assert.NoError(t, err)
+	})
 }
 
 func TestSerializeWorkflowSnapshot(t *testing.T) {
@@ -552,6 +737,7 @@ func TestDeserializeBufferedEvents(t *testing.T) {
 func TestPutReplicationTaskToDLQ(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), NewDefaultDynamicConfiguration())
 
 	now := time.Now().UTC()
@@ -584,6 +770,7 @@ func TestPutReplicationTaskToDLQ(t *testing.T) {
 func TestGetReplicationTasksFromDLQ(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), NewDefaultDynamicConfiguration())
 
 	request := &GetReplicationTasksFromDLQRequest{
@@ -623,6 +810,7 @@ func TestGetReplicationTasksFromDLQ_WithBlob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetReplicationTasksFromDLQRequest{
@@ -668,6 +856,7 @@ func TestGetReplicationTasksFromDLQ_CorruptBlob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	request := &GetReplicationTasksFromDLQRequest{
@@ -950,6 +1139,7 @@ func TestListConcreteExecutions(t *testing.T) {
 
 			tc.prepareMocks(mockedStore, mockedSerializer)
 
+			mockedStore.EXPECT().GetName().Return("").AnyTimes()
 			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			res, err := manager.ListConcreteExecutions(context.Background(), request)
@@ -1065,6 +1255,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 				WorkflowRequestMode:      CreateWorkflowRequestModeReplicated,
 			}
 
+			mockedStore.EXPECT().GetName().Return("").AnyTimes()
 			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			res, err := manager.CreateWorkflowExecution(context.Background(), request)
@@ -1231,6 +1422,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 
 			tc.prepareMocks(mockedStore, mockedSerializer)
 
+			mockedStore.EXPECT().GetName().Return("").AnyTimes()
 			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			res, err := manager.ConflictResolveWorkflowExecution(context.Background(), tc.request)
@@ -1243,6 +1435,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 func TestCreateFailoverMarkerTasks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, NewDefaultDynamicConfiguration())
 
 	req := &CreateFailoverMarkersRequest{
@@ -1334,6 +1527,7 @@ func TestGetActiveClusterSelectionPolicy(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockedStore := NewMockExecutionStore(ctrl)
 			mockedSerializer := NewMockPayloadSerializer(ctrl)
+			mockedStore.EXPECT().GetName().Return("").AnyTimes()
 			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 			test.prepareMocks(mockedStore, mockedSerializer)
@@ -1385,6 +1579,7 @@ func TestDeleteActiveClusterSelectionPolicy(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockedStore := NewMockExecutionStore(ctrl)
+			mockedStore.EXPECT().GetName().Return("").AnyTimes()
 			manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, NewDefaultDynamicConfiguration())
 
 			test.prepareMocks(mockedStore)
@@ -1748,6 +1943,7 @@ func TestUpdateWorkflowExecution_TimerTaskTracking(t *testing.T) {
 	dc := NewDefaultDynamicConfiguration()
 	dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
 	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	mutation := sampleWorkflowMutation()
@@ -1810,6 +2006,7 @@ func TestCreateWorkflowExecution_TimerTaskTracking(t *testing.T) {
 	dc := NewDefaultDynamicConfiguration()
 	dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
 	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	snapshot := sampleWorkflowSnapshot()
@@ -1864,6 +2061,7 @@ func TestUpdateWorkflowExecution_TimerTaskTrackingFlagOff(t *testing.T) {
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
 	// EnableWorkflowTimerTaskCleanup is false by default
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	mutation := sampleWorkflowMutation()
@@ -1904,6 +2102,7 @@ func TestCreateWorkflowExecution_TimerTaskTrackingFlagOff(t *testing.T) {
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
 	// EnableWorkflowTimerTaskCleanup is false by default
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	snapshot := sampleWorkflowSnapshot()
@@ -1953,6 +2152,7 @@ func TestConflictResolveWorkflowExecution_TimerTaskTracking(t *testing.T) {
 	dc := NewDefaultDynamicConfiguration()
 	dc.EnableWorkflowTimerTaskCleanup = dynamicproperties.GetBoolPropertyFn(true)
 	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	makeTimerTask := func(taskID int64) Task {
@@ -2025,6 +2225,7 @@ func TestConflictResolveWorkflowExecution_TimerTaskTrackingFlagOff(t *testing.T)
 	mockedStore := NewMockExecutionStore(ctrl)
 	mockedSerializer := NewMockPayloadSerializer(ctrl)
 
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	makeTimerTask := func(taskID int64) Task {
@@ -2075,6 +2276,7 @@ func TestFetchWorkflowTimerTasksForCleanup_FiltersCorrectly(t *testing.T) {
 
 	dc := NewDefaultDynamicConfiguration()
 	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(minTTL)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	shardID := 0
@@ -2108,6 +2310,7 @@ func TestFetchWorkflowTimerTasksForCleanup_EmptyMap(t *testing.T) {
 
 	dc := NewDefaultDynamicConfiguration()
 	dc.WorkflowTimerTaskCleanupMinTTL = dynamicproperties.GetDurationPropertyFn(time.Hour)
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, dc)
 
 	shardID := 0
@@ -2136,6 +2339,7 @@ func TestCompleteHistoryTasks(t *testing.T) {
 	taskID := int64(1)
 	visTS := time.Now().Add(48 * time.Hour)
 
+	mockedStore.EXPECT().GetName().Return("").AnyTimes()
 	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, NewDefaultDynamicConfiguration())
 
 	shardID := 0

--- a/common/persistence/nosql/nosql_execution_store_util.go
+++ b/common/persistence/nosql/nosql_execution_store_util.go
@@ -197,6 +197,20 @@ func (d *nosqlExecutionStore) prepareUpdateWorkflowExecutionRequestWithMapsAndEv
 	// delete from maps
 	executionRequest.ActivityInfoKeysToDelete = workflowMutation.DeleteActivityInfos
 	executionRequest.TimerInfoKeysToDelete = workflowMutation.DeleteTimerInfos
+	if workflowMutation.RewriteActivityInfos != nil {
+		executionRequest.RewriteActivityInfos, err = d.prepareActivityInfosForWorkflowTxn(workflowMutation.RewriteActivityInfos)
+		if err != nil {
+			return nil, err
+		}
+	}
+	executionRequest.ActivitySentinelWriteEnabled = workflowMutation.ActivitySentinelWriteEnabled
+	if workflowMutation.RewriteTimerInfos != nil {
+		executionRequest.RewriteTimerInfos, err = d.prepareTimerInfosForWorkflowTxn(workflowMutation.RewriteTimerInfos)
+		if err != nil {
+			return nil, err
+		}
+	}
+	executionRequest.TimerSentinelWriteEnabled = workflowMutation.TimerSentinelWriteEnabled
 	executionRequest.ChildWorkflowInfoKeysToDelete = workflowMutation.DeleteChildExecutionInfos
 	executionRequest.RequestCancelInfoKeysToDelete = workflowMutation.DeleteRequestCancelInfos
 	executionRequest.SignalInfoKeysToDelete = workflowMutation.DeleteSignalInfos

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -167,7 +167,7 @@ func (db *CDB) UpdateWorkflowExecutionWithTasks(
 	}
 
 	if mutatedExecution != nil {
-		err = updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, shardID, domainID, workflowID, mutatedExecution, timeStamp)
+		err = updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, shardID, domainID, workflowID, mutatedExecution, mutatedExecution.ActivitySentinelWriteEnabled, mutatedExecution.TimerSentinelWriteEnabled, timeStamp)
 		if err != nil {
 			return err
 		}

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -34,6 +34,12 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+// Sentinel values written as tombstone-free placeholders when map entries are deleted.
+const (
+	activitySentinelScheduleID int64 = -1
+	timerSentinelTimerID             = ""
+)
+
 var _ nosqlplugin.WorkflowCRUD = (*CDB)(nil)
 
 // keep batch under Cassandra's default 50KB fail threshold.
@@ -225,6 +231,9 @@ func (db *CDB) SelectWorkflowExecution(ctx context.Context, shardID int, domainI
 	aMap := result["activity_map"].(map[int64]map[string]interface{})
 	for key, value := range aMap {
 		info := parseActivityInfo(domainID, value)
+		if info.ScheduleID == activitySentinelScheduleID {
+			continue
+		}
 		activityInfos[key] = info
 	}
 	state.ActivityInfos = activityInfos
@@ -233,6 +242,9 @@ func (db *CDB) SelectWorkflowExecution(ctx context.Context, shardID int, domainI
 	tMap := result["timer_map"].(map[string]map[string]interface{})
 	for key, value := range tMap {
 		info := parseTimerInfo(value)
+		if info.TimerID == timerSentinelTimerID {
+			continue
+		}
 		timerInfos[key] = info
 	}
 	state.TimerInfos = timerInfos

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
@@ -385,6 +385,17 @@ const (
 		`and visibility_ts = ? ` +
 		`and task_id = ? `
 
+	templateSentinelActivityInfoQuery = `UPDATE executions ` +
+		`SET activity_map[ ? ] = {schedule_id: ?} ` +
+		`, last_updated_time = ? ` +
+		`WHERE shard_id = ? ` +
+		`and type = ? ` +
+		`and domain_id = ? ` +
+		`and workflow_id = ? ` +
+		`and run_id = ? ` +
+		`and visibility_ts = ? ` +
+		`and task_id = ? `
+
 	templateResetActivityInfoQuery = `UPDATE executions ` +
 		`SET activity_map = ? ` +
 		`, last_updated_time = ? ` +
@@ -398,6 +409,17 @@ const (
 
 	templateUpdateTimerInfoQuery = `UPDATE executions ` +
 		`SET timer_map[ ? ] = ` + templateTimerInfoType + ` ` +
+		`, last_updated_time = ? ` +
+		`WHERE shard_id = ? ` +
+		`and type = ? ` +
+		`and domain_id = ? ` +
+		`and workflow_id = ? ` +
+		`and run_id = ? ` +
+		`and visibility_ts = ? ` +
+		`and task_id = ? `
+
+	templateSentinelTimerInfoQuery = `UPDATE executions ` +
+		`SET timer_map[ ? ] = {timer_id: ?} ` +
 		`, last_updated_time = ? ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
@@ -24,6 +24,7 @@ package cassandra
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -510,6 +511,104 @@ func TestUpdateWorkflowExecutionWithTasks(t *testing.T) {
 	}
 }
 
+func TestUpdateWorkflowExecutionWithTasks_SentinelBehavior(t *testing.T) {
+	tests := []struct {
+		name              string
+		sentinelEnabled   bool
+		activityDeletes   []int64
+		timerDeletes      []string
+		wantSentinelQuery string
+		wantDeleteQuery   string
+	}{
+		{
+			name:              "sentinel enabled - activity delete writes sentinel instead of deleting",
+			sentinelEnabled:   true,
+			activityDeletes:   []int64{10},
+			wantSentinelQuery: "SET activity_map",
+		},
+		{
+			name:            "sentinel disabled - activity delete uses regular delete",
+			sentinelEnabled: false,
+			activityDeletes: []int64{10},
+			wantDeleteQuery: "DELETE activity_map",
+		},
+		{
+			name:              "sentinel enabled - timer delete writes sentinel instead of deleting",
+			sentinelEnabled:   true,
+			timerDeletes:      []string{"timer-1"},
+			wantSentinelQuery: "SET timer_map",
+		},
+		{
+			name:            "sentinel disabled - timer delete uses regular delete",
+			sentinelEnabled: false,
+			timerDeletes:    []string{"timer-1"},
+			wantDeleteQuery: "DELETE timer_map",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			session := &fakeSession{
+				iter:                      &fakeIter{},
+				mapExecuteBatchCASApplied: true,
+			}
+			client := gocql.NewMockClient(ctrl)
+			cfg := &config.NoSQL{}
+			logger := testlogger.New(t)
+			db := NewCassandraDBFromSession(cfg, session, logger, nil, DbWithClient(client))
+
+			mutatedExecution := testdata.WFExecRequest(
+				testdata.WFExecRequestWithMapsWriteMode(nosqlplugin.WorkflowExecutionMapsWriteModeUpdate),
+			)
+			mutatedExecution.ActivityInfoKeysToDelete = tc.activityDeletes
+			mutatedExecution.TimerInfoKeysToDelete = tc.timerDeletes
+			mutatedExecution.ActivitySentinelWriteEnabled = tc.sentinelEnabled
+			mutatedExecution.TimerSentinelWriteEnabled = tc.sentinelEnabled
+
+			err := db.UpdateWorkflowExecutionWithTasks(
+				context.Background(),
+				nil,
+				&nosqlplugin.CurrentWorkflowWriteRequest{
+					WriteMode: nosqlplugin.CurrentWorkflowWriteModeNoop,
+				},
+				mutatedExecution,
+				nil,
+				nil,
+				nil,
+				nil,
+				&nosqlplugin.ShardCondition{ShardID: 1},
+			)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(session.batches) == 0 {
+				t.Fatal("expected at least one batch")
+			}
+
+			allQueries := strings.Join(session.batches[0].queries, "\n")
+
+			if tc.wantSentinelQuery != "" {
+				if !strings.Contains(allQueries, tc.wantSentinelQuery) {
+					t.Errorf("expected batch to contain sentinel query with %q, got:\n%s", tc.wantSentinelQuery, allQueries)
+				}
+			}
+			if tc.wantDeleteQuery != "" {
+				if !strings.Contains(allQueries, tc.wantDeleteQuery) {
+					t.Errorf("expected batch to contain delete query with %q, got:\n%s", tc.wantDeleteQuery, allQueries)
+				}
+			}
+			if tc.wantSentinelQuery != "" && tc.wantDeleteQuery == "" {
+				if strings.Contains(allQueries, "DELETE activity_map") || strings.Contains(allQueries, "DELETE timer_map") {
+					t.Errorf("sentinel enabled but found DELETE map query in batch:\n%s", allQueries)
+				}
+			}
+		})
+	}
+}
+
 func TestSelectWorkflowExecution(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -599,7 +698,7 @@ func TestSelectWorkflowExecution(t *testing.T) {
 			},
 		},
 		{
-			name:       "sentinel activity and timer entries are filtered on read",
+			name:       "sentinel activity and timer entries are discarded on read",
 			shardID:    1,
 			domainID:   "test-domain-id",
 			workflowID: "test-workflow-id",

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_test.go
@@ -552,7 +552,7 @@ func TestSelectWorkflowExecution(t *testing.T) {
 						1: {"schedule_id": int64(1)},
 					}
 					m["timer_map"] = map[string]map[string]interface{}{
-						"t1": {"started_id": int64(5)},
+						"t1": {"timer_id": "t1", "started_id": int64(5)},
 					}
 					m["child_executions_map"] = map[int64]map[string]interface{}{
 						3: {"initiated_id": int64(2)},
@@ -579,7 +579,7 @@ func TestSelectWorkflowExecution(t *testing.T) {
 					1: {ScheduleID: 1, DomainID: "test-domain-id"},
 				},
 				TimerInfos: map[string]*persistence.TimerInfo{
-					"t1": {StartedID: 5},
+					"t1": {TimerID: "t1", StartedID: 5},
 				},
 				ChildExecutionInfos: map[int64]*persistence.InternalChildExecutionInfo{
 					3: {InitiatedID: 2},
@@ -596,6 +596,54 @@ func TestSelectWorkflowExecution(t *testing.T) {
 				BufferedEvents: []*persistence.DataBlob{
 					{Encoding: constants.EncodingTypeThriftRW, Data: []byte("test-buffered-events-1")},
 				},
+			},
+		},
+		{
+			name:       "sentinel activity and timer entries are filtered on read",
+			shardID:    1,
+			domainID:   "test-domain-id",
+			workflowID: "test-workflow-id",
+			runID:      "test-run-id",
+			queryMockFn: func(query *gocql.MockQuery) {
+				query.EXPECT().WithContext(gomock.Any()).Return(query).Times(1)
+				query.EXPECT().MapScan(gomock.Any()).DoAndReturn(func(m map[string]interface{}) error {
+					m["execution"] = map[string]interface{}{}
+					m["version_histories"] = []byte{}
+					m["version_histories_encoding"] = "thriftrw"
+					m["replication_state"] = map[string]interface{}{}
+					m["activity_map"] = map[int64]map[string]interface{}{
+						1:  {"schedule_id": int64(1)},
+						10: {"schedule_id": activitySentinelScheduleID},
+						20: {"schedule_id": activitySentinelScheduleID},
+					}
+					m["timer_map"] = map[string]map[string]interface{}{
+						"t1": {"timer_id": "t1", "started_id": int64(5)},
+						"0":  {"timer_id": ""},
+						"1":  {"timer_id": ""},
+						"2":  {"timer_id": ""},
+					}
+					m["child_executions_map"] = map[int64]map[string]interface{}{}
+					m["request_cancel_map"] = map[int64]map[string]interface{}{}
+					m["signal_map"] = map[int64]map[string]interface{}{}
+					m["signal_requested"] = []interface{}{}
+					m["buffered_events_list"] = []map[string]interface{}{}
+					m["checksum"] = map[string]interface{}{}
+					return nil
+				}).Times(1)
+			},
+			wantResp: &nosqlplugin.WorkflowExecution{
+				ExecutionInfo: &persistence.InternalWorkflowExecutionInfo{},
+				ActivityInfos: map[int64]*persistence.InternalActivityInfo{
+					1: {ScheduleID: 1, DomainID: "test-domain-id"},
+				},
+				TimerInfos: map[string]*persistence.TimerInfo{
+					"t1": {TimerID: "t1", StartedID: 5},
+				},
+				ChildExecutionInfos: map[int64]*persistence.InternalChildExecutionInfo{},
+				RequestCancelInfos:  map[int64]*persistence.RequestCancelInfo{},
+				SignalInfos:         map[int64]*persistence.SignalInfo{},
+				SignalRequestedIDs:  map[string]struct{}{},
+				BufferedEvents:      []*persistence.DataBlob{},
 			},
 		},
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils.go
@@ -964,8 +964,14 @@ func updateTimerInfos(
 	runID string,
 	timerInfos map[string]*persistence.TimerInfo,
 	deleteInfos []string,
+	rewriteInfos map[string]*persistence.TimerInfo,
+	sentinelWriteEnabled bool,
 	timeStamp time.Time,
 ) error {
+	if rewriteInfos != nil {
+		return resetTimerInfos(batch, shardID, domainID, workflowID, runID, rewriteInfos, timeStamp)
+	}
+
 	for _, timerInfo := range timerInfos {
 		batch.Query(templateUpdateTimerInfoQuery,
 			timerInfo.TimerID,
@@ -984,18 +990,48 @@ func updateTimerInfos(
 			rowTypeExecutionTaskID)
 	}
 
+	if len(deleteInfos) == 0 {
+		return nil
+	}
+
 	for _, deleteInfo := range deleteInfos {
-		batch.Query(templateDeleteTimerInfoQuery,
-			deleteInfo,
-			shardID,
-			rowTypeExecution,
-			domainID,
-			workflowID,
-			runID,
-			defaultVisibilityTimestamp,
-			rowTypeExecutionTaskID)
+		if sentinelWriteEnabled {
+			writeTimerInfoSentinel(batch, deleteInfo, shardID, domainID, workflowID, runID, timeStamp)
+		} else {
+			batch.Query(templateDeleteTimerInfoQuery,
+				deleteInfo,
+				shardID,
+				rowTypeExecution,
+				domainID,
+				workflowID,
+				runID,
+				defaultVisibilityTimestamp,
+				rowTypeExecutionTaskID)
+		}
 	}
 	return nil
+}
+
+func writeTimerInfoSentinel(
+	batch gocql.Batch,
+	timerID string,
+	shardID int,
+	domainID string,
+	workflowID string,
+	runID string,
+	timeStamp time.Time,
+) {
+	batch.Query(templateSentinelTimerInfoQuery,
+		timerID,
+		timerSentinelTimerID,
+		timeStamp,
+		shardID,
+		rowTypeExecution,
+		domainID,
+		workflowID,
+		runID,
+		defaultVisibilityTimestamp,
+		rowTypeExecutionTaskID)
 }
 
 // workflowTimerTaskTuple is the Cassandra tuple<timestamp, bigint> representation
@@ -1118,8 +1154,14 @@ func updateActivityInfos(
 	runID string,
 	activityInfos map[int64]*persistence.InternalActivityInfo,
 	deleteInfos []int64,
+	rewriteInfos map[int64]*persistence.InternalActivityInfo,
+	sentinelWriteEnabled bool,
 	timeStamp time.Time,
 ) error {
+	if rewriteInfos != nil {
+		return resetActivityInfos(batch, shardID, domainID, workflowID, runID, rewriteInfos, timeStamp)
+	}
+
 	for _, a := range activityInfos {
 		batch.Query(templateUpdateActivityInfoQuery,
 			a.ScheduleID,
@@ -1169,18 +1211,48 @@ func updateActivityInfos(
 			rowTypeExecutionTaskID)
 	}
 
+	if len(deleteInfos) == 0 {
+		return nil
+	}
+
 	for _, deleteInfo := range deleteInfos {
-		batch.Query(templateDeleteActivityInfoQuery,
-			deleteInfo,
-			shardID,
-			rowTypeExecution,
-			domainID,
-			workflowID,
-			runID,
-			defaultVisibilityTimestamp,
-			rowTypeExecutionTaskID)
+		if sentinelWriteEnabled {
+			writeActivityInfoSentinel(batch, deleteInfo, shardID, domainID, workflowID, runID, timeStamp)
+		} else {
+			batch.Query(templateDeleteActivityInfoQuery,
+				deleteInfo,
+				shardID,
+				rowTypeExecution,
+				domainID,
+				workflowID,
+				runID,
+				defaultVisibilityTimestamp,
+				rowTypeExecutionTaskID)
+		}
 	}
 	return nil
+}
+
+func writeActivityInfoSentinel(
+	batch gocql.Batch,
+	scheduleEventID int64,
+	shardID int,
+	domainID string,
+	workflowID string,
+	runID string,
+	timeStamp time.Time,
+) {
+	batch.Query(templateSentinelActivityInfoQuery,
+		scheduleEventID,
+		activitySentinelScheduleID,
+		timeStamp,
+		shardID,
+		rowTypeExecution,
+		domainID,
+		workflowID,
+		runID,
+		defaultVisibilityTimestamp,
+		rowTypeExecutionTaskID)
 }
 
 // NOTE: not sure we still need it. We keep the behavior for safe during refactoring
@@ -1218,11 +1290,11 @@ func createWorkflowExecutionWithMergeMaps(
 		return fmt.Errorf("should only support WorkflowExecutionMapsWriteModeCreate")
 	}
 
-	err = updateActivityInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.ActivityInfos, nil, timeStamp)
+	err = updateActivityInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.ActivityInfos, nil, nil, false, timeStamp)
 	if err != nil {
 		return err
 	}
-	err = updateTimerInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.TimerInfos, nil, timeStamp)
+	err = updateTimerInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.TimerInfos, nil, nil, false, timeStamp)
 	if err != nil {
 		return err
 	}
@@ -1346,6 +1418,8 @@ func updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(
 	domainID string,
 	workflowID string,
 	execution *nosqlplugin.WorkflowExecutionRequest,
+	activitySentinelWriteEnabled bool,
+	timerSentinelWriteEnabled bool,
 	timeStamp time.Time,
 ) error {
 	err := updateWorkflowExecution(batch, shardID, domainID, workflowID, execution, timeStamp)
@@ -1371,11 +1445,11 @@ func updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(
 
 	// In certain cases, some of the execution update cycles update particular columns asynchronously before reaching the final cycle.
 	// Each of these functions are updating a non-frozen column type in Cassandra table.
-	err = updateActivityInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.ActivityInfos, execution.ActivityInfoKeysToDelete, timeStamp)
+	err = updateActivityInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.ActivityInfos, execution.ActivityInfoKeysToDelete, execution.RewriteActivityInfos, activitySentinelWriteEnabled, timeStamp)
 	if err != nil {
 		return err
 	}
-	err = updateTimerInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.TimerInfos, execution.TimerInfoKeysToDelete, timeStamp)
+	err = updateTimerInfos(batch, shardID, domainID, workflowID, execution.RunID, execution.TimerInfos, execution.TimerInfoKeysToDelete, execution.RewriteTimerInfos, timerSentinelWriteEnabled, timeStamp)
 	if err != nil {
 		return err
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
@@ -1879,18 +1879,20 @@ func TestUpdateTimerInfos(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc        string
-		shardID     int
-		domainID    string
-		workflowID  string
-		runID       string
-		timerInfos  map[string]*persistence.TimerInfo
-		deleteInfos []string
+		desc                 string
+		shardID              int
+		domainID             string
+		workflowID           string
+		runID                string
+		timerInfos           map[string]*persistence.TimerInfo
+		deleteInfos          []string
+		rewriteInfos         map[string]*persistence.TimerInfo
+		sentinelWriteEnabled bool
 		// expectations
 		wantQueries []string
 	}{
 		{
-			desc:       "update and delete timer infos",
+			desc:       "update and delete timer infos with sentinel",
 			shardID:    1000,
 			domainID:   "domain1",
 			workflowID: "workflow1",
@@ -1904,7 +1906,37 @@ func TestUpdateTimerInfos(t *testing.T) {
 					TaskStatus: 1,
 				},
 			},
-			deleteInfos: []string{"timer2"},
+			deleteInfos:          []string{"timer2"},
+			sentinelWriteEnabled: true,
+			wantQueries: []string{
+				`UPDATE executions SET timer_map[ timer1 ] = {` +
+					`version: 1, timer_id: timer1, started_id: 2, expiry_time: 2023-12-19T22:08:41Z, task_id: 1` +
+					`} , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
+					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
+					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
+				`UPDATE executions SET timer_map[ timer2 ] = {timer_id: } ` +
+					`, last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
+					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
+					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
+			},
+		},
+		{
+			desc:       "update and delete timer infos without sentinel",
+			shardID:    1000,
+			domainID:   "domain1",
+			workflowID: "workflow1",
+			runID:      "runid1",
+			timerInfos: map[string]*persistence.TimerInfo{
+				"timer1": {
+					TimerID:    "timer1",
+					Version:    1,
+					StartedID:  2,
+					ExpiryTime: ts.UTC(),
+					TaskStatus: 1,
+				},
+			},
+			deleteInfos:          []string{"timer2"},
+			sentinelWriteEnabled: false,
 			wantQueries: []string{
 				`UPDATE executions SET timer_map[ timer1 ] = {` +
 					`version: 1, timer_id: timer1, started_id: 2, expiry_time: 2023-12-19T22:08:41Z, task_id: 1` +
@@ -1916,13 +1948,46 @@ func TestUpdateTimerInfos(t *testing.T) {
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
 		},
+		{
+			desc:       "rewrite replaces full map skipping upserts and deletes",
+			shardID:    1000,
+			domainID:   "domain1",
+			workflowID: "workflow1",
+			runID:      "runid1",
+			timerInfos: map[string]*persistence.TimerInfo{
+				"timer1": {
+					TimerID:    "timer1",
+					Version:    1,
+					StartedID:  2,
+					ExpiryTime: ts.UTC(),
+					TaskStatus: 1,
+				},
+			},
+			rewriteInfos: map[string]*persistence.TimerInfo{
+				"timer1": {
+					TimerID:    "timer1",
+					Version:    1,
+					StartedID:  2,
+					ExpiryTime: ts.UTC(),
+					TaskStatus: 1,
+				},
+			},
+			sentinelWriteEnabled: true,
+			wantQueries: []string{
+				`UPDATE executions SET timer_map = map[` +
+					`timer1:map[expiry_time:2023-12-19 22:08:41 +0000 UTC started_id:2 task_id:1 timer_id:timer1 version:1]` +
+					`] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
+					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
+					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateTimerInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.timerInfos, tc.deleteInfos, FixedTime)
+			err := updateTimerInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.timerInfos, tc.deleteInfos, tc.rewriteInfos, tc.sentinelWriteEnabled, FixedTime)
 			if err != nil {
 				t.Fatalf("updateTimerInfos() error = %v", err)
 			}
@@ -2060,18 +2125,20 @@ func TestUpdateActivityInfos(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc          string
-		shardID       int
-		domainID      string
-		workflowID    string
-		runID         string
-		activityInfos map[int64]*persistence.InternalActivityInfo
-		deleteInfos   []int64
+		desc                 string
+		shardID              int
+		domainID             string
+		workflowID           string
+		runID                string
+		activityInfos        map[int64]*persistence.InternalActivityInfo
+		deleteInfos          []int64
+		rewriteInfos         map[int64]*persistence.InternalActivityInfo
+		sentinelWriteEnabled bool
 		// expectations
 		wantQueries []string
 	}{
 		{
-			desc:       "update and delete activity infos",
+			desc:       "update and delete activity infos with sentinel",
 			shardID:    1000,
 			domainID:   "domain1",
 			workflowID: "workflow1",
@@ -2103,7 +2170,8 @@ func TestUpdateActivityInfos(t *testing.T) {
 					LastFailureReason:      "retry reason",
 				},
 			},
-			deleteInfos: []int64{2},
+			deleteInfos:          []int64{2},
+			sentinelWriteEnabled: true,
 			wantQueries: []string{
 				`UPDATE executions SET activity_map[ 1 ] = {` +
 					`version: 1, schedule_id: 1, scheduled_event_batch_id: 0, ` +
@@ -2120,8 +2188,142 @@ func TestUpdateActivityInfos(t *testing.T) {
 					`} , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
 					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
-				`DELETE activity_map[ 2 ] FROM executions ` +
-					`WHERE shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
+				`UPDATE executions SET activity_map[ 2 ] = {schedule_id: -1} ` +
+					`, last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
+					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
+					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
+			},
+		},
+		{
+			desc:       "update and delete activity infos without sentinel",
+			shardID:    1000,
+			domainID:   "domain1",
+			workflowID: "workflow1",
+			runID:      "runid1",
+			activityInfos: map[int64]*persistence.InternalActivityInfo{
+				1: {
+					Version: 1,
+					ScheduledEvent: &persistence.DataBlob{
+						Encoding: constants.EncodingTypeThriftRW,
+						Data:     []byte("thrift-encoded-scheduled-event-data"),
+					},
+					ScheduledTime: ts.UTC(),
+					ScheduleID:    1,
+					StartedID:     2,
+					StartedEvent: &persistence.DataBlob{
+						Encoding: constants.EncodingTypeThriftRW,
+						Data:     []byte("thrift-encoded-started-event-data"),
+					},
+					ActivityID:             "activity1",
+					ScheduleToStartTimeout: 1 * time.Minute,
+					ScheduleToCloseTimeout: 2 * time.Minute,
+					StartToCloseTimeout:    3 * time.Minute,
+					HeartbeatTimeout:       1 * time.Minute,
+					Attempt:                3,
+					MaximumAttempts:        5,
+					TaskList:               "tasklist1",
+					TaskListKind:           types.TaskListKindEphemeral,
+					HasRetryPolicy:         true,
+					LastFailureReason:      "retry reason",
+				},
+			},
+			deleteInfos:          []int64{2},
+			sentinelWriteEnabled: false,
+			wantQueries: []string{
+				`UPDATE executions SET activity_map[ 1 ] = {` +
+					`version: 1, schedule_id: 1, scheduled_event_batch_id: 0, ` +
+					`scheduled_event: [116 104 114 105 102 116 45 101 110 99 111 100 101 100 45 115 99 104 101 100 117 108 101 100 45 101 118 101 110 116 45 100 97 116 97], ` +
+					`scheduled_time: 2023-12-19T22:08:41Z, started_id: 2, ` +
+					`started_event: [116 104 114 105 102 116 45 101 110 99 111 100 101 100 45 115 116 97 114 116 101 100 45 101 118 101 110 116 45 100 97 116 97], ` +
+					`started_time: 0001-01-01T00:00:00Z, activity_id: activity1, request_id: , ` +
+					`details: [], schedule_to_start_timeout: 60, schedule_to_close_timeout: 120, start_to_close_timeout: 180, ` +
+					`heart_beat_timeout: 60, cancel_requested: false, cancel_request_id: 0, last_hb_updated_time: 0001-01-01T00:00:00Z, ` +
+					`timer_task_status: 0, attempt: 3, task_list: tasklist1, task_list_kind: 2, started_identity: , has_retry_policy: true, ` +
+					`init_interval: 0, backoff_coefficient: 0, max_interval: 0, expiration_time: 0001-01-01T00:00:00Z, ` +
+					`max_attempts: 5, non_retriable_errors: [], last_failure_reason: retry reason, last_worker_identity: , ` +
+					`last_failure_details: [], last_failure_category: 0, last_retry_interval_seconds: 0, event_data_encoding: thriftrw` +
+					`} , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
+					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
+					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
+				`DELETE activity_map[ 2 ] FROM executions WHERE ` +
+					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
+					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
+			},
+		},
+		{
+			desc:       "rewrite replaces full map skipping upserts and deletes",
+			shardID:    1000,
+			domainID:   "domain1",
+			workflowID: "workflow1",
+			runID:      "runid1",
+			activityInfos: map[int64]*persistence.InternalActivityInfo{
+				1: {
+					Version: 1,
+					ScheduledEvent: &persistence.DataBlob{
+						Encoding: constants.EncodingTypeThriftRW,
+						Data:     []byte("thrift-encoded-scheduled-event-data"),
+					},
+					ScheduledTime: ts.UTC(),
+					ScheduleID:    1,
+					StartedID:     2,
+					StartedEvent: &persistence.DataBlob{
+						Encoding: constants.EncodingTypeThriftRW,
+						Data:     []byte("thrift-encoded-started-event-data"),
+					},
+					ActivityID:             "activity1",
+					ScheduleToStartTimeout: 1 * time.Minute,
+					ScheduleToCloseTimeout: 2 * time.Minute,
+					StartToCloseTimeout:    3 * time.Minute,
+					HeartbeatTimeout:       1 * time.Minute,
+					Attempt:                3,
+					MaximumAttempts:        5,
+					TaskList:               "tasklist1",
+					HasRetryPolicy:         true,
+					LastFailureReason:      "retry reason",
+				},
+			},
+			rewriteInfos: map[int64]*persistence.InternalActivityInfo{
+				1: {
+					Version: 1,
+					ScheduledEvent: &persistence.DataBlob{
+						Encoding: constants.EncodingTypeThriftRW,
+						Data:     []byte("thrift-encoded-scheduled-event-data"),
+					},
+					ScheduledTime: ts.UTC(),
+					ScheduleID:    1,
+					StartedID:     2,
+					StartedEvent: &persistence.DataBlob{
+						Encoding: constants.EncodingTypeThriftRW,
+						Data:     []byte("thrift-encoded-started-event-data"),
+					},
+					ActivityID:             "activity1",
+					ScheduleToStartTimeout: 1 * time.Minute,
+					ScheduleToCloseTimeout: 2 * time.Minute,
+					StartToCloseTimeout:    3 * time.Minute,
+					HeartbeatTimeout:       1 * time.Minute,
+					Attempt:                3,
+					MaximumAttempts:        5,
+					TaskList:               "tasklist1",
+					HasRetryPolicy:         true,
+					LastFailureReason:      "retry reason",
+				},
+			},
+			sentinelWriteEnabled: true,
+			wantQueries: []string{
+				`UPDATE executions SET activity_map = map[` +
+					`1:map[` +
+					`activity_id:activity1 attempt:3 backoff_coefficient:0 cancel_request_id:0 cancel_requested:false ` +
+					`details:[] event_data_encoding:thriftrw expiration_time:0001-01-01 00:00:00 +0000 UTC has_retry_policy:true ` +
+					`heart_beat_timeout:60 init_interval:0 last_failure_category:0 last_failure_details:[] last_failure_reason:retry reason ` +
+					`last_hb_updated_time:0001-01-01 00:00:00 +0000 UTC last_retry_interval_seconds:0 last_worker_identity: max_attempts:5 max_interval:0 ` +
+					`non_retriable_errors:[] request_id: schedule_id:1 schedule_to_close_timeout:120 schedule_to_start_timeout:60 ` +
+					`scheduled_event:[116 104 114 105 102 116 45 101 110 99 111 100 101 100 45 115 99 104 101 100 117 108 101 100 45 101 118 101 110 116 45 100 97 116 97] ` +
+					`scheduled_event_batch_id:0 scheduled_time:2023-12-19 22:08:41 +0000 UTC start_to_close_timeout:180 ` +
+					`started_event:[116 104 114 105 102 116 45 101 110 99 111 100 101 100 45 115 116 97 114 116 101 100 45 101 118 101 110 116 45 100 97 116 97] ` +
+					`started_id:2 started_identity: started_time:0001-01-01 00:00:00 +0000 UTC task_list:tasklist1 timer_task_status:0 version:1` +
+					`]` +
+					`] , last_updated_time = 2025-01-06T15:00:00Z WHERE ` +
+					`shard_id = 1000 and type = 1 and domain_id = domain1 and workflow_id = workflow1 and ` +
 					`run_id = runid1 and visibility_ts = 946684800000 and task_id = -10 `,
 			},
 		},
@@ -2131,7 +2333,7 @@ func TestUpdateActivityInfos(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateActivityInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.activityInfos, tc.deleteInfos, FixedTime)
+			err := updateActivityInfos(batch, tc.shardID, tc.domainID, tc.workflowID, tc.runID, tc.activityInfos, tc.deleteInfos, tc.rewriteInfos, tc.sentinelWriteEnabled, FixedTime)
 			if err != nil {
 				t.Fatalf("updateActivityInfos() error = %v", err)
 			}
@@ -2291,6 +2493,58 @@ func TestCreateWorkflowExecutionWithMergeMaps(t *testing.T) {
 			// - 1 for signal info
 			// - 1 for signal requested IDs
 			wantQueries: 7,
+		},
+		{
+			desc:       "sentinel flags have no effect on create (no deletes)",
+			shardID:    1000,
+			domainID:   "domain1",
+			workflowID: "workflow1",
+			execution: &nosqlplugin.WorkflowExecutionRequest{
+				EventBufferWriteMode: nosqlplugin.EventBufferWriteModeNone,
+				MapsWriteMode:        nosqlplugin.WorkflowExecutionMapsWriteModeCreate,
+				InternalWorkflowExecutionInfo: persistence.InternalWorkflowExecutionInfo{
+					CompletionEvent: &persistence.DataBlob{},
+					AutoResetPoints: &persistence.DataBlob{},
+				},
+				VersionHistories: &persistence.DataBlob{},
+				Checksums:        &checksum.Checksum{},
+				ActivityInfos: map[int64]*persistence.InternalActivityInfo{
+					1: {
+						Version: 1,
+						ScheduledEvent: &persistence.DataBlob{
+							Encoding: constants.EncodingTypeThriftRW,
+							Data:     []byte("thrift-encoded-scheduled-event-data"),
+						},
+						ScheduledTime: ts.UTC(),
+						ScheduleID:    1,
+						StartedID:     2,
+						StartedEvent: &persistence.DataBlob{
+							Encoding: constants.EncodingTypeThriftRW,
+							Data:     []byte("thrift-encoded-started-event-data"),
+						},
+						ActivityID:             "activity1",
+						ScheduleToStartTimeout: 1 * time.Minute,
+						ScheduleToCloseTimeout: 2 * time.Minute,
+						StartToCloseTimeout:    3 * time.Minute,
+						HeartbeatTimeout:       1 * time.Minute,
+						Attempt:                3,
+						MaximumAttempts:        5,
+						TaskList:               "tasklist1",
+						HasRetryPolicy:         true,
+						LastFailureReason:      "retry reason",
+					},
+				},
+				TimerInfos: map[string]*persistence.TimerInfo{
+					"timer1": {
+						Version:    1,
+						TimerID:    "timer1",
+						StartedID:  2,
+						ExpiryTime: ts,
+						TaskStatus: 1,
+					},
+				},
+			},
+			wantQueries: 3,
 		},
 	}
 
@@ -2541,13 +2795,37 @@ func TestUpdateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(t *testing.
 			// - 1 for signal requested IDs update
 			wantQueries: 8,
 		},
+		{
+			desc:       "ok with sentinel deletes",
+			shardID:    1000,
+			domainID:   "domain1",
+			workflowID: "workflow1",
+			execution: &nosqlplugin.WorkflowExecutionRequest{
+				EventBufferWriteMode: nosqlplugin.EventBufferWriteModeClear,
+				MapsWriteMode:        nosqlplugin.WorkflowExecutionMapsWriteModeUpdate,
+				InternalWorkflowExecutionInfo: persistence.InternalWorkflowExecutionInfo{
+					CompletionEvent: &persistence.DataBlob{},
+					AutoResetPoints: &persistence.DataBlob{},
+				},
+				VersionHistories:         &persistence.DataBlob{},
+				Checksums:                &checksum.Checksum{},
+				ActivityInfoKeysToDelete: []int64{10, 20},
+				TimerInfoKeysToDelete:    []string{"t1", "t2"},
+			},
+			// expecting 6 queries:
+			// - 1 for execution record
+			// - 1 for deletion of buffered events
+			// - 2 for activity sentinel writes (one per deleted activity)
+			// - 2 for timer sentinel writes (one per deleted timer)
+			wantQueries: 6,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			batch := &fakeBatch{}
 
-			err := updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, FixedTime)
+			err := updateWorkflowExecutionAndEventBufferWithMergeAndDeleteMaps(batch, tc.shardID, tc.domainID, tc.workflowID, tc.execution, false, false, FixedTime)
 			gotErr := (err != nil)
 			if gotErr != tc.wantErr {
 				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -58,6 +58,10 @@ type (
 		// For WorkflowExecutionMapsWriteMode of update only
 		ActivityInfoKeysToDelete       []int64
 		TimerInfoKeysToDelete          []string
+		RewriteActivityInfos           map[int64]*persistence.InternalActivityInfo // non-nil triggers full activity_map rewrite
+		ActivitySentinelWriteEnabled   bool                                        // write sentinel placeholders instead of deleting activity map entries
+		RewriteTimerInfos              map[string]*persistence.TimerInfo           // non-nil triggers full timer_map rewrite
+		TimerSentinelWriteEnabled      bool                                        // write sentinel placeholders instead of deleting timer map entries
 		ChildWorkflowInfoKeysToDelete  []int64
 		RequestCancelInfoKeysToDelete  []int64
 		SignalInfoKeysToDelete         []int64

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -555,9 +555,8 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		PendingActivitiesCountLimitError: dc.GetIntPropertyFilteredByDomain(dynamicproperties.PendingActivitiesCountLimitError),
 		PendingActivitiesCountLimitWarn:  dc.GetIntPropertyFilteredByDomain(dynamicproperties.PendingActivitiesCountLimitWarn),
 		PendingActivityValidationEnabled: dc.GetBoolProperty(dynamicproperties.EnablePendingActivityValidation),
-
-		ThrottledLogRPS:   dc.GetIntProperty(dynamicproperties.HistoryThrottledLogRPS),
-		EnableStickyQuery: dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableStickyQuery),
+		ThrottledLogRPS:                  dc.GetIntProperty(dynamicproperties.HistoryThrottledLogRPS),
+		EnableStickyQuery:                dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableStickyQuery),
 
 		EnableQueryAttributeValidation:           dc.GetBoolProperty(dynamicproperties.EnableQueryAttributeValidation),
 		ValidSearchAttributes:                    dc.GetMapProperty(dynamicproperties.ValidSearchAttributes),

--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -239,7 +239,7 @@ func TestHandleDecisionTaskScheduled(t *testing.T) {
 				domainCache:          cache.NewMockDomainCache(ctrl),
 				activeClusterManager: activecluster.NewMockManager(ctrl),
 			}
-			expectCommonCalls(decisionHandler, test.domainID)
+			expectCommonCalls(decisionHandler, test.domainID, ctrl)
 			expectDefaultDomainCache(decisionHandler, test.domainID)
 			expectGetWorkflowExecution(decisionHandler, test.domainID, test.mutablestate)
 			if test.expectCalls != nil {
@@ -367,7 +367,7 @@ func TestHandleDecisionTaskFailed(t *testing.T) {
 				domainCache:          cache.NewMockDomainCache(ctrl),
 				activeClusterManager: activecluster.NewMockManager(ctrl),
 			}
-			expectCommonCalls(decisionHandler, test.domainID)
+			expectCommonCalls(decisionHandler, test.domainID, ctrl)
 			if !test.expectNonDefaultDomainCache {
 				expectDefaultDomainCache(decisionHandler, test.domainID)
 			}
@@ -526,7 +526,7 @@ func TestHandleDecisionTaskStarted(t *testing.T) {
 				domainCache:          cache.NewMockDomainCache(ctrl),
 				activeClusterManager: activecluster.NewMockManager(ctrl),
 			}
-			expectCommonCalls(decisionHandler, test.domainID)
+			expectCommonCalls(decisionHandler, test.domainID, ctrl)
 			expectDefaultDomainCache(decisionHandler, test.domainID)
 			expectGetWorkflowExecution(decisionHandler, test.domainID, test.mutablestate)
 			expectGetShardIDAnyTimes(decisionHandler)
@@ -791,7 +791,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
 				decisionHandler.activeClusterManager.(*activecluster.MockManager).EXPECT().GetActiveClusterInfoByClusterAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ActiveClusterInfo{ActiveClusterName: "test-active-cluster"}, nil)
 			},
 			mutableState: &persistence.WorkflowMutableState{
@@ -832,7 +831,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, execution.NewConflictError(new(testing.T), errors.New("some random conflict error")))
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
 				decisionHandler.activeClusterManager.(*activecluster.MockManager).EXPECT().GetActiveClusterInfoByClusterAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ActiveClusterInfo{ActiveClusterName: "test-active-cluster"}, nil)
 			},
 			mutableState: &persistence.WorkflowMutableState{
@@ -873,7 +871,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
 				decisionHandler.activeClusterManager.(*activecluster.MockManager).EXPECT().GetActiveClusterInfoByClusterAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ActiveClusterInfo{ActiveClusterName: "test-active-cluster"}, nil)
 				firstGetWfExecutionCall := decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&persistence.GetWorkflowExecutionResponse{
@@ -927,7 +924,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(1).Times(1).Return([]int64{0}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(&persistence.AppendHistoryNodesResponse{}, nil)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
 				decisionHandler.activeClusterManager.(*activecluster.MockManager).EXPECT().GetActiveClusterInfoByClusterAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ActiveClusterInfo{ActiveClusterName: "test-active-cluster"}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx interface{}, request interface{}) (*persistence.GetWorkflowExecutionResponse, error) {
@@ -1163,7 +1159,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				attrValidator:        newAttrValidator(domainCache, metrics.NewClient(tally.NoopScope, metrics.History, metrics.MigrationConfig{}), config.NewForTest(), testlogger.New(t)),
 				activeClusterManager: activecluster.NewMockManager(ctrl),
 			}
-			expectCommonCalls(decisionHandler, test.domainID)
+			expectCommonCalls(decisionHandler, test.domainID, ctrl)
 			if !test.expectNonDefaultDomainCache {
 				expectDefaultDomainCache(decisionHandler, test.domainID)
 			}
@@ -1421,7 +1417,7 @@ func (s *DecisionHandlerSuite) assertQueryCounts(queryRegistry query.Registry, b
 	s.Len(queryRegistry.GetFailedIDs(), failed)
 }
 
-func expectCommonCalls(handler *handlerImpl, domainID string) {
+func expectCommonCalls(handler *handlerImpl, domainID string, ctrl *gomock.Controller) {
 	handler.shard.(*shard.MockContext).EXPECT().GetConfig().AnyTimes().Return(handler.config)
 	handler.shard.(*shard.MockContext).EXPECT().GetLogger().AnyTimes().Return(handler.logger)
 	handler.shard.(*shard.MockContext).EXPECT().GetTimeSource().AnyTimes().Return(handler.timeSource)
@@ -1429,7 +1425,8 @@ func expectCommonCalls(handler *handlerImpl, domainID string) {
 	handler.shard.(*shard.MockContext).EXPECT().GetClusterMetadata().AnyTimes().Return(constants.TestClusterMetadata)
 	handler.shard.(*shard.MockContext).EXPECT().GetMetricsClient().AnyTimes().Return(handler.metricsClient)
 	handler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomainName(domainID).AnyTimes().Return(constants.TestDomainName, nil)
-	handler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
+	mockExecManager := persistence.NewMockExecutionManager(ctrl)
+	handler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Return(mockExecManager).AnyTimes()
 	handler.shard.(*shard.MockContext).EXPECT().GetActiveClusterManager().Return(handler.activeClusterManager).AnyTimes()
 }
 

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1481,6 +1481,21 @@ func (e *mutableStateBuilder) CloseTransactionAsMutation(
 		Checksum:  checksum,
 	}
 
+	if len(workflowMutation.DeleteActivityInfos) > 0 {
+		infos := slices.Collect(maps.Values(e.pendingActivityInfoIDs))
+		if infos == nil {
+			infos = []*persistence.ActivityInfo{}
+		}
+		workflowMutation.RewriteActivityInfos = infos
+	}
+	if len(workflowMutation.DeleteTimerInfos) > 0 {
+		timers := slices.Collect(maps.Values(e.pendingTimerInfoIDs))
+		if timers == nil {
+			timers = []*persistence.TimerInfo{}
+		}
+		workflowMutation.RewriteTimerInfos = timers
+	}
+
 	e.checksum = checksum
 	if err := e.cleanupTransaction(); err != nil {
 		return nil, nil, err

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -3446,6 +3446,7 @@ func TestCloseTransactionAsMutation(t *testing.T) {
 		shardContextExpectations func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache)
 		transactionPolicy        TransactionPolicy
 		expectedMutation         *persistence.WorkflowMutation
+		validateMutation         func(t *testing.T, mutation *persistence.WorkflowMutation)
 		expectedEvent            []*persistence.WorkflowEvents
 		expectedErr              error
 	}{
@@ -3505,6 +3506,112 @@ func TestCloseTransactionAsMutation(t *testing.T) {
 				DeleteChildExecutionInfos: []int64{},
 				WorkflowRequests:          []*persistence.WorkflowRequest{},
 				Condition:                 0,
+			},
+			expectedEvent: nil,
+			expectedErr:   nil,
+		},
+		"CloseTransactionAsMutation populates rewrite maps with remaining pending infos when there are deletes": {
+			mutableStateSetup: func(ms *mutableStateBuilder) {
+				ms.executionInfo.DomainID = "some-domain-id"
+				ms.executionInfo.NextEventID = 10
+				ms.executionInfo.LastProcessedEvent = 5
+				ms.executionInfo.State = persistence.WorkflowStateRunning
+				ms.executionInfo.CloseStatus = persistence.WorkflowCloseStatusNone
+				ms.pendingActivityInfoIDs = map[int64]*persistence.ActivityInfo{
+					1: {ScheduleID: 1, ActivityID: "activity-1"},
+					2: {ScheduleID: 2, ActivityID: "activity-2"},
+				}
+				ms.pendingActivityIDToEventID = map[string]int64{
+					"activity-1": 1,
+					"activity-2": 2,
+				}
+				ms.pendingTimerInfoIDs = map[string]*persistence.TimerInfo{
+					"timer-1": {TimerID: "timer-1", StartedID: 3},
+					"timer-2": {TimerID: "timer-2", StartedID: 4},
+				}
+				ms.pendingTimerEventIDToID = map[int64]string{
+					3: "timer-1",
+					4: "timer-2",
+				}
+				ms.deleteActivityInfos = map[int64]struct{}{99: {}}
+				ms.deleteTimerInfos = map[string]struct{}{"old-timer": {}}
+			},
+			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
+				shardContext.EXPECT().GetConfig().Return(&config.Config{
+					NumberOfShards:                        2,
+					IsAdvancedVisConfigExist:              false,
+					MaxResponseSize:                       0,
+					MutableStateChecksumInvalidateBefore:  dynamicproperties.GetFloatPropertyFn(10),
+					MutableStateChecksumVerifyProbability: dynamicproperties.GetIntPropertyFilteredByDomain(0.0),
+					HostName:                              "test-host",
+					EnableReplicationTaskGeneration:       func(string, string) bool { return true },
+					MaximumBufferedEventsBatch:            func(...dynamicproperties.FilterOption) int { return 100 },
+				}).AnyTimes()
+
+				shardContext.EXPECT().GetDomainCache().Return(mockDomainCache).AnyTimes()
+				mockDomainCache.EXPECT().GetDomainByID("some-domain-id").Return(mockDomain, nil)
+			},
+			validateMutation: func(t *testing.T, mutation *persistence.WorkflowMutation) {
+				require.NotNil(t, mutation, "mutation should not be nil")
+				assert.Equal(t, []int64{99}, mutation.DeleteActivityInfos)
+				assert.Equal(t, []string{"old-timer"}, mutation.DeleteTimerInfos)
+
+				assert.Len(t, mutation.RewriteActivityInfos, 2)
+				activityIDs := make(map[int64]string)
+				for _, a := range mutation.RewriteActivityInfos {
+					activityIDs[a.ScheduleID] = a.ActivityID
+				}
+				assert.Equal(t, "activity-1", activityIDs[1])
+				assert.Equal(t, "activity-2", activityIDs[2])
+
+				assert.Len(t, mutation.RewriteTimerInfos, 2)
+				timerIDs := make(map[string]int64)
+				for _, ti := range mutation.RewriteTimerInfos {
+					timerIDs[ti.TimerID] = ti.StartedID
+				}
+				assert.Equal(t, int64(3), timerIDs["timer-1"])
+				assert.Equal(t, int64(4), timerIDs["timer-2"])
+			},
+			expectedEvent: nil,
+			expectedErr:   nil,
+		},
+		"CloseTransactionAsMutation sets empty rewrite maps when there are deletes but no pending infos": {
+			mutableStateSetup: func(ms *mutableStateBuilder) {
+				ms.executionInfo.DomainID = "some-domain-id"
+				ms.executionInfo.NextEventID = 10
+				ms.executionInfo.LastProcessedEvent = 5
+				ms.executionInfo.State = persistence.WorkflowStateRunning
+				ms.executionInfo.CloseStatus = persistence.WorkflowCloseStatusNone
+				ms.pendingActivityInfoIDs = map[int64]*persistence.ActivityInfo{}
+				ms.pendingActivityIDToEventID = map[string]int64{}
+				ms.pendingTimerInfoIDs = map[string]*persistence.TimerInfo{}
+				ms.pendingTimerEventIDToID = map[int64]string{}
+				ms.deleteActivityInfos = map[int64]struct{}{1: {}}
+				ms.deleteTimerInfos = map[string]struct{}{"timer-1": {}}
+			},
+			shardContextExpectations: func(mockCache *events.MockCache, shardContext *shardCtx.MockContext, mockDomainCache *cache.MockDomainCache) {
+				shardContext.EXPECT().GetConfig().Return(&config.Config{
+					NumberOfShards:                        2,
+					IsAdvancedVisConfigExist:              false,
+					MaxResponseSize:                       0,
+					MutableStateChecksumInvalidateBefore:  dynamicproperties.GetFloatPropertyFn(10),
+					MutableStateChecksumVerifyProbability: dynamicproperties.GetIntPropertyFilteredByDomain(0.0),
+					HostName:                              "test-host",
+					EnableReplicationTaskGeneration:       func(string, string) bool { return true },
+					MaximumBufferedEventsBatch:            func(...dynamicproperties.FilterOption) int { return 100 },
+				}).AnyTimes()
+
+				shardContext.EXPECT().GetDomainCache().Return(mockDomainCache).AnyTimes()
+				mockDomainCache.EXPECT().GetDomainByID("some-domain-id").Return(mockDomain, nil)
+			},
+			validateMutation: func(t *testing.T, mutation *persistence.WorkflowMutation) {
+				require.NotNil(t, mutation, "mutation should not be nil")
+				assert.Equal(t, []int64{1}, mutation.DeleteActivityInfos)
+				assert.Equal(t, []string{"timer-1"}, mutation.DeleteTimerInfos)
+				assert.NotNil(t, mutation.RewriteActivityInfos, "rewrite activity infos should be non-nil")
+				assert.Empty(t, mutation.RewriteActivityInfos, "rewrite activity infos should be empty")
+				assert.NotNil(t, mutation.RewriteTimerInfos, "rewrite timer infos should be non-nil")
+				assert.Empty(t, mutation.RewriteTimerInfos, "rewrite timer infos should be empty")
 			},
 			expectedEvent: nil,
 			expectedErr:   nil,
@@ -3621,11 +3728,13 @@ func TestCloseTransactionAsMutation(t *testing.T) {
 			td.shardContextExpectations(mockCache, shardContext, mockDomainCache)
 
 			mutation, workflowEvents, err := ms.CloseTransactionAsMutation(now, td.transactionPolicy)
-			if diff := cmp.Diff(td.expectedMutation, mutation, cmpopts.EquateEmpty()); diff != "" {
+			assert.Equal(t, td.expectedErr, err)
+			if td.validateMutation != nil {
+				td.validateMutation(t, mutation)
+			} else if diff := cmp.Diff(td.expectedMutation, mutation, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mutation mismatch (-want +got):\n%s", diff)
 			}
 			assert.Equal(t, td.expectedEvent, workflowEvents)
-			assert.Equal(t, td.expectedErr, err)
 		})
 	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added sentinel writes instead of map deletions for pending activity and timers in Cassandra (only current supported backend).

Added a probabilistic value to rewrite pending maps to avoid accumulating too many sentinels. This is controlled by dynamic configs (history.activityMapRewriteSampleRate and history.timerMapRewriteSampleRate) and a value less or equal to 0 means that sentinel writes are disabled.

https://github.com/cadence-workflow/cadence/issues/8318

**Why?**
Cassandra creates a tombstone for every key-value pair deletion on a Cassandra map fields. Cadence use these maps to track pending activities and timers. That means that for every activity completed or timer fired, we delete the entry by creating a tombstone.

**How did you test it?**
go test -race -run "TestSelectWorkflowExecution" ./common/persistence/nosql/nosqlplugin/cassandra/ -v -count=1

# Write tests
go test -race -run "TestUpdateWorkflowExecutionWithTasks_SentinelBehavior" ./common/persistence/nosql/nosqlplugin/cassandra/ -v -count=1
go test -race -run "TestUpdateActivityInfos|TestUpdateTimerInfos" ./common/persistence/nosql/nosqlplugin/cassandra/ -v -count=1
go test -race -run "TestSerializeWorkflowMutation_RewriteProbability|FuzzRewriteSkippedForUnsupportedBackend" ./common/persistence/ -v -count=1
go test -race -run "TestCloseTransactionAsMutation" ./service/history/execution/ -v -count=1
go test -race ./common/persistence/... ./service/history/execution/... ./service/history/decision/... -count=1

**Potential risks**
This introduces a change in the write that requires the read filter to always be in place, because introducing sentinels and not filtering would cause workflow executions to break due to unexpected pending activity/timers.

**Release notes**
The [read filter commit](https://github.com/cadence-workflow/cadence/pull/8520) has to be successfully deployed before this commit to ensure that this commit can be safely rollback if necessary.

**Documentation Changes**
N/A
