### PR TITLE
docs(cli): clarify active_cluster flag description

### DIFF
--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -69,7 +69,7 @@ var (
 		&cli.StringFlag{
 			Name:    FlagActiveClusterName,
 			Aliases: []string{"ac"},
-			Usage:   "Active cluster name",
+			Usage:   "Cluster name to set as the active cluster for this domain",
 		},
 		&cli.StringSliceFlag{
 			Name:    FlagActiveClusters,
@@ -143,7 +143,7 @@ var (
 		&cli.StringFlag{
 			Name:    FlagActiveClusterName,
 			Aliases: []string{"ac"},
-			Usage:   "Active cluster name",
+			Usage:   "Cluster name to set as the active cluster for this domain",
 		},
 		&cli.StringSliceFlag{
 			Name:    FlagActiveClusters,
@@ -280,17 +280,17 @@ var (
 		&cli.StringFlag{
 			Name:    FlagActiveClusterName,
 			Aliases: []string{"ac"},
-			Usage:   "Active cluster name",
+			Usage:   "Target cluster name that will become the new active cluster after failover completes",
 		},
 		&cli.StringSliceFlag{
 			Name:    FlagActiveClusters,
 			Aliases: []string{"acs"},
-			Usage:   "Active clusters by cluster attribute in the format '<attr-scope>.<attr-name>:<cluster_name> ie: region.manilla:cluster0,region.newyork:cluster1'",
+			Usage:   "Target active clusters by cluster attribute in the format '<attr-scope>.<attr-name>:<cluster_name> ie: region.manilla:cluster0,region.newyork:cluster1'",
 		},
 		&cli.StringFlag{
 			Name:    FlagActiveClustersJSON,
 			Aliases: []string{"acs-json"},
-			Usage:   `Active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"<attr-scope>":{"clusterAttributes":{"<attr-name>":{"activeClusterName":"<cluster_name>"}}}}}`,
+			Usage:   `Target active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"<attr-scope>":{"clusterAttributes":{"<attr-name>":{"activeClusterName":"<cluster_name>"}}}}}`,
 		},
 		&cli.StringFlag{
 			Name:    FlagFailoverReason,


### PR DESCRIPTION
**What changed?**
Improved the `--active_cluster` CLI flag description across domain `register`, `update`, and `failover` commands.

**Why?**
In the `failover` command, `"Active cluster name"` was a bit confusing, as it was unclear whether this meant the current active cluster or the target. Updated to clarify it is the target cluster. The `register` and `update` commands were updated for consistency.

**How did you test it?**
```
$ make bins
$ ./cadence domain failover --help
NAME:
   cadence domain failover - Failover workflow domain to target active cluster

USAGE:
   cadence domain failover [command options]

OPTIONS:
   --active_cluster value, --ac value                                             Target cluster name that will become the new active cluster after failover completes
   --active_clusters value, --acs value [ --active_clusters value, --acs value ]  Target active clusters by cluster attribute in the format '<attr-scope>.<attr-name>:<cluster_name> ie: region.manilla:cluster0,region.newyork:cluster1'
   --active_clusters_json value, --acs-json value                                 Target active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"<attr-scope>":{"clusterAttributes":{"<attr-name>":{"activeClusterName":"<cluster_name>"}}}}}
   --reason value, -r value                                                       Reason for failover (for tracking and transparency)
   --failover_timeout_seconds value, --fts value                                  [Optional] Graceful failover timeout in seconds. When set, the incoming active cluster waits up to this duration for pending replication tasks to drain before taking over (default: 0)
   --help, -h                                                                     show help

```
**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
