### PR TITLE
feat(matching): add bucket registry and ownership lifecycle on Matching

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1848,6 +1848,14 @@ const (
 	// Default value: false
 	// Allowed filters: DomainName,TasklistName,TaskType
 	MatchingEnableAdaptiveScaler
+	// MatchingEnableDistributedSemaphore gates serving distributed semaphore buckets on matching
+	// hosts. While it is off no bucket is loaded, so no partition is scanned and nothing is held
+	// in memory.
+	// KeyName: matching.enableDistributedSemaphore
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	MatchingEnableDistributedSemaphore
 	// MatchingEnablePartitionEmptyCheck enables using TaskListStatus.empty to check if a partition is empty
 	// KeyName: matching.enablePartitionEmptyCheck
 	// Value type: Bool
@@ -4812,6 +4820,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "matching.enableAdaptiveScaler",
 		Filters:      []Filter{DomainName, TaskListName, TaskType},
 		Description:  "MatchingEnableAdaptiveScaler is to enable adaptive task list scaling",
+		DefaultValue: false,
+	},
+	MatchingEnableDistributedSemaphore: {
+		KeyName:      "matching.enableDistributedSemaphore",
+		Filters:      []Filter{DomainName},
+		Description:  "MatchingEnableDistributedSemaphore gates serving distributed semaphore buckets on matching hosts",
 		DefaultValue: false,
 	},
 	MatchingEnablePartitionEmptyCheck: {

--- a/common/errors/semaphore_not_owned_by_host_error.go
+++ b/common/errors/semaphore_not_owned_by_host_error.go
@@ -1,0 +1,26 @@
+package errors
+
+import "fmt"
+
+var _ error = &SemaphoreNotOwnedByHostError{}
+
+// SemaphoreNotOwnedByHostError says the ring puts this bucket on another host. The caller should
+// go to OwnedByIdentity rather than wait, since nothing about this host will change.
+type SemaphoreNotOwnedByHostError struct {
+	OwnedByIdentity string
+	MyIdentity      string
+	Bucket          string
+}
+
+func (m *SemaphoreNotOwnedByHostError) Error() string {
+	return fmt.Sprintf("semaphore bucket is not owned by this host: OwnedBy: %s, Me: %s, Bucket: %s",
+		m.OwnedByIdentity, m.MyIdentity, m.Bucket)
+}
+
+func NewSemaphoreNotOwnedByHostError(ownedByIdentity string, myIdentity string, bucket string) *SemaphoreNotOwnedByHostError {
+	return &SemaphoreNotOwnedByHostError{
+		OwnedByIdentity: ownedByIdentity,
+		MyIdentity:      myIdentity,
+		Bucket:          bucket,
+	}
+}

--- a/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/semaphore_tokens.go
@@ -281,6 +281,8 @@ func (db *CDB) SelectSemaphoreOwnershipsByBucket(ctx context.Context, filter *no
 		rows = append(rows, row)
 		row = &nosqlplugin.SemaphoreOwnershipRow{}
 
+		// Must match query.PageSize above: the token below points past the driver's whole
+		// page, so breaking earlier would skip rows.
 		if filter.PageSize > 0 && len(rows) >= filter.PageSize {
 			break
 		}

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -99,7 +99,9 @@ type (
 
 		// isolation configuration
 		EnableTasklistIsolation dynamicproperties.BoolPropertyFnWithDomainFilter
-		AllIsolationGroups      func() []string
+		// EnableDistributedSemaphore gates serving semaphore buckets on this host.
+		EnableDistributedSemaphore dynamicproperties.BoolPropertyFnWithDomainFilter
+		AllIsolationGroups         func() []string
 		// hostname info
 		HostName string
 		// RPCConfig contains RPC configuration including ports and bindOnLocalHost
@@ -214,6 +216,7 @@ func NewConfig(dc *dynamicconfig.Collection, operationalDC *dynamicconfig.Collec
 		EnableTaskInfoLogByDomainID:                dc.GetBoolPropertyFilteredByDomainID(dynamicproperties.MatchingEnableTaskInfoLogByDomainID),
 		ActivityTaskSyncMatchWaitTime:              dc.GetDurationPropertyFilteredByDomain(dynamicproperties.MatchingActivityTaskSyncMatchWaitTime),
 		EnableTasklistIsolation:                    dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableTasklistIsolation),
+		EnableDistributedSemaphore:                 dc.GetBoolPropertyFilteredByDomain(dynamicproperties.MatchingEnableDistributedSemaphore),
 		AppendTaskTimeout:                          dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.AppendTaskTimeout),
 		AsyncTaskDispatchTimeout:                   dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.AsyncTaskDispatchTimeout),
 		LocalPollWaitTime:                          dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.LocalPollWaitTime),

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -75,6 +75,7 @@ func TestNewConfig(t *testing.T) {
 		"EnableTaskInfoLogByDomainID":               {dynamicproperties.MatchingEnableTaskInfoLogByDomainID, true},
 		"ActivityTaskSyncMatchWaitTime":             {dynamicproperties.MatchingActivityTaskSyncMatchWaitTime, time.Duration(24)},
 		"EnableTasklistIsolation":                   {dynamicproperties.EnableTasklistIsolation, false},
+		"EnableDistributedSemaphore":                {dynamicproperties.MatchingEnableDistributedSemaphore, false},
 		"AsyncTaskDispatchTimeout":                  {dynamicproperties.AsyncTaskDispatchTimeout, time.Duration(25)},
 		"LocalPollWaitTime":                         {dynamicproperties.LocalPollWaitTime, time.Duration(10)},
 		"LocalTaskWaitTime":                         {dynamicproperties.LocalTaskWaitTime, time.Duration(10)},

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -90,12 +90,10 @@ type (
 	}
 
 	matchingEngineImpl struct {
-		taskListCreationLock  sync.Mutex
-		taskListRegistry      tasklist.TaskListRegistry
-		semaphoreCreationLock sync.Mutex
-		semaphoreRegistry     semaphore.SemaphoreRegistry
-		// TODO: pass in from NewEngine. Needs GetSemaphoreTokenManager on common/resource.Resource,
-		// which is out of scope here, so only tests set it today. NewManager rejects a nil one.
+		taskListCreationLock           sync.Mutex
+		taskListRegistry               tasklist.TaskListRegistry
+		semaphoreCreationLock          sync.Mutex
+		semaphoreRegistry              semaphore.SemaphoreRegistry
 		semaphoreTokenManager          persistence.SemaphoreTokenManager
 		shutdownCompletion             *sync.WaitGroup
 		shutdown                       chan struct{}

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -57,6 +57,7 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/matching/config"
 	"github.com/uber/cadence/service/matching/event"
+	"github.com/uber/cadence/service/matching/semaphore"
 	"github.com/uber/cadence/service/matching/tasklist"
 )
 
@@ -89,8 +90,13 @@ type (
 	}
 
 	matchingEngineImpl struct {
-		taskListCreationLock           sync.Mutex
-		taskListRegistry               tasklist.TaskListRegistry
+		taskListCreationLock  sync.Mutex
+		taskListRegistry      tasklist.TaskListRegistry
+		semaphoreCreationLock sync.Mutex
+		semaphoreRegistry     semaphore.SemaphoreRegistry
+		// TODO: pass in from NewEngine. Needs GetSemaphoreTokenManager on common/resource.Resource,
+		// which is out of scope here, so only tests set it today. NewManager rejects a nil one.
+		semaphoreTokenManager          persistence.SemaphoreTokenManager
 		shutdownCompletion             *sync.WaitGroup
 		shutdown                       chan struct{}
 		taskManager                    persistence.TaskManager
@@ -126,6 +132,20 @@ var (
 	_stickyPollerUnavailableError = &types.StickyWorkerUnavailableError{Message: "sticky worker is unavailable, please use non-sticky task list."}
 )
 
+// managerStartTimeout bounds a bucket's startup scan as a whole. Each query underneath already
+// has the Cassandra client's own timeout, so this is the backstop for a scan that keeps paging.
+//
+// Not the caller's context: a client with a short deadline would abort the scan, and the next
+// request would start over from the first page, so a busy bucket under impatient callers might
+// never finish loading. Acquire honours the caller's deadline on its own while it waits for
+// startup, so keeping the two apart costs the caller nothing.
+const managerStartTimeout = 30 * time.Second
+
+// ErrSemaphoreDisabled means the domain has distributed semaphores turned off. It is terminal,
+// unlike semaphore.ErrNotReady, which means "still starting, come back": nothing will change
+// here until an operator flips the flag.
+var ErrSemaphoreDisabled = errors.New("distributed semaphore is not enabled for this domain")
+
 var _ Engine = (*matchingEngineImpl)(nil) // Asserts that interface is indeed implemented
 
 // NewEngine creates an instance of matching engine
@@ -150,6 +170,7 @@ func NewEngine(
 ) Engine {
 	e := &matchingEngineImpl{
 		taskListRegistry:               tasklist.NewTaskListRegistry(metricsClient),
+		semaphoreRegistry:              semaphore.NewSemaphoreRegistry(),
 		shutdown:                       make(chan struct{}),
 		shutdownCompletion:             &sync.WaitGroup{},
 		taskManager:                    taskManager,
@@ -191,6 +212,10 @@ func (e *matchingEngineImpl) Stop() {
 	// Executes Stop() on each task list outside of lock
 	for _, l := range e.taskListRegistry.AllManagers() {
 		l.Stop()
+	}
+	// Same for semaphore buckets, outside the lock.
+	for _, mgr := range e.semaphoreRegistry.AllManagers() {
+		mgr.Stop()
 	}
 	e.unregisterDomainFailoverCallback()
 	e.shutdownCompletion.Wait()
@@ -371,6 +396,64 @@ func (e *matchingEngineImpl) getOrCreateTaskListManager(ctx context.Context, tas
 		EventName: "TaskListManager Started",
 		Host:      e.config.HostName,
 	})
+	return mgr, nil
+}
+
+// getOrCreateSemaphoreManager returns this host's manager for one bucket, building and starting
+// it the first time the bucket is asked for.
+func (e *matchingEngineImpl) getOrCreateSemaphoreManager(id semaphore.Identifier) (semaphore.Manager, error) {
+	// Fast path, no creation lock: almost every request finds a manager already loaded.
+	if mgr, ok := e.semaphoreRegistry.ManagerByIdentifier(id); ok {
+		return mgr, nil
+	}
+
+	// The flag filters on domain name while a bucket is keyed by domain id, so resolve the name
+	// first. Checked before the creation lock, so a disabled domain costs nothing.
+	domainName, err := e.domainCache.GetDomainName(id.DomainID)
+	if err != nil {
+		return nil, err
+	}
+	if !e.config.EnableDistributedSemaphore(domainName) {
+		return nil, ErrSemaphoreDisabled
+	}
+
+	if err := e.errIfSemaphoreOwnershipLost(id); err != nil {
+		return nil, err
+	}
+
+	// If it gets here, write lock and check again in case a semaphore manager is created between the two locks
+	e.semaphoreCreationLock.Lock()
+	if mgr, ok := e.semaphoreRegistry.ManagerByIdentifier(id); ok {
+		e.semaphoreCreationLock.Unlock()
+		return mgr, nil
+	}
+	logger := e.logger.WithTags(tag.Dynamic("semaphore-bucket", id.String()))
+	mgr, err := semaphore.NewManager(semaphore.ManagerParams{
+		ID:     id,
+		Tokens: e.semaphoreTokenManager,
+		Logger: e.logger,
+	})
+	if err != nil {
+		e.semaphoreCreationLock.Unlock()
+		return nil, err
+	}
+	// Registered before it starts, so a request arriving mid-scan reuses this manager rather
+	// than scanning the same bucket again. Acquire waits for the scan on its own.
+	e.semaphoreRegistry.Register(mgr)
+	e.semaphoreCreationLock.Unlock()
+
+	// Started outside the creation lock, so one slow scan does not hold up every other bucket
+	// this host is asked for.
+	startCtx, cancel := context.WithTimeout(context.Background(), managerStartTimeout)
+	defer cancel()
+	if err := mgr.Start(startCtx); err != nil {
+		// Drop it rather than leave a manager that can never serve: Acquire would answer
+		// ErrNotReady for as long as the host lived, with nothing to clear it. The next request
+		// builds a fresh one and tries again.
+		e.semaphoreRegistry.Unregister(mgr)
+		logger.Error("Semaphore manager failed to start", tag.Error(err))
+		return nil, err
+	}
 	return mgr, nil
 }
 
@@ -1229,6 +1312,13 @@ func (e *matchingEngineImpl) unloadTaskList(tlMgr tasklist.Manager) {
 	}
 }
 
+func (e *matchingEngineImpl) unloadSemaphoreManager(semMgr semaphore.Manager) {
+	unregistered := e.semaphoreRegistry.Unregister(semMgr)
+	if unregistered {
+		semMgr.Stop()
+	}
+}
+
 // Populate the decision task response based on context and scheduled/started events.
 func (e *matchingEngineImpl) createPollForDecisionTaskResponse(
 	task *tasklist.InternalTask,
@@ -1524,6 +1614,37 @@ func (e *matchingEngineImpl) errIfShardOwnershipLost(ctx context.Context, taskLi
 		return newNotOwnedByHostError(taskListOwner.Identity())
 	}
 
+	return nil
+}
+
+// errIfSemaphoreOwnershipLost reports an error unless the ring puts this bucket on this host.
+//
+// Two hosts serving one bucket is safe -- neither holds a lease, and the conditional write
+// decides every grant -- but it is wasteful, because each one keeps a free-set that the other
+// keeps invalidating. Routing every bucket to one host keeps both caches worth having.
+func (e *matchingEngineImpl) errIfSemaphoreOwnershipLost(id semaphore.Identifier) error {
+	self, err := e.membershipResolver.WhoAmI()
+	if err != nil {
+		return fmt.Errorf("failed to look up self in membership: %w", err)
+	}
+
+	if e.isShuttingDown() {
+		e.logger.Warn("Rejecting a semaphore request because the engine is shutting down",
+			tag.Dynamic("semaphore-bucket", id.String()))
+		// No host to name: this one is going away and the ring has not settled on the next.
+		return cadence_errors.NewSemaphoreNotOwnedByHostError("not known", self.Identity(), id.String())
+	}
+
+	owner, err := e.membershipResolver.Lookup(service.Matching, id.RingKey())
+	if err != nil {
+		return fmt.Errorf("failed to look up the owner of semaphore bucket %v: %w", id, err)
+	}
+	if owner.Identity() != self.Identity() {
+		e.logger.Warn("Rejecting a semaphore request because this host does not own the bucket",
+			tag.Dynamic("semaphore-bucket", id.String()),
+			tag.Dynamic("owned-by", owner.Identity()))
+		return cadence_errors.NewSemaphoreNotOwnedByHostError(owner.Identity(), self.Identity(), id.String())
+	}
 	return nil
 }
 

--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/matching/config"
+	"github.com/uber/cadence/service/matching/semaphore"
 	"github.com/uber/cadence/service/matching/tasklist"
 )
 
@@ -927,6 +928,7 @@ func TestIsShuttingDown(t *testing.T) {
 		shutdown:           make(chan struct{}),
 		executor:           mockExecutor,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
+		semaphoreRegistry:  semaphore.NewSemaphoreRegistry(),
 	}
 	e.Start()
 	assert.False(t, e.isShuttingDown())
@@ -1945,5 +1947,263 @@ func TestShardDistributorOnboarded(t *testing.T) {
 			engine := &matchingEngineImpl{percentageOnboarded: pct}
 			assert.Equal(t, tt.want, engine.shardDistributorOnboarded())
 		})
