### PR TITLE
refactor(diagnostics): move event IDs and other shared fields to the root level of metadata

### DIFF
--- a/.claude/skills/new-diagnostics-invariant/SKILL.md
+++ b/.claude/skills/new-diagnostics-invariant/SKILL.md
@@ -5,7 +5,7 @@ description: Step-by-step guide for adding a new invariant to Workflow Diagnosti
 
 # Adding a Workflow Diagnostics Invariant
 
-Workflow Diagnostics (`service/worker/diagnostics`) reads one workflow execution's history and reports issues, root causes, and runbook links. Each check is an "invariant". Existing ones: `timeout`, `failure`, `retry`, `timeoutrisk`. Read the one closest to yours before writing anything.
+Workflow Diagnostics (`service/worker/diagnostics`) reads one workflow execution's history and reports issues, root causes, and runbook links. Each check is an "invariant". Existing ones: `timeout`, `failure`, `retry`, `timeoutrisk`, `antipatterns`. Read the one closest to yours before writing anything.
 
 ## The interface
 
@@ -27,7 +27,7 @@ Package name is one lowercase word (`timeout`, `retry`, `timeoutrisk`).
 - `<Name>Type` string type + consts + `String()` — these become the `InvariantType` values.
 - `IssueType` string type + consts + `String()` — these become the `Reason` values. Each reason is a plain sentence ending with a period. Never build reasons with `fmt.Sprintf` — numbers belong in the metadata.
 - Thresholds are package consts, each with a comment saying what it means.
-- One metadata struct per check. If checks have different shapes, add a wrapper struct with one pointer field per check and set only the matching field (see `timeoutrisk.TimeoutRiskIssuesMetadata`). If they share a shape, one struct is enough (see `retry.RetryMetadata`).
+- One `<Name>IssuesMetadata` struct per invariant, and `Check` marshals it directly. Fields shared by every check are top-level, and every issue sets a top-level `EventID` (the event the issue anchors on). Check-specific fields go in a per-check struct held by a pointer field named after the check, tagged `json:",omitempty"`, with exactly one set per issue (see `timeoutrisk.TimeoutRiskIssuesMetadata`). If all checks share one shape, skip the sub-structs (see `retry.RetryMetadata`). Never nest event IDs: cadence-web links only top-level `EventID`, `ActivityScheduledID`, `ActivityStartedID` keys and renders nested objects as one raw-JSON row.
 
 **<name>.go**
 - `type <Name> invariant.Invariant`, an unexported struct, `NewInvariant()`.
@@ -53,7 +53,7 @@ Before writing any check on configured values, read the validator to see what th
 1. `service/worker/diagnostics/workflow.go`:
    - Add `<Name>s *<name>Diagnostics` to `DiagnosticsWorkflowResult`.
    - Add `<name>Diagnostics{Issues, Runbook}` and `<name>IssuesResult{IssueID, InvariantType, Reason, Metadata}` structs. Add a `RootCause` field only if `RootCause` does real work.
