### PR TITLE
fix(ratelimiter): never limit a host below its local fallback in global mode

### DIFF
--- a/common/quotas/global/collection/collection.go
+++ b/common/quotas/global/collection/collection.go
@@ -37,7 +37,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -473,7 +472,7 @@ func (c *Collection) doUpdate(since time.Duration, usage map[shared.GlobalKey]rp
 		target := rate.Limit(c.targetRPS(lkey))
 		limiter := c.global.Load(lkey)
 		fallbackTarget := limiter.FallbackLimit()
-		boosted := boostRPS(target, fallbackTarget, info.Weight, info.UsedRPS)
+		boosted := boostRPS(target, fallbackTarget, info.Weight)
 		limiter.Update(boosted)
 	}
 
@@ -496,37 +495,28 @@ func (c *Collection) doUpdate(since time.Duration, usage map[shared.GlobalKey]rp
 	}
 }
 
-func boostRPS(target, fallback rate.Limit, weight float64, usedRPS float64) rate.Limit {
+func boostRPS(target, fallback rate.Limit, weight float64) rate.Limit {
 	baseline := target * rate.Limit(weight)
 
 	// low weights lead to low per-host overage allowed, and this can lead to
 	// restricting low-RPS-slightly-bursty requests quite a lot more than intended,
 	// despite more than enough unused quota remaining at all times.
 	//
-	// as a partial mitigation, "boost" low-weight values, allowing them to use
-	// more of the unused RPS than their weight would normally imply, up to the
-	// fallback's limit.
-	// as overall usage increases, this "allowed overage" will shrink, helping
-	// ensure it keeps converging towards the global target RPS.
-	if baseline < fallback {
-		// unused should not go below zero, e.g. if target was lowered,
-		// so this cannot reduce below the fair baseline.
-		unused := math.Max(0, float64(target)-usedRPS)
-		boosted := math.Min(
-			// with many bursty low-weight hosts, this may allow too much.
-			// currently this isn't really a concern, but this could be adjusted
-			// by num-of-low-hosts or something if needed.
-			float64(baseline)+unused,
-			// can't exceed the local fallback value though.
-			// this is also what would be allowed if this limit was garbage collected,
-			// so it's already established as a "safe enough" value.
-			float64(fallback),
-		)
-		return rate.Limit(boosted)
-	}
-
+	// as a mitigation, never limit a host below its local fallback limit
+	// (i.e. `target / num hosts`, what would be used without global limiting),
+	// effectively using max(local, global) per host.
+	//
+	// this used to be more conservative: low-weight hosts were only allowed to use
+	// the cluster-wide *unused* RPS, still capped at the fallback.  in practice that
+	// rejected requests while cluster-wide usage was still far below the target,
+	// especially with bursty traffic concentrated on a few hosts, so the cap is now
+	// the floor.  see https://github.com/cadence-workflow/cadence/issues/8158
+	//
 	// any host with a weighted target higher than the fallback will already be
 	// allowing a relatively large "growth room" on top of its actual usage, so
 	// they don't need this boost.
+	if baseline < fallback {
+		return fallback
+	}
 	return baseline
 }

--- a/common/quotas/global/collection/collection_fuzz_test.go
+++ b/common/quotas/global/collection/collection_fuzz_test.go
@@ -30,13 +30,12 @@ import (
 )
 
 func FuzzBoostRPS(f *testing.F) {
-	f.Fuzz(func(t *testing.T, target, fallback, weight, used float64) {
+	f.Fuzz(func(t *testing.T, target, fallback, weight float64) {
 		target = math.Abs(target)
 		fallback = math.Abs(fallback)
-		used = math.Abs(used)
 		weight = weight - math.Floor(weight) // trim to 0..1
 
-		if anyInvalid(target, fallback, used, weight) {
+		if anyInvalid(target, fallback, weight) {
 			t.Skip("bad numbers")
 		}
 
@@ -45,7 +44,7 @@ func FuzzBoostRPS(f *testing.F) {
 			target, fallback = fallback, target
 		}
 
-		boosted := boostRPS(rate.Limit(target), rate.Limit(fallback), weight, used)
+		boosted := boostRPS(rate.Limit(target), rate.Limit(fallback), weight)
 
 		if boosted > rate.Limit(target) {
 			// should never exceed whole-cluster target

--- a/common/quotas/global/collection/collection_test.go
+++ b/common/quotas/global/collection/collection_test.go
@@ -424,43 +424,37 @@ func TestBoostRPS(t *testing.T) {
 	tests := map[string]struct {
 		targetLimit, fallbackLimit float64
 		weight                     float64
-		usedRPS                    float64
 		resultLimit                float64
 	}{
-		"low weight fully used": {
+		"low weight": {
 			targetLimit:   10,
 			fallbackLimit: 3,
 			weight:        0.11,
-			usedRPS:       10,
-			resultLimit:   1.1, // no unused RPS free for boost, gets fair value
+			resultLimit:   3, // fair value 1.1 is below fallback, boosted to fallback
 		},
-		"low weight mostly unused": {
-			targetLimit:   10,
-			fallbackLimit: 3,
-			weight:        0.11,
-			usedRPS:       2,
-			resultLimit:   3, // min(1.1 + 8, 3)
-		},
-		"high weight fully used": {
+		"high weight": {
 			targetLimit:   10,
 			fallbackLimit: 3,
 			weight:        0.89,
-			usedRPS:       10,
-			resultLimit:   8.9, // no unused RPS free for boost, gets fair value
-		},
-		"high weight mostly unused": {
-			targetLimit:   10,
-			fallbackLimit: 3,
-			weight:        0.89,
-			usedRPS:       2,
 			resultLimit:   8.9, // should not be boosted beyond fair, nor limited below it
 		},
-		"usage over target": {
+		"weight exactly at fallback": {
 			targetLimit:   10,
 			fallbackLimit: 3,
-			weight:        0.089,
-			usedRPS:       100,
-			resultLimit:   0.89, // should be weight-based at worst, and not be reduced by excess usage
+			weight:        0.3,
+			resultLimit:   3,
+		},
+		"zero weight": {
+			targetLimit:   10,
+			fallbackLimit: 3,
+			weight:        0,
+			resultLimit:   3, // never below fallback
+		},
+		"full weight": {
+			targetLimit:   10,
+			fallbackLimit: 3,
+			weight:        1,
+			resultLimit:   10,
 		},
 	}
 	for name, tc := range tests {
@@ -469,7 +463,7 @@ func TestBoostRPS(t *testing.T) {
 			t.Parallel()
 			assert.GreaterOrEqual(t, tc.weight, float64(0), "sanity check on weight")
 			assert.LessOrEqual(t, tc.weight, float64(1), "sanity check on weight")
-			result := boostRPS(rate.Limit(tc.targetLimit), rate.Limit(tc.fallbackLimit), tc.weight, tc.usedRPS)
+			result := boostRPS(rate.Limit(tc.targetLimit), rate.Limit(tc.fallbackLimit), tc.weight)
 			assert.InDeltaf(t, tc.resultLimit, float64(result), 0.01, "computed RPS does not match closely enough, should be %0.2f", tc.resultLimit)
 		})
 	}

--- a/common/quotas/global/collection/testdata/fuzz/FuzzBoostRPS/1b0805e3169f0ae7
+++ b/common/quotas/global/collection/testdata/fuzz/FuzzBoostRPS/1b0805e3169f0ae7
@@ -2,4 +2,3 @@ go test fuzz v1
 float64(-95)
 float64(-158)
 float64(-52.111111111111114)
-float64(0)

--- a/common/quotas/global/collection/testdata/fuzz/FuzzBoostRPS/216cd14a71215fe2
+++ b/common/quotas/global/collection/testdata/fuzz/FuzzBoostRPS/216cd14a71215fe2
@@ -2,4 +2,3 @@ go test fuzz v1
 float64(-95)
 float64(0)
 float64(0)
-float64(0)


### PR DESCRIPTION
## What changed?
In the global ratelimiter collection, `boostRPS` now returns `max(target * weight, fallback)`: the local fallback limit (`target / num-hosts`) is a floor for each host's limit instead of a cap. The previous "use cluster-wide unused RPS, capped at fallback" logic is removed along with its now-unused `usedRPS` parameter; unit and fuzz tests are updated accordingly.

## Why?
Several domains reported rejected requests while running at only 30-60% of their configured RPS, mostly during sudden bursts of traffic concentrated on a few frontend hosts. In global mode a low-weight host could be limited below what the plain per-host limiter would have allowed. See #8158.

This is a minimal, temporary mitigation. The longer-term fix is decoupling the boost from the token bucket size so hosts can absorb bursts across a refresh interval (POC in #8361).

## How did you test it?
- Updated `TestBoostRPS` table and the `FuzzBoostRPS` corpus for the new signature.
- `go test ./common/quotas/global/...` passes; `go test -fuzz FuzzBoostRPS -fuzztime 5s` finds no failures.

## Potential risks
Slightly more permissive per-host limits for low-weight hosts, bounded by the existing local fallback value, so the cluster-wide overshoot is no worse than pure local mode.

## Release notes
None.

## Documentation Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