+	}
+}
+
+const (
+	testSemaphoreDomainID   = "domain-id-1"
+	testSemaphoreDomainName = "domain-1"
+	testSemaphoreName       = "sem-1"
+)
+
+var (
+	testSelfHost  = membership.NewHostInfo("self:1234")
+	testOtherHost = membership.NewHostInfo("other:1234")
+)
+
+func mustNewSemaphoreIdentifier(t *testing.T, bucket int) semaphore.Identifier {
+	t.Helper()
+	id, err := semaphore.NewIdentifier(testSemaphoreDomainID, testSemaphoreName, bucket)
+	require.NoError(t, err)
+	return id
+}
+
+// newSemaphoreEngine builds an engine with the domain enabled and every bucket on ringOwner
+func newSemaphoreEngine(t *testing.T, ringOwner membership.HostInfo) (*matchingEngineImpl, *persistence.MockSemaphoreTokenManager) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	domainCache := cache.NewMockDomainCache(ctrl)
+	domainCache.EXPECT().GetDomainName(testSemaphoreDomainID).Return(testSemaphoreDomainName, nil).AnyTimes()
+
+	resolver := membership.NewMockResolver(ctrl)
+	resolver.EXPECT().WhoAmI().Return(testSelfHost, nil).AnyTimes()
+	resolver.EXPECT().Lookup(service.Matching, gomock.Any()).Return(ringOwner, nil).AnyTimes()
+
+	tokens := persistence.NewMockSemaphoreTokenManager(ctrl)
+
+	return &matchingEngineImpl{
+		semaphoreRegistry:     semaphore.NewSemaphoreRegistry(),
+		semaphoreTokenManager: tokens,
+		domainCache:           domainCache,
+		membershipResolver:    resolver,
+		metricsClient:         metrics.NewNoopMetricsClient(),
+		logger:                log.NewNoop(),
+		config: &config.Config{
+			EnableDistributedSemaphore: func(string) bool { return true },
+		},
+	}, tokens
+}
+
+// newSemaphoreManager builds an unstarted manager for tests that drive one directly
+func newSemaphoreManager(t *testing.T, id semaphore.Identifier, tokens persistence.SemaphoreTokenManager) semaphore.Manager {
+	t.Helper()
+	mgr, err := semaphore.NewManager(semaphore.ManagerParams{ID: id, Tokens: tokens, Logger: log.NewNoop()})
+	require.NoError(t, err)
+	return mgr
+}
+
+// expectOneScan stubs the startup load and requires it to happen exactly once, which is what
+// shows concurrent callers shared a manager rather than each building one.
+func expectOneScan(m *persistence.MockSemaphoreTokenManager, tokens int) {
+	rows := make([]*persistence.SemaphoreOwnership, 0, tokens)
+	for i := 1; i <= tokens; i++ {
+		rows = append(rows, &persistence.SemaphoreOwnership{
+			RowType:       persistence.SemaphoreRowTypeToken,
+			DomainID:      testSemaphoreDomainID,
+			SemaphoreName: testSemaphoreName,
+			TokenID:       i,
+		})
+	}
+	m.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).Times(1).
+		Return(&persistence.ScanSemaphoreBucketResponse{Ownerships: rows}, nil)
+}
+
+func TestGetOrCreateSemaphoreManager(t *testing.T) {
+	t.Run("second request reuses the manager already built", func(t *testing.T) {
+		// A bucket is built once, so the second request costs no scan.
+		e, m := newSemaphoreEngine(t, testSelfHost)
+		expectOneScan(m, 3)
+		id := mustNewSemaphoreIdentifier(t, 0)
+
+		first, err := e.getOrCreateSemaphoreManager(id)
+		require.NoError(t, err)
+		second, err := e.getOrCreateSemaphoreManager(id)
+		require.NoError(t, err)
+		assert.Same(t, first, second, "the second call must reuse the registered manager")
+	})
+
+	t.Run("domain has semaphores disabled", func(t *testing.T) {
+		// Costs nothing: no scan, no manager, no registry entry. The flag is checked before
+		// anything is built for exactly that reason.
+		e, m := newSemaphoreEngine(t, testSelfHost)
+		e.config.EnableDistributedSemaphore = func(string) bool { return false }
+		m.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).Times(0)
+
+		mgr, err := e.getOrCreateSemaphoreManager(mustNewSemaphoreIdentifier(t, 0))
+		require.ErrorIs(t, err, ErrSemaphoreDisabled)
+		assert.Nil(t, mgr)
+		assert.Empty(t, e.semaphoreRegistry.AllManagers(), "nothing may be registered for a disabled domain")
+
+		assert.NotErrorIs(t, err, semaphore.ErrNotReady)
+	})
+
+	t.Run("bucket is owned by another host", func(t *testing.T) {
+		// The error names that host, so the caller can go there instead of retrying here.
+		e, m := newSemaphoreEngine(t, testOtherHost)
+		m.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).Times(0)
+
+		mgr, err := e.getOrCreateSemaphoreManager(mustNewSemaphoreIdentifier(t, 0))
+		assert.Nil(t, mgr)
+
+		var notOwned *commonerrors.SemaphoreNotOwnedByHostError
+		require.ErrorAs(t, err, &notOwned)
+		assert.Equal(t, testOtherHost.Identity(), notOwned.OwnedByIdentity)
+		assert.Equal(t, testSelfHost.Identity(), notOwned.MyIdentity)
+		assert.Empty(t, e.semaphoreRegistry.AllManagers(), "a bucket owned elsewhere must not be loaded here")
+	})
+
+	t.Run("matching engine is shutting down", func(t *testing.T) {
+		// No new buckets: loading one now would scan a partition this host is about to stop
+		// serving.
+		e, m := newSemaphoreEngine(t, testSelfHost)
+		m.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).Times(0)
+		e.shutdown = make(chan struct{})
+		close(e.shutdown)
+
+		mgr, err := e.getOrCreateSemaphoreManager(mustNewSemaphoreIdentifier(t, 0))
+		assert.Nil(t, mgr)
+
+		var notOwned *commonerrors.SemaphoreNotOwnedByHostError
+		require.ErrorAs(t, err, &notOwned)
+		assert.Equal(t, "not known", notOwned.OwnedByIdentity, "the next owner is not settled yet")
+	})
+
+	t.Run("manager that failed to start is not left registered", func(t *testing.T) {
+		// Its Acquire answers ErrNotReady with nothing to clear it, so leaving it in place
+		// would wedge the bucket until the host restarted.
+		e, m := newSemaphoreEngine(t, testSelfHost)
+		id := mustNewSemaphoreIdentifier(t, 0)
+
+		scanErr := errors.New("cassandra unavailable")
+		m.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).Times(1).Return(nil, scanErr)
+
+		mgr, err := e.getOrCreateSemaphoreManager(id)
+		require.ErrorIs(t, err, scanErr)
+		assert.Nil(t, mgr)
+		assert.Empty(t, e.semaphoreRegistry.AllManagers(), "a manager that cannot start must not stay registered")
+
+		// The next request builds a fresh one, so a passing outage is recoverable.
+		expectOneScan(m, 2)
+		retry, err := e.getOrCreateSemaphoreManager(id)
+		require.NoError(t, err)
+		assert.NotNil(t, retry)
+	})
+
+	t.Run("domain lookup fails", func(t *testing.T) {
+		// The failure comes back as itself. The name is only needed to read the flag, so
+		// failing to resolve it says nothing about the bucket.
+		ctrl := gomock.NewController(t)
+		domainCache := cache.NewMockDomainCache(ctrl)
+		lookupErr := errors.New("domain not found")
+		domainCache.EXPECT().GetDomainName(gomock.Any()).Return("", lookupErr)
+
+		e := &matchingEngineImpl{
+			semaphoreRegistry: semaphore.NewSemaphoreRegistry(),
+			domainCache:       domainCache,
+			metricsClient:     metrics.NewNoopMetricsClient(),
+			logger:            log.NewNoop(),
+			config:            &config.Config{},
+		}
+
+		_, err := e.getOrCreateSemaphoreManager(mustNewSemaphoreIdentifier(t, 0))
+		assert.ErrorIs(t, err, lookupErr)
+	})
+
+	t.Run("load runs outside the creation lock", func(t *testing.T) {
+		// One slow load must not block other buckets. The scan for the first is held open until
+		// a second has been built, which can only finish if the two are independent -- under a
+		// shared lock the second call would sit behind a scan that is itself waiting on it, and
+		// the test would hang.
+		e, m := newSemaphoreEngine(t, testSelfHost)
+		slow := mustNewSemaphoreIdentifier(t, 0)
+		fast := mustNewSemaphoreIdentifier(t, 1)
+
+		slowScanStarted := make(chan struct{})
+		secondIsUp := make(chan struct{})
+		m.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).Times(2).
+			DoAndReturn(func(_ context.Context, req *persistence.ScanSemaphoreBucketRequest) (*persistence.ScanSemaphoreBucketResponse, error) {
+				if req.Bucket == slow.Bucket {
+					close(slowScanStarted)
+					<-secondIsUp
+				}
+				return &persistence.ScanSemaphoreBucketResponse{}, nil
+			})
+
+		slowDone := make(chan error, 1)
+		go func() {
+			_, err := e.getOrCreateSemaphoreManager(slow)
+			slowDone <- err
+		}()
+		// Wait until the slow load is in flight, so the second creation really does overlap it
+		// rather than slipping in first and passing by luck.
+		<-slowScanStarted
+
+		second, err := e.getOrCreateSemaphoreManager(fast)
+		require.NoError(t, err)
+		require.NotNil(t, second)
+		close(secondIsUp)
+
+		require.NoError(t, <-slowDone)
+	})
+}
+
+func TestUnloadSemaphoreManager(t *testing.T) {
+	// Unloading takes a manager out of the registry and stops it, so the next request builds a
+	// fresh one instead of finding the retired manager.
+	e, m := newSemaphoreEngine(t, testSelfHost)
+	expectOneScan(m, 2)
+	id := mustNewSemaphoreIdentifier(t, 0)
+
+	mgr, err := e.getOrCreateSemaphoreManager(id)
+	require.NoError(t, err)
+
+	e.unloadSemaphoreManager(mgr)
+	assert.Empty(t, e.semaphoreRegistry.AllManagers())
+
+	_, err = mgr.Acquire(context.Background(), "owner-1")
+	assert.ErrorIs(t, err, semaphore.ErrNotReady, "an unloaded manager must stop serving")
+
+	expectOneScan(m, 2)
+	fresh, err := e.getOrCreateSemaphoreManager(id)
+	require.NoError(t, err)
+	assert.NotSame(t, mgr, fresh)
+}
+
+func TestStopSemaphoreManagers(t *testing.T) {
+	// Shutdown reaches every bucket, not just the task lists beside them. A manager left running
+	// holds its slice of the partition and keeps answering after the host has given up its work.
+	e, m := newSemaphoreEngine(t, testSelfHost)
+	m.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).AnyTimes().
+		Return(&persistence.ScanSemaphoreBucketResponse{}, nil)
+	e.domainCache.(*cache.MockDomainCache).EXPECT().UnregisterDomainChangeCallback(service.Matching)
+	e.shutdown = make(chan struct{})
+	e.shutdownCompletion = &sync.WaitGroup{}
+	e.taskListRegistry = tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient())
+	e.executor = executorclient.NewNoopExecutor[tasklist.ShardProcessor]()
+
+	managers := make([]semaphore.Manager, 0, 3)
+	for i := range 3 {
+		mgr, err := e.getOrCreateSemaphoreManager(mustNewSemaphoreIdentifier(t, i))
+		require.NoError(t, err)
+		managers = append(managers, mgr)
+	}
+
+	e.Stop()
+
+	// Refusing to serve is the only thing Stop is observable through.
+	for i, mgr := range managers {
+		_, err := mgr.Acquire(context.Background(), "owner-1")
+		assert.ErrorIs(t, err, semaphore.ErrNotReady, "manager %d was left running", i)
 	}
 }

