### PR TITLE
ci: remove fixed sleeps in integration tests (v2)

### DIFF
--- a/host/async_wf_test.go
+++ b/host/async_wf_test.go
@@ -110,7 +110,7 @@ func (s *AsyncWFIntegrationSuite) SetupSuite() {
 	s.SecondaryDomainName = s.RandomizeStr("unused-test-domain")
 	s.Require().NoError(s.RegisterDomain(s.SecondaryDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
 
-	s.domainCacheRefresh()
+	s.domainCacheRefresh(s.SecondaryDomainName)
 }
 
 func (s *AsyncWFIntegrationSuite) SetupTest() {
@@ -178,7 +178,7 @@ func (s *AsyncWFIntegrationSuite) TestStartWorkflowExecutionAsync_SLOW() {
 					t.Fatalf("UpdateDomainAsyncWorkflowConfiguraton() failed: %v", err)
 				}
 
-				s.domainCacheRefresh()
+				s.domainCacheRefresh(s.DomainName)
 			}
 
 			if tc.secondaryCfg != nil {
@@ -190,7 +190,7 @@ func (s *AsyncWFIntegrationSuite) TestStartWorkflowExecutionAsync_SLOW() {
 					t.Fatalf("UpdateDomainAsyncWorkflowConfiguraton() failed: %v", err)
 				}
 
-				s.domainCacheRefresh()
+				s.domainCacheRefresh(s.SecondaryDomainName)
 			}
 
 			startTime := s.TestClusterConfig.TimeSource.Now().UnixNano()

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -135,34 +136,75 @@ func (s *IntegrationBase) setupSuite() {
 	}
 	s.TestRawHistoryDomainName = "TestRawHistoryDomain"
 	s.DomainName = s.RandomizeStr("integration-test-domain")
-	s.Require().NoError(
-		s.RegisterDomain(s.DomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
-	s.Require().NoError(
-		s.RegisterDomain(s.TestRawHistoryDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
 	s.ForeignDomainName = s.RandomizeStr("integration-foreign-test-domain")
-	s.Require().NoError(
-		s.RegisterDomain(s.ForeignDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
-
-	s.Require().NoError(s.registerArchivalDomain())
 	s.ActiveActiveDomainName = s.RandomizeStr("integration-active-active-test-domain")
-	s.Require().NoError(s.RegisterDomain(s.ActiveActiveDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", &types.ActiveClusters{
-		AttributeScopes: map[string]types.ClusterAttributeScope{
-			"region": {
-				ClusterAttributes: map[string]types.ActiveClusterInfo{
-					"us-east": {ActiveClusterName: s.TestCluster.testBase.ClusterMetadata.GetCurrentClusterName()},
-				},
-			},
-			"city": {
-				ClusterAttributes: map[string]types.ActiveClusterInfo{
-					"tokyo": {ActiveClusterName: s.TestCluster.testBase.ClusterMetadata.GetCurrentClusterName()},
-				},
-			},
-		},
-	}))
 
-	// this sleep is necessary because domainv2 cache gets refreshed in the
-	// background only every domainCacheRefreshInterval period
-	time.Sleep(cache.DomainCacheRefreshInterval + time.Second)
+	var wg sync.WaitGroup
+	errCh := make(chan error, 5)
+
+	registerDomain := func(domain string, registerFn func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- registerFn()
+		}()
+	}
+
+	registerDomain(s.DomainName, func() error {
+		return s.RegisterDomain(s.DomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil)
+	})
+	registerDomain(s.TestRawHistoryDomainName, func() error {
+		return s.RegisterDomain(s.TestRawHistoryDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil)
+	})
+	registerDomain(s.ForeignDomainName, func() error {
+		return s.RegisterDomain(s.ForeignDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil)
+	})
+	registerDomain("ArchivalDomain", func() error {
+		return s.registerArchivalDomain()
+	})
+	registerDomain(s.ActiveActiveDomainName, func() error {
+		return s.RegisterDomain(s.ActiveActiveDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", &types.ActiveClusters{
+			AttributeScopes: map[string]types.ClusterAttributeScope{
+				"region": {
+					ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"us-east": {ActiveClusterName: s.TestCluster.testBase.ClusterMetadata.GetCurrentClusterName()},
+					},
+				},
+				"city": {
+					ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"tokyo": {ActiveClusterName: s.TestCluster.testBase.ClusterMetadata.GetCurrentClusterName()},
+					},
+				},
+			},
+		})
+	})
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		s.Require().NoError(err)
+	}
+
+	domains := []string{s.DomainName, s.TestRawHistoryDomainName, s.ForeignDomainName, s.ArchivalDomainName, s.ActiveActiveDomainName}
+	s.Require().NoError(s.waitForDomains(domains))
+}
+
+func (s *IntegrationBase) waitForDomains(domains []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	for _, domain := range domains {
+		for {
+			_, err := s.TestCluster.host.GetDomainCache().GetDomain(domain)
+			if err == nil {
+				break
+			}
+			if ctx.Err() != nil {
+				return fmt.Errorf("timeout waiting for domain %s: %w", domain, err)
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	return nil
 }
 
 func (s *IntegrationBase) SetupLogger() {
@@ -261,10 +303,38 @@ func (s *IntegrationBase) RegisterDomain(
 	})
 }
 
-func (s *IntegrationBase) domainCacheRefresh() {
+// domainCacheRefresh forces the in-memory domain cache to refresh from persistence by advancing the mock clock.
+// Note: This helper polls until the domain's NotificationVersion strictly increases. It must only be called
+// when an underlying domain change (e.g. registration or UpdateDomain) has occurred; otherwise, it will time out.
+func (s *IntegrationBase) domainCacheRefresh(domainNames ...string) {
+	// get current notification versions
+	versions := make(map[string]int64)
+	for _, domain := range domainNames {
+		if entry, err := s.TestCluster.host.GetDomainCache().GetDomain(domain); err == nil {
+			versions[domain] = entry.GetNotificationVersion()
+		} else {
+			versions[domain] = -1
+		}
+	}
+
 	s.TestClusterConfig.TimeSource.Advance(cache.DomainCacheRefreshInterval + time.Second)
-	// this sleep is necessary to yield execution to other goroutines. not 100% guaranteed to work
-	time.Sleep(2 * time.Second)
+
+	// poll until versions are greater
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	for _, domain := range domainNames {
+		expected := versions[domain]
+		for {
+			entry, err := s.TestCluster.host.GetDomainCache().GetDomain(domain)
+			if err == nil && entry.GetNotificationVersion() > expected {
+				break
+			}
+			if ctx.Err() != nil {
+				s.Require().NoError(ctx.Err(), "timeout waiting for domain cache refresh")
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
 }
 
 func (s *IntegrationBase) RandomizeStr(id string) string {

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -46,6 +46,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -121,19 +122,40 @@ func (s *PinotIntegrationSuite) SetupSuite() {
 
 	s.TestRawHistoryDomainName = "TestRawHistoryDomain"
 	s.DomainName = s.RandomizeStr("integration-test-domain")
-	s.Require().NoError(
-		s.RegisterDomain(s.DomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
-	s.Require().NoError(
-		s.RegisterDomain(s.TestRawHistoryDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
 	s.ForeignDomainName = s.RandomizeStr("integration-foreign-test-domain")
-	s.Require().NoError(
-		s.RegisterDomain(s.ForeignDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
 
-	s.Require().NoError(s.registerArchivalDomain())
+	var wg sync.WaitGroup
+	errCh := make(chan error, 4)
 
-	// this sleep is necessary because domainv2 cache gets refreshed in the
-	// background only every domainCacheRefreshInterval period
-	time.Sleep(cache.DomainCacheRefreshInterval + time.Second)
+	registerDomain := func(domain string, registerFn func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- registerFn()
+		}()
+	}
+
+	registerDomain(s.DomainName, func() error {
+		return s.RegisterDomain(s.DomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil)
+	})
+	registerDomain(s.TestRawHistoryDomainName, func() error {
+		return s.RegisterDomain(s.TestRawHistoryDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil)
+	})
+	registerDomain(s.ForeignDomainName, func() error {
+		return s.RegisterDomain(s.ForeignDomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil)
+	})
+	registerDomain("ArchivalDomain", func() error {
+		return s.registerArchivalDomain()
+	})
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		s.Require().NoError(err)
+	}
+
+	domains := []string{s.DomainName, s.TestRawHistoryDomainName, s.ForeignDomainName, s.ArchivalDomainName}
+	s.Require().NoError(s.waitForDomains(domains))
 
 	tableName := "cadence_visibility_pinot" // cadence_visibility_pinot_integration_test
 	pinotConfig := &config.PinotVisibilityConfig{

--- a/host/workflowidratelimit_test.go
+++ b/host/workflowidratelimit_test.go
@@ -86,7 +86,7 @@ func (s *WorkflowIDRateLimitIntegrationSuite) SetupSuite() {
 	s.DomainName = s.RandomizeStr("integration-test-domain")
 	s.Require().NoError(s.RegisterDomain(s.DomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
 
-	s.domainCacheRefresh()
+	s.domainCacheRefresh(s.DomainName)
 }
 
 func (s *WorkflowIDRateLimitIntegrationSuite) SetupTest() {

--- a/host/workflowsidinternalratelimit_test.go
+++ b/host/workflowsidinternalratelimit_test.go
@@ -89,7 +89,7 @@ func (s *WorkflowIDInternalRateLimitIntegrationSuite) SetupSuite() {
 	s.DomainName = s.RandomizeStr("integration-test-domain")
 	s.Require().NoError(s.RegisterDomain(s.DomainName, 1, types.ArchivalStatusDisabled, "", types.ArchivalStatusDisabled, "", nil))
 
-	s.domainCacheRefresh()
+	s.domainCacheRefresh(s.DomainName)
 }
 
 func (s *WorkflowIDInternalRateLimitIntegrationSuite) SetupTest() {


### PR DESCRIPTION
Re-submitting #8415 after persistence refactor conflicts.

Replaces fixed sleeps in integration tests with direct domain cache polling and concurrent domain registration.
- `domainCacheRefresh` now polls until the domain's `NotificationVersion` increases instead of an unconditional 2s sleep.
- `setupSuite` concurrently registers test domains and polls `waitForDomains` to ensure they are available before returning, eliminating the 10+1s sleep in tests.

Fixes #8415

### How did you test it?
```bash
go test ./host/... -v
```

### Potential risks
Test-only change, low risk to production code.

### Release notes
N/A

### Documentation Changes
N/A
