### PR TITLE
fix(config): correct CADENCE_AVAILABILTY_ZONE env var typo

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -97,7 +97,7 @@ func BuildCLI(releaseVersion string, gitRevision string) *cli.App {
 			Aliases: []string{"az"},
 			Value:   "",
 			Usage:   "availability zone",
-			EnvVars: []string{config.EnvKeyAvailabilityZone},
+			EnvVars: []string{config.EnvKeyAvailabilityZone, config.EnvKeyAvailabilityZoneLegacy},
 		},
 	}
 

--- a/common/config/loader.go
+++ b/common/config/loader.go
@@ -37,7 +37,9 @@ const (
 	// EnvKeyEnvironment is the environment variable key for environment
 	EnvKeyEnvironment = "CADENCE_ENVIRONMENT"
 	// EnvKeyAvailabilityZone is the environment variable key for AZ
-	EnvKeyAvailabilityZone = "CADENCE_AVAILABILTY_ZONE"
+	EnvKeyAvailabilityZone = "CADENCE_AVAILABILITY_ZONE"
+	// EnvKeyAvailabilityZoneLegacy preserves the old misspelling for backward compatibility.
+	EnvKeyAvailabilityZoneLegacy = "CADENCE_AVAILABILTY_ZONE"
 )
 
 const (

--- a/tools/cli/database.go
+++ b/tools/cli/database.go
@@ -60,7 +60,7 @@ func getDBFlags() []cli.Flag {
 			Name:    FlagServiceZone,
 			Aliases: []string{"sz"},
 			Usage:   "service zone for loading service configuration",
-			EnvVars: []string{config.EnvKeyAvailabilityZone},
+			EnvVars: []string{config.EnvKeyAvailabilityZone, config.EnvKeyAvailabilityZoneLegacy},
 		},
 		&cli.StringFlag{
 			Name:  FlagDBType,


### PR DESCRIPTION
**What changed?**
Fixed the misspelling in the availability zone environment variable constant (`CADENCE_AVAILABILTY_ZONE` -> `CADENCE_AVAILABILITY_ZONE`). The old misspelling is preserved as `EnvKeyAvailabilityZoneLegacy` and registered as a fallback in both the server and CLI flag definitions, so existing deployments using the typo continue to work.

**Why?**
The typo has been baked into deployments since the constant was introduced. A silent rename without a fallback would break AZ assignment for anyone whose infrastructure still references the old spelling - a subtle misconfiguration with no error at startup. Keeping the legacy variant as a secondary `EnvVars` entry lets `urfave/cli` check the corrected name first and fall back to the old one, giving operators time to migrate.

**How did you test it?**
`go build ./common/config/ ./cmd/server/cadence/ ./tools/cli/` - all three packages compile cleanly.

**Potential risks**
None. The old env var is still honored; the new one takes precedence when both are set.

**Release notes**
The environment variable for availability zone is now `CADENCE_AVAILABILITY_ZONE` (corrected spelling). The previous `CADENCE_AVAILABILTY_ZONE` is still accepted as a fallback.

**Documentation Changes**
N/A