--- a/service/matching/handler/membership.go
+++ b/service/matching/handler/membership.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/service/matching/semaphore"
 	"github.com/uber/cadence/service/matching/tasklist"
 )
 
@@ -65,6 +66,12 @@ func (e *matchingEngineImpl) runMembershipChangeLoop() {
 			err := e.shutDownNonOwnedTasklists()
 			if err != nil {
 				e.logger.Error("Error while trying to determine if tasklists have been shutdown",
+					tag.Error(err),
+					tag.MembershipChangeEvent(event),
+				)
+			}
+			if err := e.shutDownNonOwnedSemaphoreManagers(); err != nil {
+				e.logger.Error("Error while trying to unload semaphore buckets this host no longer owns",
 					tag.Error(err),
 					tag.MembershipChangeEvent(event),
 				)
@@ -137,5 +144,58 @@ func (e *matchingEngineImpl) getNonOwnedTasklistsLocked() ([]tasklist.Manager, e
 	e.logger.Info("Got list of non-owned-tasklists",
 		tag.Dynamic("tasklist-debug-info", toShutDown),
 	)
+	return toShutDown, nil
+}
+
+// shutDownNonOwnedSemaphoreManagers unloads the buckets the ring has moved to another host.
+func (e *matchingEngineImpl) shutDownNonOwnedSemaphoreManagers() error {
+	noLongerOwned, err := e.getNonOwnedSemaphoreManagers()
+	if err != nil {
+		return err
+	}
+
+	semaphoreShutdownWG := sync.WaitGroup{}
+
+	for _, sem := range noLongerOwned {
+		// for each of the semaphores that are no longer owned, kick off the
+		// process of stopping them. The stopping process is IO heavy and
+		// can take a while, so do them in parallel to efficiently unload tasklists not owned
+		semaphoreShutdownWG.Add(1)
+		go func(sem semaphore.Manager) {
+			defer func() {
+				if r := recover(); r != nil {
+					e.logger.Error("panic occurred while unloading a semaphore bucket", tag.Dynamic("recovered-panic", r))
+				}
+			}()
+			defer semaphoreShutdownWG.Done()
+
+			e.logger.Info("Unloading a semaphore bucket that is no longer owned by this host",
+				tag.Dynamic("semaphore-bucket", sem.Identifier().String()),
+			)
+			e.unloadSemaphoreManager(sem)
+		}(sem)
+	}
+	semaphoreShutdownWG.Wait()
+
+	return nil
+}
+
+func (e *matchingEngineImpl) getNonOwnedSemaphoreManagers() ([]semaphore.Manager, error) {
+	self, err := e.membershipResolver.WhoAmI()
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup self im membership: %w", err)
+	}
+
+	var toShutDown []semaphore.Manager
+	for _, mgr := range e.semaphoreRegistry.AllManagers() {
+		id := mgr.Identifier()
+		owner, err := e.membershipResolver.Lookup(service.Matching, id.RingKey())
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up the owner of semaphore bucket %v: %w", id, err)
+		}
+		if owner.Identity() != self.Identity() {
+			toShutDown = append(toShutDown, mgr)
+		}
+	}
 	return toShutDown, nil
 }

