### PR TITLE
chore: gitignore Claude Code local config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ cadence_visibility.db*
 settings.local.json
 .mcp.json
 *.bak
+CLAUDE.local.md


### PR DESCRIPTION
**What changed?**
Added `CLAUDE.local.md` to `.gitignore` under the existing "Local settings" section.

**Why?**
`.claude/CLAUDE.local.md` holds per-developer Claude Code preferences (commit message style, personal workflow overrides) that should not be checked in. Adding it to `.gitignore` prevents accidental commits of personal config.

**How did you test it?**
Verified with `git status` that `.claude/CLAUDE.local.md` no longer appears as an untracked file after the change.

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
