### PR TITLE
fix(schedules): validate required action fields and default task timeout

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -89,6 +89,29 @@ func scheduleWorkflowID(scheduleID string) string {
 	return scheduleWorkflowIDPrefix + scheduleID
 }
 
+// validateScheduleAction rejects a StartWorkflow action missing a field required
+// to start the target workflow. The scheduler forwards these to
+// StartWorkflowExecution at each fire, so an invalid action would otherwise fail
+// every fire as a missed run instead of failing here at create/update time. The
+// decision task timeout is omitted on purpose: it is optional and defaulted when
+// the schedule fires.
+func validateScheduleAction(action *types.ScheduleAction) error {
+	sw := action.GetStartWorkflow()
+	if sw == nil {
+		return &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
+	}
+	if sw.GetWorkflowType().GetName() == "" {
+		return &types.BadRequestError{Message: "Action.StartWorkflow.WorkflowType.Name is not set on request."}
+	}
+	if sw.GetTaskList().GetName() == "" {
+		return &types.BadRequestError{Message: "Action.StartWorkflow.TaskList.Name is not set on request."}
+	}
+	if sw.GetExecutionStartToCloseTimeoutSeconds() <= 0 {
+		return validate.ErrInvalidExecutionStartToCloseTimeoutSeconds
+	}
+	return common.ValidateRetryPolicy(sw.GetRetryPolicy())
+}
+
 func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 	if policies == nil {
 		return nil
@@ -212,10 +235,10 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if err := validateScheduleSpecTimeRange(request.GetSpec()); err != nil {
 		return nil, err
 	}
-	if request.GetAction() == nil || request.GetAction().GetStartWorkflow() == nil {
-		return nil, &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
+	if request.GetAction() == nil {
+		return nil, &types.BadRequestError{Message: "Action is not set on request."}
 	}
-	if err := common.ValidateRetryPolicy(request.GetAction().GetStartWorkflow().GetRetryPolicy()); err != nil {
+	if err := validateScheduleAction(request.GetAction()); err != nil {
 		return nil, err
 	}
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
@@ -398,8 +421,10 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if err := validateScheduleSpecTimeRange(request.GetSpec()); err != nil {
 		return nil, err
 	}
-	if action := request.GetAction(); action != nil && action.GetStartWorkflow() != nil {
-		if err := common.ValidateRetryPolicy(action.GetStartWorkflow().GetRetryPolicy()); err != nil {
+	// An update replaces the action wholesale (see handleUpdate in the scheduler
+	// workflow), so a provided action must be complete and valid on its own.
+	if action := request.GetAction(); action != nil {
+		if err := validateScheduleAction(action); err != nil {
 			return nil, err
 		}
 	}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -36,6 +36,7 @@ import (
 	"go.uber.org/yarpc/yarpcerrors"
 
 	"github.com/uber/cadence/client/history"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/constants"
@@ -103,9 +104,10 @@ func TestCreateSchedule(t *testing.T) {
 		Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
 		Action: &types.ScheduleAction{
 			StartWorkflow: &types.StartWorkflowAction{
-				WorkflowType: &types.WorkflowType{Name: "my-workflow"},
-				TaskList:     &types.TaskList{Name: "my-tasklist"},
-				Input:        []byte(`{"k":1}`),
+				WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+				TaskList:                            &types.TaskList{Name: "my-tasklist"},
+				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
+				Input:                               []byte(`{"k":1}`),
 			},
 		},
 	}
@@ -190,8 +192,9 @@ func TestCreateSchedule(t *testing.T) {
 				},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "wf"},
-						TaskList:     &types.TaskList{Name: "tl"},
+						WorkflowType:                        &types.WorkflowType{Name: "wf"},
+						TaskList:                            &types.TaskList{Name: "tl"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 			},
@@ -207,7 +210,50 @@ func TestCreateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
-		"retry policy with no bounds rejected at create": {
+		"nil StartWorkflow action": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+				Action:     &types.ScheduleAction{},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"missing workflow type rejected": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						TaskList:                            &types.TaskList{Name: "tl"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"missing task list rejected": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType:                        &types.WorkflowType{Name: "wf"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"missing execution timeout rejected": {
+			// This is the field the web UI omitted: without it, every fire fails
+			// StartWorkflowExecution validation and is silently counted as a missed
+			// run. Reject it up front instead.
 			request: &types.CreateScheduleRequest{
 				Domain:     testDomain,
 				ScheduleID: "s1",
@@ -216,6 +262,38 @@ func TestCreateSchedule(t *testing.T) {
 					StartWorkflow: &types.StartWorkflowAction{
 						WorkflowType: &types.WorkflowType{Name: "wf"},
 						TaskList:     &types.TaskList{Name: "tl"},
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"zero execution timeout rejected": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType:                        &types.WorkflowType{Name: "wf"},
+						TaskList:                            &types.TaskList{Name: "tl"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(0),
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"retry policy with no bounds rejected at create": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType:                        &types.WorkflowType{Name: "wf"},
+						TaskList:                            &types.TaskList{Name: "tl"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 						RetryPolicy: &types.RetryPolicy{
 							InitialIntervalInSeconds: 1,
 							MaximumIntervalInSeconds: 60,
@@ -235,8 +313,9 @@ func TestCreateSchedule(t *testing.T) {
 				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "wf"},
-						TaskList:     &types.TaskList{Name: "tl"},
+						WorkflowType:                        &types.WorkflowType{Name: "wf"},
+						TaskList:                            &types.TaskList{Name: "tl"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 				Policies: &types.SchedulePolicies{
@@ -270,8 +349,9 @@ func TestCreateSchedule(t *testing.T) {
 				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
-						TaskList:     &types.TaskList{Name: "my-tasklist"},
+						WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+						TaskList:                            &types.TaskList{Name: "my-tasklist"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 				SearchAttributes: &types.SearchAttributes{IndexedFields: map[string][]byte{
@@ -297,8 +377,9 @@ func TestCreateSchedule(t *testing.T) {
 				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
-						TaskList:     &types.TaskList{Name: "my-tasklist"},
+						WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+						TaskList:                            &types.TaskList{Name: "my-tasklist"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 				Policies: &types.SchedulePolicies{
@@ -344,8 +425,9 @@ func TestCreateSchedule(t *testing.T) {
 				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
-						TaskList:     &types.TaskList{Name: "my-tasklist"},
+						WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+						TaskList:                            &types.TaskList{Name: "my-tasklist"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 				SearchAttributes: &types.SearchAttributes{
@@ -389,8 +471,9 @@ func TestCreateSchedule(t *testing.T) {
 				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
-						TaskList:     &types.TaskList{Name: "my-tasklist"},
+						WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+						TaskList:                            &types.TaskList{Name: "my-tasklist"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 				Memo: &types.Memo{Fields: map[string][]byte{"schedMemo": []byte(`"sm"`)}},
@@ -415,8 +498,9 @@ func TestCreateSchedule(t *testing.T) {
 				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
-						TaskList:     &types.TaskList{Name: "my-tasklist"},
+						WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+						TaskList:                            &types.TaskList{Name: "my-tasklist"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 				State: &types.ScheduleState{
@@ -445,8 +529,9 @@ func TestCreateSchedule(t *testing.T) {
 				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
-						TaskList:     &types.TaskList{Name: "my-tasklist"},
+						WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+						TaskList:                            &types.TaskList{Name: "my-tasklist"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 					},
 				},
 				State: &types.ScheduleState{Paused: true},
@@ -1146,8 +1231,9 @@ func TestUpdateSchedule(t *testing.T) {
 				ScheduleID: "s1",
 				Action: &types.ScheduleAction{
 					StartWorkflow: &types.StartWorkflowAction{
-						WorkflowType: &types.WorkflowType{Name: "wf"},
-						TaskList:     &types.TaskList{Name: "tl"},
+						WorkflowType:                        &types.WorkflowType{Name: "wf"},
+						TaskList:                            &types.TaskList{Name: "tl"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
 						RetryPolicy: &types.RetryPolicy{
 							InitialIntervalInSeconds: 1,
 							MaximumIntervalInSeconds: 60,
@@ -1159,6 +1245,49 @@ func TestUpdateSchedule(t *testing.T) {
 			},
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
+		},
+		"action update missing execution timeout rejected": {
+			// An update replaces the action wholesale, so a provided action must be
+			// complete; a missing execution timeout would otherwise make every
+			// subsequent fire silently skip.
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf"},
+						TaskList:     &types.TaskList{Name: "tl"},
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"action update with valid StartWorkflow succeeds": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType:                        &types.WorkflowType{Name: "wf"},
+						TaskList:                            &types.TaskList{Name: "tl"},
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(3600),
+					},
+				},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						var signal scheduler.UpdateSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						require.NotNil(t, signal.Action)
+						require.NotNil(t, signal.Action.StartWorkflow)
+						assert.Equal(t, "wf", signal.Action.StartWorkflow.GetWorkflowType().GetName())
+						return nil
+					})
+			},
+			wantErr: false,
 		},
 		"search attributes only update succeeds": {
 			request: &types.UpdateScheduleRequest{

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -31,9 +31,14 @@ import (
 	"go.uber.org/cadence/activity"
 
 	"github.com/uber/cadence/client/frontend"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
 )
+
+// defaultTaskStartToCloseTimeoutSeconds is applied when a schedule's
+// StartWorkflow action leaves the decision task timeout unset.
+const defaultTaskStartToCloseTimeoutSeconds int32 = 10
 
 // schedulerRequestIDNamespace is a stable UUID namespace used to derive
 // deterministic RequestIDs. Cassandra's schema stores create_request_id as
@@ -142,6 +147,13 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 
 	workflowID := generateWorkflowID(req.Action.WorkflowIDPrefix, req.ScheduleID, req.ScheduledTime)
 	reusePolicy := types.WorkflowIDReusePolicyAllowDuplicate
+	// StartWorkflowExecution rejects a non-positive decision task timeout, which
+	// would fail every fire and record it as a missed run. The field is optional
+	// on a schedule action, so default it here rather than reject the fire.
+	taskStartToCloseTimeout := req.Action.TaskStartToCloseTimeoutSeconds
+	if taskStartToCloseTimeout == nil || *taskStartToCloseTimeout <= 0 {
+		taskStartToCloseTimeout = common.Int32Ptr(defaultTaskStartToCloseTimeoutSeconds)
+	}
 	startReq := &types.StartWorkflowExecutionRequest{
 		Domain:                              req.Domain,
 		WorkflowID:                          workflowID,
@@ -149,7 +161,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 		TaskList:                            req.Action.TaskList,
 		Input:                               req.Action.Input,
 		ExecutionStartToCloseTimeoutSeconds: req.Action.ExecutionStartToCloseTimeoutSeconds,
-		TaskStartToCloseTimeoutSeconds:      req.Action.TaskStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      taskStartToCloseTimeout,
 		RequestID:                           generateRequestID(req.ScheduleID, req.ScheduledTime.UnixNano(), req.TriggerSource),
 		WorkflowIDReusePolicy:               &reusePolicy,
 		RetryPolicy:                         req.Action.RetryPolicy,

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -188,6 +188,65 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			},
 		},
 		{
+			name: "unset task timeout is defaulted so the fire is not silently skipped",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.Action.TaskStartToCloseTimeoutSeconds = nil
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.StartWorkflowExecutionRequest, _ ...interface{}) (*types.StartWorkflowExecutionResponse, error) {
+						require.NotNil(t, req.TaskStartToCloseTimeoutSeconds)
+						assert.Equal(t, defaultTaskStartToCloseTimeoutSeconds, *req.TaskStartToCloseTimeoutSeconds)
+						// The caller-provided execution timeout is forwarded unchanged.
+						require.NotNil(t, req.ExecutionStartToCloseTimeoutSeconds)
+						assert.Equal(t, int32(3600), *req.ExecutionStartToCloseTimeoutSeconds)
+						return &types.StartWorkflowExecutionResponse{RunID: "run-abc"}, nil
+					})
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "run-abc"},
+			},
+		},
+		{
+			name: "non-positive task timeout is defaulted",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.Action.TaskStartToCloseTimeoutSeconds = int32Ptr(0)
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.StartWorkflowExecutionRequest, _ ...interface{}) (*types.StartWorkflowExecutionResponse, error) {
+						require.NotNil(t, req.TaskStartToCloseTimeoutSeconds)
+						assert.Equal(t, defaultTaskStartToCloseTimeoutSeconds, *req.TaskStartToCloseTimeoutSeconds)
+						return &types.StartWorkflowExecutionResponse{RunID: "run-abc"}, nil
+					})
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "run-abc"},
+			},
+		},
+		{
+			name: "provided task timeout is forwarded unchanged",
+			req:  baseReq,
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.StartWorkflowExecutionRequest, _ ...interface{}) (*types.StartWorkflowExecutionResponse, error) {
+						require.NotNil(t, req.TaskStartToCloseTimeoutSeconds)
+						assert.Equal(t, int32(60), *req.TaskStartToCloseTimeoutSeconds)
+						return &types.StartWorkflowExecutionResponse{RunID: "run-abc"}, nil
+					})
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "run-abc"},
+			},
+		},
+		{
 			name: "backfill start stamps CadenceScheduleBackfillID on StartWorkflow",
 			req: func() ProcessFireRequest {
 				r := baseReq


### PR DESCRIPTION
**What changed?**

Two complementary changes to the schedules code path:
- The scheduler fire activity now defaults `TaskStartToCloseTimeoutSeconds` to 10s when the schedule's `StartWorkflow` action doesn't set it (or sets a non-positive value).
- `CreateSchedule` and `UpdateSchedule` now validate the genuinely-required `StartWorkflow` fields: `WorkflowType`, `TaskList`, and `ExecutionStartToCloseTimeoutSeconds` via a shared `validateScheduleAction` helper, returning `BadRequestError` on a missing field.

**Why?**

Schedules created via the web UI without a decision (task) timeout silently skipped every run. The create/update path stored the `StartWorkflow` action verbatim without validating or defaulting timeouts, but at fire time the scheduler forwards those fields to `StartWorkflowExecution`, which rejects a non-positive `TaskStartToCloseTimeoutSeconds`. In the scheduler workflow that start failure is counted as a missed run and dropped rather than retried, so the target workflow never ran and the fire was silently lost.

The two fixes are split by whether the field has a sensible default:
- Task timeout **has** a well-known default (10s, matching the CLI's `--decision_timeout` default), so it is defaulted at the single point of consumption (the activity). This also repairs schedules created before this change, since the default is applied on every fire.
- Execution timeout, workflow type, and task list have **no** universal default and are genuinely required, so they are validated up front. An update replaces the action wholesale, so a provided action is validated in full.

**How did you test it?**

Unit tests (all passing):
- `go test ./service/worker/scheduler/... -run TestProcessScheduleFireActivity -count=1`
- `go test ./service/frontend/api/... -run 'TestCreateSchedule|TestUpdateSchedule' -count=1` 

**Potential risks**
Low. 

**Release notes**
UpdateSchedule now rejects a StartWorkflow action that is missing a required field (workflow type, task list, or execution timeout) with BadRequestError, instead of accepting it and silently producing a schedule whose fires never start. Updates that don't set Action (including all CLI updates) are unaffected.

**Documentation Changes**

N/A, no user-facing API shape or configuration changes.