--- a/service/matching/handler/membership_test.go
+++ b/service/matching/handler/membership_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/executorclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
@@ -53,6 +54,7 @@ import (
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/matching/config"
+	"github.com/uber/cadence/service/matching/semaphore"
 	"github.com/uber/cadence/service/matching/tasklist"
 )
 
@@ -199,6 +201,7 @@ func TestSubscriptionAndShutdown(t *testing.T) {
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
+		semaphoreRegistry:  semaphore.NewSemaphoreRegistry(),
 		config:             &config.Config{},
 		shutdown:           make(chan struct{}),
 		logger:             log.NewNoop(),
@@ -234,6 +237,7 @@ func TestSubscriptionAndErrorReturned(t *testing.T) {
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
+		semaphoreRegistry:  semaphore.NewSemaphoreRegistry(),
 		config:             &config.Config{},
 		shutdown:           make(chan struct{}),
 		logger:             log.NewNoop(),
@@ -243,8 +247,12 @@ func TestSubscriptionAndErrorReturned(t *testing.T) {
 
 	// this should trigger the error case on a membership event
 	// unfortunately, this is purely for code-coverage, no checks are involved
+	//
+	// One event is handled by several passes, each of which looks up this host, so the signal
+	// fires once however many times WhoAmI is called.
+	var handled sync.Once
 	mockResolver.EXPECT().WhoAmI().DoAndReturn(func() (membership.HostInfo, error) {
-		membershipChangeHandledWG.Done()
+		handled.Do(membershipChangeHandledWG.Done)
 		return membership.HostInfo{}, errors.New("failure")
 	}).MinTimes(1)
 
@@ -288,6 +296,7 @@ func TestSubscribeToMembershipChangesQuitsIfSubscribeFails(t *testing.T) {
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
+		semaphoreRegistry:  semaphore.NewSemaphoreRegistry(),
 		config:             &config.Config{},
 		shutdown:           make(chan struct{}),
 		logger:             logger,
@@ -337,6 +346,7 @@ func TestGetTasklistManagerShutdownScenario(t *testing.T) {
 		shutdownCompletion:  &shutdownWG,
 		membershipResolver:  mockResolver,
 		taskListRegistry:    tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
+		semaphoreRegistry:   semaphore.NewSemaphoreRegistry(),
 		metricsClient:       metrics.NewNoopMetricsClient(),
 		percentageOnboarded: pct,
 		config: &config.Config{
@@ -356,4 +366,80 @@ func TestGetTasklistManagerShutdownScenario(t *testing.T) {
 	assertErr := &cadence_errors.TaskListNotOwnedByHostError{}
 	assert.ErrorAs(t, err, &assertErr)
 	assert.Nil(t, res)
+}
+
+// Tests that a ring change unloads the buckets that moved and leaves the ones this host still
+// owns alone. Without this pass a bucket keeps running on the wrong host until the process
+// exits, since a manager has no idle timer to fall back on.
+func TestShutDownNonOwnedSemaphoreManagers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mine := mustNewSemaphoreIdentifier(t, 0)
+	moved := mustNewSemaphoreIdentifier(t, 1)
+
+	resolver := membership.NewMockResolver(ctrl)
+	resolver.EXPECT().WhoAmI().Return(testSelfHost, nil).AnyTimes()
+	resolver.EXPECT().Lookup(service.Matching, gomock.Any()).DoAndReturn(
+		func(_ string, key string) (membership.HostInfo, error) {
+			if key == moved.RingKey() {
+				return testOtherHost, nil
+			}
+			return testSelfHost, nil
+		}).AnyTimes()
+
+	tokens := persistence.NewMockSemaphoreTokenManager(ctrl)
+	tokens.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).AnyTimes().
+		Return(&persistence.ScanSemaphoreBucketResponse{}, nil)
+
+	e := &matchingEngineImpl{
+		semaphoreRegistry:  semaphore.NewSemaphoreRegistry(),
+		membershipResolver: resolver,
+		logger:             log.NewNoop(),
+	}
+
+	start := func(id semaphore.Identifier) semaphore.Manager {
+		mgr := newSemaphoreManager(t, id, tokens)
+		require.NoError(t, mgr.Start(context.Background()))
+		e.semaphoreRegistry.Register(mgr)
+		return mgr
+	}
+	mineMgr := start(mine)
+	movedMgr := start(moved)
+
+	require.NoError(t, e.shutDownNonOwnedSemaphoreManagers())
+
+	remaining := e.semaphoreRegistry.AllManagers()
+	require.Len(t, remaining, 1)
+	assert.Same(t, mineMgr, remaining[0], "the bucket this host still owns stays loaded")
+
+	// Unregistering alone would leave it holding its free-set and answering grants.
+	_, err := movedMgr.Acquire(context.Background(), "owner-1")
+	assert.ErrorIs(t, err, semaphore.ErrNotReady, "the bucket that moved must be stopped too")
+}
+
+// Tests that a failed ring lookup is reported rather than treated as a lost bucket. Unloading on
+// a lookup error would drop every bucket on this host whenever membership is briefly unreadable.
+func TestShutDownNonOwnedSemaphoreManagersSurfacesALookupFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	lookupErr := errors.New("ring unavailable")
+	resolver := membership.NewMockResolver(ctrl)
+	resolver.EXPECT().WhoAmI().Return(testSelfHost, nil).AnyTimes()
+	resolver.EXPECT().Lookup(service.Matching, gomock.Any()).Return(membership.HostInfo{}, lookupErr).AnyTimes()
+
+	tokens := persistence.NewMockSemaphoreTokenManager(ctrl)
+	tokens.EXPECT().ScanSemaphoreBucket(gomock.Any(), gomock.Any()).AnyTimes().
+		Return(&persistence.ScanSemaphoreBucketResponse{}, nil)
+
+	e := &matchingEngineImpl{
+		semaphoreRegistry:  semaphore.NewSemaphoreRegistry(),
+		membershipResolver: resolver,
+		logger:             log.NewNoop(),
+	}
+	mgr := newSemaphoreManager(t, mustNewSemaphoreIdentifier(t, 0), tokens)
+	require.NoError(t, mgr.Start(context.Background()))
+	e.semaphoreRegistry.Register(mgr)
+
+	assert.ErrorIs(t, e.shutDownNonOwnedSemaphoreManagers(), lookupErr)
+	assert.Len(t, e.semaphoreRegistry.AllManagers(), 1, "a lookup failure must not unload anything")
 }

--- a/service/matching/semaphore/identifier.go
+++ b/service/matching/semaphore/identifier.go
@@ -40,3 +40,12 @@ func (id Identifier) validate() error {
 func (id Identifier) String() string {
 	return fmt.Sprintf("%s/%s/%d", id.DomainID, id.SemaphoreName, id.Bucket)
 }
+
+// RingKey is what the bucket is hashed on to find the host that owns it. One bucket is one
+// partition, so exactly one host serves it.
+//
+// Kept apart from String(), which is for logs: reformatting a log line must not move buckets
+// between hosts.
+func (id Identifier) RingKey() string {
+	return fmt.Sprintf("%s_%s_%d", id.DomainID, id.SemaphoreName, id.Bucket)
+}

--- a/service/matching/semaphore/identifier_test.go
+++ b/service/matching/semaphore/identifier_test.go
@@ -50,6 +50,18 @@ func TestNewIdentifier(t *testing.T) {
 	}
 }
 
+// Tests that the ring key separates the buckets of one semaphore. If they shared a key they
+// would all hash to one host, and splitting the semaphore into buckets would gain nothing.
+func TestRingKey(t *testing.T) {
+	first, err := NewIdentifier("domain-1", "sem-1", 0)
+	require.NoError(t, err)
+	second, err := NewIdentifier("domain-1", "sem-1", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "domain-1_sem-1_0", first.RingKey())
+	assert.NotEqual(t, first.RingKey(), second.RingKey())
+}
+
 // Tests that Identifier works as a map key. Buckets are looked up by value, so the struct has to
 // stay comparable -- adding a slice or map field would break this at compile time, which is the
 // point.

--- a/service/matching/semaphore/interfaces.go
+++ b/service/matching/semaphore/interfaces.go
@@ -20,4 +20,19 @@ type (
 		// Identifier names the bucket this manager serves.
 		Identifier() Identifier
 	}
+
+	// SemaphoreRegistry tracks the managers this host is serving, keyed by identifier. It only
+	// tracks them: starting and stopping belongs to whoever creates them.
+	SemaphoreRegistry interface {
+		// Register adds mgr under its own identifier, replacing whatever was held for that
+		// bucket.
+		Register(mgr Manager)
+		// Unregister drops mgr and reports whether it was the manager actually held.
+		Unregister(mgr Manager) bool
+		// ManagerByIdentifier returns the manager held for id, if there is one. It may still
+		// be starting: Acquire is what waits for that.
+		ManagerByIdentifier(id Identifier) (Manager, bool)
+		// AllManagers returns a snapshot of what is registered.
+		AllManagers() []Manager
+	}
 )

--- a/service/matching/semaphore/interfaces_mock.go
+++ b/service/matching/semaphore/interfaces_mock.go
@@ -94,3 +94,82 @@ func (mr *MockManagerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockManager)(nil).Stop))
 }