-   - Add `retrieve<Name>Issues(checkResult)`: switch on your `InvariantType` consts and unmarshal the metadata (copy `retrieveTimeoutRiskIssues`).
+   - Add `retrieve<Name>Issues(checkResult)`: check membership in your `InvariantType` consts and unmarshal the metadata into `<Name>IssuesMetadata` (copy `retrieveTimeoutRiskIssues`).
    - In `DiagnosticsWorkflow`, add an `if len(issues) > 0 { ... Runbook: linkTo<Name>Runbook }` block and a field in the final result.
 2. `service/worker/diagnostics/activities.go`: add `linkTo<Name>Runbook` (`https://cadenceworkflow.io/docs/workflow-troubleshooting/<topic>/`). The 10-issues-per-invariant cap applies on its own.
 3. `service/worker/diagnostics/parent_workflow.go`: add an `issueType<Name>` const and a branch in `getIssueType` (same `-` joining as the others).

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns.go
@@ -57,7 +57,7 @@ func (a *antipatterns) Check(ctx context.Context, params invariant.InvariantChec
 // treated as separate clusters once the scheduling density has genuinely dropped enough that the
 // windows no longer overlap. Events without a timestamp are excluded: a nil timestamp is unknown,
 // not time zero, and treating it as zero would collapse unrelated events into a phantom burst.
-func detectActivityScheduleBursts(events []*types.HistoryEvent) []*ActivityScheduleBurstMetadata {
+func detectActivityScheduleBursts(events []*types.HistoryEvent) []*AntipatternIssuesMetadata {
 	type scheduledEvent struct {
 		eventID   int64
 		timestamp int64
@@ -80,19 +80,21 @@ func detectActivityScheduleBursts(events []*types.HistoryEvent) []*ActivitySched
 
 	windowNanos := (time.Duration(activityBurstWindowInSeconds) * time.Second).Nanoseconds()
 
-	newBurst := func(clusterStart, clusterEnd int) *ActivityScheduleBurstMetadata {
-		return &ActivityScheduleBurstMetadata{
-			FirstEventID:    scheduled[clusterStart].eventID,
-			LastEventID:     scheduled[clusterEnd].eventID,
-			EventCount:      clusterEnd - clusterStart + 1,
-			WindowStart:     time.Unix(0, scheduled[clusterStart].timestamp).UTC(),
-			WindowEnd:       time.Unix(0, scheduled[clusterEnd].timestamp).UTC(),
-			WindowInSeconds: activityBurstWindowInSeconds,
-			Threshold:       activityBurstCountThreshold,
+	newBurst := func(clusterStart, clusterEnd int) *AntipatternIssuesMetadata {
+		return &AntipatternIssuesMetadata{
+			EventID: scheduled[clusterStart].eventID,
+			ActivityScheduleBurst: &ActivityScheduleBurstMetadata{
+				LastEventID:     scheduled[clusterEnd].eventID,
+				EventCount:      clusterEnd - clusterStart + 1,
+				WindowStart:     time.Unix(0, scheduled[clusterStart].timestamp).UTC(),
+				WindowEnd:       time.Unix(0, scheduled[clusterEnd].timestamp).UTC(),
+				WindowInSeconds: activityBurstWindowInSeconds,
+				Threshold:       activityBurstCountThreshold,
+			},
 		}
 	}
 
-	var bursts []*ActivityScheduleBurstMetadata
+	var bursts []*AntipatternIssuesMetadata
 	pendingStart, pendingEnd := -1, -1
 	left := 0
 	for right := 0; right < len(scheduled); right++ {
@@ -121,7 +123,7 @@ func detectActivityScheduleBursts(events []*types.HistoryEvent) []*ActivitySched
 // continued-as-new from workflow code. A nil Initiator reads as ContinueAsNewInitiatorDecider,
 // which is correct: the server only sets the initiator explicitly for its own cron- and
 // retry-driven continuations, and passes decisions from workflow code through unmodified.
-func detectContinueAsNewInCronWorkflow(events []*types.HistoryEvent) *ContinueAsNewInCronWorkflowMetadata {
+func detectContinueAsNewInCronWorkflow(events []*types.HistoryEvent) *AntipatternIssuesMetadata {
 	startedEvent := fetchWfStartedEvent(events)
 	if startedEvent == nil {
 		return nil
@@ -137,10 +139,12 @@ func detectContinueAsNewInCronWorkflow(events []*types.HistoryEvent) *ContinueAs
 			continue
 		}
 		if attr.GetInitiator() == types.ContinueAsNewInitiatorDecider {
-			return &ContinueAsNewInCronWorkflowMetadata{
-				StartedEventID:        startedEvent.ID,
-				CronSchedule:          cronSchedule,
-				ContinuedAsNewEventID: event.ID,
+			return &AntipatternIssuesMetadata{
+				EventID: event.ID,
+				ContinueAsNewInCronWorkflow: &ContinueAsNewInCronWorkflowMetadata{
+					StartedEventID: startedEvent.ID,
+					CronSchedule:   cronSchedule,
+				},
 			}
 		}
 	}

--- a/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
+++ b/service/worker/diagnostics/invariant/antipatterns/antipatterns_test.go
@@ -22,82 +22,96 @@ const (
 func Test__Check(t *testing.T) {
 	windowNanos := activityBurstWindowInSeconds * int64(time.Second)
 
-	burstMetadata := ActivityScheduleBurstMetadata{
-		FirstEventID:    2,
-		LastEventID:     2 + int64(activityBurstCountThreshold) - 1,
-		EventCount:      activityBurstCountThreshold,
-		WindowStart:     time.Unix(0, testTimestamp).UTC(),
-		WindowEnd:       time.Unix(0, testTimestamp+int64(activityBurstCountThreshold-1)*testStepNanos).UTC(),
-		WindowInSeconds: activityBurstWindowInSeconds,
-		Threshold:       activityBurstCountThreshold,
+	burstMetadata := AntipatternIssuesMetadata{
+		EventID: 2,
+		ActivityScheduleBurst: &ActivityScheduleBurstMetadata{
+			LastEventID:     2 + int64(activityBurstCountThreshold) - 1,
+			EventCount:      activityBurstCountThreshold,
+			WindowStart:     time.Unix(0, testTimestamp).UTC(),
+			WindowEnd:       time.Unix(0, testTimestamp+int64(activityBurstCountThreshold-1)*testStepNanos).UTC(),
+			WindowInSeconds: activityBurstWindowInSeconds,
+			Threshold:       activityBurstCountThreshold,
+		},
 	}
 	burstMetadataInBytes, err := json.Marshal(burstMetadata)
 	require.NoError(t, err)
 
-	burstAtWindowEdgeMetadata := ActivityScheduleBurstMetadata{
-		FirstEventID:    2,
-		LastEventID:     2 + int64(activityBurstCountThreshold) - 1,
-		EventCount:      activityBurstCountThreshold,
-		WindowStart:     time.Unix(0, testTimestamp).UTC(),
-		WindowEnd:       time.Unix(0, testTimestamp+windowNanos).UTC(),
-		WindowInSeconds: activityBurstWindowInSeconds,
-		Threshold:       activityBurstCountThreshold,
+	burstAtWindowEdgeMetadata := AntipatternIssuesMetadata{
+		EventID: 2,
+		ActivityScheduleBurst: &ActivityScheduleBurstMetadata{
+			LastEventID:     2 + int64(activityBurstCountThreshold) - 1,
+			EventCount:      activityBurstCountThreshold,
+			WindowStart:     time.Unix(0, testTimestamp).UTC(),
+			WindowEnd:       time.Unix(0, testTimestamp+windowNanos).UTC(),
+			WindowInSeconds: activityBurstWindowInSeconds,
+			Threshold:       activityBurstCountThreshold,
+		},
 	}
 	burstAtWindowEdgeMetadataInBytes, err := json.Marshal(burstAtWindowEdgeMetadata)
 	require.NoError(t, err)
 
-	secondBurstMetadata := ActivityScheduleBurstMetadata{
-		FirstEventID:    100,
-		LastEventID:     100 + int64(activityBurstCountThreshold) + 4,
-		EventCount:      activityBurstCountThreshold + 5,
-		WindowStart:     time.Unix(0, testTimestamp+int64(time.Hour)).UTC(),
-		WindowEnd:       time.Unix(0, testTimestamp+int64(time.Hour)+int64(activityBurstCountThreshold+4)*testStepNanos).UTC(),
-		WindowInSeconds: activityBurstWindowInSeconds,
-		Threshold:       activityBurstCountThreshold,
+	secondBurstMetadata := AntipatternIssuesMetadata{
+		EventID: 100,
+		ActivityScheduleBurst: &ActivityScheduleBurstMetadata{
+			LastEventID:     100 + int64(activityBurstCountThreshold) + 4,
+			EventCount:      activityBurstCountThreshold + 5,
+			WindowStart:     time.Unix(0, testTimestamp+int64(time.Hour)).UTC(),
+			WindowEnd:       time.Unix(0, testTimestamp+int64(time.Hour)+int64(activityBurstCountThreshold+4)*testStepNanos).UTC(),
+			WindowInSeconds: activityBurstWindowInSeconds,
+			Threshold:       activityBurstCountThreshold,
+		},
 	}
 	secondBurstMetadataInBytes, err := json.Marshal(secondBurstMetadata)
 	require.NoError(t, err)
 
 	const sustainedBurstCount = 100
 	const sustainedBurstStepNanos = int64(150 * time.Millisecond)
-	sustainedBurstMetadata := ActivityScheduleBurstMetadata{
-		FirstEventID:    2,
-		LastEventID:     2 + int64(sustainedBurstCount) - 1,
-		EventCount:      sustainedBurstCount,
-		WindowStart:     time.Unix(0, testTimestamp).UTC(),
-		WindowEnd:       time.Unix(0, testTimestamp+int64(sustainedBurstCount-1)*sustainedBurstStepNanos).UTC(),
-		WindowInSeconds: activityBurstWindowInSeconds,
-		Threshold:       activityBurstCountThreshold,
+	sustainedBurstMetadata := AntipatternIssuesMetadata{
+		EventID: 2,
+		ActivityScheduleBurst: &ActivityScheduleBurstMetadata{
+			LastEventID:     2 + int64(sustainedBurstCount) - 1,
+			EventCount:      sustainedBurstCount,
+			WindowStart:     time.Unix(0, testTimestamp).UTC(),
+			WindowEnd:       time.Unix(0, testTimestamp+int64(sustainedBurstCount-1)*sustainedBurstStepNanos).UTC(),
+			WindowInSeconds: activityBurstWindowInSeconds,
+			Threshold:       activityBurstCountThreshold,
+		},
 	}
 	sustainedBurstMetadataInBytes, err := json.Marshal(sustainedBurstMetadata)
 	require.NoError(t, err)
 
 	group1LastTimestamp := testTimestamp + int64(activityBurstCountThreshold-1)*testStepNanos
 	sharedBoundaryGroup2Start := group1LastTimestamp + windowNanos
-	sharedBoundaryMetadata := ActivityScheduleBurstMetadata{
-		FirstEventID:    2,
-		LastEventID:     2 * int64(activityBurstCountThreshold),
-		EventCount:      2*activityBurstCountThreshold - 1,
-		WindowStart:     time.Unix(0, testTimestamp).UTC(),
-		WindowEnd:       time.Unix(0, sharedBoundaryGroup2Start).UTC(),
-		WindowInSeconds: activityBurstWindowInSeconds,
-		Threshold:       activityBurstCountThreshold,
+	sharedBoundaryMetadata := AntipatternIssuesMetadata{
+		EventID: 2,
+		ActivityScheduleBurst: &ActivityScheduleBurstMetadata{
+			LastEventID:     2 * int64(activityBurstCountThreshold),
+			EventCount:      2*activityBurstCountThreshold - 1,
+			WindowStart:     time.Unix(0, testTimestamp).UTC(),
+			WindowEnd:       time.Unix(0, sharedBoundaryGroup2Start).UTC(),
+			WindowInSeconds: activityBurstWindowInSeconds,
+			Threshold:       activityBurstCountThreshold,
+		},
 	}
 	sharedBoundaryMetadataInBytes, err := json.Marshal(sharedBoundaryMetadata)
 	require.NoError(t, err)
 
-	cronCaNMetadata := ContinueAsNewInCronWorkflowMetadata{
-		StartedEventID:        1,
-		CronSchedule:          testCronSchedule,
-		ContinuedAsNewEventID: 2,
+	cronCaNMetadata := AntipatternIssuesMetadata{
+		EventID: 2,
+		ContinueAsNewInCronWorkflow: &ContinueAsNewInCronWorkflowMetadata{
+			StartedEventID: 1,
+			CronSchedule:   testCronSchedule,
+		},
 	}
 	cronCaNMetadataInBytes, err := json.Marshal(cronCaNMetadata)
 	require.NoError(t, err)
 
-	cronCaNAfterBurstMetadata := ContinueAsNewInCronWorkflowMetadata{
-		StartedEventID:        1,
-		CronSchedule:          testCronSchedule,
-		ContinuedAsNewEventID: 90,
+	cronCaNAfterBurstMetadata := AntipatternIssuesMetadata{
+		EventID: 90,
+		ContinueAsNewInCronWorkflow: &ContinueAsNewInCronWorkflowMetadata{
+			StartedEventID: 1,
+			CronSchedule:   testCronSchedule,
+		},
 	}
 	cronCaNAfterBurstMetadataInBytes, err := json.Marshal(cronCaNAfterBurstMetadata)
 	require.NoError(t, err)

--- a/service/worker/diagnostics/invariant/antipatterns/types.go
+++ b/service/worker/diagnostics/invariant/antipatterns/types.go
@@ -72,9 +72,7 @@ type ContinueAsNewInCronWorkflowMetadata struct {
 }
 
 // AntipatternIssuesMetadata is the metadata for every antipattern issue. EventID is the event the
-// issue anchors on: the first ActivityTaskScheduled event of a burst, or the
-// WorkflowExecutionContinuedAsNew event that was initiated by workflow code. Exactly one of the
-// per-check fields is set, holding the details specific to that check.
+// issue anchors on. Exactly one of the per-check fields is set, holding the details specific to that check.
 type AntipatternIssuesMetadata struct {
 	EventID int64
 

--- a/service/worker/diagnostics/invariant/antipatterns/types.go
+++ b/service/worker/diagnostics/invariant/antipatterns/types.go
@@ -54,10 +54,9 @@ const (
 // ActivityScheduleBurstMetadata describes one cluster of tightly-packed scheduled activities.
 // Every cluster that crosses the threshold is reported as its own issue, and a single sustained
 // burst spanning more than WindowInSeconds is still reported as one span rather than being split
-// at a window boundary. FirstEventID/LastEventID bound the full cluster, not just the densest
-// sub-window within it.
+// at a window boundary. The issue's EventID and LastEventID bound the full cluster, not just the
+// densest sub-window within it.
 type ActivityScheduleBurstMetadata struct {
-	FirstEventID    int64
 	LastEventID     int64
 	EventCount      int
 	WindowStart     time.Time
@@ -66,17 +65,19 @@ type ActivityScheduleBurstMetadata struct {
 	Threshold       int
 }
 
-// ContinueAsNewInCronWorkflowMetadata identifies the started event carrying the cron schedule and
-// the continue-as-new event that was initiated by workflow code.
+// ContinueAsNewInCronWorkflowMetadata identifies the started event carrying the cron schedule.
 type ContinueAsNewInCronWorkflowMetadata struct {
-	StartedEventID        int64
-	CronSchedule          string
-	ContinuedAsNewEventID int64
+	StartedEventID int64
+	CronSchedule   string
 }
 
-// AntipatternIssuesMetadata is a discriminated union of the metadata for each antipattern check,
-// with exactly one field populated per issue.
+// AntipatternIssuesMetadata is the metadata for every antipattern issue. EventID is the event the
+// issue anchors on: the first ActivityTaskScheduled event of a burst, or the
+// WorkflowExecutionContinuedAsNew event that was initiated by workflow code. Exactly one of the
+// per-check fields is set, holding the details specific to that check.
 type AntipatternIssuesMetadata struct {
-	ActivityScheduleBurst       *ActivityScheduleBurstMetadata
-	ContinueAsNewInCronWorkflow *ContinueAsNewInCronWorkflowMetadata
+	EventID int64
+
+	ActivityScheduleBurst       *ActivityScheduleBurstMetadata       `json:",omitempty"`
+	ContinueAsNewInCronWorkflow *ContinueAsNewInCronWorkflowMetadata `json:",omitempty"`
 }

--- a/service/worker/diagnostics/invariant/failure/failure.go
+++ b/service/worker/diagnostics/invariant/failure/failure.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package failure
 
 import (

--- a/service/worker/diagnostics/invariant/failure/failure_test.go
+++ b/service/worker/diagnostics/invariant/failure/failure_test.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package failure
 
 import (

--- a/service/worker/diagnostics/invariant/failure/types.go
+++ b/service/worker/diagnostics/invariant/failure/types.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package failure
 
 type ErrorType string

--- a/service/worker/diagnostics/invariant/retry/retry.go
+++ b/service/worker/diagnostics/invariant/retry/retry.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package retry
 
 import (

--- a/service/worker/diagnostics/invariant/retry/retry_test.go
+++ b/service/worker/diagnostics/invariant/retry/retry_test.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package retry
 
 import (

--- a/service/worker/diagnostics/invariant/retry/types.go
+++ b/service/worker/diagnostics/invariant/retry/types.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package retry
 
 import "github.com/uber/cadence/common/types"

--- a/service/worker/diagnostics/invariant/timeout/timeout.go
+++ b/service/worker/diagnostics/invariant/timeout/timeout.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package timeout
 
 import (

--- a/service/worker/diagnostics/invariant/timeout/timeout.go
+++ b/service/worker/diagnostics/invariant/timeout/timeout.go
@@ -58,11 +58,14 @@ func (t *timeout) Check(ctx context.Context, params invariant.InvariantCheckInpu
 	for _, event := range events {
 		if event.WorkflowExecutionTimedOutEventAttributes != nil {
 			timeoutLimit := getWorkflowExecutionConfiguredTimeout(events)
-			data := ExecutionTimeoutMetadata{
-				ExecutionTime:     getExecutionTime(1, event.ID, events),
+			data := TimeoutIssuesMetadata{
+				EventID:           event.ID,
 				ConfiguredTimeout: time.Duration(timeoutLimit) * time.Second,
-				LastOngoingEvent:  events[len(events)-2],
-				Tasklist:          getWorkflowExecutionTasklist(events),
+				ExecutionTimeout: &ExecutionTimeoutMetadata{
+					ExecutionTime:    getExecutionTime(1, event.ID, events),
+					LastOngoingEvent: events[len(events)-2],
+					Tasklist:         getWorkflowExecutionTasklist(events),
+				},
 			}
 			result = append(result, invariant.InvariantCheckResult{
 				IssueID:       issueID,
@@ -97,10 +100,13 @@ func (t *timeout) Check(ctx context.Context, params invariant.InvariantCheckInpu
 		}
 		if event.ChildWorkflowExecutionTimedOutEventAttributes != nil {
 			timeoutLimit := getChildWorkflowExecutionConfiguredTimeout(event, events)
-			data := ChildWfTimeoutMetadata{
-				ExecutionTime:     getExecutionTime(event.GetChildWorkflowExecutionTimedOutEventAttributes().StartedEventID, event.ID, events),
+			data := TimeoutIssuesMetadata{
+				EventID:           event.ID,
 				ConfiguredTimeout: time.Duration(timeoutLimit) * time.Second,
-				Execution:         event.GetChildWorkflowExecutionTimedOutEventAttributes().WorkflowExecution,
+				ChildWfTimeout: &ChildWfTimeoutMetadata{
+					ExecutionTime: getExecutionTime(event.GetChildWorkflowExecutionTimedOutEventAttributes().StartedEventID, event.ID, events),
+					Execution:     event.GetChildWorkflowExecutionTimedOutEventAttributes().WorkflowExecution,
+				},
 			}
 			result = append(result, invariant.InvariantCheckResult{
 				IssueID:       issueID,
@@ -139,23 +145,22 @@ func (t *timeout) RootCause(ctx context.Context, params invariant.InvariantRootC
 func (t *timeout) checkTasklist(ctx context.Context, issue invariant.InvariantCheckResult, domain string) (invariant.InvariantRootCauseResult, error) {
 	var taskList *types.TaskList
 	var tasklistType *shared.TaskListType
+	var metadata TimeoutIssuesMetadata
+	err := json.Unmarshal(issue.Metadata, &metadata)
+	if err != nil {
+		return invariant.InvariantRootCauseResult{}, err
+	}
 	switch issue.InvariantType {
 	case TimeoutTypeExecution.String():
-		var metadata ExecutionTimeoutMetadata
-		err := json.Unmarshal(issue.Metadata, &metadata)
-		if err != nil {
-			return invariant.InvariantRootCauseResult{}, err
-		}
-		taskList = metadata.Tasklist
 		tasklistType = shared.TaskListTypeDecision.Ptr()
-	case TimeoutTypeActivity.String():
-		var metadata ActivityTimeoutMetadata
-		err := json.Unmarshal(issue.Metadata, &metadata)
-		if err != nil {
-			return invariant.InvariantRootCauseResult{}, err
+		if metadata.ExecutionTimeout != nil {
+			taskList = metadata.ExecutionTimeout.Tasklist
 		}
-		taskList = metadata.Tasklist
+	case TimeoutTypeActivity.String():
 		tasklistType = shared.TaskListTypeActivity.Ptr()
+		if metadata.ActivityTimeout != nil {
+			taskList = metadata.ActivityTimeout.Tasklist
+		}
 	}
 	if taskList == nil {
 		return invariant.InvariantRootCauseResult{}, fmt.Errorf("tasklist not set")
@@ -202,16 +207,20 @@ func taskListKind(kind types.TaskListKind) *shared.TaskListKind {
 }
 
 func checkHeartbeatStatus(issue invariant.InvariantCheckResult) ([]invariant.InvariantRootCauseResult, error) {
-	var metadata ActivityTimeoutMetadata
+	var metadata TimeoutIssuesMetadata
 	err := json.Unmarshal(issue.Metadata, &metadata)
 	if err != nil {
 		return nil, err
 	}
+	if metadata.ActivityTimeout == nil {
+		return nil, fmt.Errorf("activity timeout metadata not set")
+	}
+	act := metadata.ActivityTimeout
 
-	heartbeatingMetadataInBytes := invariant.MarshalData(HeartbeatingMetadata{TimeElapsed: metadata.TimeElapsed, RetryPolicy: metadata.RetryPolicy})
+	heartbeatingMetadataInBytes := invariant.MarshalData(HeartbeatingMetadata{TimeElapsed: act.TimeElapsed, RetryPolicy: act.RetryPolicy})
 
-	if metadata.HeartBeatTimeout == 0 && activityStarted(metadata) {
-		if metadata.RetryPolicy != nil {
+	if act.HeartBeatTimeout == 0 && activityStarted(*act) {
+		if act.RetryPolicy != nil {
 			return []invariant.InvariantRootCauseResult{
 				{
 					IssueID:   issue.IssueID,
@@ -229,8 +238,8 @@ func checkHeartbeatStatus(issue invariant.InvariantCheckResult) ([]invariant.Inv
 		}, nil
 	}
 
-	if metadata.HeartBeatTimeout > 0 && metadata.TimeoutType.String() == types.TimeoutTypeHeartbeat.String() {
-		if metadata.RetryPolicy == nil {
+	if act.HeartBeatTimeout > 0 && act.TimeoutType.String() == types.TimeoutTypeHeartbeat.String() {
+		if act.RetryPolicy == nil {
 			return []invariant.InvariantRootCauseResult{
 				{
 					IssueID:   issue.IssueID,

--- a/service/worker/diagnostics/invariant/timeout/timeout_test.go
+++ b/service/worker/diagnostics/invariant/timeout/timeout_test.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package timeout
 
 import (

--- a/service/worker/diagnostics/invariant/timeout/timeout_test.go
+++ b/service/worker/diagnostics/invariant/timeout/timeout_test.go
@@ -49,9 +49,6 @@ const (
 )
 
 func Test__Check(t *testing.T) {
-	decisionTimeoutMetadata := DecisionTimeoutMetadata{ConfiguredTimeout: 50 * time.Second}
-	decisionTimeoutMetadataInBytes, err := json.Marshal(decisionTimeoutMetadata)
-	require.NoError(t, err)
 	testCases := []struct {
 		name           string
 		testData       *types.GetWorkflowExecutionHistoryResponse
@@ -111,13 +108,13 @@ func Test__Check(t *testing.T) {
 					IssueID:       0,
 					InvariantType: TimeoutTypeDecision.String(),
 					Reason:        "START_TO_CLOSE",
-					Metadata:      decisionTimeoutMetadataInBytes,
+					Metadata:      decisionTimeoutDataInBytes(t, 2),
 				},
 				{
 					IssueID:       1,
 					InvariantType: TimeoutTypeDecision.String(),
 					Reason:        "workflow reset - New run ID: new run ID",
-					Metadata:      decisionTimeoutMetadataInBytes,
+					Metadata:      decisionTimeoutDataInBytes(t, 4),
 				},
 			},
 			err: nil,
@@ -261,28 +258,30 @@ func decisionTimeoutHistory() *types.GetWorkflowExecutionHistoryResponse {
 		History: &types.History{
 			Events: []*types.HistoryEvent{
 				{
-					ID: 13,
+					ID: 1,
 					DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
 						StartToCloseTimeoutSeconds: common.Int32Ptr(taskTimeoutSecond),
 					},
 				},
 				{
+					ID: 2,
 					DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
-						ScheduledEventID: 13,
+						ScheduledEventID: 1,
 						StartedEventID:   14,
 						Cause:            types.DecisionTaskTimedOutCauseTimeout.Ptr(),
 						TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
 					},
 				},
 				{
-					ID: 23,
+					ID: 3,
 					DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
 						StartToCloseTimeoutSeconds: common.Int32Ptr(taskTimeoutSecond),
 					},
 				},
 				{
+					ID: 4,
 					DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
-						ScheduledEventID: 23,
+						ScheduledEventID: 3,
 						Cause:            types.DecisionTaskTimedOutCauseReset.Ptr(),
 						Reason:           "workflow reset",
 						NewRunID:         "new run ID",
@@ -293,24 +292,34 @@ func decisionTimeoutHistory() *types.GetWorkflowExecutionHistoryResponse {
 	}
 }
 
+func decisionTimeoutDataInBytes(t *testing.T, eventID int64) []byte {
+	data := TimeoutIssuesMetadata{EventID: eventID, ConfiguredTimeout: 50 * time.Second}
+	dataInBytes, err := json.Marshal(data)
+	require.NoError(t, err)
+	return dataInBytes
+}
+
 func wfTimeoutDataInBytes(t *testing.T) []byte {
-	data := ExecutionTimeoutMetadata{
-		ExecutionTime:     110 * time.Second,
+	data := TimeoutIssuesMetadata{
+		EventID:           2,
 		ConfiguredTimeout: 110 * time.Second,
-		LastOngoingEvent: &types.HistoryEvent{
-			ID:        1,
-			Timestamp: common.Int64Ptr(testTimeStamp),
-			WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
-				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
-				TaskList: &types.TaskList{
-					Name: testTasklist,
-					Kind: nil,
+		ExecutionTimeout: &ExecutionTimeoutMetadata{
+			ExecutionTime: 110 * time.Second,
+			LastOngoingEvent: &types.HistoryEvent{
+				ID:        1,
+				Timestamp: common.Int64Ptr(testTimeStamp),
+				WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+					ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+					TaskList: &types.TaskList{
+						Name: testTasklist,
+						Kind: nil,
+					},
 				},
 			},
-		},
-		Tasklist: &types.TaskList{
-			Name: testTasklist,
-			Kind: nil,
+			Tasklist: &types.TaskList{
+				Name: testTasklist,
+				Kind: nil,
+			},
 		},
 	}
 	dataInBytes, err := json.Marshal(data)
@@ -318,30 +327,36 @@ func wfTimeoutDataInBytes(t *testing.T) []byte {
 	return dataInBytes
 }
 
-func activityScheduleToStartTimeoutData() ActivityTimeoutMetadata {
-	return ActivityTimeoutMetadata{
-		TimeoutType:       types.TimeoutTypeScheduleToStart.Ptr(),
+func activityScheduleToStartTimeoutData() TimeoutIssuesMetadata {
+	return TimeoutIssuesMetadata{
+		EventID:           2,
 		ConfiguredTimeout: 50 * time.Second,
-		TimeElapsed:       50 * time.Second,
-		RetryPolicy:       nil,
-		HeartBeatTimeout:  0,
-		Tasklist: &types.TaskList{
-			Name: testTasklist,
-			Kind: nil,
+		ActivityTimeout: &ActivityTimeoutMetadata{
+			TimeoutType:      types.TimeoutTypeScheduleToStart.Ptr(),
+			TimeElapsed:      50 * time.Second,
+			RetryPolicy:      nil,
+			HeartBeatTimeout: 0,
+			Tasklist: &types.TaskList{
+				Name: testTasklist,
+				Kind: nil,
+			},
 		},
 	}
 }
 
-func activityStartToCloseTimeoutData() ActivityTimeoutMetadata {
-	return ActivityTimeoutMetadata{
-		TimeoutType:       types.TimeoutTypeStartToClose.Ptr(),
+func activityStartToCloseTimeoutData() TimeoutIssuesMetadata {
+	return TimeoutIssuesMetadata{
+		EventID:           5,
 		ConfiguredTimeout: 50 * time.Second,
-		TimeElapsed:       50 * time.Second,
-		RetryPolicy:       nil,
-		HeartBeatTimeout:  0,
-		Tasklist: &types.TaskList{
-			Name: testTasklist,
-			Kind: nil,
+		ActivityTimeout: &ActivityTimeoutMetadata{
+			TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
+			TimeElapsed:      50 * time.Second,
+			RetryPolicy:      nil,
+			HeartBeatTimeout: 0,
+			Tasklist: &types.TaskList{
+				Name: testTasklist,
+				Kind: nil,
+			},
 		},
 	}
 }
@@ -362,8 +377,8 @@ func activityStartToCloseTimeoutDataInBytes(t *testing.T) []byte {
 
 func activityHeartBeatTimeoutDataInBytes(t *testing.T) []byte {
 	actTimeoutData := activityStartToCloseTimeoutData()
-	actTimeoutData.TimeoutType = types.TimeoutTypeHeartbeat.Ptr()
-	actTimeoutData.HeartBeatTimeout = 50 * time.Second
+	actTimeoutData.ActivityTimeout.TimeoutType = types.TimeoutTypeHeartbeat.Ptr()
+	actTimeoutData.ActivityTimeout.HeartBeatTimeout = 50 * time.Second
 	actHeartBeatTimeoutDataInBytes, err := json.Marshal(actTimeoutData)
 	require.NoError(t, err)
 	return actHeartBeatTimeoutDataInBytes
@@ -371,9 +386,9 @@ func activityHeartBeatTimeoutDataInBytes(t *testing.T) []byte {
 
 func activityHeartBeatTimeoutDataWithRetryPolicyInBytes(t *testing.T) []byte {
 	actTimeoutData := activityStartToCloseTimeoutData()
-	actTimeoutData.TimeoutType = types.TimeoutTypeHeartbeat.Ptr()
-	actTimeoutData.HeartBeatTimeout = 50 * time.Second
-	actTimeoutData.RetryPolicy = &types.RetryPolicy{
+	actTimeoutData.ActivityTimeout.TimeoutType = types.TimeoutTypeHeartbeat.Ptr()
+	actTimeoutData.ActivityTimeout.HeartBeatTimeout = 50 * time.Second
+	actTimeoutData.ActivityTimeout.RetryPolicy = &types.RetryPolicy{
 		MaximumAttempts: 3,
 	}
 	actHeartBeatTimeoutDataInBytes, err := json.Marshal(actTimeoutData)
@@ -382,12 +397,15 @@ func activityHeartBeatTimeoutDataWithRetryPolicyInBytes(t *testing.T) []byte {
 }
 
 func childWfTimeoutDataInBytes(t *testing.T) []byte {
-	data := ChildWfTimeoutMetadata{
-		ExecutionTime:     110 * time.Second,
+	data := TimeoutIssuesMetadata{
+		EventID:           3,
 		ConfiguredTimeout: 110 * time.Second,
-		Execution: &types.WorkflowExecution{
-			WorkflowID: "123",
-			RunID:      "abc",
+		ChildWfTimeout: &ChildWfTimeoutMetadata{
+			ExecutionTime: 110 * time.Second,
+			Execution: &types.WorkflowExecution{
+				WorkflowID: "123",
+				RunID:      "abc",
+			},
 		},
 	}
 	dataInBytes, err := json.Marshal(data)
@@ -399,9 +417,9 @@ func Test__RootCause(t *testing.T) {
 	actStartToCloseTimeoutData := activityStartToCloseTimeoutData()
 	pollersMetadataInBytes, err := json.Marshal(PollersMetadata{TaskListName: testTasklist, TaskListBacklog: testTaskListBacklog})
 	require.NoError(t, err)
-	heartBeatingMetadataInBytes, err := json.Marshal(HeartbeatingMetadata{TimeElapsed: actStartToCloseTimeoutData.TimeElapsed})
+	heartBeatingMetadataInBytes, err := json.Marshal(HeartbeatingMetadata{TimeElapsed: actStartToCloseTimeoutData.ActivityTimeout.TimeElapsed})
 	require.NoError(t, err)
-	heartBeatingMetadataWithRetryPolicyInBytes, err := json.Marshal(HeartbeatingMetadata{TimeElapsed: actStartToCloseTimeoutData.TimeElapsed, RetryPolicy: &types.RetryPolicy{MaximumAttempts: 3}})
+	heartBeatingMetadataWithRetryPolicyInBytes, err := json.Marshal(HeartbeatingMetadata{TimeElapsed: actStartToCloseTimeoutData.ActivityTimeout.TimeElapsed, RetryPolicy: &types.RetryPolicy{MaximumAttempts: 3}})
 	require.NoError(t, err)
 	testCases := []struct {
 		name           string

--- a/service/worker/diagnostics/invariant/timeout/timeout_utils.go
+++ b/service/worker/diagnostics/invariant/timeout/timeout_utils.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package timeout
 
 import (

--- a/service/worker/diagnostics/invariant/timeout/timeout_utils.go
+++ b/service/worker/diagnostics/invariant/timeout/timeout_utils.go
@@ -31,7 +31,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func reasonForDecisionTaskTimeouts(event *types.HistoryEvent, allEvents []*types.HistoryEvent) (string, DecisionTimeoutMetadata) {
+func reasonForDecisionTaskTimeouts(event *types.HistoryEvent, allEvents []*types.HistoryEvent) (string, TimeoutIssuesMetadata) {
 	eventScheduledID := event.GetDecisionTaskTimedOutEventAttributes().GetScheduledEventID()
 	attr := event.GetDecisionTaskTimedOutEventAttributes()
 	cause := attr.GetCause()
@@ -43,7 +43,8 @@ func reasonForDecisionTaskTimeouts(event *types.HistoryEvent, allEvents []*types
 		newRunID := attr.GetNewRunID()
 		reason = fmt.Sprintf("%s - New run ID: %s", attr.Reason, newRunID)
 	}
-	return reason, DecisionTimeoutMetadata{
+	return reason, TimeoutIssuesMetadata{
+		EventID:           event.ID,
 		ConfiguredTimeout: time.Duration(getDecisionTaskConfiguredTimeout(eventScheduledID, allEvents)) * time.Second,
 	}
 }
@@ -66,7 +67,7 @@ func getWorkflowExecutionTasklist(events []*types.HistoryEvent) *types.TaskList 
 	return nil
 }
 
-func getActivityTaskMetadata(e *types.HistoryEvent, events []*types.HistoryEvent) (ActivityTimeoutMetadata, error) {
+func getActivityTaskMetadata(e *types.HistoryEvent, events []*types.HistoryEvent) (TimeoutIssuesMetadata, error) {
 	eventScheduledID := e.GetActivityTaskTimedOutEventAttributes().GetScheduledEventID()
 	eventStartedID := e.GetActivityTaskTimedOutEventAttributes().StartedEventID
 	timeoutType := e.GetActivityTaskTimedOutEventAttributes().GetTimeoutType()
@@ -89,20 +90,23 @@ func getActivityTaskMetadata(e *types.HistoryEvent, events []*types.HistoryEvent
 				configuredTimeout = attr.GetStartToCloseTimeoutSeconds()
 				timeElapsed = getExecutionTime(eventStartedID, e.ID, events)
 			default:
-				return ActivityTimeoutMetadata{}, fmt.Errorf("unknown timeout type")
+				return TimeoutIssuesMetadata{}, fmt.Errorf("unknown timeout type")
 			}
-			return ActivityTimeoutMetadata{
-				TimeoutType:       timeoutType.Ptr(),
+			return TimeoutIssuesMetadata{
+				EventID:           e.ID,
 				ConfiguredTimeout: time.Duration(configuredTimeout) * time.Second,
-				TimeElapsed:       timeElapsed,
-				RetryPolicy:       attr.RetryPolicy,
-				HeartBeatTimeout:  time.Duration(attr.GetHeartbeatTimeoutSeconds()) * time.Second,
-				Tasklist:          attr.TaskList,
+				ActivityTimeout: &ActivityTimeoutMetadata{
+					TimeoutType:      timeoutType.Ptr(),
+					TimeElapsed:      timeElapsed,
+					RetryPolicy:      attr.RetryPolicy,
+					HeartBeatTimeout: time.Duration(attr.GetHeartbeatTimeoutSeconds()) * time.Second,
+					Tasklist:         attr.TaskList,
+				},
 			}, nil
 		}
 
 	}
-	return ActivityTimeoutMetadata{}, fmt.Errorf("activity scheduled event not found")
+	return TimeoutIssuesMetadata{}, fmt.Errorf("activity scheduled event not found")
 }
 
 func getDecisionTaskConfiguredTimeout(eventScheduledID int64, events []*types.HistoryEvent) int32 {

--- a/service/worker/diagnostics/invariant/timeout/types.go
+++ b/service/worker/diagnostics/invariant/timeout/types.go
@@ -1,25 +1,3 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package timeout
 
 import (
@@ -71,8 +49,6 @@ type HeartbeatingMetadata struct {
 }
 
 // TimeoutIssuesMetadata is the metadata for every timeout issue. EventID is the timed-out event.
-// The fields shared by all checks are top-level so the UI can render and link them; at most one of
-// the per-check fields is set (none for a decision task timeout, which has no extra details).
 type TimeoutIssuesMetadata struct {
 	EventID           int64
 	ConfiguredTimeout time.Duration

--- a/service/worker/diagnostics/invariant/timeout/types.go
+++ b/service/worker/diagnostics/invariant/timeout/types.go
@@ -42,29 +42,22 @@ func (tt TimeoutType) String() string {
 }
 
 type ExecutionTimeoutMetadata struct {
-	ExecutionTime     time.Duration
-	ConfiguredTimeout time.Duration
-	Tasklist          *types.TaskList
-	LastOngoingEvent  *types.HistoryEvent
+	ExecutionTime    time.Duration
+	Tasklist         *types.TaskList
+	LastOngoingEvent *types.HistoryEvent
 }
 
 type ChildWfTimeoutMetadata struct {
-	ExecutionTime     time.Duration
-	ConfiguredTimeout time.Duration
-	Execution         *types.WorkflowExecution
+	ExecutionTime time.Duration
+	Execution     *types.WorkflowExecution
 }
 
 type ActivityTimeoutMetadata struct {
-	TimeoutType       *types.TimeoutType
-	ConfiguredTimeout time.Duration
-	TimeElapsed       time.Duration
-	RetryPolicy       *types.RetryPolicy
-	HeartBeatTimeout  time.Duration
-	Tasklist          *types.TaskList
-}
-
-type DecisionTimeoutMetadata struct {
-	ConfiguredTimeout time.Duration
+	TimeoutType      *types.TimeoutType
+	TimeElapsed      time.Duration
+	RetryPolicy      *types.RetryPolicy
+	HeartBeatTimeout time.Duration
+	Tasklist         *types.TaskList
 }
 
 type PollersMetadata struct {
@@ -77,11 +70,16 @@ type HeartbeatingMetadata struct {
 	RetryPolicy *types.RetryPolicy
 }
 
+// TimeoutIssuesMetadata is the metadata for every timeout issue. EventID is the timed-out event.
+// The fields shared by all checks are top-level so the UI can render and link them; at most one of
+// the per-check fields is set (none for a decision task timeout, which has no extra details).
 type TimeoutIssuesMetadata struct {
-	ExecutionTimeout *ExecutionTimeoutMetadata
-	ActivityTimeout  *ActivityTimeoutMetadata
-	ChildWfTimeout   *ChildWfTimeoutMetadata
-	DecisionTimeout  *DecisionTimeoutMetadata
+	EventID           int64
+	ConfiguredTimeout time.Duration
+
+	ExecutionTimeout *ExecutionTimeoutMetadata `json:",omitempty"`
+	ActivityTimeout  *ActivityTimeoutMetadata  `json:",omitempty"`
+	ChildWfTimeout   *ChildWfTimeoutMetadata   `json:",omitempty"`
 }
 
 type TimeoutRootcauseMetadata struct {

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk.go
@@ -43,12 +43,14 @@ func (t *timeoutRisk) Check(ctx context.Context, params invariant.InvariantCheck
 				IssueID:       issueID,
 				InvariantType: ActivityStartToCloseAtWorkflowTimeoutCap.String(),
 				Reason:        StartToCloseAtWorkflowTimeoutCap.String(),
-				Metadata: invariant.MarshalData(ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+				Metadata: invariant.MarshalData(TimeoutRiskIssuesMetadata{
 					EventID:             event.ID,
 					ActivityID:          activityID,
 					ActivityType:        activityType,
 					StartToCloseTimeout: time.Duration(attr.GetStartToCloseTimeoutSeconds()) * time.Second,
-					WorkflowTimeout:     time.Duration(workflowTimeoutSeconds) * time.Second,
+					ActivityStartToCloseAtWorkflowTimeoutCap: &ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+						WorkflowTimeout: time.Duration(workflowTimeoutSeconds) * time.Second,
+					},
 				}),
 			})
 			issueID++
@@ -59,12 +61,14 @@ func (t *timeoutRisk) Check(ctx context.Context, params invariant.InvariantCheck
 				IssueID:       issueID,
 				InvariantType: ActivityMissingHeartbeatTimeout.String(),
 				Reason:        MissingHeartbeatTimeoutForLongActivity.String(),
-				Metadata: invariant.MarshalData(ActivityMissingHeartbeatTimeoutMetadata{
+				Metadata: invariant.MarshalData(TimeoutRiskIssuesMetadata{
 					EventID:             event.ID,
 					ActivityID:          activityID,
 					ActivityType:        activityType,
 					StartToCloseTimeout: time.Duration(attr.GetStartToCloseTimeoutSeconds()) * time.Second,
-					Threshold:           time.Duration(longRunningActivityThresholdSeconds) * time.Second,
+					ActivityMissingHeartbeatTimeout: &ActivityMissingHeartbeatTimeoutMetadata{
+						Threshold: time.Duration(longRunningActivityThresholdSeconds) * time.Second,
+					},
 				}),
 			})
 			issueID++

--- a/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/timeoutrisk_test.go
@@ -14,52 +14,62 @@ import (
 )
 
 func Test__Check(t *testing.T) {
-	atCapMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+	atCapMetadata := TimeoutRiskIssuesMetadata{
 		EventID:             2,
 		ActivityID:          "101",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 60 * time.Second,
-		WorkflowTimeout:     60 * time.Second,
+		ActivityStartToCloseAtWorkflowTimeoutCap: &ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+			WorkflowTimeout: 60 * time.Second,
+		},
 	}
 	atCapMetadataInBytes, err := json.Marshal(atCapMetadata)
 	require.NoError(t, err)
 
-	missingHeartbeatMetadata := ActivityMissingHeartbeatTimeoutMetadata{
+	missingHeartbeatMetadata := TimeoutRiskIssuesMetadata{
 		EventID:             2,
 		ActivityID:          "102",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 900 * time.Second,
-		Threshold:           600 * time.Second,
+		ActivityMissingHeartbeatTimeout: &ActivityMissingHeartbeatTimeoutMetadata{
+			Threshold: 600 * time.Second,
+		},
 	}
 	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
 	require.NoError(t, err)
 
-	twoIssuesAtCapMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+	twoIssuesAtCapMetadata := TimeoutRiskIssuesMetadata{
 		EventID:             2,
 		ActivityID:          "107",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 1800 * time.Second,
-		WorkflowTimeout:     1800 * time.Second,
+		ActivityStartToCloseAtWorkflowTimeoutCap: &ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+			WorkflowTimeout: 1800 * time.Second,
+		},
 	}
 	twoIssuesAtCapMetadataInBytes, err := json.Marshal(twoIssuesAtCapMetadata)
 	require.NoError(t, err)
 
-	twoIssuesMissingHeartbeatMetadata := ActivityMissingHeartbeatTimeoutMetadata{
+	twoIssuesMissingHeartbeatMetadata := TimeoutRiskIssuesMetadata{
 		EventID:             2,
 		ActivityID:          "107",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 1800 * time.Second,
-		Threshold:           600 * time.Second,
+		ActivityMissingHeartbeatTimeout: &ActivityMissingHeartbeatTimeoutMetadata{
+			Threshold: 600 * time.Second,
+		},
 	}
 	twoIssuesMissingHeartbeatMetadataInBytes, err := json.Marshal(twoIssuesMissingHeartbeatMetadata)
 	require.NoError(t, err)
 
-	secondActivityRiskyMetadata := ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+	secondActivityRiskyMetadata := TimeoutRiskIssuesMetadata{
 		EventID:             3,
 		ActivityID:          "108b",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 60 * time.Second,
-		WorkflowTimeout:     60 * time.Second,
+		ActivityStartToCloseAtWorkflowTimeoutCap: &ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+			WorkflowTimeout: 60 * time.Second,
+		},
 	}
 	secondActivityRiskyMetadataInBytes, err := json.Marshal(secondActivityRiskyMetadata)
 	require.NoError(t, err)

--- a/service/worker/diagnostics/invariant/timeoutrisk/types.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/types.go
@@ -48,9 +48,8 @@ type ActivityMissingHeartbeatTimeoutMetadata struct {
 	Threshold time.Duration
 }
 
-// TimeoutRiskIssuesMetadata is the metadata for every timeout risk issue. EventID is the ActivityTaskScheduled
-// event the issue was found on. The fields shared by all checks are top-level so the UI can render and link
-// them; exactly one of the per-check fields is set, holding the details specific to that check.
+// TimeoutRiskIssuesMetadata is the metadata for every timeout risk issue.
+// EventID is the ActivityTaskScheduled event the issue was found on.
 type TimeoutRiskIssuesMetadata struct {
 	EventID             int64
 	ActivityID          string

--- a/service/worker/diagnostics/invariant/timeoutrisk/types.go
+++ b/service/worker/diagnostics/invariant/timeoutrisk/types.go
@@ -39,26 +39,24 @@ const (
 // was silently capped -- or, if genuinely configured this way, an activity with zero headroom before the
 // workflow itself times out.
 type ActivityStartToCloseAtWorkflowTimeoutCapMetadata struct {
-	EventID             int64
-	ActivityID          string
-	ActivityType        string
-	StartToCloseTimeout time.Duration
-	WorkflowTimeout     time.Duration
+	WorkflowTimeout time.Duration
 }
 
 // ActivityMissingHeartbeatTimeoutMetadata is the metadata for a long-running activity that has no
 // HeartbeatTimeout configured, meaning a dead worker would go undetected until the activity times out.
 type ActivityMissingHeartbeatTimeoutMetadata struct {
+	Threshold time.Duration
+}
+
+// TimeoutRiskIssuesMetadata is the metadata for every timeout risk issue. EventID is the ActivityTaskScheduled
+// event the issue was found on. The fields shared by all checks are top-level so the UI can render and link
+// them; exactly one of the per-check fields is set, holding the details specific to that check.
+type TimeoutRiskIssuesMetadata struct {
 	EventID             int64
 	ActivityID          string
 	ActivityType        string
 	StartToCloseTimeout time.Duration
-	Threshold           time.Duration
-}
 
-// TimeoutRiskIssuesMetadata is a discriminated union of the metadata for each timeout risk check,
-// with exactly one field populated per issue.
-type TimeoutRiskIssuesMetadata struct {
-	ActivityStartToCloseAtWorkflowTimeoutCap *ActivityStartToCloseAtWorkflowTimeoutCapMetadata
-	ActivityMissingHeartbeatTimeout          *ActivityMissingHeartbeatTimeoutMetadata
+	ActivityStartToCloseAtWorkflowTimeoutCap *ActivityStartToCloseAtWorkflowTimeoutCapMetadata `json:",omitempty"`
+	ActivityMissingHeartbeatTimeout          *ActivityMissingHeartbeatTimeoutMetadata          `json:",omitempty"`
 }

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -263,9 +263,9 @@ func retrieveTimeoutIssues(issues []invariant.InvariantCheckResult) ([]*timeoutI
 	result := make([]*timeoutIssuesResult, 0)
 	for _, issue := range issues {
 		switch issue.InvariantType {
-		case timeout.TimeoutTypeExecution.String():
-			var metadata timeout.ExecutionTimeoutMetadata
-			err := json.Unmarshal(issue.Metadata, &metadata)
+		case timeout.TimeoutTypeExecution.String(), timeout.TimeoutTypeActivity.String(), timeout.TimeoutTypeChildWorkflow.String(), timeout.TimeoutTypeDecision.String():
+			var data timeout.TimeoutIssuesMetadata
+			err := json.Unmarshal(issue.Metadata, &data)
 			if err != nil {
 				return nil, err
 			}
@@ -273,51 +273,7 @@ func retrieveTimeoutIssues(issues []invariant.InvariantCheckResult) ([]*timeoutI
 				IssueID:       issue.IssueID,
 				InvariantType: issue.InvariantType,
 				Reason:        issue.Reason,
-				Metadata: &timeout.TimeoutIssuesMetadata{
-					ExecutionTimeout: &metadata,
-				},
-			})
-		case timeout.TimeoutTypeActivity.String():
-			var metadata timeout.ActivityTimeoutMetadata
-			err := json.Unmarshal(issue.Metadata, &metadata)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, &timeoutIssuesResult{
-				IssueID:       issue.IssueID,
-				InvariantType: issue.InvariantType,
-				Reason:        issue.Reason,
-				Metadata: &timeout.TimeoutIssuesMetadata{
-					ActivityTimeout: &metadata,
-				},
-			})
-		case timeout.TimeoutTypeChildWorkflow.String():
-			var metadata timeout.ChildWfTimeoutMetadata
-			err := json.Unmarshal(issue.Metadata, &metadata)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, &timeoutIssuesResult{
-				IssueID:       issue.IssueID,
-				InvariantType: issue.InvariantType,
-				Reason:        issue.Reason,
-				Metadata: &timeout.TimeoutIssuesMetadata{
-					ChildWfTimeout: &metadata,
-				},
-			})
-		case timeout.TimeoutTypeDecision.String():
-			var metadata timeout.DecisionTimeoutMetadata
-			err := json.Unmarshal(issue.Metadata, &metadata)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, &timeoutIssuesResult{
-				IssueID:       issue.IssueID,
-				InvariantType: issue.InvariantType,
-				Reason:        issue.Reason,
-				Metadata: &timeout.TimeoutIssuesMetadata{
-					DecisionTimeout: &metadata,
-				},
+				Metadata:      &data,
 			})
 		}
 	}
@@ -433,9 +389,9 @@ func retrieveTimeoutRiskIssues(issues []invariant.InvariantCheckResult) ([]*time
 	result := make([]*timeoutRiskIssuesResult, 0)
 	for _, issue := range issues {
 		switch issue.InvariantType {
-		case timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCap.String():
-			var metadata timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCapMetadata
-			err := json.Unmarshal(issue.Metadata, &metadata)
+		case timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCap.String(), timeoutrisk.ActivityMissingHeartbeatTimeout.String():
+			var data timeoutrisk.TimeoutRiskIssuesMetadata
+			err := json.Unmarshal(issue.Metadata, &data)
 			if err != nil {
 				return nil, err
 			}
@@ -443,23 +399,7 @@ func retrieveTimeoutRiskIssues(issues []invariant.InvariantCheckResult) ([]*time
 				IssueID:       issue.IssueID,
 				InvariantType: issue.InvariantType,
 				Reason:        issue.Reason,
-				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-					ActivityStartToCloseAtWorkflowTimeoutCap: &metadata,
-				},
-			})
-		case timeoutrisk.ActivityMissingHeartbeatTimeout.String():
-			var metadata timeoutrisk.ActivityMissingHeartbeatTimeoutMetadata
-			err := json.Unmarshal(issue.Metadata, &metadata)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, &timeoutRiskIssuesResult{
-				IssueID:       issue.IssueID,
-				InvariantType: issue.InvariantType,
-				Reason:        issue.Reason,
-				Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-					ActivityMissingHeartbeatTimeout: &metadata,
-				},
+				Metadata:      &data,
 			})
 		}
 	}
@@ -470,27 +410,16 @@ func retrieveAntipatternsIssues(issues []invariant.InvariantCheckResult) ([]*ant
 	result := make([]*antipatternsIssuesResult, 0)
 	for _, issue := range issues {
 		switch issue.InvariantType {
-		case antipatterns.ActivityScheduleBurst.String():
-			var metadata antipatterns.ActivityScheduleBurstMetadata
-			if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
+		case antipatterns.ActivityScheduleBurst.String(), antipatterns.ContinueAsNewInCronWorkflow.String():
+			var data antipatterns.AntipatternIssuesMetadata
+			if err := json.Unmarshal(issue.Metadata, &data); err != nil {
 				return nil, err
 			}
 			result = append(result, &antipatternsIssuesResult{
 				IssueID:       issue.IssueID,
 				InvariantType: issue.InvariantType,
 				Reason:        issue.Reason,
-				Metadata:      &antipatterns.AntipatternIssuesMetadata{ActivityScheduleBurst: &metadata},
-			})
-		case antipatterns.ContinueAsNewInCronWorkflow.String():
-			var metadata antipatterns.ContinueAsNewInCronWorkflowMetadata
-			if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
-				return nil, err
-			}
-			result = append(result, &antipatternsIssuesResult{
-				IssueID:       issue.IssueID,
-				InvariantType: issue.InvariantType,
-				Reason:        issue.Reason,
-				Metadata:      &antipatterns.AntipatternIssuesMetadata{ContinueAsNewInCronWorkflow: &metadata},
+				Metadata:      &data,
 			})
 		}
 	}

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -94,14 +94,17 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 		WorkflowID: "123",
 		RunID:      "abc",
 	}
-	workflowTimeoutData := timeout.ExecutionTimeoutMetadata{
-		ExecutionTime:     110 * time.Second,
+	workflowTimeoutData := timeout.TimeoutIssuesMetadata{
+		EventID:           1,
 		ConfiguredTimeout: 110 * time.Second,
-		LastOngoingEvent: &types.HistoryEvent{
-			ID:        1,
-			Timestamp: common.Int64Ptr(testTimeStamp),
-			WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
-				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+		ExecutionTimeout: &timeout.ExecutionTimeoutMetadata{
+			ExecutionTime: 110 * time.Second,
+			LastOngoingEvent: &types.HistoryEvent{
+				ID:        1,
+				Timestamp: common.Int64Ptr(testTimeStamp),
+				WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+					ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+				},
 			},
 		},
 	}
@@ -133,9 +136,7 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 			IssueID:       1,
 			InvariantType: timeout.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata: &timeout.TimeoutIssuesMetadata{
-				ExecutionTimeout: &workflowTimeoutData,
-			},
+			Metadata:      &workflowTimeoutData,
 		},
 	}
 	taskListBacklog := int64(10)
@@ -239,37 +240,47 @@ func (s *diagnosticsWorkflowTestSuite) queryDiagnostics() DiagnosticsStarterWork
 }
 
 func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutIssues() {
-	workflowTimeoutData := timeout.ExecutionTimeoutMetadata{
-		ExecutionTime:     110 * time.Second,
+	workflowTimeoutData := timeout.TimeoutIssuesMetadata{
+		EventID:           1,
 		ConfiguredTimeout: 110 * time.Second,
-		LastOngoingEvent: &types.HistoryEvent{
-			ID:        1,
-			Timestamp: common.Int64Ptr(testTimeStamp),
-			WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
-				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+		ExecutionTimeout: &timeout.ExecutionTimeoutMetadata{
+			ExecutionTime: 110 * time.Second,
+			LastOngoingEvent: &types.HistoryEvent{
+				ID:        1,
+				Timestamp: common.Int64Ptr(testTimeStamp),
+				WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+					ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+				},
 			},
 		},
 	}
 	workflowTimeoutDataInBytes, err := json.Marshal(workflowTimeoutData)
 	s.NoError(err)
-	childWorkflowTimeoutData := timeout.ChildWfTimeoutMetadata{
-		ExecutionTime:     110 * time.Second,
+	childWorkflowTimeoutData := timeout.TimeoutIssuesMetadata{
+		EventID:           2,
 		ConfiguredTimeout: 110 * time.Second,
+		ChildWfTimeout: &timeout.ChildWfTimeoutMetadata{
+			ExecutionTime: 110 * time.Second,
+		},
 	}
 	childWorkflowTimeoutDataInBytes, err := json.Marshal(childWorkflowTimeoutData)
 	s.NoError(err)
-	activityTimeoutData := timeout.ActivityTimeoutMetadata{
-		TimeoutType:       types.TimeoutTypeStartToClose.Ptr(),
+	activityTimeoutData := timeout.TimeoutIssuesMetadata{
+		EventID:           3,
 		ConfiguredTimeout: 5 * time.Second,
-		TimeElapsed:       5 * time.Second,
-		HeartBeatTimeout:  0,
+		ActivityTimeout: &timeout.ActivityTimeoutMetadata{
+			TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
+			TimeElapsed:      5 * time.Second,
+			HeartBeatTimeout: 0,
+		},
 	}
 	activityTimeoutDataInBytes, err := json.Marshal(activityTimeoutData)
 	s.NoError(err)
-	descTimeoutData := timeout.DecisionTimeoutMetadata{
+	descTimeoutData := timeout.TimeoutIssuesMetadata{
+		EventID:           4,
 		ConfiguredTimeout: 5 * time.Second,
 	}
-	descTimeoutDataInBytes, err := json.Marshal(activityTimeoutData)
+	descTimeoutDataInBytes, err := json.Marshal(descTimeoutData)
 	s.NoError(err)
 	issues := []invariant.InvariantCheckResult{
 		{
@@ -302,33 +313,25 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutIssues() {
 			IssueID:       1,
 			InvariantType: timeout.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata: &timeout.TimeoutIssuesMetadata{
-				ExecutionTimeout: &workflowTimeoutData,
-			},
+			Metadata:      &workflowTimeoutData,
 		},
 		{
 			IssueID:       2,
 			InvariantType: timeout.TimeoutTypeActivity.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata: &timeout.TimeoutIssuesMetadata{
-				ActivityTimeout: &activityTimeoutData,
-			},
+			Metadata:      &activityTimeoutData,
 		},
 		{
 			IssueID:       3,
 			InvariantType: timeout.TimeoutTypeDecision.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata: &timeout.TimeoutIssuesMetadata{
-				DecisionTimeout: &descTimeoutData,
-			},
+			Metadata:      &descTimeoutData,
 		},
 		{
 			IssueID:       4,
 			InvariantType: timeout.TimeoutTypeChildWorkflow.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata: &timeout.TimeoutIssuesMetadata{
-				ChildWfTimeout: &childWorkflowTimeoutData,
-			},
+			Metadata:      &childWorkflowTimeoutData,
 		},
 	}
 	result, err := retrieveTimeoutIssues(issues)
@@ -504,21 +507,25 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveRetryIssues() {
 }
 
 func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
-	atCapMetadata := timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+	atCapMetadata := timeoutrisk.TimeoutRiskIssuesMetadata{
 		EventID:             2,
 		ActivityID:          "101",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 60 * time.Second,
-		WorkflowTimeout:     60 * time.Second,
+		ActivityStartToCloseAtWorkflowTimeoutCap: &timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCapMetadata{
+			WorkflowTimeout: 60 * time.Second,
+		},
 	}
 	atCapMetadataInBytes, err := json.Marshal(atCapMetadata)
 	s.NoError(err)
-	missingHeartbeatMetadata := timeoutrisk.ActivityMissingHeartbeatTimeoutMetadata{
+	missingHeartbeatMetadata := timeoutrisk.TimeoutRiskIssuesMetadata{
 		EventID:             3,
 		ActivityID:          "102",
 		ActivityType:        "test-activity",
 		StartToCloseTimeout: 900 * time.Second,
-		Threshold:           600 * time.Second,
+		ActivityMissingHeartbeatTimeout: &timeoutrisk.ActivityMissingHeartbeatTimeoutMetadata{
+			Threshold: 600 * time.Second,
+		},
 	}
 	missingHeartbeatMetadataInBytes, err := json.Marshal(missingHeartbeatMetadata)
 	s.NoError(err)
@@ -541,17 +548,13 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 			IssueID:       0,
 			InvariantType: timeoutrisk.ActivityStartToCloseAtWorkflowTimeoutCap.String(),
 			Reason:        timeoutrisk.StartToCloseAtWorkflowTimeoutCap.String(),
-			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-				ActivityStartToCloseAtWorkflowTimeoutCap: &atCapMetadata,
-			},
+			Metadata:      &atCapMetadata,
 		},
 		{
 			IssueID:       1,
 			InvariantType: timeoutrisk.ActivityMissingHeartbeatTimeout.String(),
 			Reason:        timeoutrisk.MissingHeartbeatTimeoutForLongActivity.String(),
-			Metadata: &timeoutrisk.TimeoutRiskIssuesMetadata{
-				ActivityMissingHeartbeatTimeout: &missingHeartbeatMetadata,
-			},
+			Metadata:      &missingHeartbeatMetadata,
 		},
 	}
 	result, err := retrieveTimeoutRiskIssues(issues)
@@ -560,21 +563,25 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRiskIssues() {
 }
 
 func (s *diagnosticsWorkflowTestSuite) Test__retrieveAntipatternsIssues() {
-	burstMetadata := antipatterns.ActivityScheduleBurstMetadata{
-		FirstEventID:    2,
-		LastEventID:     51,
-		EventCount:      50,
-		WindowStart:     time.Unix(0, 1700000000000000000).UTC(),
-		WindowEnd:       time.Unix(0, 1700000004900000000).UTC(),
-		WindowInSeconds: 10,
-		Threshold:       50,
+	burstMetadata := antipatterns.AntipatternIssuesMetadata{
+		EventID: 2,
+		ActivityScheduleBurst: &antipatterns.ActivityScheduleBurstMetadata{
+			LastEventID:     51,
+			EventCount:      50,
+			WindowStart:     time.Unix(0, 1700000000000000000).UTC(),
+			WindowEnd:       time.Unix(0, 1700000004900000000).UTC(),
+			WindowInSeconds: 10,
+			Threshold:       50,
+		},
 	}
 	burstMetadataInBytes, err := json.Marshal(burstMetadata)
 	s.NoError(err)
-	canMetadata := antipatterns.ContinueAsNewInCronWorkflowMetadata{
-		StartedEventID:        1,
-		CronSchedule:          "*/5 * * * *",
-		ContinuedAsNewEventID: 60,
+	canMetadata := antipatterns.AntipatternIssuesMetadata{
+		EventID: 60,
+		ContinueAsNewInCronWorkflow: &antipatterns.ContinueAsNewInCronWorkflowMetadata{
+			StartedEventID: 1,
+			CronSchedule:   "*/5 * * * *",
+		},
 	}
 	canMetadataInBytes, err := json.Marshal(canMetadata)
 	s.NoError(err)
@@ -597,13 +604,13 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveAntipatternsIssues() {
 			IssueID:       0,
 			InvariantType: antipatterns.ActivityScheduleBurst.String(),
 			Reason:        antipatterns.ActivityScheduleBurstDetected.String(),
-			Metadata:      &antipatterns.AntipatternIssuesMetadata{ActivityScheduleBurst: &burstMetadata},
+			Metadata:      &burstMetadata,
 		},
 		{
 			IssueID:       1,
 			InvariantType: antipatterns.ContinueAsNewInCronWorkflow.String(),
 			Reason:        antipatterns.ContinueAsNewInitiatedByDeciderInCronWorkflow.String(),
-			Metadata:      &antipatterns.AntipatternIssuesMetadata{ContinueAsNewInCronWorkflow: &canMetadata},
+			Metadata:      &canMetadata,
 		},
 	}
 	result, err := retrieveAntipatternsIssues(issues)


### PR DESCRIPTION
## What changed?
The `timeout`, `timeoutrisk` and `antipatterns` invariants now put the fields shared by all of their checks, including a new `EventID`, at the top level of the issue metadata. 

Check-specific fields stay in a per-check sub-struct behind an `omitempty` pointer. 

`Check()` builds this wrapper directly and `workflow.go` unmarshals it as is.

Before (timeoutrisk):
```json
{"ActivityMissingHeartbeatTimeout":{"EventID":5,"ActivityID":"a1","ActivityType":"T","StartToCloseTimeout":900000000000,"Threshold":600000000000}}
```
After:
```json
{"EventID":5,"ActivityID":"a1","ActivityType":"T","StartToCloseTimeout":900000000000,"ActivityMissingHeartbeatTimeout":{"Threshold":600000000000}}
```

Also:
- `timeout` issues now carry the timed-out event's ID. `DecisionTimeoutMetadata` is gone since it only held `ConfiguredTimeout`, which is now top-level.
- Fixes a masked test bug where the decision timeout fixture marshalled the activity fixture.
- The `new-diagnostics-invariant` skill describes the new shape.

## Why?
cadence-web will soon link top-level `EventID` keys directly to events in the history view.

## How did you test it?
```
make pr GEN_DIR=service/worker/diagnostics
make build
go test -race -count=1 ./service/worker/diagnostics/...
```

### Screenshots from the Cadence UI
<img width="1203" height="343" alt="Screenshot 2026-09-08 at 15 02 52" src="https://github.com/user-attachments/assets/e5b7a5ee-9336-4c43-8b78-90db8c26cb09" />
<img width="937" height="377" alt="Screenshot 2026-09-08 at 15 02 56" src="https://github.com/user-attachments/assets/ed007279-c2f9-4765-b174-5826c65f2112" />


## Potential risks
The activity output shape changed, so a diagnostics run that straddles an old and a new worker during a deploy can fail or show partial metadata; re-running it fixes that. No API/IDL, schema or flag changes; cadence-web validates metadata as `any`.

## Release notes
Workflow diagnostics metadata for timeouts, timeout risks and antipatterns now exposes `EventID` and other shared fields at the top level, so the UI can link them to the history.

## Documentation Changes
None
