### PR TITLE
fix: shardedNosqlStore GetName returns plugin name instead of wrapper

### DIFF
--- a/common/persistence/nosql/sharded_nosql_store.go
+++ b/common/persistence/nosql/sharded_nosql_store.go
@@ -149,7 +149,7 @@ func (sn *shardedNosqlStoreImpl) Close() {
 }
 
 func (sn *shardedNosqlStoreImpl) GetName() string {
-	return "shardedNosql"
+	return sn.defaultShard.GetName()
 }
 
 func (sn *shardedNosqlStoreImpl) GetShardingPolicy() shardingPolicy {

--- a/common/persistence/nosql/sharded_nosql_store_test.go
+++ b/common/persistence/nosql/sharded_nosql_store_test.go
@@ -54,6 +54,7 @@ func (s *shardedNosqlStoreTestSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
 	mockDB := nosqlplugin.NewMockDB(s.mockController)
+	mockDB.EXPECT().PluginName().Return("cassandra").AnyTimes()
 
 	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
 	mockPlugin.EXPECT().
@@ -82,8 +83,10 @@ func (s *shardedNosqlStoreTestSuite) TestValidConfiguration() {
 func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForHistoryShard() {
 	mockDB1 := nosqlplugin.NewMockDB(s.mockController)
 	mockDB1.EXPECT().Close().Times(1)
+	mockDB1.EXPECT().PluginName().Return("cassandra").AnyTimes()
 	mockDB2 := nosqlplugin.NewMockDB(s.mockController)
 	mockDB2.EXPECT().Close().Times(1)
+	mockDB2.EXPECT().PluginName().Return("cassandra").AnyTimes()
 
 	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
 	gomock.InOrder(
@@ -156,7 +159,7 @@ func (s *shardedNosqlStoreTestSuite) newShardedStoreForTest() *shardedNosqlStore
 	logger := log.NewNoop()
 	storeInterface, err := newShardedNosqlStore(cfg, logger, metrics.NewNoopMetricsClient(), nil, false)
 	s.NoError(err)
-	s.Equal("shardedNosql", storeInterface.GetName())
+	s.Equal("cassandra", storeInterface.GetName())
 	s.Equal(logger, storeInterface.GetLogger())
 	store := storeInterface.(*shardedNosqlStoreImpl)
 	s.Equal(storeInterface.GetShardingPolicy(), store.shardingPolicy)
@@ -166,8 +169,10 @@ func (s *shardedNosqlStoreTestSuite) newShardedStoreForTest() *shardedNosqlStore
 func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForTasklist() {
 	mockDB1 := nosqlplugin.NewMockDB(s.mockController)
 	mockDB1.EXPECT().Close().Times(1)
+	mockDB1.EXPECT().PluginName().Return("cassandra").AnyTimes()
 	mockDB2 := nosqlplugin.NewMockDB(s.mockController)
 	mockDB2.EXPECT().Close().Times(1)
+	mockDB2.EXPECT().PluginName().Return("cassandra").AnyTimes()
 
 	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
 	gomock.InOrder(
@@ -225,8 +230,10 @@ func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForTasklist() {
 func (s *shardedNosqlStoreTestSuite) TestEagerConnectConnectsAllShards() {
 	mockDB1 := nosqlplugin.NewMockDB(s.mockController)
 	mockDB1.EXPECT().Close().Times(1)
+	mockDB1.EXPECT().PluginName().Return("cassandra").AnyTimes()
 	mockDB2 := nosqlplugin.NewMockDB(s.mockController)
 	mockDB2.EXPECT().Close().Times(1)
+	mockDB2.EXPECT().PluginName().Return("cassandra").AnyTimes()
 
 	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
 	mockPlugin.EXPECT().
@@ -244,7 +251,7 @@ func (s *shardedNosqlStoreTestSuite) TestEagerConnectConnectsAllShards() {
 	logger := log.NewNoop()
 	storeInterface, err := newShardedNosqlStore(cfg, logger, metrics.NewNoopMetricsClient(), nil, true)
 	s.NoError(err)
-	s.Equal("shardedNosql", storeInterface.GetName())
+	s.Equal("cassandra", storeInterface.GetName())
 	s.Equal(logger, storeInterface.GetLogger())
 	defer storeInterface.Close()
 

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -6045,6 +6045,7 @@ func (s *ExecutionManagerSuite) TestWorkflowTimerTaskTracking() {
 	// Verify that FetchWorkflowTimerTasksForCleanup runs without error, which exercises
 	// the SelectWorkflowTimerTasks path on the tracking map.
 	_, err = s.ExecutionManager.FetchWorkflowTimerTasksForCleanup(ctx, &p.FetchWorkflowTimerTasksForCleanupRequest{
+		ShardID:    common.IntPtr(s.ShardInfo.ShardID),
 		DomainID:   domainID,
 		WorkflowID: workflowExecution.WorkflowID,
 		RunID:      workflowExecution.RunID,

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -109,7 +109,7 @@ func (s *MatchingPersistenceSuite) TestCreateTask() {
 		s.Equal(workflowExecution.RunID, resp.Tasks[0].RunID)
 		s.Equal(sid, resp.Tasks[0].ScheduleID)
 		s.True(resp.Tasks[0].CreatedTime.UnixNano() > 0)
-		if s.TaskMgr.GetName() != "cassandra" && s.TaskMgr.GetName() != "shardedNosql" {
+		if s.TaskMgr.GetName() != "cassandra" {
 			// cassandra uses TTL and expiry isn't stored as part of task state
 			s.True(time.Now().Before(resp.Tasks[0].Expiry))
 			s.True(resp.Tasks[0].Expiry.Before(time.Now().Add((defaultScheduleToStartTimeout + 1) * time.Second)))
@@ -524,7 +524,7 @@ func (s *MatchingPersistenceSuite) deleteAllTaskList() {
 
 // TestListWithOneTaskList test
 func (s *MatchingPersistenceSuite) TestListWithOneTaskList() {
-	if s.TaskMgr.GetName() == "cassandra" || s.TaskMgr.GetName() == "shardedNosql" {
+	if s.TaskMgr.GetName() == "cassandra" {
 		// ListTaskList API is currently not supported in cassandra
 		return
 	}
@@ -588,7 +588,7 @@ func (s *MatchingPersistenceSuite) TestListWithOneTaskList() {
 
 // TestListWithMultipleTaskList test
 func (s *MatchingPersistenceSuite) TestListWithMultipleTaskList() {
-	if s.TaskMgr.GetName() == "cassandra" || s.TaskMgr.GetName() == "shardedNosql" {
+	if s.TaskMgr.GetName() == "cassandra" {
 		// ListTaskList API is currently not supported in cassandra"
 		return
 	}
@@ -658,7 +658,7 @@ func (s *MatchingPersistenceSuite) TestGetOrphanTasks() {
 	if os.Getenv("SKIP_GET_ORPHAN_TASKS") != "" {
 		s.T().Skipf("GetOrphanTasks not supported in %v", s.TaskMgr.GetName())
 	}
-	if s.TaskMgr.GetName() == "cassandra" || s.TaskMgr.GetName() == "shardedNosql" {
+	if s.TaskMgr.GetName() == "cassandra" {
 		// GetOrphanTasks API is currently not supported in cassandra"
 		return
 	}

--- a/common/persistence/persistence-tests/shardPersistenceTest.go
+++ b/common/persistence/persistence-tests/shardPersistenceTest.go
@@ -207,7 +207,7 @@ func (s *ShardPersistenceSuite) TestUpdateShard() {
 	s.Equal(updatedInfo.ReplicationDLQAckLevel, info1.ReplicationDLQAckLevel)
 	s.Equal(updatedStolenSinceRenew, info1.StolenSinceRenew)
 
-	if s.DynamicConfiguration.ReadNoSQLShardFromDataBlob() || s.ShardMgr.GetName() != "shardedNosql" {
+	if s.DynamicConfiguration.ReadNoSQLShardFromDataBlob() || s.ShardMgr.GetName() != "cassandra" {
 		s.Equal(updatedInfo.QueueStates, info1.QueueStates)
 	}
 
@@ -236,7 +236,7 @@ func (s *ShardPersistenceSuite) TestUpdateShard() {
 	s.Equal(updatedInfo.ReplicationDLQAckLevel, info2.ReplicationDLQAckLevel)
 	s.Equal(updatedStolenSinceRenew, info2.StolenSinceRenew)
 
-	if s.DynamicConfiguration.ReadNoSQLShardFromDataBlob() || s.ShardMgr.GetName() != "shardedNosql" {
+	if s.DynamicConfiguration.ReadNoSQLShardFromDataBlob() || s.ShardMgr.GetName() != "cassandra" {
 		s.Equal(updatedInfo.QueueStates, info2.QueueStates)
 	}
 }
@@ -379,7 +379,7 @@ func (s *ShardPersistenceSuite) TestCreateGetUpdateGetShard() {
 	resp.TimerAckLevel = shardInfo.TimerAckLevel
 	resp.UpdatedAt = shardInfo.UpdatedAt
 	resp.ClusterTimerAckLevel = shardInfo.ClusterTimerAckLevel
-	if !s.DynamicConfiguration.ReadNoSQLHistoryTaskFromDataBlob() && s.ShardMgr.GetName() == "shardedNosql" {
+	if !s.DynamicConfiguration.ReadNoSQLHistoryTaskFromDataBlob() && s.ShardMgr.GetName() == "cassandra" {
 		resp.QueueStates = shardInfo.QueueStates
 	}
 	s.Equal(shardInfo, resp)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Return plugin name on GetName in the noshardedsql persistence, matching the behavior from slq persistence GetName method.

This addresses issues in some integration tests that only used "cassandra" as a check.

Also replaces checks for "noshardedsql" with "cassandra" since it's the only noshardedsql currently implemented. When it's extended, their plugin names will have to be added.

Fixed integration test that was being skipped.

**Why?**
GetName in noshardedsql was returning "noshardedsql" instead of the plugin name. In sql it returns the plugin name.

**How did you test it?**
Sharded nosql store tests (GetName behavior)
go test -race -run "TestShardedNosqlStoreTestSuite" ./common/persistence/nosql/ -v -count=1

Matching persistence tests (removed shardedNosql workarounds)
go test -race -run "TestCassandraMatchingPersistence" ./host/persistence/cassandra/ -v -count=1

Shard persistence tests (replaced shardedNosql with cassandra)
go test -race -run "TestCassandraShardPersistence" ./host/persistence/cassandra/ -v -count=1

**Potential risks**
No risk, fixing existing test bugs.

**Release notes**
N/A

**Documentation Changes**
N/A