+
+// MockSemaphoreRegistry is a mock of SemaphoreRegistry interface.
+type MockSemaphoreRegistry struct {
+	ctrl     *gomock.Controller
+	recorder *MockSemaphoreRegistryMockRecorder
+	isgomock struct{}
+}
+
+// MockSemaphoreRegistryMockRecorder is the mock recorder for MockSemaphoreRegistry.
+type MockSemaphoreRegistryMockRecorder struct {
+	mock *MockSemaphoreRegistry
+}
+
+// NewMockSemaphoreRegistry creates a new mock instance.
+func NewMockSemaphoreRegistry(ctrl *gomock.Controller) *MockSemaphoreRegistry {
+	mock := &MockSemaphoreRegistry{ctrl: ctrl}
+	mock.recorder = &MockSemaphoreRegistryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSemaphoreRegistry) EXPECT() *MockSemaphoreRegistryMockRecorder {
+	return m.recorder
+}
+
+// AllManagers mocks base method.
+func (m *MockSemaphoreRegistry) AllManagers() []Manager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllManagers")
+	ret0, _ := ret[0].([]Manager)
+	return ret0
+}
+
+// AllManagers indicates an expected call of AllManagers.
+func (mr *MockSemaphoreRegistryMockRecorder) AllManagers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllManagers", reflect.TypeOf((*MockSemaphoreRegistry)(nil).AllManagers))
+}
+
+// ManagerByIdentifier mocks base method.
+func (m *MockSemaphoreRegistry) ManagerByIdentifier(id Identifier) (Manager, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagerByIdentifier", id)
+	ret0, _ := ret[0].(Manager)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// ManagerByIdentifier indicates an expected call of ManagerByIdentifier.
+func (mr *MockSemaphoreRegistryMockRecorder) ManagerByIdentifier(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagerByIdentifier", reflect.TypeOf((*MockSemaphoreRegistry)(nil).ManagerByIdentifier), id)
+}
+
+// Register mocks base method.
+func (m *MockSemaphoreRegistry) Register(mgr Manager) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Register", mgr)
+}
+
+// Register indicates an expected call of Register.
+func (mr *MockSemaphoreRegistryMockRecorder) Register(mgr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockSemaphoreRegistry)(nil).Register), mgr)
+}
+
+// Unregister mocks base method.
+func (m *MockSemaphoreRegistry) Unregister(mgr Manager) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Unregister", mgr)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Unregister indicates an expected call of Unregister.
+func (mr *MockSemaphoreRegistryMockRecorder) Unregister(mgr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unregister", reflect.TypeOf((*MockSemaphoreRegistry)(nil).Unregister), mgr)
+}

--- a/service/matching/semaphore/semaphore_manager.go
+++ b/service/matching/semaphore/semaphore_manager.go
@@ -14,10 +14,9 @@ import (
 )
 
 const (
-	// scanPageSize sizes one page of the startup scan. A full bucket is one token row per slot
-	// plus one owner row per hold, so 2*bucket_size covers the partition, and the +1 saves the
-	// empty second fetch an exactly-full page would cost. Paging runs to the end either way, so
-	// this only ever costs round trips.
+	// scanPageSize is one larger than a full bucket -- one token row per slot plus one owner row
+	// per hold -- so the startup scan takes a single round trip. An optimization only: paging
+	// runs to the end whatever the size.
 	scanPageSize = 2*persistence.MaxSemaphoreBucketSize + 1
 
 	// maxGrantAttempts caps how many slots one acquire tries, so a badly stale free-set cannot

--- a/service/matching/semaphore/semaphore_registry.go
+++ b/service/matching/semaphore/semaphore_registry.go
@@ -1,0 +1,50 @@
+package semaphore
+
+import "sync"
+
+var _ SemaphoreRegistry = (*semaphoreRegistryImpl)(nil)
+
+type semaphoreRegistryImpl struct {
+	mu       sync.RWMutex
+	managers map[Identifier]Manager
+}
+
+func NewSemaphoreRegistry() SemaphoreRegistry {
+	return &semaphoreRegistryImpl{managers: make(map[Identifier]Manager)}
+}
+
+func (r *semaphoreRegistryImpl) Register(mgr Manager) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.managers[mgr.Identifier()] = mgr
+}
+
+func (r *semaphoreRegistryImpl) Unregister(mgr Manager) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// we need to make sure we still hold the given `mgr` or we already replaced with a new one.
+	if current, ok := r.managers[mgr.Identifier()]; !ok || current != mgr {
+		return false
+	}
+	delete(r.managers, mgr.Identifier())
+	return true
+}
+
+// ManagerByIdentifier returns the manager held for id, if there is one. It may still be
+// starting: Acquire is what waits for that.
+func (r *semaphoreRegistryImpl) ManagerByIdentifier(id Identifier) (Manager, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	mgr, ok := r.managers[id]
+	return mgr, ok
+}
+
+func (r *semaphoreRegistryImpl) AllManagers() []Manager {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	managers := make([]Manager, 0, len(r.managers))
+	for _, mgr := range r.managers {
+		managers = append(managers, mgr)
+	}
+	return managers
+}

--- a/service/matching/semaphore/semaphore_registry_test.go
+++ b/service/matching/semaphore/semaphore_registry_test.go
@@ -1,0 +1,83 @@
+package semaphore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func mustNewIdentifierForTest(t *testing.T, bucket int) Identifier {
+	t.Helper()
+	id, err := NewIdentifier("domain-1", "sem-1", bucket)
+	require.NoError(t, err)
+	return id
+}
+
+func newMockManagerWithID(t *testing.T, ctrl *gomock.Controller, id Identifier) *MockManager {
+	t.Helper()
+	mgr := NewMockManager(ctrl)
+	mgr.EXPECT().Identifier().Return(id).AnyTimes()
+	return mgr
+}
+
+// Tests the plain path: an empty registry holds nothing, a registered manager can be looked up,
+// and unregistering it takes it back out.
+func TestSemaphoreRegistry_RegisterLookupAndUnregister(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	r := NewSemaphoreRegistry()
+	id := mustNewIdentifierForTest(t, 0)
+
+	_, ok := r.ManagerByIdentifier(id)
+	assert.False(t, ok, "an empty registry holds nothing")
+
+	mgr := newMockManagerWithID(t, ctrl, id)
+	r.Register(mgr)
+
+	got, ok := r.ManagerByIdentifier(id)
+	require.True(t, ok)
+	assert.Same(t, mgr, got)
+
+	assert.True(t, r.Unregister(mgr), "unregistering the manager actually held reports true")
+	_, ok = r.ManagerByIdentifier(id)
+	assert.False(t, ok)
+
+	assert.False(t, r.Unregister(mgr), "unregistering twice reports false")
+}
+
+func TestSemaphoreRegistry_UnregisterWillNotEvictAReplacement(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	r := NewSemaphoreRegistry()
+	id := mustNewIdentifierForTest(t, 0)
+
+	old := newMockManagerWithID(t, ctrl, id)
+	replacement := newMockManagerWithID(t, ctrl, id)
+
+	r.Register(old)
+	r.Register(replacement)
+
+	assert.False(t, r.Unregister(old), "the old manager is no longer the one held")
+
+	got, ok := r.ManagerByIdentifier(id)
+	require.True(t, ok, "the replacement must survive the late teardown")
+	assert.Same(t, replacement, got)
+}
+
+// Tests that AllManagers hands back the caller's own slice. Shutdown iterates it while calling
+// Stop, so it has to stay valid while the registry underneath it changes.
+func TestSemaphoreRegistry_AllManagersIsASnapshot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	r := NewSemaphoreRegistry()
+	r.Register(newMockManagerWithID(t, ctrl, mustNewIdentifierForTest(t, 0)))
+	r.Register(newMockManagerWithID(t, ctrl, mustNewIdentifierForTest(t, 1)))
+
+	snapshot := r.AllManagers()
+	require.Len(t, snapshot, 2)
+
+	for _, mgr := range snapshot {
+		assert.True(t, r.Unregister(mgr))
+	}
+	assert.Len(t, snapshot, 2, "emptying the registry must not change a snapshot already taken")
+	assert.Empty(t, r.AllManagers())
+}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Gives the matching engine a way to load, track, and unload token buckets.
- semaphore.SemaphoreRegistry: the managers a host has loaded, keyed by identifier. 
- Identifier.RingKey() — the hash key a bucket is routed on.
- matchingEngineImpl.getOrCreateSemaphoreManager — domain flag check, ownership check, single-flight build, load outside the creation lock.
- shutDownNonOwnedSemaphoreManagers — unloads buckets the ring has moved, driven off the existing membership-change loop.
- matching.enableDistributedSemaphore — domain-filtered bool, default false.
- SemaphoreNotOwnedByHostError — typed error naming the host that should serve the bucket.

**Why?**

https://github.com/cadence-workflow/cadence/pull/8503 added per-bucket ownership. We need Matching host registry

- Routing on RingKey() (domain id + name + bucket number)
- Eviction on ring change matters more here than for task lists. A task list has an idle timer as a backstop, but a semaphore manager has none(for now, we may change this later), so one left on the wrong host stays loaded until the process exits.
- The partition read runs outside the creation lock, so one slow read doesn't hold up every other bucket on the host, and on its own 30s budget rather than the caller's deadline, since a client with a short deadline would abort the read and the next request would restart from the first page.
- The manager is registered before it starts, so a request arriving mid-read reuses it rather than reading the same partition again.
- The flag is resolved by domain name while a bucket is keyed by domain id, hence the GetDomainName hop before the flag check.

**How did you test it?**
go build ./...
go test -race -count=1 ./service/matching/...
make lint

**Potential risks**
None 

**Release notes**
N/A
**Documentation Changes**
N/A
